### PR TITLE
Allow use of main instead of android_main

### DIFF
--- a/games/arkanoid.c
+++ b/games/arkanoid.c
@@ -18,10 +18,6 @@
 #include <time.h>
 #include <math.h>
 
-#if defined(PLATFORM_ANDROID)
-    #include "android_native_app_glue.h"
-#endif
-
 #if defined(PLATFORM_WEB)
     #include <emscripten/emscripten.h>
 #endif
@@ -83,19 +79,11 @@ static void UpdateDrawFrame(void);  // Update and Draw (one frame)
 //------------------------------------------------------------------------------------
 // Program main entry point
 //------------------------------------------------------------------------------------
-#if defined(PLATFORM_ANDROID)
-void android_main(struct android_app *app) 
-#else
 int main(void)
-#endif
 {
-    // Initialization
+    // Initialization (Note windowTitle is unused on Android)
     //---------------------------------------------------------
-#if defined(PLATFORM_ANDROID)
-    InitWindow(screenWidth, screenHeight, app);
-#else
     InitWindow(screenWidth, screenHeight, "sample game: arkanoid");
-#endif
 
     InitGame();
 
@@ -122,9 +110,8 @@ int main(void)
     
     CloseWindow();        // Close window and OpenGL context
     //--------------------------------------------------------------------------------------
-#if !defined(PLATFORM_ANDROID)
+
     return 0;
-#endif
 }
 
 //------------------------------------------------------------------------------------

--- a/games/asteroids.c
+++ b/games/asteroids.c
@@ -15,10 +15,6 @@
 
 #include <math.h>
 
-#if defined(PLATFORM_ANDROID)
-    #include "android_native_app_glue.h"
-#endif
-
 #if defined(PLATFORM_WEB)
     #include <emscripten/emscripten.h>
 #endif
@@ -101,19 +97,11 @@ static void UpdateDrawFrame(void);  // Update and Draw (one frame)
 //------------------------------------------------------------------------------------
 // Program main entry point
 //------------------------------------------------------------------------------------
-#if defined(PLATFORM_ANDROID)
-void android_main(struct android_app *app) 
-#else
 int main(void)
-#endif
 {
-    // Initialization
+    // Initialization (Note windowTitle is unused on Android)
     //---------------------------------------------------------
-#if defined(PLATFORM_ANDROID)
-    InitWindow(screenWidth, screenHeight, app);
-#else
     InitWindow(screenWidth, screenHeight, "sample game: asteroids");
-#endif
 
     InitGame();
 
@@ -140,9 +128,8 @@ int main(void)
     
     CloseWindow();        // Close window and OpenGL context
     //--------------------------------------------------------------------------------------
-#if !defined(PLATFORM_ANDROID)
+
     return 0;
-#endif
 }
 
 //------------------------------------------------------------------------------------

--- a/games/asteroids_survival.c
+++ b/games/asteroids_survival.c
@@ -15,10 +15,6 @@
 
 #include <math.h>
 
-#if defined(PLATFORM_ANDROID)
-    #include "android_native_app_glue.h"
-#endif
-
 #if defined(PLATFORM_WEB)
     #include <emscripten/emscripten.h>
 #endif
@@ -84,19 +80,11 @@ static void UpdateDrawFrame(void);  // Update and Draw (one frame)
 //------------------------------------------------------------------------------------
 // Program main entry point
 //------------------------------------------------------------------------------------
-#if defined(PLATFORM_ANDROID)
-void android_main(struct android_app *app) 
-#else
 int main(void)
-#endif
 {
-    // Initialization
+    // Initialization (Note windowTitle is unused on Android)
     //---------------------------------------------------------
-#if defined(PLATFORM_ANDROID)
-    InitWindow(screenWidth, screenHeight, app);
-#else
     InitWindow(screenWidth, screenHeight, "sample game: asteroids survival");
-#endif
 
     InitGame();
 
@@ -123,9 +111,8 @@ int main(void)
     
     CloseWindow();        // Close window and OpenGL context
     //--------------------------------------------------------------------------------------
-#if !defined(PLATFORM_ANDROID)
+
     return 0;
-#endif
 }
 
 //------------------------------------------------------------------------------------

--- a/games/floppy.c
+++ b/games/floppy.c
@@ -13,10 +13,6 @@
 
 #include "raylib.h"
 
