### PR TITLE
Linux make install improvements

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -31,6 +31,9 @@ RAYLIB_PATH        ?= ..
 
 # Define default options
 
+# One of PLATFORM_DESKTOP, PLATFORM_RPI, PLATFORM_ANDROID, PLATFORM_WEB
+PLATFORM              ?= PLATFORM_DESKTOP
+
 # Default path for raylib on Raspberry Pi, if installed in different path, update it!
 ifeq ($(PLATFORM),PLATFORM_RPI)
     RAYLIB_PATH       ?= /home/pi/raylib
@@ -58,9 +61,6 @@ RAYLIB_H_INSTALL_PATH ?= /usr/local/include/raysan5
 # because it's a relative path. You must spell it out if needed.
 # To see the result, run readelf -d core/core_basic_window, looking at the RPATH attribute.
 RAYLIB_RUNTIME_PATH   ?= $(RAYLIB_INSTALL_PATH)
-
-# One of PLATFORM_DESKTOP, PLATFORM_RPI, PLATFORM_ANDROID, PLATFORM_WEB
-PLATFORM              ?= PLATFORM_DESKTOP
 
 # Library type used for raylib: STATIC (.a) or SHARED (.so/.dll)
 RAYLIB_LIBTYPE        ?= STATIC

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -56,7 +56,7 @@ RAYLIB_H_INSTALL_PATH ?= /usr/local/include/raysan5
 # Implemented for LINUX below with CFLAGS += -Wl,-rpath,$(RAYLIB_RUNTIME_PATH)
 # This should be a fully qualified path. RAYLIB_RELEASE_PATH doesn't work here
 # because it's a relative path. You must spell it out if needed.
-# To see the result, run readelf -d ./core_basic_window
+# To see the result, run readelf -d core/core_basic_window, looking at the RPATH attribute.
 RAYLIB_RUNTIME_PATH   ?= $(RAYLIB_INSTALL_PATH)
 
 # One of PLATFORM_DESKTOP, PLATFORM_RPI, PLATFORM_ANDROID, PLATFORM_WEB

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -24,28 +24,58 @@
 .PHONY: all clean
 
 # Define required raylib variables
-# WARNING: To compile to HTML5, code must be redesigned to use emscripten.h and emscripten_set_main_loop()
-PLATFORM ?= PLATFORM_DESKTOP
-RAYLIB_PATH ?= ..
-PROJECT_NAME ?= raylib_example
+PROJECT_NAME       ?= raylib_examples
+RAYLIB_VERSION     ?= 1.9.4
+RAYLIB_API_VERSION ?= 1
+RAYLIB_PATH        ?= ..
+
+# Define default options
 
 # Default path for raylib on Raspberry Pi, if installed in different path, update it!
 ifeq ($(PLATFORM),PLATFORM_RPI)
-    RAYLIB_PATH ?= /home/pi/raylib
+    RAYLIB_PATH       ?= /home/pi/raylib
 endif
 
+# RAYLIB_RELEASE_PATH points to provided binaries or your immediate build of libraylib.
+# See below for additions.
+RAYLIB_RELEASE_PATH   ?= $(RAYLIB_PATH)/release/libs
+
+# Locations of your newly installed library and associated headers. See ../src/Makefile
+# On Linux, if you have installed raylib but cannot compile the examples, check that the
+# *_INSTALL_PATH values here are the same as those in src/Makefile or point to known locations.
+# To enable system-wide runtime linking to libraylib.so, run sudo ldconfig $(RAYLIB_INSTALL_PATH).
+# ldconfig is not necessary if using RAYLIB_RUNTIME_PATH below.
+RAYLIB_INSTALL_PATH   ?= /usr/local/lib/raysan5
+RAYLIB_H_INSTALL_PATH ?= /usr/local/include/raysan5
+
+# Set runtime path to custom location of shared library if desired, avoiding sudo ldconfig.
+# If you have compiled the examples but cannot run them, examine both RAYLIB_INSTALL_PATH and 
+# RAYLIB_RUNTIME_PATH. To see which libraries a built example is using, ldd core/core_basic_window;
+# Look for libraylib.so.1 => $(RAYLIB_INSTALL_PATH)/libraylib.so.1
+# or libraylib.so.1 => $(RAYLIB_RUNTIME_PATH)/libraylib.so.1 or similar listing.
+# Implemented for LINUX below with CFLAGS += -Wl,-rpath,$(RAYLIB_RUNTIME_PATH)
+# This should be a fully qualified path. RAYLIB_RELEASE_PATH doesn't work here
+# because it's a relative path. You must spell it out if needed.
+# To see the result, run readelf -d ./core_basic_window
+RAYLIB_RUNTIME_PATH   ?= $(RAYLIB_INSTALL_PATH)
+
+# One of PLATFORM_DESKTOP, PLATFORM_RPI, PLATFORM_ANDROID, PLATFORM_WEB
+PLATFORM              ?= PLATFORM_DESKTOP
+
 # Library type used for raylib: STATIC (.a) or SHARED (.so/.dll)
