### PR TITLE
raymath.h: Use C99 inline semantics

### DIFF
--- a/examples/models/models_skybox.c
+++ b/examples/models/models_skybox.c
@@ -62,7 +62,7 @@ int main()
 
             Begin3dMode(camera);
 
-                DrawModel(skybox, Vector3Zero(), 1.0f, WHITE);
+                DrawModel(skybox, (Vector3){0, 0, 0}, 1.0f, WHITE);
                 
                 DrawGrid(10, 1.0f);
 

--- a/src/core.c
+++ b/src/core.c
@@ -98,12 +98,11 @@
     #define _POSIX_C_SOURCE 199309L // Required for CLOCK_MONOTONIC if compiled with c99 without gnu ext.
 #endif
 
+#define RAYMATH_IMPLEMENTATION  // Define external out-of-line implementation of raymath here
+#include "raymath.h"            // Required for: Vector3 and Matrix functions
+
 #include "rlgl.h"           // raylib OpenGL abstraction layer to OpenGL 1.1, 3.3+ or ES2
 #include "utils.h"          // Required for: fopen() Android mapping
-
-#define RAYMATH_IMPLEMENTATION  // Use raymath as a header-only library (includes implementation)
-#define RAYMATH_EXTERN_INLINE   // Compile raymath functions as static inline (remember, it's a compiler hint)
-#include "raymath.h"            // Required for: Vector3 and Matrix functions
 
 #if defined(SUPPORT_GESTURES_SYSTEM)
     #define GESTURES_IMPLEMENTATION

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -338,6 +338,14 @@ typedef struct Matrix {
     float m3, m7, m11, m15;
 } Matrix;
 