-#if defined(PLATFORM_ANDROID)
-    #include "android_native_app_glue.h"
-#endif
-
 #if defined(PLATFORM_WEB)
     #include <emscripten/emscripten.h>
 #endif
@@ -72,19 +68,11 @@ static void UpdateDrawFrame(void);  // Update and Draw (one frame)
 //------------------------------------------------------------------------------------
 // Program main entry point
 //------------------------------------------------------------------------------------
-#if defined(PLATFORM_ANDROID)
-void android_main(struct android_app *app) 
-#else
 int main(void)
-#endif
 {
     // Initialization
     //---------------------------------------------------------
-#if defined(PLATFORM_ANDROID)
-    InitWindow(screenWidth, screenHeight, app);
-#else
     InitWindow(screenWidth, screenHeight, "sample game: floppy");
-#endif
 
     InitGame();
 
@@ -111,9 +99,8 @@ int main(void)
     
     CloseWindow();        // Close window and OpenGL context
     //--------------------------------------------------------------------------------------
-#if !defined(PLATFORM_ANDROID)
+
     return 0;
-#endif
 }
 //------------------------------------------------------------------------------------
 // Module Functions Definitions (local)

--- a/games/gold_fever.c
+++ b/games/gold_fever.c
@@ -13,10 +13,6 @@
 
 #include "raylib.h"
 
-#if defined(PLATFORM_ANDROID)
-    #include "android_native_app_glue.h"
-#endif
-
 #if defined(PLATFORM_WEB)
     #include <emscripten/emscripten.h>
 #endif
@@ -81,19 +77,11 @@ static void UpdateDrawFrame(void);  // Update and Draw (one frame)
 //------------------------------------------------------------------------------------
 // Program main entry point
 //------------------------------------------------------------------------------------
-#if defined(PLATFORM_ANDROID)
-void android_main(struct android_app *app) 
-#else
 int main(void)
-#endif
 {
-    // Initialization
+    // Initialization (Note windowTitle is unused on Android)
     //---------------------------------------------------------
-#if defined(PLATFORM_ANDROID)
-    InitWindow(screenWidth, screenHeight, app);
-#else
     InitWindow(screenWidth, screenHeight, "sample game: gold fever");
-#endif
 
     InitGame();
 
@@ -120,9 +108,8 @@ int main(void)
 
     CloseWindow();        // Close window and OpenGL context
     //--------------------------------------------------------------------------------------
-#if !defined(PLATFORM_ANDROID)
+
     return 0;
-#endif
 }
 
 //------------------------------------------------------------------------------------

--- a/games/gorilas.c
+++ b/games/gorilas.c
@@ -18,10 +18,6 @@
 #include <time.h>
 #include <math.h>
 
-#if defined(PLATFORM_ANDROID)
-    #include "android_native_app_glue.h"
-#endif
-
 #if defined(PLATFORM_WEB)
     #include <emscripten/emscripten.h>
 #endif
@@ -120,19 +116,11 @@ static bool UpdateBall(int playerTurn);
 //------------------------------------------------------------------------------------
 // Program main entry point
 //------------------------------------------------------------------------------------
-#if defined(PLATFORM_ANDROID)
-void android_main(struct android_app *app) 
-#else
 int main(void)
-#endif
 {
-    // Initialization
+    // Initialization (Note windowTitle is unused on Android)
     //---------------------------------------------------------
-#if defined(PLATFORM_ANDROID)
-    InitWindow(screenWidth, screenHeight, app);
-#else
     InitWindow(screenWidth, screenHeight, "sample game: gorilas");
-#endif
 
     InitGame();
 
@@ -159,9 +147,8 @@ int main(void)
     
     CloseWindow();        // Close window and OpenGL context
     //--------------------------------------------------------------------------------------
-#if !defined(PLATFORM_ANDROID)
+
     return 0;
-#endif
 }
 
 //------------------------------------------------------------------------------------

--- a/games/just_do/just_do.c
+++ b/games/just_do/just_do.c
@@ -16,10 +16,6 @@
 #include "raylib.h"
 #include "screens/screens.h"    // NOTE: Defines currentScreen
 
-#if defined(PLATFORM_ANDROID)
-    #include "android_native_app_glue.h"
-#endif
-
 #if defined(PLATFORM_WEB)
     #include <emscripten/emscripten.h>
 #endif
@@ -53,19 +49,11 @@ void UpdateDrawFrame(void);     // Update and Draw one frame
 //----------------------------------------------------------------------------------
 // Main entry point
 //----------------------------------------------------------------------------------
