### PR TITLE
Update Makefiles. Automate example usage of staged libraylib.so.

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -34,33 +34,19 @@ RAYLIB_PATH        ?= ..
 # One of PLATFORM_DESKTOP, PLATFORM_RPI, PLATFORM_ANDROID, PLATFORM_WEB
 PLATFORM              ?= PLATFORM_DESKTOP
 
-# Default path for raylib on Raspberry Pi, if installed in different path, update it!
-ifeq ($(PLATFORM),PLATFORM_RPI)
-    RAYLIB_PATH       ?= /home/pi/raylib
-endif
-
-# RAYLIB_RELEASE_PATH points to provided binaries or your immediate build of libraylib.
-# See below for additions.
-RAYLIB_RELEASE_PATH   ?= $(RAYLIB_PATH)/release/libs
-
 # Locations of your newly installed library and associated headers. See ../src/Makefile
-# On Linux, if you have installed raylib but cannot compile the examples, check that the
-# *_INSTALL_PATH values here are the same as those in src/Makefile or point to known locations.
-# To enable system-wide runtime linking to libraylib.so, run sudo ldconfig $(RAYLIB_INSTALL_PATH).
-# ldconfig is not necessary if using RAYLIB_RUNTIME_PATH below.
-RAYLIB_INSTALL_PATH   ?= /usr/local/lib/raysan5
-RAYLIB_H_INSTALL_PATH ?= /usr/local/include/raysan5
-
-# Set runtime path to custom location of shared library if desired, avoiding sudo ldconfig.
-# If you have compiled the examples but cannot run them, examine both RAYLIB_INSTALL_PATH and 
-# RAYLIB_RUNTIME_PATH. To see which libraries a built example is using, ldd core/core_basic_window;
-# Look for libraylib.so.1 => $(RAYLIB_INSTALL_PATH)/libraylib.so.1
-# or libraylib.so.1 => $(RAYLIB_RUNTIME_PATH)/libraylib.so.1 or similar listing.
-# Implemented for LINUX below with CFLAGS += -Wl,-rpath,$(RAYLIB_RUNTIME_PATH)
-# This should be a fully qualified path. RAYLIB_RELEASE_PATH doesn't work here
-# because it's a relative path. You must spell it out if needed.
-# To see the result, run readelf -d core/core_basic_window, looking at the RPATH attribute.
-RAYLIB_RUNTIME_PATH   ?= $(RAYLIB_INSTALL_PATH)
+# On Linux, if you have installed raylib but cannot compile the examples, check that
+# the *_INSTALL_PATH values here are the same as those in src/Makefile or point to known locations.
+# To enable system-wide compile-time and runtime linking to libraylib.so, run ../src/$ sudo make install RAYLIB_LIBTYPE_SHARED.
+# To enable compile-time linking to a special version of libraylib.so, change these variables here.
+# To enable runtime linking to a special version of libraylib.so, see EXAMPLE_RUNTIME_PATH below.
+# If there is a libraylib in both EXAMPLE_RUNTIME_PATH and RAYLIB_INSTALL_PATH, at runtime,
+# the library at EXAMPLE_RUNTIME_PATH, if present, will take precedence over the one at RAYLIB_INSTALL_PATH.
+# RAYLIB_INSTALL_PATH should be the desired full path to libraylib. No relative paths.
+DESTDIR ?= /usr/local
+RAYLIB_INSTALL_PATH ?= $(DESTDIR)/lib
+# RAYLIB_H_INSTALL_PATH locates the installed raylib header and associated source files.
+RAYLIB_H_INSTALL_PATH ?= $(DESTDIR)/include
 
 # Library type used for raylib: STATIC (.a) or SHARED (.so/.dll)
 RAYLIB_LIBTYPE        ?= STATIC
@@ -69,6 +55,7 @@ RAYLIB_LIBTYPE        ?= STATIC
 RAYLIB_BUILD_MODE     ?= RELEASE
 
 # Use external GLFW library instead of rglfw module