-RAYLIB_LIBTYPE ?= STATIC
+RAYLIB_LIBTYPE        ?= STATIC
+
+# Build mode for project: DEBUG or RELEASE
+RAYLIB_BUILD_MODE     ?= RELEASE
 
 # Use external GLFW library instead of rglfw module
-USE_EXTERNAL_GLFW ?= FALSE
+USE_EXTERNAL_GLFW     ?= FALSE
 
 # Use Wayland display server protocol on Linux desktop
 # by default it uses X11 windowing system
-USE_WAYLAND_DISPLAY ?= FALSE
+USE_WAYLAND_DISPLAY   ?= FALSE
 
 # NOTE: On PLATFORM_WEB OpenAL Soft backend is used by default (check raylib/src/Makefile)
-
 
 # Determine PLATFORM_OS in case PLATFORM_DESKTOP selected
 ifeq ($(PLATFORM),PLATFORM_DESKTOP)
@@ -83,8 +113,6 @@ ifeq ($(PLATFORM),PLATFORM_WEB)
     export PATH=$(EMSDK_PATH);$(EMSDK_PATH)\clang\$(CLANG_VERSION);$(EMSDK_PATH)\node\$(NODE_VERSION)\bin;$(EMSDK_PATH)\python\$(PYTHON_VERSION);$(EMSDK_PATH)\emscripten\$(EMSCRIPTEN_VERSION);C:\raylib\MinGW\bin:$$(PATH)
     EMSCRIPTEN=$(EMSDK_PATH)\emscripten\$(EMSCRIPTEN_VERSION)
 endif
-
-RAYLIB_RELEASE_PATH ?= $(RAYLIB_PATH)/release/libs
 
 # Define raylib release directory for compiled library
 ifeq ($(PLATFORM),PLATFORM_DESKTOP)
@@ -130,6 +158,7 @@ ifeq ($(PLATFORM),PLATFORM_RPI)
     endif
 endif
 ifeq ($(PLATFORM),PLATFORM_WEB)
+    # WARNING: To compile to HTML5, code must be redesigned to use emscripten.h and emscripten_set_main_loop()
     # HTML5 emscripten compiler
     CC = emcc
 endif
@@ -164,7 +193,13 @@ ifeq ($(PLATFORM),PLATFORM_DESKTOP)
         CFLAGS += $(RAYLIB_PATH)/src/resources -Wl,--subsystem,windows
     endif
     ifeq ($(PLATFORM_OS),LINUX)
+        ifeq ($(RAYLIB_LIBTYPE),STATIC)
         CFLAGS += -no-pie -D_DEFAULT_SOURCE
+        endif
+        ifeq ($(RAYLIB_LIBTYPE),SHARED)
+        # Explicitly enable runtime link to libraylib
+        CFLAGS += -Wl,-rpath,$(RAYLIB_RUNTIME_PATH)
+        endif
     endif
 endif
 ifeq ($(PLATFORM),PLATFORM_RPI)
@@ -179,31 +214,39 @@ ifeq ($(PLATFORM),PLATFORM_WEB)
     # -s WASM=1                  # support Web Assembly (https://github.com/kripken/emscripten/wiki/WebAssembly)
     # --preload-file resources   # specify a resources folder for data compilation
     CFLAGS += -s USE_GLFW=3 -s ASSERTIONS=1 -s WASM=1 --profiling --preload-file resources
