### PR TITLE
Conditional compilation of PLATFORM_DESKTOP segments should also apply to PLATFORM_DESKTOP_LINUX segments

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -5,12 +5,14 @@
 *   Basic functions to manage windows, OpenGL context and input on multiple platforms
 *
 *   The following platforms are supported:
-*       PLATFORM_DESKTOP - Windows, Linux, Mac (OSX)
+*       PLATFORM_DESKTOP - Windows, Mac (OSX)
+*       PLATFORM_DESKTOP_LINUX - Linux
 *       PLATFORM_ANDROID - Only OpenGL ES 2.0 devices
 *       PLATFORM_RPI - Rapsberry Pi (tested on Raspbian)
 *
-*   On PLATFORM_DESKTOP, the external lib GLFW3 (www.glfw.com) is used to manage graphic
-*   device, OpenGL context and input on multiple operating systems (Windows, Linux, OSX).
+*   On PLATFORM_DESKTOP and PLATFORM_DESKTOP_LINUX, the external lib GLFW3 (www.glfw.com)
+*   is used to manage graphic device, OpenGL context and input on multiple operating systems 
+*   (Windows, Linux, OSX).
 *
 *   On PLATFORM_ANDROID, graphic device is managed by EGL and input system by Android activity.
 *
@@ -49,7 +51,7 @@
 #include <string.h>         // String function definitions, memset()
 #include <errno.h>          // Macros for reporting and retrieving error conditions through error codes
 
-#if defined(PLATFORM_DESKTOP)
+#if defined(PLATFORM_DESKTOP) || defined(PLATFORM_DESKTOP_LINUX)
     #include <GLFW/glfw3.h>     // GLFW3 library: Windows, OpenGL context and Input management
     //#include <GL/gl.h>        // OpenGL functions (GLFW3 already includes gl.h)
     //#define GLFW_DLL          // Using GLFW DLL on Windows -> No, we use static version!
@@ -101,7 +103,7 @@
 //----------------------------------------------------------------------------------
 // Global Variables Definition
 //----------------------------------------------------------------------------------
-#if defined(PLATFORM_DESKTOP)
+#if defined(PLATFORM_DESKTOP) || defined(PLATFORM_DESKTOP_LINUX)
 static GLFWwindow *window;                      // Native window (graphic device)
 #elif defined(PLATFORM_ANDROID)
 static struct android_app *app;                 // Android activity
@@ -157,10 +159,10 @@ static int renderWidth, renderHeight;       // Framebuffer width and height (ren
 
 static int renderOffsetX = 0;               // Offset X from render area (must be divided by 2)
 static int renderOffsetY = 0;               // Offset Y from render area (must be divided by 2)
-static bool fullscreen = false;             // Fullscreen mode (useful only for PLATFORM_DESKTOP)
+static bool fullscreen = false;             // Fullscreen mode (useful only for PLATFORM_DESKTOP_*)
 static Matrix downscaleView;                // Matrix to downscale view (in case screen size bigger than display size)
 
-#if defined(PLATFORM_DESKTOP) || defined(PLATFORM_RPI)
+#if defined(PLATFORM_DESKTOP) || defined(PLATFORM_DESKTOP_LINUX) || defined(PLATFORM_RPI)
 static const char *windowTitle;             // Window text title...
 static char configFlags = 0;
 
@@ -226,7 +228,7 @@ static void RestoreKeyboard(void);                      // Restore keyboard syst
 static void InitGamepad(void);                          // Init raw gamepad input
 #endif
 
-#if defined(PLATFORM_DESKTOP)
+#if defined(PLATFORM_DESKTOP) || defined(PLATFORM_DESKTOP_LINUX)  
 static void ErrorCallback(int error, const char *description);                             // GLFW3 Error Callback, runs on GLFW3 error
 static void KeyCallback(GLFWwindow *window, int key, int scancode, int action, int mods);  // GLFW3 Keyboard Callback, runs on key pressed
 static void ScrollCallback(GLFWwindow *window, double xoffset, double yoffset);            // GLFW3 Srolling Callback, runs on mouse wheel
@@ -243,7 +245,7 @@ static void CommandCallback(struct android_app *app, int32_t cmd);           // 
 //----------------------------------------------------------------------------------
 // Module Functions Definition - Window and OpenGL Context Functions
 //----------------------------------------------------------------------------------
