### PR TITLE
Note that raylib can now be installed via Homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@ to accomodate to Android, Raspberry Pi and HTML5.
 build and installation
 ----------------------
 
-Binary releases for Windows, Linux and macOS are available at the [Github Releases](https://github.com/raysan5/raylib/releases) page.
+Binary releases for Windows, Linux and macOS are available at the [Github Releases](https://github.com/raysan5/raylib/releases) page. Raylib is also available via following package managers:
+
+   * Homebrew: `brew install raylib`
 
 To build raylib yourself, check out the [raylib Wiki](https://github.com/raysan5/raylib/wiki) for detailed instructions.
 


### PR DESCRIPTION
`brew install raylib` now install the 1.9.1-dev release, unless `--build-from-source` is supplied, it downloads a prebuilt raylib from Homebrew's servers. `brew install --HEAD` builds the latest commit available on the `develop` branch.