-    
+
     # Define a custom shell .html and output extension
     CFLAGS += --shell-file $(RAYLIB_PATH)\templates\web_shell\shell.html
     EXT = .html
 endif
 
-# Define include paths for required headers
+# Define include paths for required headers.
+# Precedence: immediately local, raysan5 provided sources
 # NOTE: Several external required libraries (stb and others)
 INCLUDE_PATHS = -I. -I$(RAYLIB_PATH)/release/include -I$(RAYLIB_PATH)/src -I$(RAYLIB_PATH)/src/external
 
 # Define additional directories containing required header files
 ifeq ($(PLATFORM),PLATFORM_RPI)
-    # RPI requried libraries
+    # RPI required libraries
     INCLUDE_PATHS += -I/opt/vc/include
     INCLUDE_PATHS += -I/opt/vc/include/interface/vmcs_host/linux
     INCLUDE_PATHS += -I/opt/vc/include/interface/vcos/pthreads
 endif
 
-# Define library paths containing required libs
-LDFLAGS = -L. -L$(RAYLIB_RELEASE_PATH) -L$(RAYLIB_PATH)/src 
+# Define library paths containing required libs.
+# Precedence: immediately local, then raysan5 provided libs
+LDFLAGS = -L. -L$(RAYLIB_RELEASE_PATH) -L$(RAYLIB_PATH)/src
 
 ifeq ($(PLATFORM),PLATFORM_DESKTOP)
     ifeq ($(PLATFORM_OS),FREEBSD)
         INCLUDE_PATHS += -I/usr/local/include
         LDFLAGS += -L. -Lsrc -L/usr/local/lib
+    endif
+    ifeq ($(PLATFORM_OS),LINUX)
+        # Reset everything.
+        # Precedence: immediately local, installed version, raysan5 provided libs
+        INCLUDE_PATHS = -I. -I$(RAYLIB_H_INSTALL_PATH) -I$(RAYLIB_PATH)/release/include -I$(RAYLIB_PATH)/src -I$(RAYLIB_PATH)/src/external
+        LDFLAGS = -L. -L$(RAYLIB_INSTALL_PATH) -L$(RAYLIB_RELEASE_PATH) -L$(RAYLIB_PATH)/src
     endif
 endif
 
@@ -217,7 +260,7 @@ ifeq ($(PLATFORM),PLATFORM_DESKTOP)
     ifeq ($(PLATFORM_OS),WINDOWS)
         # Libraries for Windows desktop compilation
         LDLIBS = -lraylib -lopengl32 -lgdi32
-        
+
         # Required for physac examples
         LDLIBS += -static -lpthread
     endif
@@ -225,15 +268,20 @@ ifeq ($(PLATFORM),PLATFORM_DESKTOP)
         # Libraries for Debian GNU/Linux desktop compiling
         # NOTE: Required packages: libegl1-mesa-dev
         LDLIBS = -lraylib -lGL -lm -lpthread -ldl -lrt
-        
+
         # On X11 requires also below libraries
         LDLIBS += -lX11
         # NOTE: It seems additional libraries are not required any more, latest GLFW just dlopen them
         #LDLIBS += -lXrandr -lXinerama -lXi -lXxf86vm -lXcursor
-        
+
         # On Wayland windowing system, additional libraries requires
         ifeq ($(USE_WAYLAND_DISPLAY),TRUE)
             LDLIBS += -lwayland-client -lwayland-cursor -lwayland-egl -lxkbcommon
+        endif
+
+        # Explicit link to libc
+        ifeq ($(RAYLIB_LIBTYPE),SHARED)
+            LDLIBS += -lc
         endif
     endif
     ifeq ($(PLATFORM_OS),OSX)
@@ -360,7 +408,7 @@ ifeq ($(PLATFORM),PLATFORM_DESKTOP)
 		del *.o *.exe /s
     endif
     ifeq ($(PLATFORM_OS),LINUX)
-		find -type f -executable | xargs file -i | grep -E 'x-object|x-archive|x-sharedlib|x-executable' | rev | cut -d ':' -f 2- | rev | xargs rm -f
+		find -type f -executable | xargs file -i | grep -E 'x-object|x-archive|x-sharedlib|x-executable' | rev | cut -d ':' -f 2- | rev | xargs rm -fv
     endif
     ifeq ($(PLATFORM_OS),OSX)
 		find . -type f -perm +ugo+x -delete
