### PR TITLE
Restore inadvertant changes to Makefiles

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -87,7 +87,7 @@ ifeq ($(PLATFORM),PLATFORM_DESKTOP)
     endif
 endif
 ifeq ($(PLATFORM),PLATFORM_WEB)
-    CFLAGS = -O1 -Wall -std=c99 -s USE_GLFW=3 -s ASSERTIONS=1 --preload-file resources
+    CFLAGS = -O2 -Wall -std=c99 -s USE_GLFW=3 -s ASSERTIONS=1 --preload-file resources --profiling
     #-s ALLOW_MEMORY_GROWTH=1   # to allow memory resizing
     #-s TOTAL_MEMORY=16777216   # to specify heap memory size (default = 16MB)
 endif
@@ -122,13 +122,20 @@ ifeq ($(PLATFORM),PLATFORM_RPI)
     INCLUDES += -I/opt/vc/include -I/opt/vc/include/interface/vcos/pthreads
 endif
 ifeq ($(PLATFORM),PLATFORM_DESKTOP)
-    # add standard directories for GNU/Linux
     ifeq ($(PLATFORM_OS),WINDOWS)
         # external libraries headers
         # GLFW3
             INCLUDES += -I../src/external/glfw3/include
         # OpenAL Soft
             INCLUDES += -I../src/external/openal_soft/include
+    endif
+    ifeq ($(PLATFORM_OS),LINUX)
+        # you may optionally create this directory and install raylib 
+        # and related headers there. Edit ../src/Makefile appropriately.
+            INCLUDES += -I/usr/local/include/raylib
+    endif
+    ifeq ($(PLATFORM_OS),OSX)
+        # additional directories for MacOS
     endif
 endif
 

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -87,9 +87,11 @@ ifeq ($(PLATFORM),PLATFORM_DESKTOP)
     endif
 endif
 ifeq ($(PLATFORM),PLATFORM_WEB)
-    CFLAGS = -O2 -Wall -std=c99 -s USE_GLFW=3 -s ASSERTIONS=1 --profiling --preload-file resources
-    #-s ALLOW_MEMORY_GROWTH=1   # to allow memory resizing
-    #-s TOTAL_MEMORY=16777216   # to specify heap memory size (default = 16MB)
+    CFLAGS = -O1 -Wall -std=c99 -s USE_GLFW=3 -s ASSERTIONS=1 --profiling --preload-file resources
+    # -O2                        # if used, also set --memory-init-file 0
+    # --memory-init-file 0       # to avoid an external memory initialization code file (.mem)
+    #-s ALLOW_MEMORY_GROWTH=1    # to allow memory resizing
+    #-s TOTAL_MEMORY=16777216    # to specify heap memory size (default = 16MB)
 endif
 ifeq ($(PLATFORM),PLATFORM_RPI)
     CFLAGS = -O2 -s -Wall -std=gnu99 -fgnu89-inline

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -87,7 +87,7 @@ ifeq ($(PLATFORM),PLATFORM_DESKTOP)
     endif
 endif
 ifeq ($(PLATFORM),PLATFORM_WEB)
-    CFLAGS = -O2 -Wall -std=c99 -s USE_GLFW=3 -s ASSERTIONS=1 --preload-file resources --profiling
+    CFLAGS = -O2 -Wall -std=c99 -s USE_GLFW=3 -s ASSERTIONS=1 --profiling --preload-file resources
     #-s ALLOW_MEMORY_GROWTH=1   # to allow memory resizing
     #-s TOTAL_MEMORY=16777216   # to specify heap memory size (default = 16MB)
 endif

--- a/src/Makefile
+++ b/src/Makefile
@@ -172,9 +172,10 @@ ifeq ($(PLATFORM),PLATFORM_DESKTOP)
     endif
 endif
 ifeq ($(PLATFORM),PLATFORM_WEB)
-    CFLAGS = -O1 -Wall -std=c99 -s USE_GLFW=3 -s ASSERTIONS=1 --preload-file resources
-    #-s ALLOW_MEMORY_GROWTH=1   # to allow memory resizing
-    #-s TOTAL_MEMORY=16777216   # to specify heap memory size (default = 16MB)
+    CFLAGS = -O2 -Wall -std=c99 -s USE_GLFW=3 -s ASSERTIONS=1 --profiling --preload-file resources
+    # -s ALLOW_MEMORY_GROWTH=1   # to allow memory resizing
+    # -s TOTAL_MEMORY=16777216   # to specify heap memory size (default = 16MB)
+    # -s USE_PTHREADS=1          # multithreading support
 endif
 ifeq ($(PLATFORM),PLATFORM_RPI)
     CFLAGS = -O1 -Wall -std=gnu99 -fgnu89-inline -Wno-missing-braces

--- a/src/Makefile
+++ b/src/Makefile
@@ -172,7 +172,9 @@ ifeq ($(PLATFORM),PLATFORM_DESKTOP)
     endif
 endif
 ifeq ($(PLATFORM),PLATFORM_WEB)
-    CFLAGS = -O2 -Wall -std=c99 -s USE_GLFW=3 -s ASSERTIONS=1 --profiling --preload-file resources
+    CFLAGS = -O1 -Wall -std=c99 -s USE_GLFW=3 -s ASSERTIONS=1 --profiling --preload-file resources
+    # -O2                        # if used, also set --memory-init-file 0
+    # --memory-init-file 0       # to avoid an external memory initialization code file (.mem)
     # -s ALLOW_MEMORY_GROWTH=1   # to allow memory resizing
     # -s TOTAL_MEMORY=16777216   # to specify heap memory size (default = 16MB)
     # -s USE_PTHREADS=1          # multithreading support


### PR DESCRIPTION
Restore /usr/local/include/raylib to INCLUDES in examples/Makefile. Is in use by at least one user.
Modify CFLAGS for PLATFORM_WEB in examples/Makefile and src/Makefile to reflect emscripten recommended optimizations.