### PR TITLE
Return false from InitWindow if glfwInit or glfwCreateWindow fails

### DIFF
--- a/src/raylib.h
+++ b/src/raylib.h
@@ -684,7 +684,7 @@ extern "C" {            // Prevents name mangling of functions
 //------------------------------------------------------------------------------------
 
 // Window-related functions
-RLAPI void InitWindow(int width, int height, void *data);         // Initialize window and OpenGL context
+RLAPI bool InitWindow(int width, int height, void *data);         // Initialize window and OpenGL context
 RLAPI void CloseWindow(void);                                     // Close window and unload OpenGL context
 RLAPI bool WindowShouldClose(void);                               // Check if KEY_ESCAPE pressed or Close icon pressed
 RLAPI bool IsWindowMinimized(void);                               // Check if window has been minimized (or lost focus)


### PR DESCRIPTION
You can't do much with raylib if glfwInit or glfwCreateWindow fails,
currently it just exits by means of TraceLog(LOG_ERROR.
User code, however, might want to fall back to a text-only UI
or display a warning if raylib can't be used.