### PR TITLE
Integrate Android build into Makefile

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -83,6 +83,10 @@ ifeq ($(PLATFORM),PLATFORM_ANDROID)
     ANDROID_TOOLCHAIN = $(CURDIR)/toolchain
 endif
 
+ifeq ($(PLATFORM),PLATFORM_RPI)
+    CROSS_COMPILE ?= NO
+endif
+
 # define raylib graphics api depending on selected platform
 ifeq ($(PLATFORM),PLATFORM_ANDROID)
     GRAPHICS = GRAPHICS_API_OPENGL_ES2
@@ -121,6 +125,13 @@ ifeq ($(PLATFORM),PLATFORM_ANDROID)
         else
             CC = $(ANDROID_TOOLCHAIN)/bin/aarch64-linux-android-gcc
         endif
+    endif
+endif
+
+ifeq ($(PLATFORM),PLATFORM_RPI)
+    ifeq ($(CROSS_COMPILE),YES)
+    	# rpi compiler
+        CC = armv6j-hardfloat-linux-gnueabi-gcc
     endif
 endif
 
@@ -170,11 +181,6 @@ endif
 #CFLAGSEXTRA = -Wextra -Wmissing-prototypes -Wstrict-prototypes
 
 # define any directories containing required header files
-ifeq ($(PLATFORM),PLATFORM_RPI)
-    INCLUDES = -I. -Iexternal -I/opt/vc/include \
-    -I/opt/vc/include/interface/vmcs_host/linux \
-    -I/opt/vc/include/interface/vcos/pthreads
-endif
 ifeq ($(PLATFORM),PLATFORM_ANDROID)
 # STB libraries and others
     INCLUDES = -I. -Iexternal
@@ -188,6 +194,16 @@ else
     INCLUDES = -I. -Iexternal
 # GLFW3 library
     INCLUDES += -Iexternal/glfw3/include
+# OpenAL Soft library
+    INCLUDES += -Iexternal/openal_soft/include
+endif
+ifeq ($(PLATFORM),PLATFORM_RPI)
+# STB libraries and others
+    INCLUDES = -I. -Iexternal
+# RPi libraries
+    INCLUDES += -I/opt/vc/include
+    INCLUDES += -I/opt/vc/include/interface/vmcs_host/linux
+    INCLUDES += -I/opt/vc/include/interface/vcos/pthreads
 # OpenAL Soft library
     INCLUDES += -Iexternal/openal_soft/include
 endif

--- a/src/Makefile
+++ b/src/Makefile
@@ -32,7 +32,7 @@
 .PHONY: all clean install unistall
 
 # define raylib platform to compile for
-# possible platforms: PLATFORM_DESKTOP PLATFORM_RPI PLATFORM_WEB
+# possible platforms: PLATFORM_DESKTOP PLATFORM_ANDROID PLATFORM_RPI PLATFORM_WEB
 PLATFORM ?= PLATFORM_DESKTOP
 
 # define YES if you want shared/dynamic version of library instead of static (default)
@@ -69,7 +69,24 @@ ifeq ($(PLATFORM),PLATFORM_DESKTOP)
     endif
 endif
 
+ifeq ($(PLATFORM),PLATFORM_ANDROID)
+    # path to Android NDK
+    ANDROID_NDK = $(ANDROID_NDK_HOME)
+
+    # possible Android architectures: ARM ARM64
+    ANDROID_ARCH ?= ARM
+
+    # define YES to use clang instead of gcc
+    ANDROID_LLVM ?= NO
+
+    # standalone Android toolchain install dir
+    ANDROID_TOOLCHAIN = $(CURDIR)/toolchain
+endif
+
 # define raylib graphics api depending on selected platform
+ifeq ($(PLATFORM),PLATFORM_ANDROID)
+    GRAPHICS = GRAPHICS_API_OPENGL_ES2
+endif
 ifeq ($(PLATFORM),PLATFORM_RPI)
     # define raylib graphics api to use (on RPI, OpenGL ES 2.0 must be used)
     GRAPHICS = GRAPHICS_API_OPENGL_ES2
