### PR TITLE
GCC/Clang: Treat void pointer arithmetic as error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,11 @@ if(CMAKE_VERSION VERSION_LESS "3.1")
 else()
   set (CMAKE_C_STANDARD 99)
 endif()
+include(CheckCCompilerFlag)
+CHECK_C_COMPILER_FLAG("-Werror=pointer-arith" COMPILER_HAS_POINTER_ARITH_TOGGLE)
+if(COMPILER_HAS_POINTER_ARITH_TOGGLE)
+    set(CMAKE_C_FLAGS "-Werror=pointer-arith ${CMAKE_C_FLAGS}")
+endif()
 
 add_subdirectory(src release)
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -250,16 +250,17 @@ ifeq ($(PLATFORM),PLATFORM_ANDROID)
 endif
 
 # Define compiler flags:
-#  -O1                  defines optimization level
-#  -g                   enable debugging
-#  -s                   strip unnecessary data from build
-#  -Wall                turns on most, but not all, compiler warnings
-#  -std=c99             defines C language mode (standard C from 1999 revision)
-#  -std=gnu99           defines C language mode (GNU C from 1999 revision)
-#  -fgnu89-inline       declaring inline functions support (GCC optimized)
-#  -Wno-missing-braces  ignore invalid warning (GCC bug 53119)
-#  -D_DEFAULT_SOURCE    use with -std=c99 on Linux and PLATFORM_WEB, required for timespec
-CFLAGS += -O1 -Wall -std=c99 -D_DEFAULT_SOURCE -fgnu89-inline -Wno-missing-braces
+#  -O1                   defines optimization level
+#  -g                    enable debugging
+#  -s                    strip unnecessary data from build
+#  -Wall                 turns on most, but not all, compiler warnings
+#  -std=c99              defines C language mode (standard C from 1999 revision)
+#  -std=gnu99            defines C language mode (GNU C from 1999 revision)
+#  -fgnu89-inline        declaring inline functions support (GCC optimized)
+#  -Wno-missing-braces   ignore invalid warning (GCC bug 53119)
+#  -D_DEFAULT_SOURCE     use with -std=c99 on Linux and PLATFORM_WEB, required for timespec
+#  -Werror=pointer-arith catch unportable code that does direct arithmetic on void pointers
+CFLAGS += -O1 -Wall -std=c99 -D_DEFAULT_SOURCE -fgnu89-inline -Wno-missing-braces -Werror=pointer-arith
 
 # Additional flags for compiler (if desired)
 #CFLAGS += -Wextra -Wmissing-prototypes -Wstrict-prototypes


### PR DESCRIPTION
As an extension, GNU C treats `sizeof(void)` as `1`. MSVC doesn't.
Make it an error on GCC/Clang to avoid accidental MSVC breakage.