### PR TITLE
linux-c99

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -40,7 +40,7 @@ ifeq ($(PLATFORM),PLATFORM_DESKTOP)
     else
         UNAMEOS:=$(shell uname)
         ifeq ($(UNAMEOS),Linux)
-            PLATFORM_OS=LINUX
+            PLATFORM_OS=linux
             LIBPATH=linux
         else
         ifeq ($(UNAMEOS),Darwin)
@@ -73,7 +73,9 @@ endif
 ifeq ($(PLATFORM),PLATFORM_RPI)
     CFLAGS = -O2 -s -Wall -std=gnu99 -fgnu89-inline
 else
-    CFLAGS = -O2 -s -Wall -std=c99
+    ifeq ($(PLATFORM_OS),LINUX)
+    CFLAGS = -O2 -s -Wall -std=c99 --D_DEFAULT_SOURCE
+    endif
 endif
 ifeq ($(PLATFORM),PLATFORM_WEB)
     CFLAGS = -O1 -Wall -std=c99 -s USE_GLFW=3 -s ASSERTIONS=1 --preload-file resources
@@ -88,7 +90,7 @@ ifeq ($(PLATFORM),PLATFORM_DESKTOP)
     ifeq ($(PLATFORM_OS),WINDOWS)
         RAYLIB_PATH = ../release/win32/mingw32
     endif
-    ifeq ($(PLATFORM_OS),LINUX)
+    ifeq ($(PLATFORM_OS),linux)
         RAYLIB_PATH = ../release/linux
     endif
     ifeq ($(PLATFORM_OS),OSX)
@@ -110,7 +112,7 @@ ifeq ($(PLATFORM),PLATFORM_RPI)
 endif
 ifeq ($(PLATFORM),PLATFORM_DESKTOP)
     # add standard directories for GNU/Linux
-    ifeq ($(PLATFORM_OS),LINUX)
+    ifeq ($(PLATFORM_OS),linux)
         INCLUDES += -I/usr/local/include/raylib/
     else ifeq ($(PLATFORM_OS),WINDOWS)
         # external libraries headers
@@ -141,7 +143,7 @@ endif
 # define any libraries to link into executable
 # if you want to link libraries (libname.so or libname.a), use the -lname
 ifeq ($(PLATFORM),PLATFORM_DESKTOP)
-    ifeq ($(PLATFORM_OS),LINUX)
+    ifeq ($(PLATFORM_OS),linux)
         # libraries for Debian GNU/Linux desktop compiling
         # requires the following packages:
         # libglfw3-dev libopenal-dev libegl1-mesa-dev
@@ -185,6 +187,11 @@ ifeq ($(PLATFORM_OS),WINDOWS)
     WINFLAGS = ../src/resources -Wl,--subsystem,windows
 endif
 
+# Linux Fix to timespect from 
+ifeq ($(PLATFORM_OS),linux)
+        CFLAGS += -D_DEFAULT_SOURCE
+    endif
+
 ifeq ($(PLATFORM),PLATFORM_WEB)
     EXT = .html
 endif
@@ -207,7 +214,6 @@ EXAMPLES = \
     core_3d_camera_first_person \
     core_2d_camera \
     core_world_screen \
-    core_oculus_rift \
     shapes_logo_raylib \
     shapes_basic_shapes \
     shapes_colors_palette \
@@ -338,8 +344,8 @@ core_world_screen: core_world_screen.c
 	$(CC) -o $@$(EXT) $< $(CFLAGS) $(INCLUDES) $(LFLAGS) $(LIBS) -D$(PLATFORM) $(WINFLAGS)
 
 # compile [core] example - oculus rift
-core_oculus_rift: core_oculus_rift.c
-	$(CC) -o $@$(EXT) $< $(CFLAGS) $(INCLUDES) $(LFLAGS) $(LIBS) -D$(PLATFORM) $(WINFLAGS)
+#core_oculus_rift: core_oculus_rift.c
+#	$(CC) -o $@$(EXT) $< $(CFLAGS) $(INCLUDES) $(LFLAGS) $(LIBS) -D$(PLATFORM) $(WINFLAGS)
 
 # compile [shapes] example - raylib logo (with basic shapes)
 shapes_logo_raylib: shapes_logo_raylib.c
@@ -497,13 +503,6 @@ audio_module_playing: audio_module_playing.c
 audio_raw_stream: audio_raw_stream.c
 	$(CC) -o $@$(EXT) $< $(CFLAGS) $(INCLUDES) $(LFLAGS) $(LIBS) -D$(PLATFORM) $(WINFLAGS)
 
