### PR TITLE
Accept external CFLAGS

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -198,7 +198,7 @@ endif
 #  -fgnu89-inline       declaring inline functions support (GCC optimized)
 #  -Wno-missing-braces  ignore invalid warning (GCC bug 53119)
 #  -D_DEFAULT_SOURCE    use with -std=c99
-CFLAGS = -O1 -Wall -std=c99 -D_DEFAULT_SOURCE -fgnu89-inline -Wno-missing-braces
+CFLAGS += -O1 -Wall -std=c99 -D_DEFAULT_SOURCE -fgnu89-inline -Wno-missing-braces
 
 ifeq ($(PLATFORM),PLATFORM_WEB)
     CFLAGS += -s USE_GLFW=3 -s ASSERTIONS=1 --profiling --preload-file resources


### PR DESCRIPTION
Some distributions build the programs with a specific set of CFLAGS.
Lets allow that by adding raylibs flags.