### PR TITLE
Fix warning about unsequenced modification of variable

### DIFF
--- a/src/shapes.c
+++ b/src/shapes.c
@@ -682,6 +682,8 @@ Rectangle GetCollisionRec(Rectangle rec1, Rectangle rec2)
 // NOTE: Required for DrawLineBezier()
 static float EaseCubicInOut(float t, float b, float c, float d) 
 { 
-    if ((t/=d/2) < 1) return (c/2*t*t*t + b);
-    return (c/2*((t-2)*t*t + 2) + b);
+    if ((t /= 0.5*d) < 1)
+        return 0.5*c*t*t*t + b;
+    t -= 2;
+    return 0.5*c*(t*t*t + 2) + b;
 }

--- a/src/shapes.c
+++ b/src/shapes.c
@@ -683,5 +683,5 @@ Rectangle GetCollisionRec(Rectangle rec1, Rectangle rec2)
 static float EaseCubicInOut(float t, float b, float c, float d) 
 { 
     if ((t/=d/2) < 1) return (c/2*t*t*t + b);
-    return (c/2*((t-=2)*t*t + 2) + b);
+    return (c/2*((t-2)*t*t + 2) + b);
 }


### PR DESCRIPTION
Variable t was read and modified without interleaving sequence points,
technically undefined behavior. Report by Clang's -Wunsequenced.

Reported by Travis CI. I want to test Automatic build on pull request too.