-# Linux Fix to timespect from 
-ifeq ($(PLATFORM),PLATFORM_DESKTOP)
-    ifeq ($(PLATFORM_OS),LINUX)
-        CFLAGS += -D_POSIX_C_SOURCE=199309L
-    endif
-endif
-
 # compile [physac] example - physics demo
 physics_demo: physics_demo.c
 	$(CC) -o $@$(EXT) $< $(CFLAGS) $(INCLUDES) $(LFLAGS) $(LIBS) -lpthread -D$(PLATFORM) $(WINFLAGS)
@@ -537,7 +536,7 @@ ifeq ($(PLATFORM),PLATFORM_DESKTOP)
 		find . -type f -perm +ugo+x -delete
 		rm -f *.o
     else
-    ifeq ($(PLATFORM_OS),LINUX)
+    ifeq ($(PLATFORM_OS),linux)
 		find -type f -executable | xargs file -i | grep -E 'x-object|x-archive|x-sharedlib|x-executable' | rev | cut -d ':' -f 2- | rev | xargs rm -f
     else
 		del *.o *.exe

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -40,7 +40,7 @@ ifeq ($(PLATFORM),PLATFORM_DESKTOP)
     else
         UNAMEOS:=$(shell uname)
         ifeq ($(UNAMEOS),Linux)
-            PLATFORM_OS=linux
+            PLATFORM_OS=LINUX
             LIBPATH=linux
         else
         ifeq ($(UNAMEOS),Darwin)
@@ -66,15 +66,24 @@ endif
 endif
 
 # define compiler flags:
-#  -O2         defines optimization level
-#  -s          strip unnecessary data from build
-#  -Wall       turns on most, but not all, compiler warnings
-#  -std=c99    use standard C from 1999 revision
-ifeq ($(PLATFORM),PLATFORM_RPI)
-    CFLAGS = -O2 -s -Wall -std=gnu99 -fgnu89-inline
-else
+#  -O2                  defines optimization level
+#  -Og                  enable debugging
+#  -s                   strip unnecessary data from build
+#  -Wall                turns on most, but not all, compiler warnings
+#  -std=c99             defines C language mode (standard C from 1999 revision)
+#  -std=gnu99           defines C language mode (GNU C from 1999 revision)
+#  -fgnu89-inline       declaring inline functions support (GCC optimized)
+#  -Wno-missing-braces  ignore invalid warning (GCC bug 53119)
+#  -D_DEFAULT_SOURCE    use with -std=c99 on Linux to enable timespec and drflac
+ifeq ($(PLATFORM),PLATFORM_DESKTOP)
+    ifeq ($(PLATFORM_OS),WINDOWS)
+        CFLAGS = -O2 -s -Wall -std=c99
+    endif
     ifeq ($(PLATFORM_OS),LINUX)
-    CFLAGS = -O2 -s -Wall -std=c99 --D_DEFAULT_SOURCE
+        CFLAGS = -O2 -s -Wall -std=c99 -D_DEFAULT_SOURCE
+    endif
+    ifeq ($(PLATFORM_OS),OSX)
+        CFLAGS = -O2 -s -Wall -std=c99
     endif
 endif
 ifeq ($(PLATFORM),PLATFORM_WEB)
@@ -82,7 +91,9 @@ ifeq ($(PLATFORM),PLATFORM_WEB)
     #-s ALLOW_MEMORY_GROWTH=1   # to allow memory resizing
     #-s TOTAL_MEMORY=16777216   # to specify heap memory size (default = 16MB)
 endif
-
+ifeq ($(PLATFORM),PLATFORM_RPI)
+    CFLAGS = -O2 -s -Wall -std=gnu99 -fgnu89-inline 
+endif
 #CFLAGSEXTRA = -Wextra -Wmissing-prototypes -Wstrict-prototypes
 
 # define raylib release directory for compiled library
@@ -90,7 +101,7 @@ ifeq ($(PLATFORM),PLATFORM_DESKTOP)
     ifeq ($(PLATFORM_OS),WINDOWS)
         RAYLIB_PATH = ../release/win32/mingw32
     endif
-    ifeq ($(PLATFORM_OS),linux)
+    ifeq ($(PLATFORM_OS),LINUX)
         RAYLIB_PATH = ../release/linux
     endif
     ifeq ($(PLATFORM_OS),OSX)
@@ -112,9 +123,7 @@ ifeq ($(PLATFORM),PLATFORM_RPI)
 endif
 ifeq ($(PLATFORM),PLATFORM_DESKTOP)
     # add standard directories for GNU/Linux
