### PR TITLE
Able to make a .dylib for OS X

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -145,6 +145,14 @@ endif
 # default gcc compiler
 CC = gcc
 
+
+# For OS X
+ifeq ($(PLATFORM),PLATFORM_DESKTOP)
+    ifeq ($(PLATFORM_OS),OSX)
+		CC = clang
+	endif
+endif
+
 # Android toolchain compiler
 ifeq ($(PLATFORM),PLATFORM_ANDROID)
     ifeq ($(ANDROID_ARCH),ARM)
@@ -328,8 +336,9 @@ else
 			@echo "raylib shared library generated (libraylib.so)!"
         endif
         ifeq ($(PLATFORM_OS),OSX)
-			$(CC) -shared -o $(OUTPUT_PATH)/libraylib.so $(OBJS) -lglfw -framework OpenGL -framework OpenAL -framework Cocoa
-			@echo "raylib shared library generated (libraylib.so)!"
+			$(CC) -dynamiclib -o $(OUTPUT_PATH)/libraylib.dylib $(OBJS) -L/usr/local/Cellar/glfw/3.2.1/lib -lglfw -framework OpenGL -framework OpenAL -framework Cocoa
+			install_name_tool -id "libraylib.dylib" $(OUTPUT_PATH)/libraylib.dylib
+			@echo "raylib shared library generated (libraylib.dylib)!"
         endif
         ifeq ($(PLATFORM),PLATFORM_ANDROID)
 			$(CC) -shared -o $(OUTPUT_PATH)/libraylib.so $(OBJS)


### PR DESCRIPTION
This should make the proper `.dylib` file, and set it so that whatever program is trying to be run, the .dylib can be in the same folder.

1. There should be a note of that `same folder` thing somewhere in the docs.
2. I haven't tested how this effects of building the examples.

Discussion should go back to ticket #328 to resolves those two things