-#if defined(PLATFORM_ANDROID)
-void android_main(struct android_app *app) 
-#else
 int main(void)
-#endif
 {
-	// Initialization
+	// Initialization (Note windowTitle is unused on Android)
 	//---------------------------------------------------------
-#if defined(PLATFORM_ANDROID)
-    InitWindow(screenWidth, screenHeight, app);
-#else
     InitWindow(screenWidth, screenHeight, "GGJ15 - JUST DO");
-#endif
 
     // Load global data here (assets that must be available in all screens, i.e. fonts)
     InitAudioDevice();
@@ -104,9 +92,8 @@ int main(void)
     
     CloseWindow();        // Close window and OpenGL context
     //--------------------------------------------------------------------------------------
-#if !defined(PLATFORM_ANDROID)
+
     return 0;
-#endif
 }
 
 //----------------------------------------------------------------------------------

--- a/games/koala_seasons/koala_seasons.c
+++ b/games/koala_seasons/koala_seasons.c
@@ -15,10 +15,6 @@
 #include "raylib.h"
 #include "screens/screens.h"    // NOTE: Defines currentScreen
 
-#if defined(PLATFORM_ANDROID)
-    #include "android_native_app_glue.h"
-#endif
-
 #if defined(PLATFORM_WEB)
     #include <emscripten/emscripten.h>
 #endif
@@ -47,12 +43,7 @@ void UpdateDrawFrame(void);     // Update and Draw one frame
 //----------------------------------------------------------------------------------
 // Main entry point
 //----------------------------------------------------------------------------------
