### PR TITLE
Add orthographic 3d rendering mode

### DIFF
--- a/examples/models/models_orthographic_projection.c
+++ b/examples/models/models_orthographic_projection.c
@@ -1,0 +1,109 @@
+/*******************************************************************************************
+*
+*   raylib [models] example - Show the difference between perspective and orthographic projection 
+*
+*   This program is heavily based on the geometric objects example
+*
+*   This example has been created using raylib 1.0 (www.raylib.com)
+*   raylib is licensed under an unmodified zlib/libpng license (View raylib.h for details)
+*
+*   Copyright (c) 2014 Ramon Santamaria (@raysan5)
+*
+********************************************************************************************/
+
+#include "raylib.h"
+
+int main()
+{
+    // Initialization
+    //--------------------------------------------------------------------------------------
+    int screenWidth = 800;
+    int screenHeight = 450;
+    bool view_ortho = true;
+
+    InitWindow(screenWidth, screenHeight, "raylib [models] example - geometric shapes");
+
+    // Define the camera to look into our 3d world
+    Camera camera; 
+
+    SetTargetFPS(60);   // Set our game to run at 60 frames-per-second
+    //--------------------------------------------------------------------------------------
+
+    // Main game loop
+    while (!WindowShouldClose())    // Detect window close button or ESC key
+    {
+        // Update
+        //----------------------------------------------------------------------------------
+        // TODO: Update your variables here
+        //----------------------------------------------------------------------------------
+        //
+
+        // Input
+        //----------------------------------------------------------------------------------
+        if(IsKeyPressed(KEY_SPACE)) 
+        {
+            view_ortho = !view_ortho;
+        }
+
+
+        // Draw
+        //----------------------------------------------------------------------------------
+
+        if(view_ortho) 
+        {
+            camera = (Camera){{ 0.0f, 10.0f, 10.0f }, { 0.0f, 0.0f, 0.0f }, { 0.0f, 1.0f, 0.0f }, 10.0f, CAMERA_ORTHOGRAPHIC };
+        } 
+        else 
+        {
+            camera = (Camera){{ 0.0f, 10.0f, 10.0f }, { 0.0f, 0.0f, 0.0f }, { 0.0f, 1.0f, 0.0f }, 45.0f, CAMERA_PERSPECTIVE };
+        }
+
+        BeginDrawing();
+
+            ClearBackground(RAYWHITE);
+
+            Begin3dMode(camera);
+
+                DrawCube((Vector3){-4.0f, 0.0f, 2.0f}, 2.0f, 5.0f, 2.0f, RED);
+                DrawCubeWires((Vector3){-4.0f, 0.0f, 2.0f}, 2.0f, 5.0f, 2.0f, GOLD);
+                DrawCubeWires((Vector3){-4.0f, 0.0f, -2.0f}, 3.0f, 6.0f, 2.0f, MAROON);
+
+                DrawSphere((Vector3){-1.0f, 0.0f, -2.0f}, 1.0f, GREEN);
+                DrawSphereWires((Vector3){1.0f, 0.0f, 2.0f}, 2.0f, 16, 16, LIME);
+
+                DrawCylinder((Vector3){4.0f, 0.0f, -2.0f}, 1.0f, 2.0f, 3.0f, 4, SKYBLUE);
+                DrawCylinderWires((Vector3){4.0f, 0.0f, -2.0f}, 1.0f, 2.0f, 3.0f, 4, DARKBLUE);
+                DrawCylinderWires((Vector3){4.5f, -1.0f, 2.0f}, 1.0f, 1.0f, 2.0f, 6, BROWN);
+
+                DrawCylinder((Vector3){1.0f, 0.0f, -4.0f}, 0.0f, 1.5f, 3.0f, 8, GOLD);
+                DrawCylinderWires((Vector3){1.0f, 0.0f, -4.0f}, 0.0f, 1.5f, 3.0f, 8, PINK);
+
+                DrawGrid(10, 1.0f);        // Draw a grid
+
+            End3dMode();
+
+            DrawFPS(10, 10);
+
+            DrawText("Press Spacebar to switch camera type", 10, 40, 24, BLACK);
+
+            if(view_ortho)
+            {
+                DrawText("Orthographic", 10, 65, 24, BLACK);
+            }
+            else
+            {
+                DrawText("Perspective", 10, 65, 24, BLACK);
+            }
+
+
+        EndDrawing();
+        //----------------------------------------------------------------------------------
+    }
+
+    // De-Initialization
+    //--------------------------------------------------------------------------------------
+    CloseWindow();        // Close window and OpenGL context
+    //--------------------------------------------------------------------------------------
+
+    return 0;
+}