+typedef struct Float3 {
+    float f[3];
+} Float3;
+
+typedef struct Float16 {
+    float f[16];
+} Float16;
+
 // Color type, RGBA (32bit)
 typedef struct Color {
     unsigned char r;
@@ -743,11 +751,17 @@ RLAPI Color GetColor(int hexValue);                               // Returns a C
 RLAPI Color Fade(Color color, float alpha);                       // Color fade-in or fade-out, alpha goes from 0.0f to 1.0f
 
 // Math useful functions (available from raymath.h)
-RLAPI float *Vector3ToFloat(Vector3 vec);                         // Returns Vector3 as float array
-RLAPI float *MatrixToFloat(Matrix mat);                           // Returns Matrix as float array
 RLAPI Vector3 Vector3Zero(void);                                  // Vector with components value 0.0f
 RLAPI Vector3 Vector3One(void);                                   // Vector with components value 1.0f
 RLAPI Matrix MatrixIdentity(void);                                // Returns identity matrix
+#ifndef Vector3ToFloat
+#define Vector3ToFloat(vec) (Vector3ToFloat_(vec).f)              // Returns Vector3 as float array
+RLAPI Float3 Vector3ToFloat_(Vector3 vec);                        // don't use, use above
+#endif
+#ifndef MatrixToFloat
+#define MatrixToFloat(mat) (MatrixToFloat_(mat).f)                // Returns Matrix as float array
+RLAPI Float16 MatrixToFloat_(Matrix mat);                         // don't use, use above
+#endif
 
 // Misc. functions
 RLAPI void ShowLogo(void);                                        // Activate raylib logo at startup (can be done with flags)

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -338,14 +338,6 @@ typedef struct Matrix {
     float m3, m7, m11, m15;
 } Matrix;
 
-typedef struct Float3 {
-    float f[3];
-} Float3;
-
-typedef struct Float16 {
-    float f[16];
-} Float16;
-
 // Color type, RGBA (32bit)
 typedef struct Color {
     unsigned char r;
@@ -749,19 +741,6 @@ RLAPI int ColorToInt(Color color);                                // Returns hex
 RLAPI Vector3 ColorToHSV(Color color);                            // Returns HSV values for a Color
 RLAPI Color GetColor(int hexValue);                               // Returns a Color struct from hexadecimal value
 RLAPI Color Fade(Color color, float alpha);                       // Color fade-in or fade-out, alpha goes from 0.0f to 1.0f
-
-// Math useful functions (available from raymath.h)
-RLAPI Vector3 Vector3Zero(void);                                  // Vector with components value 0.0f
-RLAPI Vector3 Vector3One(void);                                   // Vector with components value 1.0f
-RLAPI Matrix MatrixIdentity(void);                                // Returns identity matrix
-#ifndef Vector3ToFloat
-#define Vector3ToFloat(vec) (Vector3ToFloat_(vec).f)              // Returns Vector3 as float array
-RLAPI Float3 Vector3ToFloat_(Vector3 vec);                        // don't use, use above
-#endif
-#ifndef MatrixToFloat
-#define MatrixToFloat(mat) (MatrixToFloat_(mat).f)                // Returns Matrix as float array
-RLAPI Float16 MatrixToFloat_(Matrix mat);                         // don't use, use above
-#endif
 
 // Misc. functions
 RLAPI void ShowLogo(void);                                        // Activate raylib logo at startup (can be done with flags)

--- a/src/raymath.h
+++ b/src/raymath.h
@@ -100,6 +100,12 @@
         float m2, m6, m10, m14;
         float m3, m7, m11, m15;
     } Matrix;
+    typedef struct Float3 {
+        float f[3];
+    } Float3;
+    typedef struct Float16 {
+        float f[16];
+    } Float16;
 #endif
 
 // Quaternion type
@@ -156,7 +162,7 @@ RMDEF Vector3 Vector3Reflect(Vector3 vector, Vector3 normal);    // Calculate re
 RMDEF Vector3 Vector3Min(Vector3 vec1, Vector3 vec2);            // Return min value for each pair of components
 RMDEF Vector3 Vector3Max(Vector3 vec1, Vector3 vec2);            // Return max value for each pair of components
 RMDEF Vector3 Vector3Barycenter(Vector3 p, Vector3 a, Vector3 b, Vector3 c); // Barycenter coords for p in triangle abc
-RMDEF float *Vector3ToFloat(Vector3 vec);                        // Returns Vector3 as float array
+RMDEF Float3 Vector3ToFloat_(Vector3 vec);                       // Returns Vector3 as float array
 
 //------------------------------------------------------------------------------------
 // Functions Declaration to work with Matrix
@@ -180,7 +186,7 @@ RMDEF Matrix MatrixFrustum(double left, double right, double bottom, double top,
 RMDEF Matrix MatrixPerspective(double fovy, double aspect, double near, double far);                        // Returns perspective projection matrix
 RMDEF Matrix MatrixOrtho(double left, double right, double bottom, double top, double near, double far);    // Returns orthographic projection matrix
 RMDEF Matrix MatrixLookAt(Vector3 position, Vector3 target, Vector3 up);  // Returns camera look-at matrix (view matrix)
-RMDEF float *MatrixToFloat(Matrix mat);                         // Returns float array of Matrix data
+RMDEF Float16 MatrixToFloat_(Matrix mat);                       // Returns float array of Matrix data
 
 //------------------------------------------------------------------------------------
 // Functions Declaration to work with Quaternions
@@ -548,16 +554,19 @@ RMDEF Vector3 Vector3Barycenter(Vector3 p, Vector3 a, Vector3 b, Vector3 c)
 }
 
 // Returns Vector3 as float array
-RMDEF float *Vector3ToFloat(Vector3 vec)
+RMDEF Float3 Vector3ToFloat_(Vector3 vec)
 {
-    static float buffer[3];
+    Float3 buffer;
 
-    buffer[0] = vec.x;
-    buffer[1] = vec.y;
-    buffer[2] = vec.z;
+    buffer.f[0] = vec.x;
+    buffer.f[1] = vec.y;
+    buffer.f[2] = vec.z;
 
     return buffer;
 }
+#ifndef Vector3ToFloat
+#define Vector3ToFloat(vec) (Vector3ToFloat_(vec).f) 
+#endif
 
 //----------------------------------------------------------------------------------
 // Module Functions Definition - Matrix math
@@ -993,29 +1002,32 @@ RMDEF Matrix MatrixLookAt(Vector3 eye, Vector3 target, Vector3 up)
 }
 
 // Returns float array of matrix data