-    ifeq ($(PLATFORM_OS),linux)
-        INCLUDES += -I/usr/local/include/raylib/
-    else ifeq ($(PLATFORM_OS),WINDOWS)
+    ifeq ($(PLATFORM_OS),WINDOWS)
         # external libraries headers
         # GLFW3
             INCLUDES += -I../src/external/glfw3/include
@@ -143,7 +152,7 @@ endif
 # define any libraries to link into executable
 # if you want to link libraries (libname.so or libname.a), use the -lname
 ifeq ($(PLATFORM),PLATFORM_DESKTOP)
-    ifeq ($(PLATFORM_OS),linux)
+    ifeq ($(PLATFORM_OS),LINUX)
         # libraries for Debian GNU/Linux desktop compiling
         # requires the following packages:
         # libglfw3-dev libopenal-dev libegl1-mesa-dev
@@ -186,11 +195,6 @@ ifeq ($(PLATFORM_OS),WINDOWS)
     # -Wl,--subsystem,windows hides the console window
     WINFLAGS = ../src/resources -Wl,--subsystem,windows
 endif
-
-# Linux Fix to timespect from 
-ifeq ($(PLATFORM_OS),linux)
-        CFLAGS += -D_DEFAULT_SOURCE
-    endif
 
 ifeq ($(PLATFORM),PLATFORM_WEB)
     EXT = .html
@@ -536,7 +540,7 @@ ifeq ($(PLATFORM),PLATFORM_DESKTOP)
 		find . -type f -perm +ugo+x -delete
 		rm -f *.o
     else
-    ifeq ($(PLATFORM_OS),linux)
+    ifeq ($(PLATFORM_OS),LINUX)
 		find -type f -executable | xargs file -i | grep -E 'x-object|x-archive|x-sharedlib|x-executable' | rev | cut -d ':' -f 2- | rev | xargs rm -f
     else
 		del *.o *.exe

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -5,15 +5,15 @@
 #   NOTE: By default examples are compiled using raylib static library and OpenAL Soft shared library
 #
 #   Copyright (c) 2013-2016 Ramon Santamaria (@raysan5)
-#    
-#   This software is provided "as-is", without any express or implied warranty. In no event 
+#
+#   This software is provided "as-is", without any express or implied warranty. In no event
 #   will the authors be held liable for any damages arising from the use of this software.
 #
-#   Permission is granted to anyone to use this software for any purpose, including commercial 
+#   Permission is granted to anyone to use this software for any purpose, including commercial
 #   applications, and to alter it and redistribute it freely, subject to the following restrictions:
 #
-#     1. The origin of this software must not be misrepresented; you must not claim that you 
-#     wrote the original software. If you use this software in a product, an acknowledgment 
+#     1. The origin of this software must not be misrepresented; you must not claim that you
+#     wrote the original software. If you use this software in a product, an acknowledgment
 #     in the product documentation would be appreciated but is not required.
 #
 #     2. Altered source versions must be plainly marked as such, and must not be misrepresented
@@ -92,7 +92,7 @@ ifeq ($(PLATFORM),PLATFORM_WEB)
     #-s TOTAL_MEMORY=16777216   # to specify heap memory size (default = 16MB)
 endif
 ifeq ($(PLATFORM),PLATFORM_RPI)
-    CFLAGS = -O2 -s -Wall -std=gnu99 -fgnu89-inline 
+    CFLAGS = -O2 -s -Wall -std=gnu99 -fgnu89-inline
 endif
 #CFLAGSEXTRA = -Wextra -Wmissing-prototypes -Wstrict-prototypes
 
@@ -337,12 +337,12 @@ core_3d_camera_free: core_3d_camera_free.c
 
 # compile [core] example - 3d camera first person
 core_3d_camera_first_person: core_3d_camera_first_person.c
-	$(CC) -o $@$(EXT) $< $(CFLAGS) $(INCLUDES) $(LFLAGS) $(LIBS) -D$(PLATFORM) $(WINFLAGS)    
+	$(CC) -o $@$(EXT) $< $(CFLAGS) $(INCLUDES) $(LFLAGS) $(LIBS) -D$(PLATFORM) $(WINFLAGS)
 
 # compile [core] example - 2d camera
 core_2d_camera: core_2d_camera.c
 	$(CC) -o $@$(EXT) $< $(CFLAGS) $(INCLUDES) $(LFLAGS) $(LIBS) -D$(PLATFORM) $(WINFLAGS)
-    
+
 # compile [core] example - world screen
 core_world_screen: core_world_screen.c
 	$(CC) -o $@$(EXT) $< $(CFLAGS) $(INCLUDES) $(LFLAGS) $(LIBS) -D$(PLATFORM) $(WINFLAGS)
