### PR TITLE
CMake: Add tristate option for using system GLFW

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
       env: ARCH=i386
       sudo: required
     - os: linux
-      env: ARCH=amd64
+      env: ARCH=amd64 GLFW=SYSTEM
       sudo: required
     - os: osx
       env: ARCH=universal
@@ -30,14 +30,22 @@ before_install:
       export RAYLIB_PACKAGE_SUFFIX="-Linux-$ARCH";
       if [ "$ARCH" == "i386" ]; then export CFLAGS="-m32"; fi;
       if [ "$ARCH" == "amd64" ]; then export CFLAGS="-m64"; fi;
+      if [ "$GLFW" == "SYSTEM" ]; then
+        wget 'http://ftp.de.debian.org/debian/pool/main/g/glfw3/libglfw3_3.2.1-1_amd64.deb';
+        wget 'http://ftp.de.debian.org/debian/pool/main/g/glfw3/libglfw3-dev_3.2.1-1_amd64.deb';
+        sudo dpkg -i libglfw3_3.2.1-1_amd64.deb libglfw3-dev_3.2.1-1_amd64.deb;
+      fi;
     fi
-  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then export RAYLIB_PACKAGE_SUFFIX="-macOS"; fi
+  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then
+      export RAYLIB_PACKAGE_SUFFIX="-macOS";
+      if [ "$GLFW" == "SYSTEM" ]; then brew update; brew install glfw; fi;
+    fi
   - "$CC --version"
 
 script:
   - mkdir build
   - cd build