-#if defined(PLATFORM_ANDROID)
-void android_main(struct android_app *app)
-#else
-int main(void)
-#endif
-{
+int main(void) {
 	// Initialization
 	//---------------------------------------------------------
     const int screenWidth = 1280;
@@ -62,11 +53,8 @@ int main(void)
     //ShowLogo();
     //SetConfigFlags(FLAG_FULLSCREEN_MODE);
     
-#if defined(PLATFORM_ANDROID)
-    InitWindow(screenWidth, screenHeight, app);
-#else
+    // Note that windowTitle is ignored on Android
     InitWindow(screenWidth, screenHeight, windowTitle);
-#endif
 
     // Load global data here (assets that must be available in all screens, i.e. fonts)
     font = LoadSpriteFont("resources/graphics/mainfont.png");
@@ -145,9 +133,8 @@ int main(void)
 
     CloseWindow();              // Close window and OpenGL context
     //--------------------------------------------------------------------------------------
-#if !defined(PLATFORM_ANDROID)
+
     return 0;
-#endif
 }
 
 void TransitionToScreen(int screen)

--- a/games/light_my_ritual/light_my_ritual.c
+++ b/games/light_my_ritual/light_my_ritual.c
@@ -19,10 +19,6 @@
 
 #include <stdlib.h>
 
-#if defined(PLATFORM_ANDROID)
-    #include "android_native_app_glue.h"
-#endif
-
 #if defined(PLATFORM_WEB)
     #include <emscripten/emscripten.h>
 #endif
@@ -55,19 +51,11 @@ void UpdateDrawFrame(void);         // Update and Draw one frame
 //----------------------------------------------------------------------------------
 // Main entry point
 //----------------------------------------------------------------------------------
-#if defined(PLATFORM_ANDROID)
-void android_main(struct android_app *app) 
-#else
 int main(void)
-#endif
 {
-	// Initialization
+	// Initialization (Note windowTitle is unused on Android)
 	//---------------------------------------------------------
-#if defined(PLATFORM_ANDROID)
-    InitWindow(screenWidth, screenHeight, app);
-#else
     InitWindow(screenWidth, screenHeight, "GGJ16 - LIGHT MY RITUAL!");
-#endif
 
     // Global data loading (assets that must be available in all screens, i.e. fonts)
     InitAudioDevice();
@@ -129,9 +117,8 @@ int main(void)
     
     CloseWindow();        // Close window and OpenGL context
     //--------------------------------------------------------------------------------------
-#if !defined(PLATFORM_ANDROID)
+
     return 0;
-#endif
 }
 
 void TransitionToScreen(int screen)

--- a/games/missile_commander.c
+++ b/games/missile_commander.c
@@ -18,10 +18,6 @@
 #include <time.h>
 #include <math.h>
 
-#if defined(PLATFORM_ANDROID)
-    #include "android_native_app_glue.h"
-#endif
-
 #if defined(PLATFORM_WEB)
     #include <emscripten/emscripten.h>
 #endif
@@ -119,19 +115,11 @@ static void UpdateIncomingFire();
 //------------------------------------------------------------------------------------
 // Program main entry point
 //------------------------------------------------------------------------------------
-#if defined(PLATFORM_ANDROID)
-void android_main(struct android_app *app) 
-#else
 int main(void)
-#endif
 {
-    // Initialization
+    // Initialization (Note windowTitle is unused on Android)
     //---------------------------------------------------------
-#if defined(PLATFORM_ANDROID)
-    InitWindow(screenWidth, screenHeight, app);
-#else
     InitWindow(screenWidth, screenHeight, "sample game: missile commander");
-#endif
 
     InitGame();
 
@@ -158,9 +146,8 @@ int main(void)
     
     CloseWindow();        // Close window and OpenGL context
     //--------------------------------------------------------------------------------------
-#if !defined(PLATFORM_ANDROID)
+
     return 0;
-#endif
 }
 
 //--------------------------------------------------------------------------------------

--- a/games/pang.c
+++ b/games/pang.c
@@ -15,10 +15,6 @@
 
 #include <math.h>
 
-#if defined(PLATFORM_ANDROID)
-    #include "android_native_app_glue.h"
-#endif
-
 #if defined(PLATFORM_WEB)
     #include <emscripten/emscripten.h>
 #endif
@@ -110,19 +106,11 @@ static void UpdateDrawFrame(void);  // Update and Draw (one frame)
 //------------------------------------------------------------------------------------
 // Program main entry point
 //------------------------------------------------------------------------------------
-#if defined(PLATFORM_ANDROID)
-void android_main(struct android_app *app) 
-#else
 int main(void)
-#endif
 {
-    // Initialization
+    // Initialization (Note windowTitle is unused on Android)
     //---------------------------------------------------------
-#if defined(PLATFORM_ANDROID)
-    InitWindow(screenWidth, screenHeight, app);
-#else
     InitWindow(screenWidth, screenHeight, "sample game: pang");
-#endif
 
     InitGame();
 
@@ -149,9 +137,8 @@ int main(void)
     
     CloseWindow();        // Close window and OpenGL context
     //--------------------------------------------------------------------------------------
-#if !defined(PLATFORM_ANDROID)
+
     return 0;
-#endif
 }
 
 //------------------------------------------------------------------------------------

--- a/games/skully_escape/skully_escape.c
+++ b/games/skully_escape/skully_escape.c
@@ -14,10 +14,6 @@
 
 #include "player.h"
 
-#if defined(PLATFORM_ANDROID)
-    #include "android_native_app_glue.h"
-#endif
-
 #if defined(PLATFORM_WEB)
     #include <emscripten/emscripten.h>
 #endif
@@ -52,19 +48,11 @@ void UpdateDrawFrame(void);         // Update and Draw one frame
 //----------------------------------------------------------------------------------
 // Main entry point
 //----------------------------------------------------------------------------------
-#if defined(PLATFORM_ANDROID)
-void android_main(struct android_app *app) 
-#else
 int main(void)
-#endif
 {
-	// Initialization
+	// Initialization (Note windowTitle is unused on Android)
 	//---------------------------------------------------------
-#if defined(PLATFORM_ANDROID)
-    InitWindow(screenWidth, screenHeight, app);
-#else
     InitWindow(screenWidth, screenHeight, "SKULLY ESCAPE [KING GAMEJAM]");
-#endif
 
     // Global data loading (assets that must be available in all screens, i.e. fonts)
     InitAudioDevice();
@@ -112,9 +100,8 @@ int main(void)
     
     CloseWindow();        // Close window and OpenGL context
     //--------------------------------------------------------------------------------------
-#if !defined(PLATFORM_ANDROID)
+
     return 0;
-#endif
 }
 
 void TransitionToScreen(int screen)

--- a/games/snake.c
+++ b/games/snake.c
@@ -13,10 +13,6 @@
 
 #include "raylib.h"
 
-#if defined(PLATFORM_ANDROID)
-    #include "android_native_app_glue.h"
-#endif
-
 #if defined(PLATFORM_WEB)
     #include <emscripten/emscripten.h>
 #endif
@@ -73,19 +69,11 @@ static void UpdateDrawFrame(void);  // Update and Draw (one frame)
 //------------------------------------------------------------------------------------
 // Program main entry point
 //------------------------------------------------------------------------------------
-#if defined(PLATFORM_ANDROID)
-void android_main(struct android_app *app) 
-#else
 int main(void)
-#endif
 {
-    // Initialization
+    // Initialization (Note windowTitle is unused on Android)
     //---------------------------------------------------------
-#if defined(PLATFORM_ANDROID)
-    InitWindow(screenWidth, screenHeight, app);
-#else
     InitWindow(screenWidth, screenHeight, "sample game: snake");
-#endif
 
     InitGame();
 
@@ -112,9 +100,8 @@ int main(void)
     
     CloseWindow();        // Close window and OpenGL context
     //--------------------------------------------------------------------------------------
-#if !defined(PLATFORM_ANDROID)
+
     return 0;
-#endif
 }
 
 //------------------------------------------------------------------------------------

--- a/games/space_invaders.c
+++ b/games/space_invaders.c
@@ -13,10 +13,6 @@
 
 #include "raylib.h"
 
-#if defined(PLATFORM_ANDROID)
-    #include "android_native_app_glue.h"
-#endif
-
 #if defined(PLATFORM_WEB)
     #include <emscripten/emscripten.h>
 #endif
@@ -90,19 +86,11 @@ static void UpdateDrawFrame(void);  // Update and Draw (one frame)
 //------------------------------------------------------------------------------------
 // Program main entry point
 //------------------------------------------------------------------------------------
-#if defined(PLATFORM_ANDROID)
-void android_main(struct android_app *app) 
-#else
 int main(void)
-#endif
 {
-    // Initialization
+    // Initialization (Note windowTitle is unused on Android)
     //---------------------------------------------------------
-#if defined(PLATFORM_ANDROID)
-    InitWindow(screenWidth, screenHeight, app);
-#else
     InitWindow(screenWidth, screenHeight, "sample game: space invaders");
-#endif
 
     InitGame();
 
@@ -129,9 +117,8 @@ int main(void)
     
     CloseWindow();        // Close window and OpenGL context
     //--------------------------------------------------------------------------------------
-#if !defined(PLATFORM_ANDROID)
+
     return 0;
-#endif
 }
 
 //------------------------------------------------------------------------------------

--- a/games/tetris.c
+++ b/games/tetris.c
@@ -18,10 +18,6 @@
 #include <time.h>
 #include <math.h>
 
-#if defined(PLATFORM_ANDROID)
-    #include "android_native_app_glue.h"
-#endif
-
 #if defined(PLATFORM_WEB)
     #include <emscripten/emscripten.h>
 #endif
@@ -109,19 +105,11 @@ static void DeleteCompleteLines();
 //------------------------------------------------------------------------------------
 // Program main entry point
 //------------------------------------------------------------------------------------
-#if defined(PLATFORM_ANDROID)
-void android_main(struct android_app *app) 
-#else
 int main(void)
-#endif
 {
-    // Initialization
+    // Initialization (Note windowTitle is unused on Android)
     //---------------------------------------------------------
-#if defined(PLATFORM_ANDROID)
-    InitWindow(screenWidth, screenHeight, app);
-#else
     InitWindow(screenWidth, screenHeight, "sample game: tetris");
-#endif
 
     InitGame();
 
@@ -148,9 +136,8 @@ int main(void)
     
     CloseWindow();        // Close window and OpenGL context
     //--------------------------------------------------------------------------------------
-#if !defined(PLATFORM_ANDROID)
+
     return 0;
-#endif
 }
 
 //--------------------------------------------------------------------------------------

--- a/games/transmission/transmission.c
+++ b/games/transmission/transmission.c
@@ -17,10 +17,6 @@
 #include <stdlib.h>
 #include <stdio.h>
 
-#if defined(PLATFORM_ANDROID)
-    #include "android_native_app_glue.h"
-#endif
-
 #if defined(PLATFORM_WEB)
     #include <emscripten/emscripten.h>
 #endif
@@ -55,20 +51,15 @@ static void UpdateDrawFrame(void);          // Update and Draw one frame
 //----------------------------------------------------------------------------------
 // Main entry point
 //----------------------------------------------------------------------------------
-#if defined(PLATFORM_ANDROID)
-void android_main(struct android_app *app) 
-#else
 int main(void)
-#endif
 {
     // Initialization
     //---------------------------------------------------------
-#if defined(PLATFORM_ANDROID)
-    InitWindow(screenWidth, screenHeight, app);
-#else
+#ifndef PLATFORM_ANDROID
     SetConfigFlags(FLAG_SHOW_LOGO); // | FLAG_FULLSCREEN_MODE);
-    InitWindow(screenWidth, screenHeight, "raylib game - transmission mission");
 #endif
+    // Note windowTitle is unused on Android
+    InitWindow(screenWidth, screenHeight, "raylib game - transmission mission");
 
     // Global data loading (assets that must be available in all screens, i.e. fonts)
     InitAudioDevice();
@@ -138,9 +129,8 @@ int main(void)
     
     CloseWindow();          // Close window and OpenGL context
     //--------------------------------------------------------------------------------------
-#if !defined(PLATFORM_ANDROID)
+
     return 0;
-#endif
 }
 
 //----------------------------------------------------------------------------------

--- a/games/wave_collector/wave_collector.c
+++ b/games/wave_collector/wave_collector.c
@@ -22,10 +22,6 @@
 #include <stdio.h>              // Required for: printf()
 #include <string.h>             // Required for: strcpy()
 
-#if defined(PLATFORM_ANDROID)
-    #include "android_native_app_glue.h"
-#endif
-
 #if defined(PLATFORM_WEB)
     #include <emscripten/emscripten.h>
 #endif
@@ -60,11 +56,7 @@ static void UpdateDrawFrame(void);          // Update and Draw one frame
 //----------------------------------------------------------------------------------
 // Main entry point
 //----------------------------------------------------------------------------------
-#if defined(PLATFORM_ANDROID)
-void android_main(struct android_app *app) 
-#else
 int main(int argc, char *argv[])
-#endif
 {
 	// Initialization
 	//---------------------------------------------------------
@@ -89,12 +81,11 @@ int main(int argc, char *argv[])
     }
 #endif
 
-#if defined(PLATFORM_ANDROID)
-    InitWindow(screenWidth, screenHeight, app);
-#else
+#ifndef PLATFORM_ANDROID
     SetConfigFlags(FLAG_MSAA_4X_HINT);
-    InitWindow(screenWidth, screenHeight, "GGJ17 - WAVE COLLECTOR");
 #endif
+    // Note windowTitle is unused on Android
+    InitWindow(screenWidth, screenHeight, "GGJ17 - WAVE COLLECTOR");
 
     // Global data loading (assets that must be available in all screens, i.e. fonts)
     InitAudioDevice();
@@ -143,9 +134,8 @@ int main(int argc, char *argv[])
     
     CloseWindow();          // Close window and OpenGL context
     //--------------------------------------------------------------------------------------
-#if !defined(PLATFORM_ANDROID)
+
     return 0;
-#endif
 }
 
 //----------------------------------------------------------------------------------