+# TODO: Review usage on Linux. Target version of choice. Switch on -lglfw or -lglfw3
 USE_EXTERNAL_GLFW     ?= FALSE
 
 # Use Wayland display server protocol on Linux desktop
@@ -103,6 +90,22 @@ ifeq ($(PLATFORM),PLATFORM_RPI)
     endif
 endif
 
+# RAYLIB_PATH adjustment for different platforms.
+# If using GNU make, we can get the full path to the top of the tree. Windows? BSD?
+# Required for ldconfig or other tools that do not perform path expansion.
+ifeq ($(PLATFORM),PLATFORM_DESKTOP)
+    ifeq ($(PLATFORM_OS),LINUX)
+        RAYLIB_PREFIX ?= ..
+        RAYLIB_PATH    = $(realpath $(RAYLIB_PREFIX))
+    endif
+endif
+# Default path for raylib on Raspberry Pi, if installed in different path, update it!
+# This is not currently used by src/Makefile. Not sure of its origin or usage. Refer to wiki.
+# TODO: update install: target in src/Makefile for RPI, consider relation to LINUX.
+ifeq ($(PLATFORM),PLATFORM_RPI)
+    RAYLIB_PATH       ?= /home/pi/raylib
+endif
+
 ifeq ($(PLATFORM),PLATFORM_WEB)
     # Emscripten required variables
     EMSDK_PATH = C:/emsdk
@@ -114,7 +117,8 @@ ifeq ($(PLATFORM),PLATFORM_WEB)
     EMSCRIPTEN=$(EMSDK_PATH)\emscripten\$(EMSCRIPTEN_VERSION)
 endif
 
-# Define raylib release directory for compiled library
+# Define raylib release directory for compiled library.
+# RAYLIB_RELEASE_PATH points to provided binaries or your freshly built version.
 ifeq ($(PLATFORM),PLATFORM_DESKTOP)
     ifeq ($(PLATFORM_OS),WINDOWS)
         RAYLIB_RELEASE_PATH = $(RAYLIB_PATH)/release/libs/win32/mingw32
@@ -135,6 +139,20 @@ endif
 ifeq ($(PLATFORM),PLATFORM_WEB)
     RAYLIB_RELEASE_PATH = $(RAYLIB_PATH)/release/libs/html5
 endif
+
+# EXAMPLE_RUNTIME_PATH embeds a custom runtime location of libraylib.so or other desired libraries
+# into each example binary compiled with RAYLIB_LIBTYPE=SHARED. It defaults to RAYLIB_RELEASE_PATH
+# so that these examples link at runtime with your version of libraylib.so in ../release/libs/linux
+# without formal installation from ../src/Makefile. It aids portability and is useful if you have
+# multiple versions of raylib, have raylib installed to a non-standard location, or want to
+# bundle libraylib.so with your game. Change it to your liking.
+# Note: If, at runtime, there is a libraylib.so at both EXAMPLE_RUNTIME_PATH and RAYLIB_INSTALL_PATH,
+# The library at EXAMPLE_RUNTIME_PATH, if present, will take precedence over RAYLIB_INSTALL_PATH,
+# Implemented for LINUX below with CFLAGS += -Wl,-rpath,$(EXAMPLE_RUNTIME_PATH)
+# To see the result, run readelf -d core/core_basic_window; looking at the RPATH or RUNPATH attribute.
+# To see which libraries a built example is linking to, ldd core/core_basic_window;
+# Look for libraylib.so.1 => $(RAYLIB_INSTALL_PATH)/libraylib.so.1 or similar listing.
+EXAMPLE_RUNTIME_PATH   ?= $(RAYLIB_RELEASE_PATH)
 
 # Define default C compiler: gcc
 # NOTE: define g++ compiler if using C++