-RMDEF float *MatrixToFloat(Matrix mat)
+RMDEF Float16 MatrixToFloat_(Matrix mat)
 {
-    static float buffer[16];
+    Float16 buffer;
 
-    buffer[0] = mat.m0;
-    buffer[1] = mat.m1;
-    buffer[2] = mat.m2;
-    buffer[3] = mat.m3;
-    buffer[4] = mat.m4;
-    buffer[5] = mat.m5;
-    buffer[6] = mat.m6;
-    buffer[7] = mat.m7;
-    buffer[8] = mat.m8;
-    buffer[9] = mat.m9;
-    buffer[10] = mat.m10;
-    buffer[11] = mat.m11;
-    buffer[12] = mat.m12;
-    buffer[13] = mat.m13;
-    buffer[14] = mat.m14;
-    buffer[15] = mat.m15;
+    buffer.f[0] = mat.m0;
+    buffer.f[1] = mat.m1;
+    buffer.f[2] = mat.m2;
+    buffer.f[3] = mat.m3;
+    buffer.f[4] = mat.m4;
+    buffer.f[5] = mat.m5;
+    buffer.f[6] = mat.m6;
+    buffer.f[7] = mat.m7;
+    buffer.f[8] = mat.m8;
+    buffer.f[9] = mat.m9;
+    buffer.f[10] = mat.m10;
+    buffer.f[11] = mat.m11;
+    buffer.f[12] = mat.m12;
+    buffer.f[13] = mat.m13;
+    buffer.f[14] = mat.m14;
+    buffer.f[15] = mat.m15;
 
     return buffer;
 }
+#ifndef MatrixToFloat
+#define MatrixToFloat(mat) (MatrixToFloat_(mat).f)
+#endif
 
 //----------------------------------------------------------------------------------
 // Module Functions Definition - Quaternion math

--- a/src/raymath.h
+++ b/src/raymath.h
@@ -9,8 +9,9 @@
 *       If not defined, the library is in header only mode and can be included in other headers
 *       or source files without problems. But only ONE file should hold the implementation.
 *
-*   #define RAYMATH_EXTERN_INLINE
-*       Inlines all functions code, so it runs faster. This requires lots of memory on system.
+*   #define RAYMATH_HEADER_ONLY
+*       Define static inline functions code, so #include header suffices for use.
+*       This may use up lots of memory.
 *   
 *   #define RAYMATH_STANDALONE
 *       Avoid raylib.h header inclusion in this file. 
@@ -41,8 +42,8 @@
 #ifndef RAYMATH_H
 #define RAYMATH_H
 
-//#define RAYMATH_STANDALONE        // NOTE: To use raymath as standalone lib, just uncomment this line
-//#define RAYMATH_EXTERN_INLINE     // NOTE: To compile functions as static inline, uncomment this line
+//#define RAYMATH_STANDALONE      // NOTE: To use raymath as standalone lib, just uncomment this line
+//#define RAYMATH_HEADER_ONLY     // NOTE: To compile functions as static inline, uncomment this line
 
 #ifndef RAYMATH_STANDALONE
     #include "raylib.h"             // Required for structs: Vector3, Matrix
@@ -51,14 +52,21 @@
 #ifdef __cplusplus
     #define RMEXTERN extern "C"     // Functions visible from other files (no name mangling of functions in C++)
 #else
-    #define RMEXTERN extern         // Functions visible from other files
+    #define RMEXTERN                // Functions visible from other files
 #endif
 
