### PR TITLE
CMake: Explicitly ask for C99 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,24 @@
 language: c
-sudo: required
 dist: trusty
 
 git:
   depth: 3
 
-os:
-  - osx
-  - linux
+# TODO we could use a 32 bit Docker container for running true 32-bit tests
+# services: - docker
 
-env:
-  global:
-    - VERBOSE=1
-  matrix: # We don't install x11 32-bit libraries, so skip shared libraries on -m32
-    - ARCH=i386 SHARED=OFF
-    - ARCH=amd64 SHARED=ON
-
-matrix:
-  exclude: # This is already covered by building universal (fat) libraries by default
-  - os: osx
-    env: ARCH=i386 SHARED=OFF
+matrix: # We don't install x11 32-bit libraries, so skip shared libraries on -m32
+  include:
+    - os: linux
+      env: ARCH=i386 SHARED=OFF EXAMPLES=OFF
+      sudo: required
+    - os: linux
+      env: ARCH=amd64 SHARED=ON EXAMPLES=ON
+      sudo: required
+    - os: osx
+      env: ARCH=amd64 SHARED=ON EXAMPLES=ON
 
 before_script:
-  - export CFLAGS="-std=gnu99"
 
 before_install:
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then
@@ -32,8 +28,8 @@ before_install:
                               mesa-common-dev libx11-dev libxrandr-dev libxi-dev xorg-dev
                               libgl1-mesa-dev libglu1-mesa-dev libglew-dev;
       export RAYLIB_PACKAGE_SUFFIX="-Linux-$ARCH";
-      if [ "$ARCH" == "i386" ]; then export CFLAGS="$CFLAGS -m32"; fi;
-      if [ "$ARCH" == "amd64" ]; then export CFLAGS="$CFLAGS -m64"; fi;
+      if [ "$ARCH" == "i386" ]; then export CFLAGS="-m32"; fi;
+      if [ "$ARCH" == "amd64" ]; then export CFLAGS="-m64"; fi;
     fi
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then export RAYLIB_PACKAGE_SUFFIX="-macOS"; fi
   - "$CC --version"
@@ -41,8 +37,8 @@ before_install:
 script:
   - mkdir build
   - cd build
-  - cmake -DMACOS_FATLIB=ON -DSTATIC_RAYLIB=ON -DSHARED_RAYLIB=$SHARED ..
-  - make
+  - cmake -DMACOS_FATLIB=ON -DSTATIC_RAYLIB=ON -DSHARED_RAYLIB=$SHARED -DBUILD_EXAMPLES=$EXAMPLES -DBUILD_GAMES=$EXAMPLES ..
+  - make VERBOSE=1
   - make package
 
 deploy:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,14 @@ cmake_minimum_required(VERSION 3.0)
 set(BUILD_EXAMPLES ON CACHE BOOL "Build the examples.")
 set(BUILD_GAMES ON CACHE BOOL "Build the example games.")
 
+if(CMAKE_VERSION VERSION_LESS "3.1")
+  if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
+    set(CMAKE_C_FLAGS "-std=gnu99 ${CMAKE_C_FLAGS}")
+  endif()
+else()
+  set (CMAKE_C_STANDARD 99)
+endif()
+
 add_subdirectory(src release)
 
 if (${BUILD_EXAMPLES})


### PR DESCRIPTION
Otherwise using a compiler that defaults to -std=c89 or -std=gnu89 will
fail. Example:
http://www.cpantesters.org/cpan/report/abb85066-d283-11e7-9926-b2f4efb9c382