@@ -369,7 +417,7 @@ ifeq ($(PLATFORM),PLATFORM_DESKTOP)
 endif
 ifeq ($(PLATFORM),PLATFORM_RPI)
 	find . -type f -executable -delete
-	rm -f *.o
+	rm -fv *.o
 endif
 ifeq ($(PLATFORM),PLATFORM_WEB)
 	del *.o *.html *.js

--- a/src/Makefile
+++ b/src/Makefile
@@ -529,7 +529,7 @@ RAYLIB_H_INSTALL_PATH ?= /usr/local/include/raysan5
 
 install :
 ifeq ($(ROOT),root)
-	# Attention! You are root. Consult this Makefile for more information."
+	# Attention! You are root. Consult this Makefile for more information.
     ifeq ($(PLATFORM_OS),LINUX)
 		# Prepare the environment as needed.
 		mkdir --parents --verbose $(RAYLIB_INSTALL_PATH)

--- a/src/Makefile
+++ b/src/Makefile
@@ -518,7 +518,7 @@ utils.o : utils.c utils.h
 # (without a package manager). We'll use /usr/local/lib/raysan5 and /usr/local/include/raysan5
 # for our -L and -I specification to simplify management of the raylib source package.
 # Customize these locations if you like but don't forget to pass them to make
-# for compilation and enable runtime linking with -rpath, LD_LIBRARY_PATH, or ldconfig,.
+# for compilation and enable runtime linking with -rpath, LD_LIBRARY_PATH, or ldconfig.
 # Hint: add -L$(RAYLIB_INSTALL_PATH) -I$(RAYLIB_H_INSTALL_PATH) to your own makefiles.
 # See below and ../examples/Makefile for more information.
 
@@ -568,6 +568,8 @@ ifeq ($(ROOT),root)
     ifeq ($(PLATFORM_OS),LINUX)
         ifeq ($(RAYLIB_LIBTYPE),SHARED)
 		rm --force --interactive --verbose $(RAYLIB_INSTALL_PATH)/libraylib.so*
+		rm --force --interactive --verbose $(RAYLIB_INSTALL_PATH)/libraylib.so.$(RAYLIB_API_VERSION)
+		rm --force --interactive --verbose $(RAYLIB_INSTALL_PATH)/libraylib.so.$(RAYLIB_VERSION)
 		# Uncomment to clean up the runtime linker cache. See install target.
 		ldconfig
         else

--- a/src/Makefile
+++ b/src/Makefile
@@ -2,7 +2,7 @@
 #
 #  raylib makefile
 #
-#  Platforms supported: 
+#  Platforms supported:
 #    PLATFORM_DESKTOP:  Windows (Win32, Win64)
 #    PLATFORM_DESKTOP:  Linux (32 and 64 bit)
 #    PLATFORM_DESKTOP:  OSX/macOS
@@ -42,38 +42,52 @@
 .PHONY: all clean install uninstall
 
 # Define required raylib variables
-PLATFORM          ?= PLATFORM_DESKTOP
-RAYLIB_PATH        = ..
 RAYLIB_VERSION     = 1.9.4
 RAYLIB_API_VERSION = 1
+RAYLIB_PATH        = ..
+
+# Define default options
+
+# RAYLIB_RELEASE_PATH points to provided binaries and your immediate build of raylib.
+# It is further modified below by PLATFORM below.
+RAYLIB_RELEASE_PATH  ?= $(RAYLIB_PATH)/release/libs
+
+# See install target for *_INSTALL_PATH locations.
+
+# One of PLATFORM_DESKTOP, PLATFORM_RPI, PLATFORM_ANDROID, PLATFORM_WEB
+PLATFORM             ?= PLATFORM_DESKTOP
+
 # Library type used for raylib: STATIC (.a) or SHARED (.so/.dll)
-RAYLIB_LIBTYPE    ?= STATIC
+RAYLIB_LIBTYPE       ?= STATIC
+
 # Build mode for library: DEBUG or RELEASE