@@ -386,31 +386,31 @@ textures_srcrec_dstrec: textures_srcrec_dstrec.c
 # compile [textures] example - texture to image
 textures_to_image: textures_to_image.c
 	$(CC) -o $@$(EXT) $< $(CFLAGS) $(INCLUDES) $(LFLAGS) $(LIBS) -D$(PLATFORM) $(WINFLAGS)
-    
+
 # compile [textures] example - texture raw data
 textures_raw_data: textures_raw_data.c
 	$(CC) -o $@$(EXT) $< $(CFLAGS) $(INCLUDES) $(LFLAGS) $(LIBS) -D$(PLATFORM) $(WINFLAGS)
-    
+
 # compile [textures] example - texture formats loading
 textures_formats_loading: textures_formats_loading.c
 	$(CC) -o $@$(EXT) $< $(CFLAGS) $(INCLUDES) $(LFLAGS) $(LIBS) -D$(PLATFORM) $(WINFLAGS)
-    
+
 # compile [textures] example - texture particles trail blending
 textures_particles_trail_blending: textures_particles_trail_blending.c
 	$(CC) -o $@$(EXT) $< $(CFLAGS) $(INCLUDES) $(LFLAGS) $(LIBS) -D$(PLATFORM) $(WINFLAGS)
-    
+
 # compile [textures] example - texture image processing
 textures_image_processing: textures_image_processing.c
 	$(CC) -o $@$(EXT) $< $(CFLAGS) $(INCLUDES) $(LFLAGS) $(LIBS) -D$(PLATFORM) $(WINFLAGS)
-    
+
 # compile [textures] example - texture image drawing
 textures_image_drawing: textures_image_drawing.c
 	$(CC) -o $@$(EXT) $< $(CFLAGS) $(INCLUDES) $(LFLAGS) $(LIBS) -D$(PLATFORM) $(WINFLAGS)
-    
+
 # compile [text] example - sprite fonts loading
 text_sprite_fonts: text_sprite_fonts.c
 	$(CC) -o $@$(EXT) $< $(CFLAGS) $(INCLUDES) $(LFLAGS) $(LIBS) -D$(PLATFORM) $(WINFLAGS)
-    
+
 # compile [text] example - bmfonts and ttf loading
 text_bmfont_ttf: text_bmfont_ttf.c
 	$(CC) -o $@$(EXT) $< $(CFLAGS) $(INCLUDES) $(LFLAGS) $(LIBS) -D$(PLATFORM) $(WINFLAGS)
@@ -446,7 +446,7 @@ models_geometric_shapes: models_geometric_shapes.c
 # compile [models] example - box collisions
 models_box_collisions: models_box_collisions.c
 	$(CC) -o $@$(EXT) $< $(CFLAGS) $(INCLUDES) $(LFLAGS) $(LIBS) -D$(PLATFORM) $(WINFLAGS)
-    
+
 # compile [models] example - basic window
 models_planes: models_planes.c
 	$(CC) -o $@$(EXT) $< $(CFLAGS) $(INCLUDES) $(LFLAGS) $(LIBS) -D$(PLATFORM) $(WINFLAGS)
@@ -474,15 +474,15 @@ models_ray_picking: models_ray_picking.c
 # compile [shaders] example - model shader
 shaders_model_shader: shaders_model_shader.c
 	$(CC) -o $@$(EXT) $< $(CFLAGS) $(INCLUDES) $(LFLAGS) $(LIBS) -D$(PLATFORM) $(WINFLAGS)
-    
+
 # compile [shaders] example - shapes texture shader
 shaders_shapes_textures: shaders_shapes_textures.c
 	$(CC) -o $@$(EXT) $< $(CFLAGS) $(INCLUDES) $(LFLAGS) $(LIBS) -D$(PLATFORM) $(WINFLAGS)
-    
+
 # compile [shaders] example - custom uniform in shader
 shaders_custom_uniform: shaders_custom_uniform.c
 	$(CC) -o $@$(EXT) $< $(CFLAGS) $(INCLUDES) $(LFLAGS) $(LIBS) -D$(PLATFORM) $(WINFLAGS)
-    
+
 # compile [shaders] example - postprocessing shader
 shaders_postprocessing: shaders_postprocessing.c
 	$(CC) -o $@$(EXT) $< $(CFLAGS) $(INCLUDES) $(LFLAGS) $(LIBS) -D$(PLATFORM) $(WINFLAGS)
