### PR TITLE
Add mouse input and revert keyboard to callback model

### DIFF
--- a/project/vs2015.UWP/raylib.App.UWP/App.h
+++ b/project/vs2015.UWP/raylib.App.UWP/App.h
@@ -33,6 +33,14 @@ namespace raylibUWP
 		void OnDpiChanged(Windows::Graphics::Display::DisplayInformation^ sender, Platform::Object^ args);
 		void OnOrientationChanged(Windows::Graphics::Display::DisplayInformation^ sender, Platform::Object^ args);
 
+		// Input event handlers
+		void PointerPressed(Windows::UI::Core::CoreWindow^ sender, Windows::UI::Core::PointerEventArgs^ args);
+		void PointerReleased(Windows::UI::Core::CoreWindow ^sender, Windows::UI::Core::PointerEventArgs^ args);
+		void PointerWheelChanged(Windows::UI::Core::CoreWindow ^sender, Windows::UI::Core::PointerEventArgs^ args);
+		void MouseMoved(Windows::Devices::Input::MouseDevice^ mouseDevice, Windows::Devices::Input::MouseEventArgs^ args);
+		void OnKeyDown(Windows::UI::Core::CoreWindow ^ sender, Windows::UI::Core::KeyEventArgs ^ args);
+		void OnKeyUp(Windows::UI::Core::CoreWindow ^ sender, Windows::UI::Core::KeyEventArgs ^ args);
+
 	private:
 
         bool mWindowClosed;


### PR DESCRIPTION
Mouse input is implemented, with all bells-and-whistles. This includes cursor locking and scroll wheel support.

Keyboard input is reverted to a callback model to better reflect the existing architecture in "core.c"