-  - cmake -DMACOS_FATLIB=ON -DSTATIC_RAYLIB=ON -DSHARED_RAYLIB=ON -DBUILD_EXAMPLES=ON -DBUILD_GAMES=ON ..
+  - cmake -DMACOS_FATLIB=ON -DSTATIC_RAYLIB=ON -DSHARED_RAYLIB=ON -DBUILD_EXAMPLES=ON -DBUILD_GAMES=ON -DWITH_SYSTEM_GLFW=IF_POSSIBLE ..
   - make VERBOSE=1
   - make package
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,9 +26,19 @@ set_property(CACHE PLATFORM PROPERTY STRINGS "Desktop" "Web" "Android" "Raspberr
 set(OPENGL_VERSION "3.3" CACHE STRING "OpenGL Version to build raylib with")
 set_property(CACHE OPENGL_VERSION PROPERTY STRINGS "3.3" "2.1" "1.1" "ES 2.0")
 
-### Config options ###
-include_directories(external/glfw/include)
+# Get the sources together
+file(GLOB raylib_sources *.c)
+if(glfw3_FOUND)
+  list(REMOVE_ITEM raylib_sources ${CMAKE_CURRENT_SOURCE_DIR}/rglfw.c)
+else()
+  include_directories(external/glfw/include)
+endif()
 
+file(GLOB stb_vorbis external/stb_vorbis.c)
+file(GLOB mini_al external/mini_al.c ${stb_vorbis})
+set(sources ${raylib_sources} ${mini_al})
+
+### Config options ###
 # Translate the config options to what raylib wants
 if(${PLATFORM} MATCHES "Desktop")
   set(PLATFORM "PLATFORM_DESKTOP")
@@ -81,37 +91,8 @@ if(MACOS_FATLIB)
     endif()
 endif()
 
-# Get the sources together
-file(GLOB raylib_sources *.c)
-file(GLOB stb_vorbis external/stb_vorbis.c)
-file(GLOB mini_al external/mini_al.c ${stb_vorbis})
-set(sources ${raylib_sources} ${mini_al})
-
 # Which platform?
 if(${PLATFORM} MATCHES "PLATFORM_DESKTOP")
-
-  foreach(L ${LIBS_PRIVATE})
-      get_filename_component(DIR  ${L} PATH)
-      get_filename_component(LIBFILE ${L} NAME_WE)
-      STRING(REGEX REPLACE "^lib" "" FILE ${LIBFILE})
-
-      if (${L} MATCHES "[.]framework$")
-          set(FILE_OPT "-framework ${FILE}")
-          set(DIR_OPT  "-F${DIR} ")
-      else()
-          set(FILE_OPT "-l${FILE}")
-          set(DIR_OPT  "-L${DIR} ")
-      endif()
-
-      if ("${DIR}" STREQUAL "" OR "${DIR}" STREQUAL "${LASTDIR}")
-          set (DIR_OPT "")
-      endif()
-
-      set(LASTDIR ${DIR})
-
-      set(PKG_CONFIG_LIBS_PRIVATE "${PKG_CONFIG_LIBS_PRIVATE} ${DIR_OPT}${FILE_OPT}")
-  endforeach(L)
-
 
   if(${SHARED_RAYLIB})
     add_library(${RAYLIB}_shared SHARED ${sources})

--- a/utils.cmake
+++ b/utils.cmake
@@ -1,6 +1,9 @@
 # All sorts of things that we need cross project
 cmake_minimum_required(VERSION 2.8.0)
 
+set(WITH_SYSTEM_GLFW  OFF  CACHE STRING "Link raylib against system GLFW instead of embedded one")
+set_property(CACHE WITH_SYSTEM_GLFW PROPERTY STRINGS ON OFF IF_POSSIBLE)
+
 # Linking for OS X -framework options
 # Will do nothing on other OSes
 if(APPLE)
@@ -27,24 +30,59 @@ else()
     find_library(XINERAMA_LIBRARY Xinerama)
     find_library(XXF86VM_LIBRARY Xxf86vm)
     find_library(XCURSOR_LIBRARY Xcursor)
-
     include_directories(${OPENGL_INCLUDE_DIR})
 
     set(LIBS_PRIVATE m ${pthread} ${OPENGL_LIBRARIES} ${X11_LIBRARIES} ${XRANDR_LIBRARY} ${XINERAMA_LIBRARY} ${XI_LIBRARY} ${XXF86VM_LIBRARY} ${XCURSOR_LIBRARY})
   endif()
 endif()
 
+if(WITH_SYSTEM_GLFW STREQUAL "ON")
+    find_package(glfw3 3.2.1 REQUIRED)
+else(WITH_SYSTEM_GLFW STREQUAL "IF_POSSIBLE")
+    find_package(glfw3 3.2.1)
+endif()
+if (glfw3_FOUND)
+  set(LIBS_PRIVATE ${LIBS_PRIVATE} glfw)
+endif()
+
+
 if(CMAKE_SYSTEM_NAME STREQUAL Linux)
   set(LINUX TRUE)
   set(LIBS_PRIVATE dl ${LIBS_PRIVATE})
 endif()
 
+foreach(L ${LIBS_PRIVATE})
+  get_filename_component(DIR  ${L} PATH)
+  get_filename_component(LIBFILE ${L} NAME_WE)
+  STRING(REGEX REPLACE "^lib" "" FILE ${LIBFILE})
+
+  if (${L} MATCHES "[.]framework$")
+      set(FILE_OPT "-framework ${FILE}")
+      set(DIR_OPT  "-F${DIR}")
+  else()
+      set(FILE_OPT "-l${FILE}")
+      set(DIR_OPT  "-L${DIR}")
+  endif()
+
+  if ("${DIR}" STREQUAL "" OR "${DIR}" STREQUAL "${LASTDIR}")
+      set (DIR_OPT "")
+  endif()
+
+  set(LASTDIR ${DIR})
+
+  set(PKG_CONFIG_LIBS_PRIVATE ${PKG_CONFIG_LIBS_PRIVATE} ${DIR_OPT} ${FILE_OPT})
+  string (REPLACE ";" " " PKG_CONFIG_LIBS_PRIVATE "${PKG_CONFIG_LIBS_PRIVATE}")
+endforeach(L)
+
+
+
 # Do the linking for executables that are meant to link raylib
 function(link_libraries_to_executable executable)
-  # And raylib
-  target_link_libraries(${executable} raylib)
-
-  # Link the libraries
-  target_link_libraries(${executable} ${LIBS_PRIVATE})
+  # Link raylib
+  if (TARGET raylib_shared)
+    target_link_libraries(${executable} raylib_shared)
+  else()
+    target_link_libraries(${executable} raylib ${PKG_CONFIG_LIBS_PRIVATE})
+  endif()
 endfunction()
 


### PR DESCRIPTION
`-DWITH_SYSTEM_GLFW=ON`: Link against system glfw and fail otherwise
`-DWITH_SYSTEM_GLFW=OFF`: Use embedded `rglfw.c`
`-DWITH_SYSTEM_GLFW=IF_POSSIBLE`: Probe for system glfw but fallback to
                                rglfw if unavailable

Also change Linux 64-bit CI build to install system glfw and use it,
so this doesn't bitrot.