--- a/examples/models/models_orthographic_projection.c
+++ b/examples/models/models_orthographic_projection.c
@@ -13,6 +13,9 @@
 
 #include "raylib.h"
 
+#define FOVY_PERSPECTIVE 45.0f
+#define WIDTH_ORTHOGRAPHIC 10.0f
+
 int main()
 {
     // Initialization
@@ -22,10 +25,8 @@ int main()
 
     InitWindow(screenWidth, screenHeight, "raylib [models] example - geometric shapes");
 
-    const Camera perspective_camera = (Camera){{ 0.0f, 10.0f, 10.0f }, { 0.0f, 0.0f, 0.0f }, { 0.0f, 1.0f, 0.0f }, 45.0f, CAMERA_PERSPECTIVE };
-    const Camera orthographic_camera = (Camera){{ 0.0f, 10.0f, 10.0f }, { 0.0f, 0.0f, 0.0f }, { 0.0f, 1.0f, 0.0f }, 10.0f, CAMERA_ORTHOGRAPHIC };
     // Define the camera to look into our 3d world
-    Camera camera = perspective_camera;
+    Camera camera = {{ 0.0f, 10.0f, 10.0f }, { 0.0f, 0.0f, 0.0f }, { 0.0f, 1.0f, 0.0f }, FOVY_PERSPECTIVE, CAMERA_PERSPECTIVE };
 
     SetTargetFPS(60);   // Set our game to run at 60 frames-per-second
     //--------------------------------------------------------------------------------------
@@ -45,11 +46,13 @@ int main()
         {
             if(camera.type == CAMERA_PERSPECTIVE) 
             {
-                camera = orthographic_camera;
+                camera.fovy = WIDTH_ORTHOGRAPHIC;
+                camera.type = CAMERA_ORTHOGRAPHIC;
             } 
             else 
             {
-                camera = perspective_camera;
+                camera.fovy = FOVY_PERSPECTIVE;
+                camera.type = CAMERA_PERSPECTIVE;
             }
         }
 

--- a/examples/models/models_orthographic_projection.c
+++ b/examples/models/models_orthographic_projection.c
@@ -19,12 +19,13 @@ int main()
     //--------------------------------------------------------------------------------------
     int screenWidth = 800;
     int screenHeight = 450;
-    bool view_ortho = true;
 
     InitWindow(screenWidth, screenHeight, "raylib [models] example - geometric shapes");
 
+    const Camera perspective_camera = (Camera){{ 0.0f, 10.0f, 10.0f }, { 0.0f, 0.0f, 0.0f }, { 0.0f, 1.0f, 0.0f }, 45.0f, CAMERA_PERSPECTIVE };
+    const Camera orthographic_camera = (Camera){{ 0.0f, 10.0f, 10.0f }, { 0.0f, 0.0f, 0.0f }, { 0.0f, 1.0f, 0.0f }, 10.0f, CAMERA_ORTHOGRAPHIC };
     // Define the camera to look into our 3d world
-    Camera camera; 
+    Camera camera = perspective_camera;
 
     SetTargetFPS(60);   // Set our game to run at 60 frames-per-second
     //--------------------------------------------------------------------------------------
@@ -42,21 +43,20 @@ int main()
         //----------------------------------------------------------------------------------
         if(IsKeyPressed(KEY_SPACE)) 
         {
-            view_ortho = !view_ortho;
+            if(camera.type == CAMERA_PERSPECTIVE) 
+            {
+                camera = orthographic_camera;
+            } 
+            else 
+            {
+                camera = perspective_camera;
+            }
         }
 
 
         // Draw
         //----------------------------------------------------------------------------------
 
-        if(view_ortho) 
-        {
-            camera = (Camera){{ 0.0f, 10.0f, 10.0f }, { 0.0f, 0.0f, 0.0f }, { 0.0f, 1.0f, 0.0f }, 10.0f, CAMERA_ORTHOGRAPHIC };
-        } 
-        else 
-        {
-            camera = (Camera){{ 0.0f, 10.0f, 10.0f }, { 0.0f, 0.0f, 0.0f }, { 0.0f, 1.0f, 0.0f }, 45.0f, CAMERA_PERSPECTIVE };
-        }
 
         BeginDrawing();
 
@@ -86,11 +86,11 @@ int main()
 
             DrawText("Press Spacebar to switch camera type", 10, 40, 24, BLACK);
 
-            if(view_ortho)
+            if(camera.type == CAMERA_ORTHOGRAPHIC)
             {
                 DrawText("Orthographic", 10, 65, 24, BLACK);
             }
-            else
+            else if(camera.type == CAMERA_PERSPECTIVE)
             {
                 DrawText("Perspective", 10, 65, 24, BLACK);
             }

--- a/src/core.c
+++ b/src/core.c
@@ -919,10 +919,11 @@ void Begin3dMode(Camera camera)
     rlPushMatrix();                     // Save previous matrix, which contains the settings for the 2d ortho projection
     rlLoadIdentity();                   // Reset current matrix (PROJECTION)
 
+    float aspect = (float)screenWidth/(float)screenHeight;
+
     if(camera.type == CAMERA_PERSPECTIVE) 
     {
         // Setup perspective projection
-        float aspect = (float)screenWidth/(float)screenHeight;
         double top = 0.01*tan(camera.fovy*0.5*DEG2RAD);
         double right = top*aspect;
 
@@ -931,7 +932,6 @@ void Begin3dMode(Camera camera)
     else if(camera.type == CAMERA_ORTHOGRAPHIC)
     {
         // Setup orthographic projection
-        float aspect = (float)screenWidth/(float)screenHeight;
         double top = camera.fovy/2.0;
         double right = top*aspect;
 

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -398,12 +398,19 @@ typedef struct SpriteFont {
     CharInfo *chars;        // Characters info data
 } SpriteFont;
 
+// Camera projection modes
+typedef enum {
+    CAMERA_PERSPECTIVE = 0,
+    CAMERA_ORTHOGRAPHIC
+} CameraType;
+
 // Camera type, defines a camera position/orientation in 3d space
 typedef struct Camera {
     Vector3 position;       // Camera position
     Vector3 target;         // Camera target it looks-at
     Vector3 up;             // Camera up vector (rotation over its axis)
-    float fovy;             // Camera field-of-view apperture in Y (degrees)
+    float fovy;             // Camera field-of-view apperture in Y (degrees) in perspective, used as near plane width in orthographic
+    CameraType type;        // Camera type, controlling projection type, either CAMERA_PERSPECTIVE or CAMERA_ORTHOGRAPHIC.
 } Camera;
 
 // Camera2D type, defines a 2d camera
@@ -726,7 +733,7 @@ RLAPI void BeginTextureMode(RenderTexture2D target);              // Initializes
 RLAPI void EndTextureMode(void);                                  // Ends drawing to render texture
 
 // Screen-space-related functions
-RLAPI Ray GetMouseRay(Vector2 mousePosition, Camera camera);      // Returns a ray trace from mouse position
+RLAPI Ray GetMouseRay(Vector2 mousePosition, Camera camera);            // Returns a ray trace from mouse position
 RLAPI Vector2 GetWorldToScreen(Vector3 position, Camera camera);  // Returns the screen space position for a 3d world space position
 RLAPI Matrix GetCameraMatrix(Camera camera);                      // Returns camera transform matrix (view matrix)
 


### PR DESCRIPTION
I needed orthographic rendering for my own things. This solution doesn't modify the existing Camera struct but instead uses a new one called CameraOrtho and a new Begin3dModeOrtho() call. This means that the input systems and picking functions are not compatible, but for that to be possible they would need a lot of internal reimplementation. Some of the semantics might not be compatible either, suggesting that only a partial reimplementation would be necessary, further suggesting that a separate set of functionality is warranted.

This is a (at least partial) solution of issue #439 