@@ -192,12 +210,16 @@ ifeq ($(PLATFORM),PLATFORM_DESKTOP)
         CFLAGS += $(RAYLIB_PATH)/src/resources -Wl,--subsystem,windows
     endif
     ifeq ($(PLATFORM_OS),LINUX)
+        ifeq ($(RAYLIB_BUILD_MODE),DEBUG)
+            CFLAGS += -g
+            #CC = clang
+        endif
         ifeq ($(RAYLIB_LIBTYPE),STATIC)
         CFLAGS += -no-pie -D_DEFAULT_SOURCE
         endif
         ifeq ($(RAYLIB_LIBTYPE),SHARED)
-        # Explicitly enable runtime link to libraylib
-        CFLAGS += -Wl,-rpath,$(RAYLIB_RUNTIME_PATH)
+        # Explicitly enable runtime link to libraylib.so
+        CFLAGS += -Wl,-rpath,$(EXAMPLE_RUNTIME_PATH)
         endif
     endif
 endif
@@ -231,6 +253,17 @@ ifeq ($(PLATFORM),PLATFORM_RPI)
     INCLUDE_PATHS += -I/opt/vc/include/interface/vmcs_host/linux
     INCLUDE_PATHS += -I/opt/vc/include/interface/vcos/pthreads
 endif
+ifeq ($(PLATFORM),PLATFORM_DESKTOP)
+    ifeq ($(PLATFORM_OS),FREEBSD)
+        # Consider -L$(RAYLIB_H_INSTALL_PATH)
+        INCLUDE_PATHS += -I/usr/local/include
+    endif
+    ifeq ($(PLATFORM_OS),LINUX)
+        # Reset everything.
+        # Precedence: immediately local, installed version, raysan5 provided libs -I$(RAYLIB_H_INSTALL_PATH) -I$(RAYLIB_PATH)/release/include
+        INCLUDE_PATHS = -I$(RAYLIB_H_INSTALL_PATH) -isystem. -isystem$(RAYLIB_PATH)/src -isystem$(RAYLIB_PATH)/release/include -isystem$(RAYLIB_PATH)/src/external
+    endif
+endif
 
 # Define library paths containing required libs.
 # Precedence: immediately local, then raysan5 provided libs
@@ -238,13 +271,12 @@ LDFLAGS = -L. -L$(RAYLIB_RELEASE_PATH) -L$(RAYLIB_PATH)/src
 
 ifeq ($(PLATFORM),PLATFORM_DESKTOP)
     ifeq ($(PLATFORM_OS),FREEBSD)
-        INCLUDE_PATHS += -I/usr/local/include
+        # Consider -L$(RAYLIB_INSTALL_PATH)
         LDFLAGS += -L. -Lsrc -L/usr/local/lib
     endif
     ifeq ($(PLATFORM_OS),LINUX)
         # Reset everything.
         # Precedence: immediately local, installed version, raysan5 provided libs
-        INCLUDE_PATHS = -I. -I$(RAYLIB_H_INSTALL_PATH) -I$(RAYLIB_PATH)/release/include -I$(RAYLIB_PATH)/src -I$(RAYLIB_PATH)/src/external
         LDFLAGS = -L. -L$(RAYLIB_INSTALL_PATH) -L$(RAYLIB_RELEASE_PATH) -L$(RAYLIB_PATH)/src
     endif
 endif
@@ -259,7 +291,6 @@ ifeq ($(PLATFORM),PLATFORM_DESKTOP)
     ifeq ($(PLATFORM_OS),WINDOWS)
         # Libraries for Windows desktop compilation
         LDLIBS = -lraylib -lopengl32 -lgdi32
-
         # Required for physac examples
         LDLIBS += -static -lpthread
     endif
@@ -267,17 +298,14 @@ ifeq ($(PLATFORM),PLATFORM_DESKTOP)
         # Libraries for Debian GNU/Linux desktop compiling
         # NOTE: Required packages: libegl1-mesa-dev
         LDLIBS = -lraylib -lGL -lm -lpthread -ldl -lrt
