### PR TITLE
Compiler Issues in Linux and raylib_demo

### DIFF
--- a/games/raylib_demo/raylib_demo.c
+++ b/games/raylib_demo/raylib_demo.c
@@ -203,7 +203,7 @@ int main()
 
     catTexture = LoadTexture("resources/catsham.png");   // Load model texture
     cat = LoadModel("resources/cat.obj");                // Load OBJ model
-    cat.material.texDiffuse = texture;                   // Set cat model diffuse texture
+    cat.material.texDiffuse = catTexture;                   // Set cat model diffuse texture
     
     fxWav = LoadSound("resources/audio/weird.wav");         // Load WAV audio file
     fxOgg = LoadSound("resources/audio/tanatana.ogg");      // Load OGG audio file
@@ -464,11 +464,11 @@ void UpdateDrawOneFrame(void)
 
                 if (selectedModule == AUDIO)
                 {
-                    if (IsKeyPressed(KEY_SPACE) && !MusicIsPlaying()) PlayMusicStream("resources/audio/guitar_noodling.ogg");         // Play music stream
+                    if (IsKeyPressed(KEY_SPACE) && !MusicIsPlaying()) PlayMusicStream(1,"resources/audio/guitar_noodling.ogg");         // Play music stream
 
                     if (IsKeyPressed('S'))
                     {
-                        StopMusicStream();
+                        StopMusicStream(1);
                         timePlayed = 0.0f;
 
                         for (int i = 0; i < MAX_BALLS; i++)
@@ -484,7 +484,7 @@ void UpdateDrawOneFrame(void)
 
                     if (MusicIsPlaying())
                     {
-                        timePlayed = GetMusicTimePlayed() / GetMusicTimeLength() * 100 * 4;
+                        timePlayed = GetMusicTimePlayed(1) / GetMusicTimeLength(11) * 100 * 4;
 
                         if ((framesCounter%10) == 0)
                         {

--- a/src/Makefile
+++ b/src/Makefile
@@ -222,10 +222,10 @@ ifeq ($(ROOT),root)
         # /usr/local/include/) are for libraries that are installed
         # manually (without a package manager).
         ifeq ($(SHARED),YES)
-			cp --update libraylib.so /usr/local/lib/libraylib.so
+			cp --update ~/raylib/release/linux/libraylib.so /usr/local/lib/libraylib.so
         else
-			cp --update raylib.h /usr/local/include/raylib.h
-			cp --update libraylib.a /usr/local/lib/libraylib.a
+			cp --update ~/raylib/release/linux/raylib.h /usr/local/include/raylib.h
+			cp --update ~/raylib/release/linux/libraylib.a /usr/local/lib/libraylib.a
         endif
 		@echo "raylib dev files installed/updated!"
     else


### PR DESCRIPTION
Fixed compile errors in raylib_demo.c where audio methods are not supplied enough args
sudo make install gathers files from release folder rather than cwd.