### PR TITLE
Update Makefile

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -292,8 +292,7 @@ endif
 #  -D_DEFAULT_SOURCE     use with -std=c99 on Linux and PLATFORM_WEB, required for timespec
 #  -Werror=pointer-arith catch unportable code that does direct arithmetic on void pointers
 #  -fno-strict-aliasing  jar_xm.h does shady stuff (breaks strict aliasing)
-CFLAGS += -O1 -Wall -std=c99 -D_DEFAULT_SOURCE -Wno-missing-braces -Werror=pointer-arith 
--fno-strict-aliasing
+CFLAGS += -O1 -Wall -std=c99 -D_DEFAULT_SOURCE -Wno-missing-braces -Werror=pointer-arith -fno-strict-aliasing
 
 ifeq ($(RAYLIB_BUILD_MODE), DEBUG)
     CFLAGS += -g


### PR DESCRIPTION
$ make clean
Makefile:296: *** missing separator.  Stop.