-RAYLIB_BUILD_MODE ?= RELEASE
+RAYLIB_BUILD_MODE    ?= RELEASE
 
 # Included raylib audio module on compilation
 # NOTE: Some programs like tools could not require audio support
 INCLUDE_AUDIO_MODULE ?= TRUE
 
 # Use OpenAL Soft backend for audio
-USE_OPENAL_BACKEND ?= FALSE
-
-# Use external GLFW library instead of rglfw module
-USE_EXTERNAL_GLFW ?= FALSE
-
-# Use Wayland display server protocol on Linux desktop
-# by default it uses X11 windowing system
-USE_WAYLAND_DISPLAY ?= FALSE
+USE_OPENAL_BACKEND   ?= FALSE
 
 # OpenAL Soft audio backend forced on HTML5 and OSX (see below)
 ifeq ($(PLATFORM),PLATFORM_WEB)
     USE_OPENAL_BACKEND = TRUE
 endif
 
+# Use external GLFW library instead of rglfw module
+USE_EXTERNAL_GLFW    ?= FALSE
+
+# Use Wayland display server protocol on Linux desktop
+# by default it uses X11 windowing system
+USE_WAYLAND_DISPLAY  ?= FALSE
+
+# See below for more GRAPHICS options.
+
 # Use cross-compiler for PLATFORM_RPI
 ifeq ($(PLATFORM),PLATFORM_RPI)
     USE_RPI_CROSS_COMPILER ?= FALSE
-    
+
     ifeq ($(USE_RPI_CROSS_COMPILER),TRUE)
         RPI_TOOLCHAIN ?= C:/SysGCC/Raspberry
         RPI_TOOLCHAIN_SYSROOT ?= $(RPI_TOOLCHAIN)/arm-linux-gnueabihf/sysroot
@@ -137,8 +151,6 @@ ifeq ($(PLATFORM),PLATFORM_ANDROID)
     # Android architecture: ARM or ARM64
     ANDROID_ARCH ?= ARM
 endif
-
-RAYLIB_RELEASE_PATH ?= $(RAYLIB_PATH)/release/libs
 
 # Define output directory for compiled library
 ifeq ($(PLATFORM),PLATFORM_DESKTOP)
@@ -299,7 +311,7 @@ endif
 # Define required compilation flags for raylib SHARED lib
 ifeq ($(RAYLIB_LIBTYPE),SHARED)
     # make sure code is compiled as position independent
-    # BE CAREFUL: It seems that for gcc -fpic si not the same as -fPIC
+    # BE CAREFUL: It seems that for gcc -fpic is not the same as -fPIC
     # MinGW32 just doesn't need -fPIC, it shows warnings
     CFLAGS += -fPIC -DBUILD_LIBTYPE_SHARED
 endif
@@ -350,8 +362,8 @@ endif
 
 # Define linker options
 ifeq ($(PLATFORM),PLATFORM_ANDROID)
-    LDFLAGS = -Wl,-soname,libraylib.$(API_VERSION).so -Wl,--exclude-libs,libatomic.a 
-    LDFLAGS += -Wl,--build-id -Wl,--no-undefined -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now -Wl,--warn-shared-textrel -Wl,--fatal-warnings 
+    LDFLAGS = -Wl,-soname,libraylib.$(API_VERSION).so -Wl,--exclude-libs,libatomic.a
+    LDFLAGS += -Wl,--build-id -Wl,--no-undefined -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now -Wl,--warn-shared-textrel -Wl,--fatal-warnings
     # Force linking of library module to define symbol
     LDFLAGS += -u ANativeActivity_onCreate
     # Library paths containing required libs
@@ -374,7 +386,7 @@ OBJS = core.o \
        text.o \
        models.o \
        utils.o
-       
+
 ifeq ($(PLATFORM),PLATFORM_DESKTOP)
     ifeq ($(USE_EXTERNAL_GLFW),FALSE)
         OBJS += rglfw.o
@@ -419,10 +431,10 @@ else
         ifeq ($(PLATFORM_OS),LINUX)
             # Compile raylib to shared library version for GNU/Linux.
             # WARNING: you should type "make clean" before doing this target