-#if defined(RAYMATH_EXTERN_INLINE)
-    #define RMDEF RMEXTERN inline   // Functions are embeded inline (compiler generated code)
-#else
-    #define RMDEF RMEXTERN
+#if defined RAYMATH_IMPLEMENTATION && defined RAYMATH_HEADER_ONLY
+    #error "Specifying both RAYMATH_IMPLEMENTATION and RAYMATH_HEADER_ONLY is contradictory"
 #endif
+
+#ifdef RAYMATH_IMPLEMENTATION
+    #define RMDEF extern inline // Provide external definition
+#elif defined RAYMATH_HEADER_ONLY
+    #define RMDEF static inline // Functions may be inlined, no external out-of-line definition
+#else
+    #define RMDEF inline        // Functions may be inlined or external definition used
+#endif
+
 
 //----------------------------------------------------------------------------------
 // Defines and Macros
@@ -100,13 +108,15 @@
         float m2, m6, m10, m14;
         float m3, m7, m11, m15;
     } Matrix;
-    typedef struct Float3 {
-        float f[3];
-    } Float3;
-    typedef struct Float16 {
-        float f[16];
-    } Float16;
 #endif
+
+// Helper types to be used instead of array return types for *ToFloat functions
+typedef struct Float3 {
+    float f[3];
+} Float3;
+typedef struct Float16 {
+    float f[16];
+} Float16;
 
 // Quaternion type
 typedef struct Quaternion {
@@ -115,105 +125,6 @@ typedef struct Quaternion {
     float z;
     float w;
 } Quaternion;
-
-#ifndef RAYMATH_EXTERN_INLINE
-
-//------------------------------------------------------------------------------------
-// Functions Declaration - math utils
-//------------------------------------------------------------------------------------
-RMDEF float Clamp(float value, float min, float max);           // Clamp float value
-
-//------------------------------------------------------------------------------------
-// Functions Declaration to work with Vector2
-//------------------------------------------------------------------------------------
-RMDEF Vector2 Vector2Zero(void);                                // Vector with components value 0.0f
-RMDEF Vector2 Vector2One(void);                                 // Vector with components value 1.0f
-RMDEF Vector2 Vector2Add(Vector2 v1, Vector2 v2);               // Add two vectors (v1 + v2)
-RMDEF Vector2 Vector2Subtract(Vector2 v1, Vector2 v2);          // Subtract two vectors (v1 - v2)
-RMDEF float Vector2Length(Vector2 v);                           // Calculate vector length
-RMDEF float Vector2DotProduct(Vector2 v1, Vector2 v2);          // Calculate two vectors dot product
-RMDEF float Vector2Distance(Vector2 v1, Vector2 v2);            // Calculate distance between two vectors
-RMDEF float Vector2Angle(Vector2 v1, Vector2 v2);               // Calculate angle between two vectors in X-axis
-RMDEF void Vector2Scale(Vector2 *v, float scale);               // Scale vector (multiply by value)
-RMDEF void Vector2Negate(Vector2 *v);                           // Negate vector
-RMDEF void Vector2Divide(Vector2 *v, float div);                // Divide vector by a float value
-RMDEF void Vector2Normalize(Vector2 *v);                        // Normalize provided vector
-
-//------------------------------------------------------------------------------------
-// Functions Declaration to work with Vector3
-//------------------------------------------------------------------------------------
-RMDEF Vector3 Vector3Zero(void);                                 // Vector with components value 0.0f
-RMDEF Vector3 Vector3One(void);                                  // Vector with components value 1.0f
-RMDEF Vector3 Vector3Add(Vector3 v1, Vector3 v2);                // Add two vectors
-RMDEF Vector3 Vector3Multiply(Vector3 v, float scalar);          // Multiply vector by scalar
-RMDEF Vector3 Vector3MultiplyV(Vector3 v1, Vector3 v2);          // Multiply vector by vector
-RMDEF Vector3 Vector3Subtract(Vector3 v1, Vector3 v2);           // Substract two vectors
-RMDEF Vector3 Vector3CrossProduct(Vector3 v1, Vector3 v2);       // Calculate two vectors cross product
-RMDEF Vector3 Vector3Perpendicular(Vector3 v);                   // Calculate one vector perpendicular vector
-RMDEF float Vector3Length(const Vector3 v);                      // Calculate vector length
-RMDEF float Vector3DotProduct(Vector3 v1, Vector3 v2);           // Calculate two vectors dot product
-RMDEF float Vector3Distance(Vector3 v1, Vector3 v2);             // Calculate distance between two points
-RMDEF void Vector3Scale(Vector3 *v, float scale);                // Scale provided vector
-RMDEF void Vector3Negate(Vector3 *v);                            // Negate provided vector (invert direction)
-RMDEF void Vector3Normalize(Vector3 *v);                         // Normalize provided vector
-RMDEF void Vector3Transform(Vector3 *v, Matrix mat);             // Transforms a Vector3 by a given Matrix
-RMDEF Vector3 Vector3Lerp(Vector3 v1, Vector3 v2, float amount); // Calculate linear interpolation between two vectors
-RMDEF Vector3 Vector3Reflect(Vector3 vector, Vector3 normal);    // Calculate reflected vector to normal
-RMDEF Vector3 Vector3Min(Vector3 vec1, Vector3 vec2);            // Return min value for each pair of components
-RMDEF Vector3 Vector3Max(Vector3 vec1, Vector3 vec2);            // Return max value for each pair of components
-RMDEF Vector3 Vector3Barycenter(Vector3 p, Vector3 a, Vector3 b, Vector3 c); // Barycenter coords for p in triangle abc
-RMDEF Float3 Vector3ToFloat_(Vector3 vec);                       // Returns Vector3 as float array
-
-//------------------------------------------------------------------------------------
-// Functions Declaration to work with Matrix
-//------------------------------------------------------------------------------------
-RMDEF float MatrixDeterminant(Matrix mat);                      // Compute matrix determinant
-RMDEF float MatrixTrace(Matrix mat);                            // Returns the trace of the matrix (sum of the values along the diagonal)
-RMDEF void MatrixTranspose(Matrix *mat);                        // Transposes provided matrix
-RMDEF void MatrixInvert(Matrix *mat);                           // Invert provided matrix
-RMDEF void MatrixNormalize(Matrix *mat);                        // Normalize provided matrix
-RMDEF Matrix MatrixIdentity(void);                              // Returns identity matrix
-RMDEF Matrix MatrixAdd(Matrix left, Matrix right);              // Add two matrices
-RMDEF Matrix MatrixSubstract(Matrix left, Matrix right);        // Substract two matrices (left - right)
-RMDEF Matrix MatrixTranslate(float x, float y, float z);        // Returns translation matrix
-RMDEF Matrix MatrixRotate(Vector3 axis, float angle);           // Returns rotation matrix for an angle around an specified axis (angle in radians)
-RMDEF Matrix MatrixRotateX(float angle);                        // Returns x-rotation matrix (angle in radians)
-RMDEF Matrix MatrixRotateY(float angle);                        // Returns y-rotation matrix (angle in radians)
-RMDEF Matrix MatrixRotateZ(float angle);                        // Returns z-rotation matrix (angle in radians)
-RMDEF Matrix MatrixScale(float x, float y, float z);            // Returns scaling matrix
-RMDEF Matrix MatrixMultiply(Matrix left, Matrix right);         // Returns two matrix multiplication
-RMDEF Matrix MatrixFrustum(double left, double right, double bottom, double top, double near, double far);  // Returns perspective projection matrix
-RMDEF Matrix MatrixPerspective(double fovy, double aspect, double near, double far);                        // Returns perspective projection matrix
-RMDEF Matrix MatrixOrtho(double left, double right, double bottom, double top, double near, double far);    // Returns orthographic projection matrix
-RMDEF Matrix MatrixLookAt(Vector3 position, Vector3 target, Vector3 up);  // Returns camera look-at matrix (view matrix)
-RMDEF Float16 MatrixToFloat_(Matrix mat);                       // Returns float array of Matrix data
-
-//------------------------------------------------------------------------------------
-// Functions Declaration to work with Quaternions
-//------------------------------------------------------------------------------------
-RMDEF Quaternion QuaternionIdentity(void);                      // Returns identity quaternion
-RMDEF float QuaternionLength(Quaternion quat);                  // Compute the length of a quaternion
-RMDEF void QuaternionNormalize(Quaternion *q);                  // Normalize provided quaternion
-RMDEF void QuaternionInvert(Quaternion *quat);                  // Invert provided quaternion
-RMDEF Quaternion QuaternionMultiply(Quaternion q1, Quaternion q2);    // Calculate two quaternion multiplication
-RMDEF Quaternion QuaternionLerp(Quaternion q1, Quaternion q2, float amount);    // Calculate linear interpolation between two quaternions
-RMDEF Quaternion QuaternionNlerp(Quaternion q1, Quaternion q2, float amount);   // Calculate slerp-optimized interpolation between two quaternions
-RMDEF Quaternion QuaternionSlerp(Quaternion q1, Quaternion q2, float amount);   // Calculates spherical linear interpolation between two quaternions
-RMDEF Quaternion QuaternionFromVector3ToVector3(Vector3 from, Vector3 to);      // Calculate quaternion based on the rotation from one vector to another
-RMDEF Quaternion QuaternionFromMatrix(Matrix matrix);                 // Returns a quaternion for a given rotation matrix
-RMDEF Matrix QuaternionToMatrix(Quaternion q);                        // Returns a matrix for a given quaternion
-RMDEF Quaternion QuaternionFromAxisAngle(Vector3 axis, float angle);  // Returns rotation quaternion for an angle and axis
-RMDEF void QuaternionToAxisAngle(Quaternion q, Vector3 *outAxis, float *outAngle);  // Returns the rotation angle and axis for a given quaternion
-RMDEF Quaternion QuaternionFromEuler(float roll, float pitch, float yaw);           // Returns he quaternion equivalent to Euler angles
-RMDEF Vector3 QuaternionToEuler(Quaternion q);                  // Return the Euler angles equivalent to quaternion (roll, pitch, yaw)
-RMDEF void QuaternionTransform(Quaternion *q, Matrix mat);      // Transform a quaternion given a transformation matrix
-
-#endif  // notdef RAYMATH_EXTERN_INLINE
-
-#endif  // RAYMATH_H
-//////////////////////////////////////////////////////////////////// end of header file
-
-#if defined(RAYMATH_IMPLEMENTATION) || defined(RAYMATH_EXTERN_INLINE)
 
 #include <math.h>       // Required for: sinf(), cosf(), tan(), fabs()
 
@@ -1390,4 +1301,4 @@ RMDEF void QuaternionTransform(Quaternion *q, Matrix mat)
     q->w = mat.m3*x + mat.m7*y + mat.m11*z + mat.m15*w;
 }
 
-#endif  // RAYMATH_IMPLEMENTATION
+#endif  // RAYMATH_H


### PR DESCRIPTION
RAYMATH_EXTERN_INLINE was renamed to RAYMATH_HEADER_ONLY, which user code
may define if they want to use it as header-only library. If multiple
files in the same project define RAYMATH_HEADER_ONLY, they might each
have duplicate out-of-line definitions of the same functions.

By default, raymath.h exposes inline definitions, which instructs the
compiler _not_ to generate out-of-line definitons, if out-of-line
definitions are required, those of the file defined with
RAYLIB_IMPLEMENTATION are used instead. There may be only one such file.

In C++ mode, the compiler will select only one out-of-line definition
automatically, so no need to define a RAYLIB_IMPLEMENTATION.

Unfortunately, we have to remove raymath function declaration from
raylib.h as those declarations would lead to duplicate out-of-line
definitions which would yield linker errors. This problem didn't
exist with GNU89 or C++, because there multiple defintions are ok,
but in C99 they aren't.

Addresses #478.