### PR TITLE
Add the SaveImageAs function

### DIFF
--- a/src/raylib.h
+++ b/src/raylib.h
@@ -835,7 +835,7 @@ RLAPI bool CheckCollisionPointTriangle(Vector2 point, Vector2 p1, Vector2 p2, Ve
 // Texture Loading and Drawing Functions (Module: textures)
 //------------------------------------------------------------------------------------
 
-// Image/Texture2D data loading/unloading functions
+// Image/Texture2D data loading/unloading/saving functions
 RLAPI Image LoadImage(const char *fileName);                                                             // Load image from file into CPU memory (RAM)
 RLAPI Image LoadImageEx(Color *pixels, int width, int height);                                           // Load image from Color array data (RGBA - 32bit)
 RLAPI Image LoadImagePro(void *data, int width, int height, int format);                                 // Load image from raw data with parameters
@@ -849,6 +849,7 @@ RLAPI void UnloadRenderTexture(RenderTexture2D target);                         
 RLAPI Color *GetImageData(Image image);                                                                  // Get pixel data from image as a Color struct array
 RLAPI Image GetTextureData(Texture2D texture);                                                           // Get pixel data from GPU texture and return an Image
 RLAPI void UpdateTexture(Texture2D texture, const void *pixels);                                         // Update GPU texture with new data
+RLAPI void SaveImageAs(Image image, const char *fileName);                                               // Save image to a PNG file
 
 // Image manipulation functions
 RLAPI void ImageToPOT(Image *image, Color fillColor);                                                    // Convert image to POT (power-of-two)

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -849,7 +849,7 @@ RLAPI void UnloadRenderTexture(RenderTexture2D target);                         
 RLAPI Color *GetImageData(Image image);                                                                  // Get pixel data from image as a Color struct array
 RLAPI Image GetTextureData(Texture2D texture);                                                           // Get pixel data from GPU texture and return an Image
 RLAPI void UpdateTexture(Texture2D texture, const void *pixels);                                         // Update GPU texture with new data
-RLAPI void SaveImageAs(Image image, const char *fileName);                                               // Save image to a PNG file
+RLAPI void SaveImageAs(const char *fileName, Image image);                                               // Save image to a PNG file
 
 // Image manipulation functions
 RLAPI void ImageToPOT(Image *image, Color fillColor);                                                    // Convert image to POT (power-of-two)

--- a/src/textures.c
+++ b/src/textures.c
@@ -553,6 +553,18 @@ void UpdateTexture(Texture2D texture, const void *pixels)
     rlglUpdateTexture(texture.id, texture.width, texture.height, texture.format, pixels);
 }
 
+// Save image to a PNG file
+void SaveImageAs(Image image, const char *fileName)
+{
+#if defined(PLATFORM_DESKTOP) || defined(PLATFORM_RPI)
+    unsigned char* imgData = (unsigned char*)GetImageData(image); // this works since Color is just a container for the RGBA values
+    SavePNG(fileName, imgData, image.width, image.height, 4);
+    free(imgData);
+
+    TraceLog(INFO, "Image saved: %s", fileName);
+#endif
+}
+
 // Convert image data to desired format
 void ImageFormat(Image *image, int newFormat)
 {

--- a/src/textures.c
+++ b/src/textures.c
@@ -554,7 +554,7 @@ void UpdateTexture(Texture2D texture, const void *pixels)
 }
 
 // Save image to a PNG file
-void SaveImageAs(Image image, const char *fileName)
+void SaveImageAs(const char* fileName, Image image)
 {
 #if defined(PLATFORM_DESKTOP) || defined(PLATFORM_RPI)
     unsigned char* imgData = (unsigned char*)GetImageData(image); // this works since Color is just a container for the RGBA values


### PR DESCRIPTION
Signature: `SaveImageAs(Image image, const char *filename);`

I think this would be useful for the users who generate procedural textures, it allows them to save them (for example to upload or share them)
Right now the workaround is to display the image on the entire window and to take a screenshot, but I think a dedicated function makes sense