### PR TITLE
Initialize the timer after the graphics device on desktop and web.

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -442,13 +442,13 @@ void InitWindow(int width, int height, void *data)
     uwpWindow = (EGLNativeWindowType)data;
 #endif
 
-    // Init hi-res timer
-    InitTimer();
-
     // Init graphics device (display device and OpenGL context)
     // NOTE: returns true if window and graphic device has been initialized successfully
     windowReady = InitGraphicsDevice(width, height);
     if (!windowReady) return;
+
+    // Init hi-res timer
+    InitTimer();
 
 #if defined(SUPPORT_DEFAULT_FONT)
     // Load default font


### PR DESCRIPTION
This is already the order that is used for Android (InitGraphicsDevice before InitTimer).

It doesn't appear to make a difference on desktop but on web using the timer before it's been initialized (by glfwInit, inside InitGraphicsDevice) causes the a long (and variable but often several seconds) sleep between the first and second frame.

I've seen many instances of sleeping for between 1 and 3 seconds but also a few of >100 seconds.

I see previousTime isn't used in InitGraphicsDevice so I would expect there to be few negative side-effects of this, but admittedly I haven't looked particularly hard.