### PR TITLE
 Fix macOS build of new rglfw.c approach

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,8 @@ before_install:
                               libopenal-dev
                               libxcursor-dev libxinerama-dev
                               mesa-common-dev libx11-dev libxrandr-dev libxi-dev xorg-dev libgl1-mesa-dev libglu1-mesa-dev libglew-dev;
-      wget 'https://github.com/a3f/GLFW-3.2.1-Debian-binary-package/releases/download/v3.2.1/GLFW-3.2.1-Linux.deb' && sudo dpkg -i GLFW-3.2.1-Linux.deb;
     fi
-  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew update; brew install glfw; export CC=clang; fi
+  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew update; brew install glfw; fi
   - "$CC --version"
 
 script:

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,6 +20,7 @@ set(OPENGL_VERSION "3.3" CACHE STRING "OpenGL Version to build raylib with")
 set_property(CACHE OPENGL_VERSION PROPERTY STRINGS "3.3" "2.1" "1.1" "ES 2.0")
 ### Config options ###
 
+include_directories(external/glfw/include)
 
 # Translate the config options to what raylib wants
 if(${PLATFORM} MATCHES "Desktop")
@@ -40,6 +41,8 @@ if(${PLATFORM} MATCHES "Desktop")
   # See: https://github.com/raysan5/raylib/issues/341
   if(APPLE)
     set(GRAPHICS "GRAPHICS_API_OPENGL_33")
+    set_source_files_properties(rglfw.c PROPERTIES COMPILE_FLAGS "-x objective-c")
+    link_libraries("-framework CoreFoundation -framework Cocoa -framework IOKit -framework CoreVideo")
   endif()
 elseif(${PLATFORM} MATCHES "Web")
   set(PLATFORM "PLATFORM_WEB")
@@ -92,9 +95,6 @@ if(${PLATFORM} MATCHES "PLATFORM_DESKTOP")
     target_link_libraries(${RAYLIB} openal)
     target_link_libraries(${RAYLIB} GL)
   endif()
-  
-  # Add in GLFW as a linking target
-  target_link_libraries(${RAYLIB} glfw)
   
   # Library file & Header
   set_target_properties(${RAYLIB} PROPERTIES PUBLIC_HEADER "raylib.h")

--- a/src/core.c
+++ b/src/core.c
@@ -88,6 +88,11 @@
 
 #include "raylib.h"
 
+#if (defined(__linux__) || defined(PLATFORM_WEB)) && _POSIX_S_SOURCE < 199309L
+    #undef _POSIX_C_SOURCE
+    #define _POSIX_C_SOURCE 199309L // Required for CLOCK_MONOTONIC if compiled with c99 without gnu ext.
+#endif
+
 #include "rlgl.h"           // raylib OpenGL abstraction layer to OpenGL 1.1, 3.3+ or ES2
 #include "utils.h"          // Required for: fopen() Android mapping
 
@@ -108,10 +113,6 @@
 #if defined(SUPPORT_GIF_RECORDING)
     #define RGIF_IMPLEMENTATION
     #include "external/rgif.h"   // Support GIF recording
-#endif
-
-#if defined(__linux__) || defined(PLATFORM_WEB)
-    #define _POSIX_C_SOURCE 199309L // Required for CLOCK_MONOTONIC if compiled with c99 without gnu ext.
 #endif
 
 #include <stdio.h>          // Standard input / output lib

--- a/src/gestures.h
+++ b/src/gestures.h
@@ -148,7 +148,10 @@ float GetGesturePinchAngle(void);                       // Get gesture pinch ang
     int __stdcall QueryPerformanceCounter(unsigned long long int *lpPerformanceCount);
     int __stdcall QueryPerformanceFrequency(unsigned long long int *lpFrequency);
 #elif defined(__linux__)
-    #define _POSIX_C_SOURCE 199309L // Required for CLOCK_MONOTONIC if compiled with c99 without gnu ext.
+    #if _POSIX_C_SOURCE < 199309L
+        #undef _POSIX_C_SOURCE
+        #define _POSIX_C_SOURCE 199309L // Required for CLOCK_MONOTONIC if compiled with c99 without gnu ext.
+    #endif
     #include <sys/time.h>           // Required for: timespec
     #include <time.h>               // Required for: clock_gettime()
 #endif

--- a/src/gestures.h
+++ b/src/gestures.h
@@ -140,9 +140,6 @@ float GetGesturePinchAngle(void);                       // Get gesture pinch ang
 
 #if defined(GESTURES_IMPLEMENTATION)
 
