### PR TITLE
Fix building examples on OSX

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -85,6 +85,8 @@ ifeq ($(PLATFORM),PLATFORM_DESKTOP)
     # add standard directories for GNU/Linux
     ifeq ($(PLATFORM_OS),LINUX)
         INCLUDES = -I. -I../src -I/usr/local/include/raylib/
+    else ifeq ($(PLATFORM_OS),OSX)
+        INCLUDES = -I. -I../src
     else
         INCLUDES = -I. -I../../src -IC:/raylib/raylib/src
         # external libraries headers
@@ -103,6 +105,8 @@ ifeq ($(PLATFORM),PLATFORM_DESKTOP)
     # add standard directories for GNU/Linux
     ifeq ($(PLATFORM_OS),LINUX)
         LFLAGS = -L. -L../../src
+    else ifeq ($(PLATFORM_OS),OSX)
+        LFLAGS = -L. -L../src
     else
         LFLAGS = -L. -L../../src -LC:/raylib/raylib/src
         # external libraries to link with
@@ -129,7 +133,7 @@ ifeq ($(PLATFORM),PLATFORM_DESKTOP)
         # libraries for OS X 10.9 desktop compiling
         # requires the following packages:
         # libglfw3-dev libopenal-dev libegl1-mesa-dev
-        LIBS = -lraylib -lglfw -framework OpenGL -framework OpenAl -framework Cocoa
+        LIBS = -lraylib -lglfw3 -framework OpenGL -framework OpenAl -framework Cocoa
     else
         # libraries for Windows desktop compiling
         # NOTE: GLFW3 and OpenAL Soft libraries should be installed

--- a/src/core.c
+++ b/src/core.c
@@ -1447,7 +1447,11 @@ static void InitDisplay(int width, int height)
         glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);        // Choose OpenGL minor version (just hint)
         glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE); // Profiles Hint: Only 3.3 and above!
                                                                        // Other values: GLFW_OPENGL_ANY_PROFILE, GLFW_OPENGL_COMPAT_PROFILE
+#ifdef __APPLE__
+        glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);  // OSX Requires 
+#else
         glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_FALSE); // Fordward Compatibility Hint: Only 3.3 and above!
+#endif
         //glfwWindowHint(GLFW_OPENGL_DEBUG_CONTEXT, GL_TRUE);
     }
 

--- a/templates/advance_game/Makefile
+++ b/templates/advance_game/Makefile
@@ -109,7 +109,10 @@ ifeq ($(PLATFORM),PLATFORM_DESKTOP)
     ifeq ($(PLATFORM_OS),LINUX)
         LFLAGS = -L. -L../../src
     else
-        LFLAGS = -L. -L../../src -LC:/raylib/raylib/src
+        LFLAGS = -L. -L../../src
+        ifeq ($(PLATFORM_OS),WINDOWS)
+            LFLAGS += -LC:/raylib/raylib/src
+        endif
         # external libraries to link with
         # GLFW3
             LFLAGS += -L../../external/glfw3/lib/$(LIBPATH)
@@ -134,7 +137,7 @@ ifeq ($(PLATFORM),PLATFORM_DESKTOP)
         # libraries for OS X 10.9 desktop compiling
         # requires the following packages:
         # libglfw3-dev libopenal-dev libegl1-mesa-dev
-        LIBS = -lraylib -lglfw -framework OpenGL -framework OpenAl -framework Cocoa
+        LIBS = -lraylib -lglfw3 -framework OpenGL -framework OpenAl -framework Cocoa
     else
         # libraries for Windows desktop compiling
         # NOTE: GLFW3 and OpenAL Soft libraries should be installed

--- a/templates/basic_game/Makefile
+++ b/templates/basic_game/Makefile
@@ -109,7 +109,10 @@ ifeq ($(PLATFORM),PLATFORM_DESKTOP)
     ifeq ($(PLATFORM_OS),LINUX)
         LFLAGS = -L. -L../../src
     else
-        LFLAGS = -L. -L../../src -LC:/raylib/raylib/src
+        LFLAGS = -L. -L../../src
+        ifeq ($(PLATFORM_OS),WINDOWS)
+            LFLAGS += -LC:/raylib/raylib/src
+        endif
         # external libraries to link with
         # GLFW3
             LFLAGS += -L../../external/glfw3/lib/$(LIBPATH)