-
         # On X11 requires also below libraries
         LDLIBS += -lX11
         # NOTE: It seems additional libraries are not required any more, latest GLFW just dlopen them
         #LDLIBS += -lXrandr -lXinerama -lXi -lXxf86vm -lXcursor
-
         # On Wayland windowing system, additional libraries requires
         ifeq ($(USE_WAYLAND_DISPLAY),TRUE)
             LDLIBS += -lwayland-client -lwayland-cursor -lwayland-egl -lxkbcommon
         endif
-
         # Explicit link to libc
         ifeq ($(RAYLIB_LIBTYPE),SHARED)
             LDLIBS += -lc
@@ -292,7 +320,6 @@ ifeq ($(PLATFORM),PLATFORM_DESKTOP)
         # Libraries for FreeBSD desktop compiling
         # NOTE: Required packages: mesa-libs
         LDLIBS = -lraylib -lGL -lpthread -lm
-
         # On XWindow requires also below libraries
         LDLIBS += -lX11 -lXrandr -lXinerama -lXi -lXxf86vm -lXcursor
     endif
@@ -422,4 +449,3 @@ ifeq ($(PLATFORM),PLATFORM_WEB)
 	del *.o *.html *.js
 endif
 	@echo Cleaning done
-

--- a/src/Makefile
+++ b/src/Makefile
@@ -44,15 +44,11 @@
 # Define required raylib variables
 RAYLIB_VERSION     = 1.9.4
 RAYLIB_API_VERSION = 1
+
+# See below for alternatives.
 RAYLIB_PATH        = ..
 
 # Define default options
-
-# RAYLIB_RELEASE_PATH points to provided binaries and your immediate build of raylib.
-# It is further modified below by PLATFORM below.
-RAYLIB_RELEASE_PATH  ?= $(RAYLIB_PATH)/release/libs
-
-# See install target for *_INSTALL_PATH locations.
 
 # One of PLATFORM_DESKTOP, PLATFORM_RPI, PLATFORM_ANDROID, PLATFORM_WEB
 PLATFORM             ?= PLATFORM_DESKTOP
@@ -76,6 +72,7 @@ ifeq ($(PLATFORM),PLATFORM_WEB)
 endif
 
 # Use external GLFW library instead of rglfw module
+# TODO: Review usage of examples on Linux.
 USE_EXTERNAL_GLFW    ?= FALSE
 
 # Use Wayland display server protocol on Linux desktop
@@ -84,10 +81,13 @@ USE_WAYLAND_DISPLAY  ?= FALSE
 
 # See below for more GRAPHICS options.
 
+# See below for RAYLIB_RELEASE_PATH.
+
+# See install target for *_INSTALL_PATH locations.
+
 # Use cross-compiler for PLATFORM_RPI
 ifeq ($(PLATFORM),PLATFORM_RPI)
     USE_RPI_CROSS_COMPILER ?= FALSE
-
     ifeq ($(USE_RPI_CROSS_COMPILER),TRUE)
         RPI_TOOLCHAIN ?= C:/SysGCC/Raspberry
         RPI_TOOLCHAIN_SYSROOT ?= $(RPI_TOOLCHAIN)/arm-linux-gnueabihf/sysroot
@@ -125,6 +125,23 @@ ifeq ($(PLATFORM),PLATFORM_RPI)
     endif
 endif
 
