### PR TITLE
Add Travis CI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,50 @@
+language: c
+sudo: required
+dist: trusty
+
+git:
+  depth: 3
+
+os:
+  - osx
+  - linux
+
+env:
+  global:
+    - VERBOSE=1
+  matrix:
+    - CFLAGS=-m64
+    - CFLAGS=-m32
+
+before_script:
+  - export CFLAGS="-std=gnu99 $CFLAGS"
+
+before_install:
+  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then
+      sudo apt-get install -y gcc-multilib
+                              libopenal-dev
+                              libxcursor-dev libxinerama-dev
+                              mesa-common-dev libx11-dev libxrandr-dev libxi-dev xorg-dev libgl1-mesa-dev libglu1-mesa-dev libglew-dev;
+      wget 'https://github.com/a3f/GLFW-3.2.1-Debian-binary-package/releases/download/v3.2.1/GLFW-3.2.1-Linux.deb' && sudo dpkg -i GLFW-3.2.1-Linux.deb;
+    fi
+  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew update; brew install glfw; fi
+  - "$CC --version"
+
+script:
+  - mkdir build
+  - cd build
+  - cmake -DBUILD_EXAMPLES=OFF -DBUILD_GAMES=OFF ..
+  - make
+#  - make package
+#  - sudo make install
+#
+#deploy:
+#  provider: releases
+#  api_key:
+#    secure: XXX
+#  file_glob: true
+#  file: raylib-*.tar.gz
+#  skip_cleanup: true
+#  on:
+#    branch: master
+#    tags: true

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ NOTE for ADVENTURERS: raylib is a programming library to learn videogames progra
 no fancy interface, no visual helpers, no auto-debugging... just coding in the most 
 pure spartan-programmers way. Are you ready to learn? Jump to [code examples!](http://www.raylib.com/examples.html)
 
+[![Build Status](https://travis-ci.org/raysan5/raylib.svg?branch=develop)](https://travis-ci.org/raysan5/raylib)
+
 features
 --------
  


### PR DESCRIPTION
Automatically attempts, for both macOS and Linux, 32-bit and 64-bit desktop CMake builds for new commits and pull requests. Adds a develop branch build status indicator icon [![Build Status](https://travis-ci.org/a3f/raylib.svg?branch=develop)](https://travis-ci.org/a3f/raylib) to README.md. https://docs.travis-ci.com/user/getting-started/#To-get-started-with-Travis-CI

On macOS, GLFW is installed via Homebrew, On Linux, I built a `*.deb`, which I host at a [Github repo](https://github.com/a3f/GLFW-3.2.1-Debian-binary-package/releases/tag/v3.2.1). It can be recreated by forking said repo and running `cmake && make package`.

Windows support via AppVeyor didn't make it in, because GLFW installation via Chocolatey needs to be debugged still. Here's [what I got so far](https://gist.github.com/a3f/50670969019621ff859e07d89f39e787).

On some of my [own projects](https://github.com/a3f/libvas), I configured AppVeyor and Travis CI to run `make package` and push the binary files to the Github releases page. I have commented out that deployment code and left it in just in case.