--- a/templates/basic_test/Makefile
+++ b/templates/basic_test/Makefile
@@ -108,7 +108,10 @@ ifeq ($(PLATFORM),PLATFORM_DESKTOP)
     ifeq ($(PLATFORM_OS),LINUX)
         LFLAGS = -L. -L../../src
     else
-        LFLAGS = -L. -L../../src -LC:/raylib/raylib/src
+        LFLAGS = -L. -L../../src
+        ifeq ($(PLATFORM_OS),WINDOWS)
+            LFLAGS += -LC:/raylib/raylib/src
+        endif
         # external libraries to link with
         # GLFW3
             LFLAGS += -L../../external/glfw3/lib/$(LIBPATH)
@@ -133,7 +136,7 @@ ifeq ($(PLATFORM),PLATFORM_DESKTOP)
         # libraries for OS X 10.9 desktop compiling
         # requires the following packages:
         # libglfw3-dev libopenal-dev libegl1-mesa-dev
-        LIBS = -lraylib -lglfw -framework OpenGL -framework OpenAl -framework Cocoa
+        LIBS = -lraylib -lglfw3 -framework OpenGL -framework OpenAl -framework Cocoa
     else
         # libraries for Windows desktop compiling
         # NOTE: GLFW3 and OpenAL Soft libraries should be installed

--- a/templates/simple_game/Makefile
+++ b/templates/simple_game/Makefile
@@ -109,7 +109,10 @@ ifeq ($(PLATFORM),PLATFORM_DESKTOP)
     ifeq ($(PLATFORM_OS),LINUX)
         LFLAGS = -L. -L../../src
     else
-        LFLAGS = -L. -L../../src -LC:/raylib/raylib/src
+        LFLAGS = -L. -L../../src
+        ifeq ($(PLATFORM_OS),WINDOWS)
+            LFLAGS += -LC:/raylib/raylib/src
+        endif
         # external libraries to link with
         # GLFW3
             LFLAGS += -L../../external/glfw3/lib/$(LIBPATH)
@@ -134,7 +137,7 @@ ifeq ($(PLATFORM),PLATFORM_DESKTOP)
         # libraries for OS X 10.9 desktop compiling
         # requires the following packages:
         # libglfw3-dev libopenal-dev libegl1-mesa-dev
-        LIBS = -lraylib -lglfw -framework OpenGL -framework OpenAl -framework Cocoa
+        LIBS = -lraylib -lglfw3 -framework OpenGL -framework OpenAl -framework Cocoa
     else
         # libraries for Windows desktop compiling
         # NOTE: GLFW3 and OpenAL Soft libraries should be installed

--- a/templates/standard_game/Makefile
+++ b/templates/standard_game/Makefile
@@ -109,7 +109,10 @@ ifeq ($(PLATFORM),PLATFORM_DESKTOP)
     ifeq ($(PLATFORM_OS),LINUX)
         LFLAGS = -L. -L../../src
     else
-        LFLAGS = -L. -L../../src -LC:/raylib/raylib/src
+        LFLAGS = -L. -L../../src
+        ifeq ($(PLATFORM_OS),WINDOWS)
+            LFLAGS += -LC:/raylib/raylib/src
+        endif
         # external libraries to link with
         # GLFW3
             LFLAGS += -L../../external/glfw3/lib/$(LIBPATH)
@@ -134,7 +137,7 @@ ifeq ($(PLATFORM),PLATFORM_DESKTOP)
         # libraries for OS X 10.9 desktop compiling
         # requires the following packages:
         # libglfw3-dev libopenal-dev libegl1-mesa-dev
-        LIBS = -lraylib -lglfw -framework OpenGL -framework OpenAl -framework Cocoa
+        LIBS = -lraylib -lglfw3 -framework OpenGL -framework OpenAl -framework Cocoa
     else
         # libraries for Windows desktop compiling
         # NOTE: GLFW3 and OpenAL Soft libraries should be installed


### PR DESCRIPTION
This fixes building the examples on OSX.

If you install glfw3 with [homebrew](http://brew.sh), the library is called "glfw3" and so the linker command needed to change. Ideally, there should be a way to work with the library being called glfw as well, but I don't know the correct linker command for this.

`core_input_gamepad` does not compile, but this is because `GetGamepadMovement` does not seem to exist anymore in develop. I have just removed it from my own makefile for now, and will file a separate issue later.