+# RAYLIB_PATH adjustment for different platforms.
+# If using GNU make, we can get the full path to the top of the tree. Windows? BSD?
+# Required for ldconfig or other tools that do not perform path expansion.
+ifeq ($(PLATFORM),PLATFORM_DESKTOP)
+    ifeq ($(PLATFORM_OS),LINUX)
+        RAYLIB_PREFIX ?= ..
+        RAYLIB_PATH    = $(realpath $(RAYLIB_PREFIX))
+    endif
+endif
+# Default path for raylib on Raspberry Pi, if installed in different path, update it!
+# TODO: update install: target in src/Makefile for RPI, consider relation to LINUX.
+# WARNING: The following is copied from examples/Makefile and is here only for reference.
+# Consequences of enabling this are UNKNOWN. Please test and report.
+#ifeq ($(PLATFORM),PLATFORM_RPI)
+#    RAYLIB_PATH       ?= /home/pi/raylib
+#endif
+
 # Force OpenAL Soft audio backend for OSX platform
 # NOTE 1: mini_al library does not support CoreAudio yet
 # NOTE 2: Required OpenAL libraries should be available on OSX
@@ -151,6 +168,10 @@ ifeq ($(PLATFORM),PLATFORM_ANDROID)
     # Android architecture: ARM or ARM64
     ANDROID_ARCH ?= ARM
 endif
+
+# RAYLIB_RELEASE_PATH points to provided binaries or your immediate build of raylib.
+# It is further modified below by PLATFORM below.
+RAYLIB_RELEASE_PATH  ?= $(RAYLIB_PATH)/release/libs
 
 # Define output directory for compiled library
 ifeq ($(PLATFORM),PLATFORM_DESKTOP)
@@ -189,17 +210,14 @@ ifeq ($(PLATFORM),PLATFORM_DESKTOP)
     #GRAPHICS = GRAPHICS_API_OPENGL_11  # Uncomment to use OpenGL 1.1
     #GRAPHICS = GRAPHICS_API_OPENGL_21  # Uncomment to use OpenGL 2.1
 endif
-
 ifeq ($(PLATFORM),PLATFORM_RPI)
     # On RPI OpenGL ES 2.0 must be used
     GRAPHICS = GRAPHICS_API_OPENGL_ES2
 endif
-
 ifeq ($(PLATFORM),PLATFORM_WEB)
     # On HTML5 OpenGL ES 2.0 is used, emscripten translates it to WebGL 1.0
     GRAPHICS = GRAPHICS_API_OPENGL_ES2
 endif
-
 ifeq ($(PLATFORM),PLATFORM_ANDROID)
     # By default use OpenGL ES 2.0 on Android
     GRAPHICS = GRAPHICS_API_OPENGL_ES2
@@ -277,6 +295,7 @@ CFLAGS += -O1 -Wall -std=c99 -D_DEFAULT_SOURCE -Wno-missing-braces -Werror=point
 
 ifeq ($(RAYLIB_BUILD_MODE), DEBUG)
     CFLAGS += -g
+    #CC      = clang
 endif
 
 # Additional flags for compiler (if desired)
@@ -339,13 +358,15 @@ ifeq ($(PLATFORM),PLATFORM_DESKTOP)
         LDFLAGS += -L. -Lsrc -L/usr/local/lib -L$(RAYLIB_RELEASE_PATH)
     endif
     ifeq ($(USE_EXTERNAL_GLFW),TRUE)
+        # Check the version name. If GLFW3 was built manually, it may have produced
+        # a static library known as libglfw3.a. In that case, the name should be -lglfw3
         LDFLAGS += -lglfw
     endif
 endif
 
 # Define additional directories containing required header files
 ifeq ($(PLATFORM),PLATFORM_RPI)
-    # RPI requried libraries
+    # RPI required libraries
     INCLUDE_PATHS += -I$(RPI_TOOLCHAIN_SYSROOT)/opt/vc/include
     INCLUDE_PATHS += -I$(RPI_TOOLCHAIN_SYSROOT)/opt/vc/include/interface/vmcs_host/linux
     INCLUDE_PATHS += -I$(RPI_TOOLCHAIN_SYSROOT)/opt/vc/include/interface/vcos/pthreads
@@ -428,10 +449,10 @@ else
 			@echo "raylib dynamic library (raylib.dll) and import library (libraylibdll.a) generated!"
         endif
         ifeq ($(PLATFORM_OS),LINUX)
