### PR TITLE
Initial meson support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,5 @@ src/libraylib.bc
 !release/rpi/libraylib.a
 !release/win32/mingw32/raylib.dll
 
+# Meson build system
+builddir/

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ features
    *  Basic 3d support for Geometrics, Models, Billboards, Heightmaps and Cubicmaps
    *  Flexible Materials system, supporting by default diffuse, normal and specular maps
    *  Shaders support, including Model shaders and Postprocessing shaders
-   *  Powerful math module for Vector, Matrix and Quaternion operations: [raymath](https://github.com/raysan5/raylib/blob/master/src/raymath.c) 
+   *  Powerful math module for Vector, Matrix and Quaternion operations: [raymath](https://github.com/raysan5/raylib/blob/master/src/raymath.h)
    *  Audio loading and playing with streaming support (WAV, OGG, FLAC, XM, MOD)
    *  Multiple platforms support: Windows, Linux, Mac, **Android**, **Raspberry Pi** and **HTML5**
    *  VR stereo rendering support with configurable HMD device parameters

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,14 @@
+project('raylib', 'c', version:	'1.7.0',
+		license: 'zlib',
+		meson_version: '>= 0.39.1')
+
+cc = meson.get_compiler('c')
+
+glfw_dep = dependency('glfw3')
+gl_dep = dependency('gl')
+openal_dep = dependency('openal')
+x11_dep = dependency('x11')
+m_dep = cc.find_library('m', required : false)
+
+subdir('src')
+

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,0 +1,19 @@
+install_headers('raylib.h')
+
+source_c = [
+  'audio.c',
+  'core.c',
+  'models.c',
+  'rlgl.c',
+  'shapes.c',
+  'text.c',
+  'textures.c',
+  'utils.c',
+  'external/stb_vorbis.c',
+]
+
+raylib = shared_library('raylib',
+                        source_c,
+                        dependencies : [ glfw_dep, gl_dep, openal_dep, m_dep, x11_dep],
+                        install : true)
+

--- a/src/meson.build
+++ b/src/meson.build
@@ -12,8 +12,10 @@ source_c = [
   'external/stb_vorbis.c',
 ]
 
-raylib = shared_library('raylib',
-                        source_c,
-                        dependencies : [ glfw_dep, gl_dep, openal_dep, m_dep, x11_dep],
-                        install : true)
+# use 'meson --default-library=static builddir' to build as static, if no builddir yet exists
+# use 'mesonconf -Ddefault_library=static builddir' to change the type
+raylib = library('raylib',
+                  source_c,
+                  dependencies : [ glfw_dep, gl_dep, openal_dep, m_dep, x11_dep],
+                  install : true)
 


### PR DESCRIPTION
I would like to add this initial meson support, so far working for Linux, along the Makefile.
Once the meson support is also done for Windows, Android and Web one might drop the Makefile.

I rebased my commits since in the first one I had a mistake, because of this 1adc0313015b30cf061a3bc9d47292f82dc649f8 has the 'with jubalh'. Sorry for that one.

This commit also regards https://github.com/raysan5/raylib/issues/176
I suggest to close that issue since the initial request was to support CMake to have easier building on Linux, which is now solved through meson.