### PR TITLE
InitWindow: return false if no monitor found

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -1733,7 +1733,13 @@ static bool InitGraphicsDevice(int width, int height)
     // NOTE: Getting video modes is not implemented in emscripten GLFW3 version
 #if defined(PLATFORM_DESKTOP)
     // Find monitor resolution
-    const GLFWvidmode *mode = glfwGetVideoMode(glfwGetPrimaryMonitor());
+    GLFWmonitor *monitor = glfwGetPrimaryMonitor();
+    if (!monitor)
+    {
+        TraceLog(LOG_WARNING, "Failed to get monitor");
+        return false;
+    }
+    const GLFWvidmode *mode = glfwGetVideoMode(monitor);
 
     displayWidth = mode->width;
     displayHeight = mode->height;


### PR DESCRIPTION
Otherwise we run into an assertion failure inside GLFW's `glfwGetVideoMode`.
Example:
http://www.cpantesters.org/cpan/report/b4ba5894-0bdb-11e8-841e-2c60b04e1d2d

This is related to #456.