-#if defined(PLATFORM_DESKTOP) || defined(PLATFORM_RPI)
+#if defined(PLATFORM_DESKTOP) || defined(PLATFORM_DESKTOP_LINUX) || defined(PLATFORM_RPI)
 // Initialize Window and Graphics Context (OpenGL)
 void InitWindow(int width, int height, const char *title)
 {
@@ -348,7 +350,7 @@ void CloseWindow(void)
 
     rlglClose();                // De-init rlgl
 
-#if defined(PLATFORM_DESKTOP)
+#if defined(PLATFORM_DESKTOP) || defined(PLATFORM_DESKTOP_LINUX)
     glfwDestroyWindow(window);
     glfwTerminate();
 #elif defined(PLATFORM_ANDROID) || defined(PLATFORM_RPI)
@@ -380,7 +382,7 @@ void CloseWindow(void)
 // Detect if KEY_ESCAPE pressed or Close icon pressed
 bool WindowShouldClose(void)
 {
-#if defined(PLATFORM_DESKTOP)
+#if defined(PLATFORM_DESKTOP) || defined(PLATFORM_DESKTOP_LINUX)
     return (glfwWindowShouldClose(window));
 #elif defined(PLATFORM_ANDROID) || defined(PLATFORM_RPI)
     return windowShouldClose;
@@ -390,7 +392,7 @@ bool WindowShouldClose(void)
 // Fullscreen toggle
 void ToggleFullscreen(void)
 {
-#if defined(PLATFORM_DESKTOP)
+#if defined(PLATFORM_DESKTOP) || defined(PLATFORM_DESKTOP_LINUX)
     fullscreen = !fullscreen;          // Toggle fullscreen flag
 
     rlglClose();                       // De-init rlgl
@@ -402,7 +404,7 @@ void ToggleFullscreen(void)
 #endif
 }
 
-#if defined(PLATFORM_DESKTOP) || defined(PLATFORM_RPI)
+#if defined(PLATFORM_DESKTOP) || defined(PLATFORM_RPI) || defined(PLATFORM_DESKTOP_LINUX)
 // Set a custom cursor icon/image
 void SetCustomCursor(const char *cursorImage)
 {
@@ -410,7 +412,7 @@ void SetCustomCursor(const char *cursorImage)
 
     cursor = LoadTexture(cursorImage);
 
-#if defined(PLATFORM_DESKTOP)
+#if defined(PLATFORM_DESKTOP) || defined(PLATFORM_DESKTOP_LINUX)
     glfwSetInputMode(window, GLFW_CURSOR, GLFW_CURSOR_HIDDEN);
 #endif
     customCursor = true;
@@ -612,7 +614,7 @@ void ShowLogo(void)
 //----------------------------------------------------------------------------------
 // Module Functions Definition - Input (Keyboard, Mouse, Gamepad) Functions
 //----------------------------------------------------------------------------------
-#if defined(PLATFORM_DESKTOP) || defined(PLATFORM_RPI)
+#if defined(PLATFORM_DESKTOP) || defined(PLATFORM_RPI) || defined(PLATFORM_DESKTOP_LINUX)
 // Detect if a key has been pressed once
 bool IsKeyPressed(int key)
 {
@@ -739,7 +741,7 @@ int GetMouseWheelMove(void)
 #endif
 
 // TODO: Enable gamepad usage on Rapsberr Pi
-#if defined(PLATFORM_DESKTOP)
+#if defined(PLATFORM_DESKTOP) || defined(PLATFORM_DESKTOP_LINUX)
 // Detect if a gamepad is available
 bool IsGamepadAvailable(int gamepad)
 {
@@ -881,7 +883,7 @@ static void InitDisplay(int width, int height)
     // Downscale matrix is required in case desired screen area is bigger than display area
     downscaleView = MatrixIdentity();
 
-#if defined(PLATFORM_DESKTOP)
+#if defined(PLATFORM_DESKTOP) || defined(PLATFORM_DESKTOP_LINUX)
     glfwSetErrorCallback(ErrorCallback);
 
     if (!glfwInit()) TraceLog(ERROR, "Failed to initialize GLFW");
@@ -1116,7 +1118,7 @@ void InitGraphics(void)
 #endif
 }
 
-#if defined(PLATFORM_DESKTOP)
+#if defined(PLATFORM_DESKTOP) || defined(PLATFORM_DESKTOP_LINUX)
 // GLFW3 Error Callback, runs on GLFW3 error
 static void ErrorCallback(int error, const char *description)
 {
@@ -1343,7 +1345,7 @@ static void CommandCallback(struct android_app *app, int32_t cmd)
 }
 #endif
 
-#if defined(PLATFORM_DESKTOP) || defined(PLATFORM_RPI)
+#if defined(PLATFORM_DESKTOP) || defined(PLATFORM_RPI) || defined(PLATFORM_DESKTOP_LINUX)
 // Takes a screenshot and saves it in the same folder as executable
 static void TakeScreenshot(void)
 {
@@ -1386,7 +1388,7 @@ static void InitTimer(void)
 // Get current time measure since InitTimer()
 static double GetTime(void)
 {
-#if defined(PLATFORM_DESKTOP)
+#if defined(PLATFORM_DESKTOP) || defined(PLATFORM_DESKTOP_LINUX)
     return glfwGetTime();
 #elif defined(PLATFORM_ANDROID) || defined(PLATFORM_RPI)
     struct timespec ts;
@@ -1400,7 +1402,7 @@ static double GetTime(void)
 // Get one key state
 static bool GetKeyStatus(int key)
 {
-#if defined(PLATFORM_DESKTOP)
+#if defined(PLATFORM_DESKTOP) || defined(PLATFORM_DESKTOP_LINUX)
     return glfwGetKey(window, key);
 #elif defined(PLATFORM_ANDROID)
     // TODO: Check virtual keyboard (?)
@@ -1415,7 +1417,7 @@ static bool GetKeyStatus(int key)
 // Get one mouse button state
 static bool GetMouseButtonStatus(int button)
 {
-#if defined(PLATFORM_DESKTOP)
+#if defined(PLATFORM_DESKTOP) || defined(PLATFORM_DESKTOP_LINUX)
     return glfwGetMouseButton(window, button);
 #elif defined(PLATFORM_ANDROID)
     // TODO: Check virtual keyboard (?)
@@ -1429,7 +1431,7 @@ static bool GetMouseButtonStatus(int button)
 // Poll (store) all input events
 static void PollInputEvents(void)
 {
-#if defined(PLATFORM_DESKTOP)
+#if defined(PLATFORM_DESKTOP) || defined(PLATFORM_DESKTOP_LINUX)
     // Mouse input polling
     double mouseX;
     double mouseY;
@@ -1722,7 +1724,7 @@ static void InitGamepad(void)
 // Copy back buffer to front buffers
 static void SwapBuffers(void)
 {
-#if defined(PLATFORM_DESKTOP)
+#if defined(PLATFORM_DESKTOP) || defined(PLATFORM_DESKTOP_LINUX)
     glfwSwapBuffers(window);
 #elif defined(PLATFORM_ANDROID) || defined(PLATFORM_RPI)
     eglSwapBuffers(display, surface);

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -60,12 +60,13 @@
 #define RAYLIB_H
 
 // Choose your platform here or just define it at compile time: -DPLATFORM_DESKTOP
-//#define PLATFORM_DESKTOP      // Windows, Linux or OSX
-//#define PLATFORM_ANDROID      // Android device
-//#define PLATFORM_RPI          // Raspberry Pi
+//#define PLATFORM_DESKTOP          // Windows or OSX
+//#define PLATFORM_DESKTOP_LINUX    // Linux
+//#define PLATFORM_ANDROID          // Android device
+//#define PLATFORM_RPI              // Raspberry Pi
 
 // Security check in case no PLATFORM_* defined
-#if !defined(PLATFORM_DESKTOP) && !defined(PLATFORM_ANDROID) && !defined(PLATFORM_RPI)
+#if !defined(PLATFORM_DESKTOP) && !defined(PLATFORM_ANDROID) && !defined(PLATFORM_RPI) && !defined(PLATFORM_DESKTOP_LINUX)
     #define PLATFORM_DESKTOP
 #endif
 
@@ -281,14 +282,14 @@ extern "C" {            // Prevents name mangling of functions
 //------------------------------------------------------------------------------------
 #if defined(PLATFORM_ANDROID)
 void InitWindow(int width, int height, struct android_app *state);  // Init Android activity
-#elif defined(PLATFORM_DESKTOP) || defined(PLATFORM_RPI)
+#elif defined(PLATFORM_DESKTOP) || defined(PLATFORM_RPI) || defined(PLATFORM_DESKTOP_LINUX)
 void InitWindow(int width, int height, const char *title);  // Initialize Window and OpenGL Graphics
 #endif
 
 void CloseWindow(void);                                     // Close Window and Terminate Context
 bool WindowShouldClose(void);                               // Detect if KEY_ESCAPE pressed or Close icon pressed
-void ToggleFullscreen(void);                                // Fullscreen toggle (only PLATFORM_DESKTOP)
-#if defined(PLATFORM_DESKTOP) || defined(PLATFORM_RPI)
+void ToggleFullscreen(void);                                // Fullscreen toggle (only PLATFORM_DESKTOP_*)
+#if defined(PLATFORM_DESKTOP) || defined(PLATFORM_RPI) || defined(PLATFORM_DESKTOP_LINUX)
 void SetCustomCursor(const char *cursorImage);              // Set a custom cursor icon/image
 void SetExitKey(int key);                                   // Set a custom key to exit program (default is ESC)
 #endif
@@ -319,7 +320,7 @@ void ShowLogo(void);                                        // Activates raylib 
 //------------------------------------------------------------------------------------
 // Input Handling Functions (Module: core)
 //------------------------------------------------------------------------------------
-#if defined(PLATFORM_DESKTOP) || defined(PLATFORM_RPI)
+#if defined(PLATFORM_DESKTOP) || defined(PLATFORM_RPI) || defined(PLATFORM_DESKTOP_LINUX)
 bool IsKeyPressed(int key);                             // Detect if a key has been pressed once
 bool IsKeyDown(int key);                                // Detect if a key is being pressed
 bool IsKeyReleased(int key);                            // Detect if a key has been released once

--- a/src/rlgl.h
+++ b/src/rlgl.h
@@ -43,8 +43,8 @@
 // if OpenGL version is required by any other module, it uses rlGetVersion()
 
 // Choose opengl version here or just define it at compile time: -DGRAPHICS_API_OPENGL_33
-//#define GRAPHICS_API_OPENGL_11     // Only available on PLATFORM_DESKTOP
-//#define GRAPHICS_API_OPENGL_33     // Only available on PLATFORM_DESKTOP
+//#define GRAPHICS_API_OPENGL_11     // Only available on PLATFORM_DESKTOP_*
+//#define GRAPHICS_API_OPENGL_33     // Only available on PLATFORM_DESKTOP_*
 //#define GRAPHICS_API_OPENGL_ES2    // Only available on PLATFORM_ANDROID or PLATFORM_RPI
 
 // Security check in case no GRAPHICS_API_OPENGL_* defined

--- a/src/utils.c
+++ b/src/utils.c
@@ -40,7 +40,7 @@
 #include <stdarg.h>             // Used for functions with variable number of parameters (TraceLog())
 //#include <string.h>           // String management functions: strlen(), strrchr(), strcmp()
 
-#if defined(PLATFORM_DESKTOP) || defined(PLATFORM_RPI)
+#if defined(PLATFORM_DESKTOP) || defined(PLATFORM_RPI) || defined(PLATFORM_DESKTOP_LINUX)
     #define STB_IMAGE_WRITE_IMPLEMENTATION
     #include "stb_image_write.h"    // Create PNG file
 #endif
@@ -107,7 +107,7 @@ unsigned char *DecompressData(const unsigned char *data, unsigned long compSize,
     return pUncomp;
 }
 
-#if defined(PLATFORM_DESKTOP) || defined(PLATFORM_RPI)
+#if defined(PLATFORM_DESKTOP) || defined(PLATFORM_RPI) || defined(PLATFORM_DESKTOP_LINUX) 
 // Creates a bitmap (BMP) file from an array of pixel data
 // NOTE: This function is not explicitly available to raylib users
 void WriteBitmap(const char *fileName, unsigned char *imgData, int width, int height)

--- a/src/utils.h
+++ b/src/utils.h
@@ -70,7 +70,7 @@ extern "C" {            // Prevents name mangling of functions
 //----------------------------------------------------------------------------------
 unsigned char *DecompressData(const unsigned char *data, unsigned long compSize, int uncompSize);
 
-#if defined(PLATFORM_DESKTOP) || defined(PLATFORM_RPI)
+#if defined(PLATFORM_DESKTOP) || defined(PLATFORM_RPI) || defined(PLATFORM_DESKTOP_LINUX)
 void WriteBitmap(const char *fileName, unsigned char *imgData, int width, int height);
 void WritePNG(const char *fileName, unsigned char *imgData, int width, int height);
 #endif

--- a/templates/android_project/jni/include/raylib.h
+++ b/templates/android_project/jni/include/raylib.h
@@ -60,9 +60,10 @@
 #define RAYLIB_H
 
 // Choose your platform here or just define it at compile time: -DPLATFORM_DESKTOP
-//#define PLATFORM_DESKTOP      // Windows, Linux or OSX
-//#define PLATFORM_ANDROID      // Android device
-//#define PLATFORM_RPI          // Raspberry Pi
+//#define PLATFORM_DESKTOP          // Windows or OSX
+//#define PLATFORM_DESKTOP_LINUX    // Linux
+//#define PLATFORM_ANDROID          // Android device
+//#define PLATFORM_RPI              // Raspberry Pi
 
 #if defined(PLATFORM_ANDROID)
     #include <android_native_app_glue.h>    // Defines android_app struct
@@ -269,14 +270,14 @@ extern "C" {            // Prevents name mangling of functions
 //------------------------------------------------------------------------------------
 #if defined(PLATFORM_ANDROID)
 void InitWindow(int width, int height, struct android_app *state);  // Init Android activity
-#elif defined(PLATFORM_DESKTOP) || defined(PLATFORM_RPI)
+#elif defined(PLATFORM_DESKTOP) || defined(PLATFORM_DESKTOP_LINUX) || defined(PLATFORM_RPI)
 void InitWindow(int width, int height, const char *title);  // Initialize Window and OpenGL Graphics
 #endif
 
 void CloseWindow(void);                                     // Close Window and Terminate Context
 bool WindowShouldClose(void);                               // Detect if KEY_ESCAPE pressed or Close icon pressed
 void ToggleFullscreen(void);                                // Fullscreen toggle (only PLATFORM_DESKTOP)
-#if defined(PLATFORM_DESKTOP) || defined(PLATFORM_RPI)
+#if defined(PLATFORM_DESKTOP) || defined(PLATFORM_DESKTOP_LINUX) || defined(PLATFORM_RPI)
 void SetCustomCursor(const char *cursorImage);              // Set a custom cursor icon/image
 void SetExitKey(int key);                                   // Set a custom key to exit program (default is ESC)
 #endif
@@ -305,7 +306,7 @@ void ShowLogo(void);                                        // Activates raylib 
 //------------------------------------------------------------------------------------
 // Input Handling Functions (Module: core)
 //------------------------------------------------------------------------------------
-#if defined(PLATFORM_DESKTOP) || defined(PLATFORM_RPI)
+#if defined(PLATFORM_DESKTOP) || defined(PLATFORM_DESKTOP_LINUX) || defined(PLATFORM_RPI)
 bool IsKeyPressed(int key);                             // Detect if a key has been pressed once
 bool IsKeyDown(int key);                                // Detect if a key is being pressed
 bool IsKeyReleased(int key);                            // Detect if a key has been released once


### PR DESCRIPTION
While checking the correctness of my last pull request, I had a version of libraysan.a compiled using `-DPLATFORM_DESKTOP`, which turned out to build correctly every example. However, I failed to notice that using `-DPLATFORM_DESKTOP_LINUX` excludes several raylib functions from the library. This pull request should fix that.

As a matter of style, I'm beginning to feel that preprocessing directives such as

```
#if defined(PLATFORM_DESKTOP) || defined(PLATFORM_RPI) || defined(PLATFORM_DESKTOP_LINUX)
```

are starting to get a bit unwieldy, but I'm sticking to the overall coding style of libraysan. Maybe a shared `PLATFORM_DESKTOP` definition and separate `DESKTOP_WINDOWS` and `DESKTOP_LINUX` definitions would turn out to be more readable, but then again, maybe not.

Cheers!