-            # Compile raylib to shared library version for GNU/Linux.
-            # WARNING: you should type "make clean" before doing this target
+			# Compile raylib shared library version $(RAYLIB_VERSION).
+			# WARNING: you should type "make clean" before doing this target
 			$(CC) -shared -o $(RAYLIB_RELEASE_PATH)/libraylib.so.$(RAYLIB_VERSION) $(OBJS) -shared -Wl,-soname,libraylib.so.$(RAYLIB_API_VERSION) -lGL -lc -lm -lpthread -ldl -lrt
-			@echo "raylib shared library generated (libraylib.so.$(RAYLIB_VERSION))!"
+			@echo "raylib shared library generated (libraylib.so.$(RAYLIB_VERSION)) in $(RAYLIB_RELEASE_PATH)!"
 			cd $(RAYLIB_RELEASE_PATH) && ln -fsv libraylib.so.$(RAYLIB_VERSION) libraylib.so.$(RAYLIB_API_VERSION)
 			cd $(RAYLIB_RELEASE_PATH) && ln -fsv libraylib.so.$(RAYLIB_API_VERSION) libraylib.so
         endif
@@ -443,7 +464,7 @@ else
 			cd $(RAYLIB_RELEASE_PATH) && ln -fs libraylib.$(RAYLIB_VERSION).dylib libraylib.dylib
         endif
         ifeq ($(PLATFORM_OS),FREEBSD)
-        # WARNING: you should type "gmake clean" before doing this target
+			# WARNING: you should type "gmake clean" before doing this target
 			$(CC) -shared -o $(RAYLIB_RELEASE_PATH)/libraylib.$(RAYLIB_VERSION).so $(OBJS) -Wl,-soname,libraylib.$(RAYLIB_API_VERSION).so -lGL -lpthread
 			@echo "raylib shared library generated (libraylib.$(RAYLIB_VERSION).so)!"
 			cd $(RAYLIB_RELEASE_PATH) && ln -fs libraylib.$(RAYLIB_VERSION).so libraylib.$(RAYLIB_API_VERSION).so
@@ -456,10 +477,10 @@ else
 			cd $(RAYLIB_RELEASE_PATH) && ln -fs libraylib.$(RAYLIB_VERSION).so libraylib.so
         endif
     else
-        # Compile raylib static library
-		@echo raylib library release path is $(RAYLIB_RELEASE_PATH)
+		# Compile raylib static library version $(RAYLIB_VERSION)
+		# WARNING: You should type "make clean" before doing this target.
 		$(AR) rcs $(RAYLIB_RELEASE_PATH)/libraylib.a $(OBJS)
-		@echo "raylib static library generated (libraylib.a)!"
+		@echo "raylib static library generated (libraylib.a) in $(RAYLIB_RELEASE_PATH)!"
     endif
 endif
 
@@ -509,8 +530,7 @@ stb_vorbis.o: external/stb_vorbis.c external/stb_vorbis.h
 utils.o : utils.c utils.h
 	$(CC) -c $< $(CFLAGS) $(INCLUDE_PATHS) -D$(PLATFORM)
 
-# Install generated and needed files to required directories
-# TODO: Add other platforms. Remove sudo requirement, i.e. add USER mode.
+# Install generated and needed files to desired directories.
 # On GNU/Linux and BSDs, there are some standard directories that contain extra
 # libraries and header files. These directories (often /usr/local/lib and
 # /usr/local/include) are for libraries that are installed manually
@@ -520,37 +540,41 @@ utils.o : utils.c utils.h
 # for compilation and enable runtime linking with -rpath, LD_LIBRARY_PATH, or ldconfig.
 # Hint: add -L$(RAYLIB_INSTALL_PATH) -I$(RAYLIB_H_INSTALL_PATH) to your own makefiles.
 # See below and ../examples/Makefile for more information.