@@ -526,7 +526,7 @@ physics_restitution: physics_restitution.c
 # compile [physac] example - physics shatter
 physics_shatter: physics_shatter.c
 	$(CC) -o $@$(EXT) $< $(CFLAGS) $(INCLUDES) $(LFLAGS) $(LIBS) -lpthread -D$(PLATFORM) $(WINFLAGS)
-    
+
 # fix dylib install path name for each executable (MAC)
 fix_dylib:
 ifeq ($(PLATFORM_OS),OSX)

--- a/examples/audio_standalone.c
+++ b/examples/audio_standalone.c
@@ -29,7 +29,7 @@
 #endif
 #include "audio.h"
 
-#if defined(__linux)
+#if defined(__linux__)
 
 #include <stdio.h>
 #include <termios.h>

--- a/src/Makefile
+++ b/src/Makefile
@@ -60,7 +60,7 @@ ifeq ($(PLATFORM),PLATFORM_DESKTOP)
     else
         UNAMEOS:=$(shell uname)
         ifeq ($(UNAMEOS),Linux)
-            PLATFORM_OS=LINUX
+            PLATFORM_OS=linux
         else
         ifeq ($(UNAMEOS),Darwin)
             PLATFORM_OS=OSX
@@ -153,12 +153,16 @@ endif
 
 # define compiler flags:
 #  -O1                  defines optimization level
+#  -Og                  enable debugging
 #  -Wall                turns on most, but not all, compiler warnings
 #  -std=c99             defines C language mode (standard C from 1999 revision)
 #  -std=gnu99           defines C language mode (GNU C from 1999 revision)
 #  -fgnu89-inline       declaring inline functions support (GCC optimized)
 #  -Wno-missing-braces  ignore invalid warning (GCC bug 53119)
-CFLAGS = -O1 -Wall -std=gnu99 -fgnu89-inline -Wno-missing-braces
+#  -D_DEFAULT_SOURCE    use with -std=c99 on Linux to enable timespec and audio
+#CFLAGS = -O1 -Wall -std=gnu99 -fgnu89-inline -Wno-missing-braces
+CFLAGS = -O1 -Wall -std=c99 -D_DEFAULT_SOURCE
+
 
 # if shared library required, make sure code is compiled as position independent
 ifeq ($(SHARED),YES)
@@ -213,7 +217,7 @@ ifeq ($(PLATFORM),PLATFORM_DESKTOP)
     ifeq ($(PLATFORM_OS),WINDOWS)
         OUTPUT_PATH = ../release/win32/mingw32
     endif
-    ifeq ($(PLATFORM_OS),LINUX)
+    ifeq ($(PLATFORM_OS),linux)
         OUTPUT_PATH = ../release/linux
     endif
     ifeq ($(PLATFORM_OS),OSX)
@@ -264,7 +268,7 @@ ifeq ($(PLATFORM),PLATFORM_WEB)
 	@echo "libraylib.bc generated (web version)!"
 else
     ifeq ($(SHARED),YES)
-        ifeq ($(PLATFORM_OS),LINUX)
+        ifeq ($(PLATFORM_OS),linux)
             # compile raylib to shared library version for GNU/Linux.
             # WARNING: you should type "make clean" before doing this target 
 			$(CC) -shared -o $(OUTPUT_PATH)/libraylib.so $(OBJS)
@@ -333,7 +337,7 @@ utils.o : utils.c utils.h
 # TODO: add other platforms.
 install :
 ifeq ($(ROOT),root)
-    ifeq ($(PLATFORM_OS),LINUX)
+    ifeq ($(PLATFORM_OS),linux)
         # On GNU/Linux there are some standard directories that contain
         # libraries and header files. These directory (/usr/local/lib and
         # /usr/local/include/) are for libraries that are installed
@@ -356,7 +360,7 @@ endif
 # TODO: see 'install' target.
 unistall :
 ifeq ($(ROOT),root)
-    ifeq ($(PLATFORM_OS),LINUX)
+    ifeq ($(PLATFORM_OS),linux)
 			rm --force /usr/local/include/raylib.h
         ifeq ($(SHARED),YES)
 			rm --force /usr/local/lib/libraylib.so

--- a/src/Makefile
+++ b/src/Makefile
@@ -152,7 +152,7 @@ ifeq ($(PLATFORM),PLATFORM_ANDROID)
 endif
 
 # define compiler flags:
-#  -O2                  defines optimization level
+#  -O1                  defines optimization level
 #  -Og                  enable debugging
 #  -Wall                turns on most, but not all, compiler warnings
 #  -std=c99             defines C language mode (standard C from 1999 revision)

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,7 +1,7 @@
 #******************************************************************************
 #
 #  raylib makefile for desktop platforms, Raspberry Pi and HTML5 (emscripten)
