### PR TITLE
Add a density parameter to GenImageRadialGradient

### DIFF
--- a/examples/textures/textures_image_generation.c
+++ b/examples/textures/textures_image_generation.c
@@ -22,7 +22,7 @@ int main()
 
     Image verticalGradient = GenImageGradientV(screenWidth, screenHeight, RED, BLUE);
     Image horizontalGradient = GenImageGradientH(screenWidth, screenHeight, RED, BLUE);
-    Image radialGradient = GenImageRadialGradient(screenWidth, screenHeight, WHITE, BLACK);
+    Image radialGradient = GenImageRadialGradient(screenWidth, screenHeight, 0.f, WHITE, BLACK);
     Image checked = GenImageChecked(screenWidth, screenHeight, 32, 32, RED, BLUE);
     Image whiteNoise = GenImageWhiteNoise(screenWidth, screenHeight, 0.5f);
     Image perlinNoise = GenImagePerlinNoise(screenWidth, screenHeight, 8.f);

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -877,7 +877,7 @@ RLAPI void ImageColorBrightness(Image *image, int brightness);                  
 // Image generation functions
 RLAPI Image GenImageGradientV(int width, int height, Color top, Color bottom);                           // Generate image: vertical gradient
 RLAPI Image GenImageGradientH(int width, int height, Color left, Color right);                           // Generate image: horizontal gradient
-RLAPI Image GenImageRadialGradient(int width, int height, Color inner, Color outer);                     // Generate image: radial gradient
+RLAPI Image GenImageRadialGradient(int width, int height, float density, Color inner, Color outer);      // Generate image: radial gradient
 RLAPI Image GenImageChecked(int width, int height, int checksX, int checksY, Color col1, Color col2);    // Generate image: checked
 RLAPI Image GenImageWhiteNoise(int width, int height, float factor);                                     // Generate image: white noise
 RLAPI Image GenImagePerlinNoise(int width, int height, float scale);                                     // Generate image: perlin noise

--- a/src/textures.c
+++ b/src/textures.c
@@ -1493,7 +1493,7 @@ Image GenImageGradientH(int width, int height, Color left, Color right)
 }
 
 // Generate image: radial gradient
-Image GenImageRadialGradient(int width, int height, Color inner, Color outer)
+Image GenImageRadialGradient(int width, int height, float density, Color inner, Color outer)
 {
     Color *pixels = (Color*)malloc(width * height * sizeof(Color));
     float radius = (width < height) ? (float)width / 2.f : (float)height / 2.f;
@@ -1505,7 +1505,8 @@ Image GenImageRadialGradient(int width, int height, Color inner, Color outer)
         for (int x = 0; x < width; x++)
         {
             float dist = hypotf((float)x - center_x, (float)y - center_y);
-            float factor = dist / radius;
+            float factor = (dist - radius * density) / (radius * (1.f - density));
+            factor = fmax(factor, 0.f);
             factor = fmin(factor, 1.f); // dist can be bigger than radius so we have to check
             pixels[y*width + x].r = (int)((float)outer.r * factor + (float)inner.r * (1.f - factor));
             pixels[y*width + x].g = (int)((float)outer.g * factor + (float)inner.g * (1.f - factor));


### PR DESCRIPTION
And here are some results:
- Density = 0.0
![density0](https://user-images.githubusercontent.com/6280095/27646732-b4a2ba2a-5c29-11e7-80fc-9249d1625ada.png)
- Density = 0.3
![density3](https://user-images.githubusercontent.com/6280095/27646738-bbbd0734-5c29-11e7-85ac-bf7dd1c81ca5.png)
- Density = 0.5
![density5](https://user-images.githubusercontent.com/6280095/27646752-c4b8b36a-5c29-11e7-9bcb-b75df3815e03.png)
- Density = 0.8
![density8](https://user-images.githubusercontent.com/6280095/27646758-c9d1eb3c-5c29-11e7-826c-51aea1d87bc2.png)
- Density = 1.0
![density1](https://user-images.githubusercontent.com/6280095/27646766-ce94d1ca-5c29-11e7-8976-a4bfa9fa248e.png)

I don't know if this is really what you expected, tell me 😄 