+# TODO: Add other platforms. Remove sudo requirement, i.e. add USER mode.
 
 # RAYLIB_INSTALL_PATH should be the desired full path to libraylib. No relative paths.
-RAYLIB_INSTALL_PATH ?= /usr/local/lib/raysan5
+DESTDIR ?= /usr/local
+RAYLIB_INSTALL_PATH ?= $(DESTDIR)/lib
 # RAYLIB_H_INSTALL_PATH locates the installed raylib header and associated source files.
-RAYLIB_H_INSTALL_PATH ?= /usr/local/include/raysan5
+RAYLIB_H_INSTALL_PATH ?= $(DESTDIR)/include
 
 install :
 ifeq ($(ROOT),root)
-	# Attention! You are root. Consult this Makefile for more information.
     ifeq ($(PLATFORM_OS),LINUX)
+		# Attention! You are root, writing files to $(RAYLIB_INSTALL_PATH)
+		# and $(RAYLIB_H_INSTALL_PATH). Consult this Makefile for more information.
 		# Prepare the environment as needed.
 		mkdir --parents --verbose $(RAYLIB_INSTALL_PATH)
 		mkdir --parents --verbose $(RAYLIB_H_INSTALL_PATH)
                 ifeq ($(RAYLIB_LIBTYPE),SHARED)
-			# Installing the shared library.
+			# Installing raylib to $(RAYLIB_INSTALL_PATH).
 			cp --update --verbose $(RAYLIB_RELEASE_PATH)/libraylib.so.$(RAYLIB_VERSION) $(RAYLIB_INSTALL_PATH)/libraylib.so.$(RAYLIB_VERSION)
 			cd $(RAYLIB_INSTALL_PATH); ln -fsv libraylib.so.$(RAYLIB_VERSION) libraylib.so.$(RAYLIB_API_VERSION)
 			cd $(RAYLIB_INSTALL_PATH); ln -fsv libraylib.so.$(RAYLIB_API_VERSION) libraylib.so
-			# Uncomment to update the runtime linker cache with RAYLIB_INSTALL_PATH.
-			# Not necessary if later embedding RPATH in your executable. See examples/Makefile.
+                        # Uncomment to update the runtime linker cache with RAYLIB_INSTALL_PATH.
+                        # Not necessary if later embedding RPATH in your executable. See examples/Makefile.
 			ldconfig $(RAYLIB_INSTALL_PATH)
                 else
-			# Installing the static library.
+			# Installing raylib to $(RAYLIB_INSTALL_PATH).
 			cp --update --verbose $(RAYLIB_RELEASE_PATH)/libraylib.a $(RAYLIB_INSTALL_PATH)/libraylib.a
                 endif