-#  
+#
 #  Many Thanks to Emanuele Petriglia for his contribution on GNU/Linux pipeline.
 #
 #  Copyright (c) 2014-2016 Ramon Santamaria (@raysan5)
@@ -267,7 +267,7 @@ OBJS += external/stb_vorbis.o
 
 # typing 'make' will invoke the default target entry called 'all',
 # in this case, the 'default' target entry is raylib
-all: toolchain raylib 
+all: toolchain raylib
 
 # make standalone Android toolchain
 toolchain:
@@ -290,7 +290,7 @@ else
     ifeq ($(SHARED),YES)
         ifeq ($(PLATFORM_OS),LINUX)
             # compile raylib to shared library version for GNU/Linux.
-            # WARNING: you should type "make clean" before doing this target 
+            # WARNING: you should type "make clean" before doing this target
 			$(CC) -shared -o $(OUTPUT_PATH)/libraylib.so $(OBJS)
 			@echo "raylib shared library (libraylib.so) generated!"
         endif
@@ -323,11 +323,11 @@ core.o : core.c raylib.h rlgl.h utils.h raymath.h gestures.h
 # compile rlgl module
 rlgl.o : rlgl.c rlgl.h raymath.h
 	$(CC) -c $< $(CFLAGS) $(INCLUDES) -D$(GRAPHICS)
-    
+
 # compile shapes module
 shapes.o : shapes.c raylib.h rlgl.h
 	$(CC) -c $< $(CFLAGS) $(INCLUDES) -D$(SHAREDFLAG)
-    
+
 # compile textures module
 textures.o : textures.c rlgl.h utils.h
 	$(CC) -c $< $(CFLAGS) $(INCLUDES) -D$(PLATFORM) -D$(GRAPHICS) -D$(SHAREDFLAG)
@@ -343,7 +343,7 @@ models.o : models.c raylib.h rlgl.h raymath.h
 # compile audio module
 audio.o : audio.c raylib.h
 	$(CC) -c $< $(CFLAGS) $(INCLUDES) -D$(PLATFORM) -D$(SHAREDFLAG) -D$(SHAREDOPENALFLAG)
-    
+
 # compile stb_vorbis library
 external/stb_vorbis.o: external/stb_vorbis.c external/stb_vorbis.h
 	$(CC) -c -o $@ $< -O1 $(CFLAGS) $(INCLUDES) -D$(PLATFORM)

--- a/src/Makefile
+++ b/src/Makefile
@@ -60,7 +60,7 @@ ifeq ($(PLATFORM),PLATFORM_DESKTOP)
     else
         UNAMEOS:=$(shell uname)
         ifeq ($(UNAMEOS),Linux)
-            PLATFORM_OS=linux
+            PLATFORM_OS=LINUX
         else
         ifeq ($(UNAMEOS),Darwin)
             PLATFORM_OS=OSX
@@ -152,16 +152,36 @@ ifeq ($(PLATFORM),PLATFORM_ANDROID)
 endif
 
 # define compiler flags:
-#  -O1                  defines optimization level
+#  -O2                  defines optimization level
 #  -Og                  enable debugging
 #  -Wall                turns on most, but not all, compiler warnings
 #  -std=c99             defines C language mode (standard C from 1999 revision)
 #  -std=gnu99           defines C language mode (GNU C from 1999 revision)
 #  -fgnu89-inline       declaring inline functions support (GCC optimized)
 #  -Wno-missing-braces  ignore invalid warning (GCC bug 53119)
-#  -D_DEFAULT_SOURCE    use with -std=c99 on Linux to enable timespec and audio
-#CFLAGS = -O1 -Wall -std=gnu99 -fgnu89-inline -Wno-missing-braces
-CFLAGS = -O1 -Wall -std=c99 -D_DEFAULT_SOURCE
+#  -D_DEFAULT_SOURCE    use with -std=c99 on Linux to enable timespec and drflac
+ifeq ($(PLATFORM),PLATFORM_DESKTOP)
+    ifeq ($(PLATFORM_OS),WINDOWS)
+        CFLAGS = -O1 -Wall -std=gnu99 -fgnu89-inline -Wno-missing-braces
+    endif
+    ifeq ($(PLATFORM_OS),LINUX)
+        CFLAGS = -O1 -Wall -std=c99 -D_DEFAULT_SOURCE
+    endif
+    ifeq ($(PLATFORM_OS),OSX)
+        CFLAGS = -O1 -Wall -std=gnu99 -fgnu89-inline -Wno-missing-braces
+    endif
+endif
+ifeq ($(PLATFORM),PLATFORM_WEB)
+    CFLAGS = -O1 -Wall -std=c99 -s USE_GLFW=3 -s ASSERTIONS=1 --preload-file resources
+    #-s ALLOW_MEMORY_GROWTH=1   # to allow memory resizing
+    #-s TOTAL_MEMORY=16777216   # to specify heap memory size (default = 16MB)
+endif
+ifeq ($(PLATFORM),PLATFORM_RPI)
+    CFLAGS = -O1 -Wall -std=gnu99 -fgnu89-inline -Wno-missing-braces
+endif
+#CFLAGSEXTRA = -Wextra -Wmissing-prototypes -Wstrict-prototypes
+
+###########
 
 
 # if shared library required, make sure code is compiled as position independent