@@ -86,12 +103,41 @@ endif
 # NOTE: makefiles targets require tab indentation
 
 # define compiler: gcc for C program, define as g++ for C++
+
+# default gcc compiler
+CC = gcc
+
+ifeq ($(PLATFORM),PLATFORM_ANDROID)
+    ifeq ($(ANDROID_ARCH),ARM)
+        ifeq ($(ANDROID_LLVM),YES)
+            CC = $(ANDROID_TOOLCHAIN)/bin/arm-linux-androideabi-clang
+        else
+            CC = $(ANDROID_TOOLCHAIN)/bin/arm-linux-androideabi-gcc
+        endif
+    endif
+    ifeq ($(ANDROID_ARCH),ARM64)
+        ifeq ($(ANDROID_LLVM),YES)
+            CC = $(ANDROID_TOOLCHAIN)/bin/aarch64-linux-android-clang
+        else
+            CC = $(ANDROID_TOOLCHAIN)/bin/aarch64-linux-android-gcc
+        endif
+    endif
+endif
+
 ifeq ($(PLATFORM),PLATFORM_WEB)
     # emscripten compiler
     CC = emcc
-else
-    # default gcc compiler
-    CC = gcc
+endif
+
+AR = ar
+
+ifeq ($(PLATFORM),PLATFORM_ANDROID)
+    ifeq ($(ANDROID_ARCH),ARM)
+        AR = $(ANDROID_TOOLCHAIN)/bin/arm-linux-androideabi-ar
+    endif
+    ifeq ($(ANDROID_ARCH),ARM64)
+        AR = $(ANDROID_TOOLCHAIN)/bin/aarch64-linux-android-ar
+    endif
 endif
 
 # define compiler flags:
@@ -128,6 +174,15 @@ ifeq ($(PLATFORM),PLATFORM_RPI)
     INCLUDES = -I. -Iexternal -I/opt/vc/include \
     -I/opt/vc/include/interface/vmcs_host/linux \
     -I/opt/vc/include/interface/vcos/pthreads
+endif
+ifeq ($(PLATFORM),PLATFORM_ANDROID)
+# STB libraries and others
+    INCLUDES = -I. -Iexternal
+# OpenAL Soft library
+    INCLUDES += -Iexternal/openal_soft/include
+# Android includes
+    INCLUDES += -I$(ANDROID_TOOLCHAIN)/sysroot/usr/include
+    INCLUDES += -I$(ANDROID_NDK)/sources/android/native_app_glue
 else
 # STB libraries and others
     INCLUDES = -I. -Iexternal
@@ -149,6 +204,14 @@ ifeq ($(PLATFORM),PLATFORM_DESKTOP)
         OUTPUT_PATH = ../release/osx
     endif
 endif
+ifeq ($(PLATFORM),PLATFORM_ANDROID)
+    ifeq ($(ANDROID_ARCH),ARM)
+        OUTPUT_PATH = ../release/android/armeabi-v7a
+    endif
+    ifeq ($(ANDROID_ARCH),ARM64)
+        OUTPUT_PATH = ../release/android/arm64-v8a
+    endif
+endif
 ifeq ($(PLATFORM),PLATFORM_WEB)
     OUTPUT_PATH = ../release/html5
 endif
@@ -164,7 +227,18 @@ OBJS += external/stb_vorbis.o
 
 # typing 'make' will invoke the default target entry called 'all',
 # in this case, the 'default' target entry is raylib
-all: raylib
+all: toolchain raylib 
+
+# make standalone Android toolchain
+toolchain:
+ifeq ($(PLATFORM),PLATFORM_ANDROID)
+    ifeq ($(ANDROID_ARCH),ARM)
+		$(ANDROID_NDK)/build/tools/make-standalone-toolchain.sh --platform=android-9 --toolchain=arm-linux-androideabi-4.9 --use-llvm --install-dir=$(ANDROID_TOOLCHAIN)
+    endif
+    ifeq ($(ANDROID_ARCH),ARM64)
+		$(ANDROID_NDK)/build/tools/make-standalone-toolchain.sh --platform=android-21 --toolchain=aarch64-linux-androideabi-4.9 --use-llvm --install-dir=$(ANDROID_TOOLCHAIN)
+    endif
+endif
 
 # compile raylib library
 raylib: $(OBJS)
