### PR TITLE
Disable cursor feature

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -1097,6 +1097,24 @@ void ShowCursor()
     cursorHidden = false;
 }
 
+// Disable mouse cursor
+void DisableCursor()
+{
+#if defined(PLATFORM_DESKTOP)
+    glfwSetInputMode(window, GLFW_CURSOR, GLFW_CURSOR_DISABLED);
+#endif
+    cursorHidden = true;
+}
+
+// Enable mouse cursor
+void EnableCursor()
+{
+#if defined(PLATFORM_DESKTOP)
+    glfwSetInputMode(window, GLFW_CURSOR, GLFW_CURSOR_NORMAL);
+#endif
+    cursorHidden = false;
+}
+
 // Check if mouse cursor is hidden
 bool IsCursorHidden()
 {

--- a/src/makefile
+++ b/src/makefile
@@ -91,7 +91,7 @@ else
 endif
 
 # define all object files required
-OBJS = core.o rlgl.o raymath.o shapes.o text.o textures.o models.o audio.o utils.o camera.o gestures.o stb_vorbis.o
+OBJS = core.o rlgl.o glad.o shapes.o text.o textures.o models.o audio.o utils.o camera.o gestures.o stb_vorbis.o
 
 # typing 'make' will invoke the first target entry in the file,
 # in this case, the 'default' target entry is raylib
@@ -114,9 +114,9 @@ core.o: core.c
 rlgl.o: rlgl.c
 	$(CC) -c rlgl.c $(CFLAGS) $(INCLUDES) -D$(PLATFORM) -D$(GRAPHICS)
 
-# compile raymath module
-raymath.o: raymath.c
-	$(CC) -c raymath.c $(CFLAGS) $(INCLUDES)
+# compile glad module
+raymath.o: glad.c
+	$(CC) -c glad.c $(CFLAGS) $(INCLUDES)
 
 # compile shapes module
 shapes.o: shapes.c

--- a/src/makefile
+++ b/src/makefile
@@ -115,7 +115,7 @@ rlgl.o: rlgl.c
 	$(CC) -c rlgl.c $(CFLAGS) $(INCLUDES) -D$(PLATFORM) -D$(GRAPHICS)
 
 # compile glad module
-raymath.o: glad.c
+glad.o: glad.c
 	$(CC) -c glad.c $(CFLAGS) $(INCLUDES)
 
 # compile shapes module

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -586,6 +586,8 @@ int GetMouseWheelMove(void);                            // Returns mouse wheel m
 
 void ShowCursor(void);                                  // Shows cursor
 void HideCursor(void);                                  // Hides cursor
+void EnableCursor(void);                                // Enables cursor
+void DisableCursor(void);                               // Disables cursor
 bool IsCursorHidden(void);                              // Returns true if cursor is not visible
 #endif
 


### PR DESCRIPTION
Exposes `GLFW_CURSOR_DISABLED` flag that disables cursor so the mouse can't leave the window, essentially a better hide function for 3D cameras than `GLFW_CURSOR_HIDDEN` flag.