### PR TITLE
Fix for OBJ loading

### DIFF
--- a/src/models.c
+++ b/src/models.c
@@ -1637,6 +1637,7 @@ static Mesh LoadOBJ(const char *fileName)
     // NOTE: faces MUST be defined as TRIANGLES (3 vertex per face)
     while (!feof(objFile))
     {
+        dataType = '\0';
         fscanf(objFile, "%c", &dataType);
 
         switch (dataType)


### PR DESCRIPTION
When there is a newline at the end of an .OBJ file, this can cause a bogus triangle to be added to the mesh. In LoadOBJ(), the "dataType" does not get reset, and the result from fscanf is not checked, so at the end of the file the last triangle is sometime counted twice, but since there isn't a corresponding entry in the vertex data it can create a bogus triangle. Usually the verts are all zero and you don't see it, but this has been causing occasional glitchy rendering for me.

Simply resetting the dataType for each line fixes this, as it won't process the last entry twice.