### PR TITLE
Fixed WAV loading under 64-bit systems.

### DIFF
--- a/src/audio.c
+++ b/src/audio.c
@@ -683,24 +683,24 @@ static Wave LoadWAV(const char *fileName)
     // Basic WAV headers structs
     typedef struct {
         char chunkID[4];
-        long chunkSize;
+        int chunkSize;
         char format[4];
     } RiffHeader;
 
     typedef struct {
         char subChunkID[4];
-        long subChunkSize;
+        int subChunkSize;
         short audioFormat;
         short numChannels;
-        long sampleRate;
-        long byteRate;
+        int sampleRate;
+        int byteRate;
         short blockAlign;
         short bitsPerSample;
     } WaveFormat;
 
     typedef struct {
         char subChunkID[4];
-        long subChunkSize;
+        int subChunkSize;
     } WaveData;
 
     RiffHeader riffHeader;
@@ -722,8 +722,8 @@ static Wave LoadWAV(const char *fileName)
         fread(&riffHeader, sizeof(RiffHeader), 1, wavFile);
 
         // Check for RIFF and WAVE tags
-        if (((riffHeader.chunkID[0] != 'R') || (riffHeader.chunkID[1] != 'I') || (riffHeader.chunkID[2] != 'F') || (riffHeader.chunkID[3] != 'F')) ||
-            ((riffHeader.format[0] != 'W') || (riffHeader.format[1] != 'A') || (riffHeader.format[2] != 'V') || (riffHeader.format[3] != 'E')))
+        if (strncmp(riffHeader.chunkID, "RIFF", 4) ||
+            strncmp(riffHeader.format, "WAVE", 4))
         {
                 TraceLog(WARNING, "[%s] Invalid RIFF or WAVE Header", fileName);
         }


### PR DESCRIPTION
Hi!

The size of the long integer type varies across operating systems and compilers. On windows, both the 32-bit and the 64-bit of Microsoft Visual C++ and MinGW use 4 bytes for integers as well as for long integers, while GCC on a 64-bit linux system makes them 8-byte long. That difference **breaks the recognition of WAV file headers** in `src/audio.c` under 64-bit linuces, triggering an `Invalid RIFF or WAVE Header` error.

To ensure compatibility in the recognition of the WAV header, it is preferable to stick to plain integers, which take four bytes under all target systems. That way, both MinGW and GCC behave the same way, regardless of the underlying OS.

Just so you can double check my reasoning, here's a [short article](https://software.intel.com/en-us/articles/size-of-long-integer-type-on-different-architecture-and-os) detailing Intel's thoughts on the issue. They have their own C compiler that must remain compatible to the dominant compiler of any given platform (Visual C++ for windows, GCC for linux and macosx). MinGW [shares those concerns](http://sourceforge.net/p/mingw-w64/discussion/723798/thread/134f7720), so the same reasoning applies.

Thanks and keep up the good work!