-			$(CC) -shared -o $(RAYLIB_RELEASE_PATH)/libraylib.$(RAYLIB_VERSION).so $(OBJS) -Wl,-soname,libraylib.$(RAYLIB_API_VERSION).so -lGL -lm -lpthread -ldl -lrt
-			@echo "raylib shared library generated (libraylib.$(RAYLIB_VERSION).so)!"
-			cd $(RAYLIB_RELEASE_PATH) && ln -fs libraylib.$(RAYLIB_VERSION).so libraylib.$(RAYLIB_API_VERSION).so
-			cd $(RAYLIB_RELEASE_PATH) && ln -fs libraylib.$(RAYLIB_VERSION).so libraylib.so
+			$(CC) -shared -o $(RAYLIB_RELEASE_PATH)/libraylib.so.$(RAYLIB_VERSION) $(OBJS) -shared -Wl,-soname,libraylib.so.$(RAYLIB_API_VERSION) -lGL -lc -lm -lpthread -ldl -lrt
+			@echo "raylib shared library generated (libraylib.so.$(RAYLIB_VERSION))!"
+			cd $(RAYLIB_RELEASE_PATH) && ln -fsv libraylib.so.$(RAYLIB_VERSION) libraylib.so.$(RAYLIB_API_VERSION)
+			cd $(RAYLIB_RELEASE_PATH) && ln -fsv libraylib.so.$(RAYLIB_API_VERSION) libraylib.so
         endif
         ifeq ($(PLATFORM_OS),OSX)
 			$(CC) -dynamiclib -o $(RAYLIB_RELEASE_PATH)/libraylib.$(RAYLIB_VERSION).dylib $(OBJS) -compatibility_version $(RAYLIB_API_VERSION) -current_version $(RAYLIB_VERSION) -framework OpenGL -framework OpenAL -framework IOKit -framework CoreVideo -framework Cocoa
@@ -457,7 +469,7 @@ endif
 # Compile core module
 core.o : core.c raylib.h rlgl.h utils.h raymath.h gestures.h
 	$(CC) -c $< $(CFLAGS) $(INCLUDE_PATHS) -D$(PLATFORM) -D$(GRAPHICS)
-    
+
 # Compile rglfw module
 rglfw.o : rglfw.c
 	$(CC) $(GLFW_CFLAGS) -c $< $(CFLAGS) $(INCLUDE_PATHS) -D$(PLATFORM) -D$(GRAPHICS)
@@ -485,10 +497,10 @@ models.o : models.c raylib.h rlgl.h raymath.h
 # Compile audio module
 audio.o : audio.c raylib.h
 	$(CC) -c $< $(CFLAGS) $(INCLUDE_PATHS) -D$(PLATFORM)
-    
+
 # Compile mini_al audio library
 mini_al.o : external/mini_al.c external/mini_al.h
-	$(CC) -c $< $(CFLAGS) $(INCLUDE_PATHS) -D$(PLATFORM) 
+	$(CC) -c $< $(CFLAGS) $(INCLUDE_PATHS) -D$(PLATFORM)
 
 # Compile stb_vorbis library
 stb_vorbis.o: external/stb_vorbis.c external/stb_vorbis.h
@@ -499,49 +511,75 @@ utils.o : utils.c utils.h
 	$(CC) -c $< $(CFLAGS) $(INCLUDE_PATHS) -D$(PLATFORM)
 
 # Install generated and needed files to required directories
-# TODO: add other platforms.
+# TODO: Add other platforms. Remove sudo requirement, i.e. add USER mode.
+# On GNU/Linux and BSDs, there are some standard directories that contain extra
+# libraries and header files. These directories (often /usr/local/lib and
+# /usr/local/include) are for libraries that are installed manually
+# (without a package manager). We'll use /usr/local/lib/raysan5 and /usr/local/include/raysan5
+# for our -L and -I specification to simplify management of the raylib source package.
+# Customize these locations if you like but don't forget to pass them to make
+# for compilation and enable runtime linking with -rpath, LD_LIBRARY_PATH, or ldconfig,.
+# Hint: add -L$(RAYLIB_INSTALL_PATH) -I$(RAYLIB_H_INSTALL_PATH) to your own makefiles.
+# See below and ../examples/Makefile for more information.
+
+# RAYLIB_INSTALL_PATH should be the desired full path to libraylib. No relative paths.
+RAYLIB_INSTALL_PATH ?= /usr/local/lib/raysan5
+# RAYLIB_H_INSTALL_PATH locates the installed raylib header and associated source files.
+RAYLIB_H_INSTALL_PATH ?= /usr/local/include/raysan5
+
 install :
 ifeq ($(ROOT),root)
