### PR TITLE
Fix compiling on Linux

### DIFF
--- a/src/gestures.c
+++ b/src/gestures.c
@@ -37,6 +37,7 @@
 #if defined(_WIN32)
     //#include <Windows.h>
 #elif defined(__linux)
+    #include <sys/time.h>       // Declares storage size of ‘now’
     #include <time.h>           // Used for clock functions
 #endif
 

--- a/src/makefile
+++ b/src/makefile
@@ -73,7 +73,7 @@ endif
 ifeq ($(PLATFORM),PLATFORM_RPI)
     CFLAGS = -O1 -Wall -std=gnu99 -fgnu89-inline
 else
-    CFLAGS = -O1 -Wall -std=c99
+    CFLAGS = -O1 -Wall -std=gnu99
 endif
 
 #CFLAGSEXTRA = -Wextra -Wmissing-prototypes -Wstrict-prototypes


### PR DESCRIPTION
`#include <sys/time.h>` is needed for this compile-time error:

```
gestures.c:553:21: error: storage size of ‘now’ isn’t known
     struct timespec now;
                     ^
```
                     
`-std=gnu99` is required for `CLOCK_MONOTONIC`:

```             
gestures.c:554:19: error: ‘CLOCK_MONOTONIC’ undeclared (first use in this function)
     clock_gettime(CLOCK_MONOTONIC, &now);
                   ^
```