### PR TITLE
Add define to have CLOCK_MONOTONIC work in c99

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -109,6 +109,10 @@
     #include "external/gif.h"   // Support GIF recording
 #endif
 
+#if defined(__linux__) || defined(PLATFORM_WEB)
+    #define _POSIX_C_SOURCE 199309L // Required for CLOCK_MONOTONIC if compiled with c99 without gnu ext.
+#endif
+
 #include <stdio.h>          // Standard input / output lib
 #include <stdlib.h>         // Required for: malloc(), free(), rand(), atexit()
 #include <stdint.h>         // Required for: typedef unsigned long long int uint64_t, used by hi-res timer

--- a/src/gestures.h
+++ b/src/gestures.h
@@ -148,8 +148,9 @@ float GetGesturePinchAngle(void);                       // Get gesture pinch ang
     int __stdcall QueryPerformanceCounter(unsigned long long int *lpPerformanceCount);
     int __stdcall QueryPerformanceFrequency(unsigned long long int *lpFrequency);
 #elif defined(__linux__)
-    #include <sys/time.h>       // Required for: timespec
-    #include <time.h>           // Required for: clock_gettime()
+    #define _POSIX_C_SOURCE 199309L // Required for CLOCK_MONOTONIC if compiled with c99 without gnu ext.
+    #include <sys/time.h>           // Required for: timespec
+    #include <time.h>               // Required for: clock_gettime()
 #endif
 
 //----------------------------------------------------------------------------------

--- a/src/physac.h
+++ b/src/physac.h
@@ -253,6 +253,7 @@ PHYSACDEF void ClosePhysics(void);                                              
     int __stdcall QueryPerformanceCounter(unsigned long long int *lpPerformanceCount);
     int __stdcall QueryPerformanceFrequency(unsigned long long int *lpFrequency);
 #elif defined(__linux__) || defined(PLATFORM_WEB)
+    #define _POSIX_C_SOURCE 199309L // Required for CLOCK_MONOTONIC if compiled with c99 without gnu ext.
     //#define _DEFAULT_SOURCE         // Enables BSD function definitions and C99 POSIX compliance
     #include <sys/time.h>           // Required for: timespec
     #include <time.h>               // Required for: clock_gettime()


### PR DESCRIPTION
If we compile with c99 without gnu extensions (gnu99) we need this
define, to have CLOCK_MONOTONIC and similar macros available