-		# Let's have all the source.
-		cp --update --recursive $(RAYLIB_PATH)/src/*.h $(RAYLIB_H_INSTALL_PATH)/
-		cp --update --recursive $(RAYLIB_PATH)/src/*.c $(RAYLIB_H_INSTALL_PATH)/
-		cp --update --recursive $(RAYLIB_PATH)/src/external $(RAYLIB_H_INSTALL_PATH)/
-		cp --update --recursive $(RAYLIB_PATH)/release/include/AL $(RAYLIB_H_INSTALL_PATH)/external
-		@echo "raylib dev files installed/updated!"
+		# Copying raylib development files to $(RAYLIB_H_INSTALL_PATH).
+		cp --update raylib.h $(RAYLIB_H_INSTALL_PATH)/raylib.h
+		cp --update raymath.h $(RAYLIB_H_INSTALL_PATH)/raymath.h
+		cp --update rlgl.h $(RAYLIB_H_INSTALL_PATH)/rlgl.h
+		cp --update rlgl.c $(RAYLIB_H_INSTALL_PATH)/rlgl.c
+		cp --update physac.h $(RAYLIB_H_INSTALL_PATH)/physac.h
+		@echo "raylib development files installed/updated!"
     else
 		@echo "This function currently works on GNU/Linux systems. Add yours today (^;"
     endif
@@ -562,22 +586,26 @@ endif
 # TODO: see 'install' target.
 uninstall :
 ifeq ($(ROOT),root)
-		# Warning! You are root. Please confirm that there is nothing here to keep.
-		# Proceeding will remove everything under the specified locations!
+		# WARNING: You are root, about to delete items from $(RAYLIB_INSTALL_PATH).
+		# and $(RAYLIB_H_INSTALL_PATH). Please confirm each item.
     ifeq ($(PLATFORM_OS),LINUX)
         ifeq ($(RAYLIB_LIBTYPE),SHARED)
 		rm --force --interactive --verbose $(RAYLIB_INSTALL_PATH)/libraylib.so
 		rm --force --interactive --verbose $(RAYLIB_INSTALL_PATH)/libraylib.so.$(RAYLIB_API_VERSION)
 		rm --force --interactive --verbose $(RAYLIB_INSTALL_PATH)/libraylib.so.$(RAYLIB_VERSION)
-		# Uncomment to clean up the runtime linker cache. See install target.
+                # Uncomment to clean up the runtime linker cache. See install target.
 		ldconfig
         else
 		rm --force --interactive --verbose $(RAYLIB_INSTALL_PATH)/libraylib.a
         endif
-	rm --force --interactive=once --recursive $(RAYLIB_H_INSTALL_PATH)/*
-	@echo "raylib development files removed!"
-    else
-		@echo "This function works only on GNU/Linux systems"
+		rm --force --interactive --verbose $(RAYLIB_H_INSTALL_PATH)/raylib.h
+		rm --force --interactive --verbose $(RAYLIB_H_INSTALL_PATH)/raymath.h
+		rm --force --interactive --verbose $(RAYLIB_H_INSTALL_PATH)/rlgl.h
+		rm --force --interactive --verbose $(RAYLIB_H_INSTALL_PATH)/rlgl.c
+		rm --force --interactive --verbose $(RAYLIB_H_INSTALL_PATH)/physac.h
+		@echo "raylib development files removed!"
+        else
+		@echo "This function currently works on GNU/Linux systems. Add yours today (^;"
     endif
 else
 	@echo "Error: Root permissions needed for uninstallation. Try sudo make uninstall"


### PR DESCRIPTION
The default setting of `EXAMPLE_RUNTIME_PATH ?= $(RAYLIB_RELEASE_PATH)` in ../examples/Makefile makes it so that the examples run automatically against a freshly built, but not yet installed, libraylib.so in ../release/libs/linux. This is like an implicit USER mode. It does not require root permissions or any special input beyond `RAYLIB_LIBTYPE=SHARED` but is easily customizable if desired. The value of `EXAMPLE_RUNTIME_PATH` will override that of `RAYLIB_INSTALL_PATH` at an example's run time, if libraries exist at both locations. It is recommended to set `EXAMPLE_RUNTIME_PATH = $(RAYLIB_INSTALL_PATH)` if you don't want to pick up fresh versions of libraylib in ../release/libs/linux. If no libraylib exists at `EXAMPLE_RUNTIME_PATH`, ld.so moves on to check the location set by `ldconfig` during `../src$ sudo make install RAYLIB_LIBTYPE=SHARED`, i.e. `RAYLIB_INSTALL_PATH`.

Add `RAYLIB_PREFIX` and some adjustments to `RAYLIB_PATH` on `PLATFORM_OS = LINUX` to acquire the explicit string needed by `ldconfig` and possibly other tools that do not perform path variable expansion. Depending upon the capabilities of each platform's `make`, it may be possible to generalize `realpath` out of the `PLATFORM_OS` switch. I believe this emulates the usage of DESTDIR but with helpfully explicit naming of the path variables.

Additional comments to clarify usage. Miscellaneous cleanup for consistency.