### PR TITLE
Fix a buffer overflow in the OSS/BSD backend of mini_al.

### DIFF
--- a/src/external/mini_al.h
+++ b/src/external/mini_al.h
@@ -6974,7 +6974,7 @@ static mal_result mal_device_init__oss(mal_context* pContext, mal_device_type ty
 
     // When not using MMAP mode, we need to use an intermediary buffer for the client <-> device transfer. We do
     // everything by the size of a fragment.
-    pDevice->oss.pIntermediaryBuffer = mal_malloc(fragmentSizeInBytes);
+    pDevice->oss.pIntermediaryBuffer = mal_malloc(actualFragmentSizeInBytes);
     if (pDevice->oss.pIntermediaryBuffer == NULL) {
         close(pDevice->oss.fd);
         return mal_post_error(pDevice, "[OSS] Failed to allocate memory for intermediary buffer.", MAL_OUT_OF_MEMORY);


### PR DESCRIPTION
Related to issue #506.

This should fix a crash on OSS/BSD resulting from a buffer overflow.