@@ -217,7 +237,7 @@ ifeq ($(PLATFORM),PLATFORM_DESKTOP)
     ifeq ($(PLATFORM_OS),WINDOWS)
         OUTPUT_PATH = ../release/win32/mingw32
     endif
-    ifeq ($(PLATFORM_OS),linux)
+    ifeq ($(PLATFORM_OS),LINUX)
         OUTPUT_PATH = ../release/linux
     endif
     ifeq ($(PLATFORM_OS),OSX)
@@ -268,7 +288,7 @@ ifeq ($(PLATFORM),PLATFORM_WEB)
 	@echo "libraylib.bc generated (web version)!"
 else
     ifeq ($(SHARED),YES)
-        ifeq ($(PLATFORM_OS),linux)
+        ifeq ($(PLATFORM_OS),LINUX)
             # compile raylib to shared library version for GNU/Linux.
             # WARNING: you should type "make clean" before doing this target 
 			$(CC) -shared -o $(OUTPUT_PATH)/libraylib.so $(OBJS)
@@ -337,7 +357,7 @@ utils.o : utils.c utils.h
 # TODO: add other platforms.
 install :
 ifeq ($(ROOT),root)
-    ifeq ($(PLATFORM_OS),linux)
+    ifeq ($(PLATFORM_OS),LINUX)
         # On GNU/Linux there are some standard directories that contain
         # libraries and header files. These directory (/usr/local/lib and
         # /usr/local/include/) are for libraries that are installed
@@ -360,7 +380,7 @@ endif
 # TODO: see 'install' target.
 unistall :
 ifeq ($(ROOT),root)
-    ifeq ($(PLATFORM_OS),linux)
+    ifeq ($(PLATFORM_OS),LINUX)
 			rm --force /usr/local/include/raylib.h
         ifeq ($(SHARED),YES)
 			rm --force /usr/local/lib/libraylib.so

--- a/src/Makefile
+++ b/src/Makefile
@@ -179,10 +179,8 @@ endif
 ifeq ($(PLATFORM),PLATFORM_RPI)
     CFLAGS = -O1 -Wall -std=gnu99 -fgnu89-inline -Wno-missing-braces
 endif
+
 #CFLAGSEXTRA = -Wextra -Wmissing-prototypes -Wstrict-prototypes
-
-###########
-
 
 # if shared library required, make sure code is compiled as position independent
 ifeq ($(SHARED),YES)

--- a/src/core.c
+++ b/src/core.c
@@ -105,7 +105,7 @@
 #include <string.h>         // Required for: strcmp()
 //#include <errno.h>          // Macros for reporting and retrieving error conditions through error codes
 
-#if defined __linux || defined(PLATFORM_WEB)
+#if defined __linux__ || defined(PLATFORM_WEB)
     #include <sys/time.h>           // Required for: timespec, nanosleep(), select() - POSIX
 #elif defined __APPLE__
     #include <unistd.h>             // Required for: usleep()
@@ -115,7 +115,7 @@
     //#define GLFW_INCLUDE_NONE     // Disable the standard OpenGL header inclusion on GLFW3
     #include <GLFW/glfw3.h>         // GLFW3 library: Windows, OpenGL context and Input management
 
-    #ifdef __linux
+    #ifdef __linux__
         #define GLFW_EXPOSE_NATIVE_X11   // Linux specific definitions for getting
         #define GLFW_EXPOSE_NATIVE_GLX   // native functions like glfwGetX11Window
         #include <GLFW/glfw3native.h>    // which are required for hiding mouse
