### PR TITLE
Update Makefile

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -165,7 +165,7 @@ endif
 
 # Define include paths for required headers
 # NOTE: Several external required libraries (stb and others)
-INCLUDE_PATHS = -I. -I$(RAYLIB_PATH)/release/include -I$(RAYLIB_PATH)/src -I$(RAYLIB_PATH)/src/external
+INCLUDE_PATHS = -I. -I$(RAYLIB_PATH)/src -I$(RAYLIB_PATH)/release/include -I$(RAYLIB_PATH)/src/external
 
 # Define additional directories containing required header files
 ifeq ($(PLATFORM),PLATFORM_RPI)


### PR DESCRIPTION
Causes the example Makefile to prefer src/raylib.h over release/include/raylib.h. It fixes one example needing the newer header.