+	# Attention! You are root. Consult this Makefile for more information."
     ifeq ($(PLATFORM_OS),LINUX)
-        # On GNU/Linux there are some standard directories that contain
-        # libraries and header files. These directory (/usr/local/lib and
-        # /usr/local/include/) are for libraries that are installed
-        # manually (without a package manager).
-        ifeq ($(RAYLIB_LIBTYPE),SHARED)
-			cp --update $(RAYLIB_RELEASE_PATH)/libraylib.$(RAYLIB_VERSION).so /usr/local/lib/libraylib.$(RAYLIB_VERSION).so
-			cp --update $(RAYLIB_RELEASE_PATH)/libraylib.$(RAYLIB_API_VERSION).so /usr/local/lib/libraylib.$(RAYLIB_API_VERSION).so
-			cp --update $(RAYLIB_RELEASE_PATH)/libraylib.so /usr/local/lib/libraylib.so
-        else
-			cp --update raylib.h /usr/local/include/raylib.h
-			cp --update $(RAYLIB_RELEASE_PATH)/libraylib.a /usr/local/lib/libraylib.a
-        endif
+		# Prepare the environment as needed.
+		mkdir --parents --verbose $(RAYLIB_INSTALL_PATH)
+		mkdir --parents --verbose $(RAYLIB_H_INSTALL_PATH)
+                ifeq ($(RAYLIB_LIBTYPE),SHARED)
+			# Installing the shared library.
+			cp --update --verbose $(RAYLIB_RELEASE_PATH)/libraylib.so.$(RAYLIB_VERSION) $(RAYLIB_INSTALL_PATH)/libraylib.so.$(RAYLIB_VERSION)
+			cd $(RAYLIB_INSTALL_PATH); ln -fsv libraylib.so.$(RAYLIB_VERSION) libraylib.so.$(RAYLIB_API_VERSION)
+			cd $(RAYLIB_INSTALL_PATH); ln -fsv libraylib.so.$(RAYLIB_API_VERSION) libraylib.so
+			# Uncomment to update the runtime linker cache with RAYLIB_INSTALL_PATH.
+			# Not necessary if later embedding RPATH in your executable. See examples/Makefile.
+			ldconfig $(RAYLIB_INSTALL_PATH)
+                else
+			# Installing the static library.
+			cp --update --verbose $(RAYLIB_RELEASE_PATH)/libraylib.a $(RAYLIB_INSTALL_PATH)/libraylib.a
+                endif
+		# Let's have all the source.
+		cp --update --recursive $(RAYLIB_PATH)/src/*.h $(RAYLIB_H_INSTALL_PATH)/
+		cp --update --recursive $(RAYLIB_PATH)/src/*.c $(RAYLIB_H_INSTALL_PATH)/
+		cp --update --recursive $(RAYLIB_PATH)/src/external $(RAYLIB_H_INSTALL_PATH)/
+		cp --update --recursive $(RAYLIB_PATH)/release/include/AL $(RAYLIB_H_INSTALL_PATH)/external
 		@echo "raylib dev files installed/updated!"
     else
-		@echo "This function works only on GNU/Linux systems"
+		@echo "This function currently works on GNU/Linux systems. Add yours today (^;"
     endif
 else
-	@echo "Error: no root permissions"
+	@echo "Error: Root permissions needed for installation. Try sudo make install"
 endif
 
 # Remove raylib dev files installed on the system
 # TODO: see 'install' target.
 uninstall :
 ifeq ($(ROOT),root)
+		# Warning! You are root. Please confirm that there is nothing here to keep.
+		# Proceeding will remove everything under the specified locations!
     ifeq ($(PLATFORM_OS),LINUX)
-			rm --force /usr/local/include/raylib.h
         ifeq ($(RAYLIB_LIBTYPE),SHARED)
-			rm --force /usr/local/lib/libraylib.so
-			rm --force /usr/local/lib/libraylib.$(RAYLIB_API_VERSION).so
-			rm --force /usr/local/lib/libraylib.$(RAYLIB_VERSION).so
+		rm --force --interactive --verbose $(RAYLIB_INSTALL_PATH)/libraylib.so*
+		# Uncomment to clean up the runtime linker cache. See install target.
+		ldconfig
         else
-			rm --force /usr/local/lib/libraylib.a
+		rm --force --interactive --verbose $(RAYLIB_INSTALL_PATH)/libraylib.a
         endif
-		@echo "raylib development files removed!"
+	rm --force --interactive=once --recursive $(RAYLIB_H_INSTALL_PATH)/*
+	@echo "raylib development files removed!"
     else
 		@echo "This function works only on GNU/Linux systems"
     endif
 else
-	@echo "Error: no root permissions"
+	@echo "Error: Root permissions needed for uninstallation. Try sudo make uninstall"
 endif
 
 # Clean everything
@@ -549,7 +587,7 @@ clean:
 ifeq ($(PLATFORM_OS),WINDOWS)
 	del *.o $(RAYLIB_RELEASE_PATH)/libraylib.a $(RAYLIB_RELEASE_PATH)/libraylib.bc $(RAYLIB_RELEASE_PATH)/libraylib.so external/stb_vorbis.o
 else
-	rm -f *.o $(RAYLIB_RELEASE_PATH)/libraylib.a $(RAYLIB_RELEASE_PATH)/libraylib.bc $(RAYLIB_RELEASE_PATH)/libraylib.so $(RAYLIB_RELEASE_PATH)/libraylib.$(RAYLIB_API_VERSION).so $(RAYLIB_RELEASE_PATH)/libraylib.$(RAYLIB_VERSION).so external/stb_vorbis.o
+	rm -fv *.o $(RAYLIB_RELEASE_PATH)/libraylib.a $(RAYLIB_RELEASE_PATH)/libraylib.bc $(RAYLIB_RELEASE_PATH)/libraylib.so* external/stb_vorbis.o
 endif
 ifeq ($(PLATFORM),PLATFORM_ANDROID)
 	rm -rf $(ANDROID_TOOLCHAIN)

--- a/src/Makefile
+++ b/src/Makefile
@@ -567,7 +567,7 @@ ifeq ($(ROOT),root)
 		# Proceeding will remove everything under the specified locations!
     ifeq ($(PLATFORM_OS),LINUX)
         ifeq ($(RAYLIB_LIBTYPE),SHARED)
-		rm --force --interactive --verbose $(RAYLIB_INSTALL_PATH)/libraylib.so*
+		rm --force --interactive --verbose $(RAYLIB_INSTALL_PATH)/libraylib.so
 		rm --force --interactive --verbose $(RAYLIB_INSTALL_PATH)/libraylib.so.$(RAYLIB_API_VERSION)
 		rm --force --interactive --verbose $(RAYLIB_INSTALL_PATH)/libraylib.so.$(RAYLIB_VERSION)
 		# Uncomment to clean up the runtime linker cache. See install target.


### PR DESCRIPTION
Quite a few additions to the makefiles here, mostly limited to LINUX and RAYLIB_LIBTYPE=SHARED, to avoid the dreaded `./core_basic_window: error while loading shared libraries: libraylib.so.1: cannot open shared object file: No such file or directory`  by formally installing libraylib (to the location of your choice) or by customizing RAYLIB_RUNTIME_PATH. This adds control, portability, and a running choice of shared libraries to the developer experience. Now distro-agnostic! 

That is to say, one can have multiple builds of libraylib to choose from at compile and run time, without sudo, using only make, on any ELF-aware system with binutils. FreeBSD and MacOS users might extend these changes if desired. I'm curious if this plays on WSL.

The default `make; make install; cd ../examples; make` behavior is unchanged.

With `make RAYLIB_LIBTYPE=SHARED`, the examples compile but still don't run against our staged .so in RAYLIB_RELEASE_PATH unless that location is provided _in full_ to RAYLIB_RUNTIME_PATH or RAYLIB_INSTALL_PATH. Instructions on how to do this are included in the comments of [examples/Makefile](https://github.com/RDR8/raylib/blob/develop-make-install-linux/examples/Makefile).

The examples DO compile and run against our version after `make install` or `make install RAYLIB_LIBTYPE=SHARED`. More context is provided by the comments in both Makefiles.