@@ -641,7 +641,7 @@ int GetScreenHeight(void)
 void ShowCursor()
 {
 #if defined(PLATFORM_DESKTOP)
-    #ifdef __linux
+    #ifdef __linux__
         XUndefineCursor(glfwGetX11Display(), glfwGetX11Window(window));
     #else
         glfwSetInputMode(window, GLFW_CURSOR, GLFW_CURSOR_NORMAL);
@@ -654,7 +654,7 @@ void ShowCursor()
 void HideCursor()
 {
 #if defined(PLATFORM_DESKTOP)
-    #ifdef __linux
+    #ifdef __linux__
         XColor col;
         const char nil[] = {0};
 
@@ -2036,7 +2036,7 @@ static void Wait(float ms)
 #else
     #if defined _WIN32
         Sleep(ms);
-    #elif defined __linux || defined(PLATFORM_WEB)
+    #elif defined __linux__ || defined(PLATFORM_WEB)
         struct timespec req = { 0 };
         time_t sec = (int)(ms/1000.0f);
         ms -= (sec*1000);

--- a/src/gestures.h
+++ b/src/gestures.h
@@ -147,7 +147,7 @@ float GetGesturePinchAngle(void);                       // Get gesture pinch ang
     // Functions required to query time on Windows
     int __stdcall QueryPerformanceCounter(unsigned long long int *lpPerformanceCount);
     int __stdcall QueryPerformanceFrequency(unsigned long long int *lpFrequency);
-#elif defined(__linux)
+#elif defined(__linux__)
     #include <sys/time.h>       // Required for: timespec
     #include <time.h>           // Required for: clock_gettime()
 #endif
@@ -517,7 +517,7 @@ static double GetCurrentTime(void)
     time = (double)currentTime/clockFrequency*1000.0f;  // Time in miliseconds
 #endif
 
-#if defined(__linux)
+#if defined(__linux__)
     // NOTE: Only for Linux-based systems
     struct timespec now;
     clock_gettime(CLOCK_MONOTONIC, &now);

--- a/src/physac.h
+++ b/src/physac.h
@@ -249,7 +249,7 @@ PHYSACDEF void ClosePhysics(void);                                              
     // Functions required to query time on Windows
     int __stdcall QueryPerformanceCounter(unsigned long long int *lpPerformanceCount);
     int __stdcall QueryPerformanceFrequency(unsigned long long int *lpFrequency);
-#elif defined(__linux) || defined(PLATFORM_WEB)
+#elif defined(__linux__) || defined(PLATFORM_WEB)
     #include <sys/time.h>           // Required for: timespec
     #include <time.h>               // Required for: clock_gettime()
     #include <stdint.h>
@@ -277,7 +277,7 @@ PHYSACDEF void ClosePhysics(void);                                              
 static unsigned int usedMemory = 0;                         // Total allocated dynamic memory
 static bool physicsThreadEnabled = false;                   // Physics thread enabled state
 static double currentTime = 0;                              // Current time in milliseconds
-#if defined(PLATFORM_ANDROID) || defined(PLATFORM_RPI) || defined(__linux) || defined(PLATFORM_WEB)
+#if defined(PLATFORM_ANDROID) || defined(PLATFORM_RPI) || defined(__linux__) || defined(PLATFORM_WEB)
     static double baseTime = 0;                             // Android and RPI platforms base time
 #endif
 static double startTime = 0;                                // Start time in milliseconds
@@ -1906,7 +1906,7 @@ static double GetCurrentTime(void)
         time = (double)((double)currentTime/clockFrequency)*1000;
     #endif
 
-    #if defined(PLATFORM_ANDROID) || defined(PLATFORM_RPI) || defined(__linux) || defined(PLATFORM_WEB)
+    #if defined(PLATFORM_ANDROID) || defined(PLATFORM_RPI) || defined(__linux__) || defined(PLATFORM_WEB)
         struct timespec ts;
         clock_gettime(CLOCK_MONOTONIC, &ts);
         uint64_t temp = (uint64_t)ts.tv_sec*1000000000LLU + (uint64_t)ts.tv_nsec;


### PR DESCRIPTION
C99 fix. Automate CFLAGS selection by platform. Standardization and whitespace removal.

Following on from #230,  _DEFAULT_SOURCE is equivalent to -D_BSD_SOURCE -D_SVID_SOURCE -D_POSIX_C_SOURCE=200809. This fixes not only the physics examples but also enables compilation of the library  with -std=c99. Previously, dr_flac.h would compile into the library but the audio examples failed due to not finding the functions in endian.h. dr_flac needs _BSD_SOURCE or, more correctly, _DEFAULT_SOURCE. to use endian.h. http://man7.org/linux/man-pages/man7/feature_test_macros.7.html

Try me!