-#include <math.h>               // Required for: atan2(), sqrt()
-#include <stdint.h>             // Required for: uint64_t
-
 #if defined(_WIN32)
     // Functions required to query time on Windows
     int __stdcall QueryPerformanceCounter(unsigned long long int *lpPerformanceCount);
@@ -154,6 +151,9 @@ float GetGesturePinchAngle(void);                       // Get gesture pinch ang
     #endif
     #include <sys/time.h>           // Required for: timespec
     #include <time.h>               // Required for: clock_gettime()
+
+    #include <math.h>               // Required for: atan2(), sqrt()
+    #include <stdint.h>             // Required for: uint64_t
 #endif
 
 //----------------------------------------------------------------------------------

--- a/src/physac.h
+++ b/src/physac.h
@@ -235,6 +235,22 @@ PHYSACDEF void ClosePhysics(void);                                              
 
 #if defined(PHYSAC_IMPLEMENTATION)
 
+#if defined(_WIN32)
+    // Functions required to query time on Windows
+    int __stdcall QueryPerformanceCounter(unsigned long long int *lpPerformanceCount);
+    int __stdcall QueryPerformanceFrequency(unsigned long long int *lpFrequency);
+#elif (defined(__linux__) || defined(__APPLE__) || defined(PLATFORM_WEB))
+    #if _POSIX_C_SOURCE < 199309L
+        #undef _POSIX_C_SOURCE
+        #define _POSIX_C_SOURCE 199309L // Required for CLOCK_MONOTONIC if compiled with c99 without gnu ext.
+    #endif
+    //#define _DEFAULT_SOURCE         // Enables BSD function definitions and C99 POSIX compliance
+    #include <sys/time.h>           // Required for: timespec
+    #include <time.h>               // Required for: clock_gettime()
+    #include <stdint.h>
+#endif
+
+
 #if !defined(PHYSAC_NO_THREADS)
     #include <pthread.h>            // Required for: pthread_t, pthread_create()
 #endif
@@ -247,18 +263,6 @@ PHYSACDEF void ClosePhysics(void);                                              
 #include <math.h>                   // Required for: cosf(), sinf(), fabs(), sqrtf()
 
 #include "raymath.h"                // Required for: Vector2Add(), Vector2Subtract()
-
-#if defined(_WIN32)
-    // Functions required to query time on Windows
-    int __stdcall QueryPerformanceCounter(unsigned long long int *lpPerformanceCount);
-    int __stdcall QueryPerformanceFrequency(unsigned long long int *lpFrequency);
-#elif defined(__linux__) || defined(__APPLE__) || defined(PLATFORM_WEB)
-    #define _POSIX_C_SOURCE 199309L // Required for CLOCK_MONOTONIC if compiled with c99 without gnu ext.
-    //#define _DEFAULT_SOURCE         // Enables BSD function definitions and C99 POSIX compliance
-    #include <sys/time.h>           // Required for: timespec
-    #include <time.h>               // Required for: clock_gettime()
-    #include <stdint.h>
-#endif
 
 //----------------------------------------------------------------------------------
 // Defines and Macros

--- a/src/rglfw.c
+++ b/src/rglfw.c
@@ -86,5 +86,5 @@
     #include "external/glfw/src/posix_thread.c"
     #include "external/glfw/src/nsgl_context.m" 
     #include "external/glfw/src/egl_context.c" 
-    #include "external/glfw/src/osmesa_context.c.m"
+    #include "external/glfw/src/osmesa_context.c"
 #endif

--- a/utils.cmake
+++ b/utils.cmake
@@ -6,10 +6,6 @@ if(UNIX AND NOT APPLE)
   set(LINUX TRUE)
 endif()
 
-# Need GLFW 3.2.1
-find_package(glfw3 3.2.1 REQUIRED)
-
-
 # Linking for OS X -framework options
 # Will do nothing on other OSes
 function(link_os_x_frameworks binary)
@@ -40,9 +36,6 @@ function(link_libraries_to_executable executable)
     # TODO windows
   endif()
   
-  # Add in GLFW as a linking target
-  target_link_libraries(${executable} glfw)
-
   # And raylib
   target_link_libraries(${executable} raylib)
 endfunction()


### PR DESCRIPTION
There have been two problems:

* GLFW itself was compiled with the definitions for compiling
_against_ GLFW (Fixed by removing requirement for external glfw)

* rglfw.c was being compiled as C code, although it includes
Objective C files.

This _might_ break the Windows build, needs to be checked.

Fixes #391, but as noted I'd prefer though a separate source directory
and build script for GLFW.

The prior commit fixes a Travis CI compile error when compiling for Linux.