@@ -184,9 +258,13 @@ else
 			$(CC) -shared -o $(OUTPUT_PATH)/raylib.dll $(OBJS) $(SHAREDLIBS) -Wl,--out-implib,$(OUTPUT_PATH)/libraylibdll.a
 			@echo "raylib dynamic library (raylib.dll) and import library (libraylibdll.a) generated!"
         endif
+        ifeq ($(PLATFORM),PLATFORM_ANDROID)
+			$(CC) -shared -o $(OUTPUT_PATH)/libraylib.so $(OBJS)
+			@echo "raylib shared library (libraylib.so) generated!"
+        endif
     else
-        # compile raylib static library for desktop platforms.
-		ar rcs $(OUTPUT_PATH)/libraylib.a $(OBJS)
+		# compile raylib static library.
+		$(AR) rcs $(OUTPUT_PATH)/libraylib.a $(OBJS)
 		@echo "libraylib.a generated (static library)!"
         ifeq ($(SHARED_OPENAL),NO)
 			@echo "expected OpenAL Soft static library linking"
@@ -283,5 +361,8 @@ ifeq ($(PLATFORM_OS),WINDOWS)
 	del *.o $(OUTPUT_PATH)/libraylib.a $(OUTPUT_PATH)/libraylib.bc $(OUTPUT_PATH)/libraylib.so external/stb_vorbis.o
 else
 	rm -f *.o $(OUTPUT_PATH)/libraylib.a $(OUTPUT_PATH)/libraylib.bc $(OUTPUT_PATH)/libraylib.so external/stb_vorbis.o
+endif
+ifeq ($(PLATFORM),PLATFORM_ANDROID)
+	rm -rf $(ANDROID_TOOLCHAIN)
 endif
 	@echo "removed all generated files!"


### PR DESCRIPTION
Library for Android can now be built with make. ANDROID_NDK_HOME needs to point to whetever android-ndk is installed. Same variable is used for Android Studio so there is a chance that it will be already configured. I also added support for arm64 arch, it is common now on newer phones, and support for clang.

Currently build fails with clang:
`
audio.c:197:6: error: conflicting types for 'IsAudioDeviceReady'
bool IsAudioDeviceReady(void)
     ^
./raylib.h:930:12: note: previous declaration is here
RLAPI bool IsAudioDeviceReady(void);                                  // Check if audio device has been initialized successfully
           ^
audio.c:526:6: error: conflicting types for 'IsSoundPlaying'
bool IsSoundPlaying(Sound sound)
     ^
./raylib.h:944:12: note: previous declaration is here
RLAPI bool IsSoundPlaying(Sound sound);                               // Check if a sound is currently playing
           ^
audio.c:917:6: error: conflicting types for 'IsMusicPlaying'
bool IsMusicPlaying(Music music)
     ^
./raylib.h:958:12: note: previous declaration is here
RLAPI bool IsMusicPlaying(Music music);                               // Check if music is playing
           ^
audio.c:1073:6: error: conflicting types for 'IsAudioBufferProcessed'
bool IsAudioBufferProcessed(AudioStream stream)
     ^
./raylib.h:969:12: note: previous declaration is here
RLAPI bool IsAudioBufferProcessed(AudioStream stream);                // Check if any audio stream buffers requires refill
           ^
4 errors generated.
make: *** [Makefile:305: audio.o] Error 1
`

Same will happen with src/android and ndk-build when newer version of ndk is used, clang is now default, unless NDK_TOOLCHAIN_VERSION is set in Application.mk or is exported, to for example 4.9. Then it will use gcc for build.

Example:
`ANDROID_NDK_HOME=/opt/android-ndk make PLATFORM=PLATFORM_ANDROID ANDROID_ARCH=ARM64`