### PR TITLE
fix example

### DIFF
--- a/examples/core_input_gamepad.c
+++ b/examples/core_input_gamepad.c
@@ -36,7 +36,8 @@ int main()
         //----------------------------------------------------------------------------------
         if (IsGamepadAvailable(GAMEPAD_PLAYER1))
         {
-            gamepadMovement = GetGamepadMovement(GAMEPAD_PLAYER1);
+            gamepadMovement.x = GetGamepadAxisMovement(GAMEPAD_PLAYER1, GAMEPAD_XBOX_AXIS_LEFT_X);
+            gamepadMovement.y = GetGamepadAxisMovement(GAMEPAD_PLAYER1, GAMEPAD_XBOX_AXIS_LEFT_Y);
 
             ballPosition.x += gamepadMovement.x;
             ballPosition.y -= gamepadMovement.y;


### PR DESCRIPTION
Replaces usage of removed `GetGamepadMovement()` function in core_input_gamepad.c with 2 calls to the new `GetGamepadAxisMovement()`