--- a/src/core.c
+++ b/src/core.c
@@ -499,17 +499,33 @@ void InitWindow(int width, int height, void *data)
 #endif
 
 #if defined(PLATFORM_ANDROID)
+/* To allow easier porting to android, we allow the user to define a main function
+ * which we call from android_main, that we define ourselves
+ */
+extern int main(int argc, char *argv[]);
+void android_main(struct android_app *_app) {
+    char arg0[] = "raylib"; /* argv[] are mutable */
+    app = _app;
+    /* TODO should we maybe report != 0 return codes somewhere? */
+    (void)main(1, (char*[]){ arg0, NULL });
+}
+/* TODO add this to header, if apps really need it) */
+struct android_app *GetAndroidApp(void)
+{
+    return app;
+}
+
 // Initialize window and OpenGL context (and Android activity)
 // NOTE: data parameter could be used to pass any kind of required data to the initialization
 void InitWindow(int width, int height, void *data)
 {
+    (void)data; // ignored
     TraceLog(LOG_INFO, "Initializing raylib (v1.9.6-dev)");
 
     screenWidth = width;
     screenHeight = height;
 
     // Input data is android app pointer
-    app = (struct android_app *)data;
     internalDataPath = app->activity->internalDataPath;
 
     // Set desired windows flags before initializing anything

--- a/templates/advance_game/advance_game.c
+++ b/templates/advance_game/advance_game.c
@@ -15,10 +15,6 @@
 #include "raylib.h"
 #include "screens/screens.h"    // NOTE: Defines global variable: currentScreen
 
-#if defined(PLATFORM_ANDROID)
-    #include "android_native_app_glue.h"
-#endif
-
 #if defined(PLATFORM_WEB)
     #include <emscripten/emscripten.h>
 #endif
@@ -53,19 +49,11 @@ static void UpdateDrawFrame(void);          // Update and Draw one frame
 //----------------------------------------------------------------------------------
 // Main entry point
 //----------------------------------------------------------------------------------
-#if defined(PLATFORM_ANDROID)
-void android_main(struct android_app *app) 
-#else
 int main(void)
-#endif
 {
-    // Initialization
+    // Initialization (Note windowTitle is unused on Android)
     //---------------------------------------------------------
-#if defined(PLATFORM_ANDROID)
-    InitWindow(screenWidth, screenHeight, app);
-#else
     InitWindow(screenWidth, screenHeight, "raylib template - advance game");
-#endif
 
     // Global data loading (assets that must be available in all screens, i.e. fonts)
     InitAudioDevice();
@@ -116,9 +104,8 @@ int main(void)
     
     CloseWindow();          // Close window and OpenGL context
     //--------------------------------------------------------------------------------------
-#if !defined(PLATFORM_ANDROID)
+
     return 0;
-#endif
 }
 
 //----------------------------------------------------------------------------------

--- a/templates/simple_game/simple_game.c
+++ b/templates/simple_game/simple_game.c
@@ -14,10 +14,6 @@
 
 #include "raylib.h"
 
-#if defined(PLATFORM_ANDROID)
-    #include "android_native_app_glue.h"
-#endif
-
 //----------------------------------------------------------------------------------
 // Types and Structures Definition
 //----------------------------------------------------------------------------------
@@ -26,22 +22,14 @@ typedef enum GameScreen { LOGO = 0, TITLE, GAMEPLAY, ENDING } GameScreen;
 //----------------------------------------------------------------------------------
 // Main entry point
 //----------------------------------------------------------------------------------
-#if defined(PLATFORM_ANDROID)
-void android_main(struct android_app *app) 
-#else
 int main(void)
-#endif
 {
-    // Initialization
+    // Initialization (Note windowTitle is unused on Android)
     //--------------------------------------------------------------------------------------
     const int screenWidth = 800;
     const int screenHeight = 450;
 
-#if defined(PLATFORM_ANDROID)
-    InitWindow(screenWidth, screenHeight, app);
-#else
     InitWindow(screenWidth, screenHeight, "raylib template - simple game");
-#endif
 
     GameScreen currentScreen = LOGO;
 
@@ -158,7 +146,6 @@ int main(void)
     
     CloseWindow();        // Close window and OpenGL context
     //--------------------------------------------------------------------------------------
-#if !defined(PLATFORM_ANDROID)
+
     return 0;
-#endif
 }

--- a/templates/standard_game/standard_game.c
+++ b/templates/standard_game/standard_game.c
@@ -15,29 +15,17 @@
 #include "raylib.h"
 #include "screens/screens.h"    // NOTE: Defines global variable: currentScreen
 
-#if defined(PLATFORM_ANDROID)
-    #include "android_native_app_glue.h"
-#endif
-
 //----------------------------------------------------------------------------------
 // Main entry point
 //----------------------------------------------------------------------------------
-#if defined(PLATFORM_ANDROID)
-void android_main(struct android_app *app) 
-#else
 int main(void)
-#endif
 {
-    // Initialization
+    // Initialization (Note windowTitle is unused on Android)
     //---------------------------------------------------------
     const int screenWidth = 800;
     const int screenHeight = 450;
 
-#if defined(PLATFORM_ANDROID)
-    InitWindow(screenWidth, screenHeight, app);
-#else
     InitWindow(screenWidth, screenHeight, "raylib template - standard game");
-#endif
 
     // TODO: Load global data here (assets that must be available in all screens, i.e. fonts)
     
@@ -150,7 +138,6 @@ int main(void)
     
     CloseWindow();        // Close window and OpenGL context
     //--------------------------------------------------------------------------------------
-#if !defined(PLATFORM_ANDROID)
+
     return 0;
-#endif
 }


### PR DESCRIPTION
Inspired by #504.
Instead of requiring the user to do `PLATFORM_ANDROID` `#ifdef`ery,
have the `android_main` entry point exported by raylib and call
the user-defined `main`. This way many games could (in theory)
run unmodified on Android.

**This is untested!**