### PR TITLE
Refactor all #define SUPPORT_* into a config.h

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,21 +1,25 @@
 # Setup the project and settings
 project(raylib)
-include("../utils.cmake")
 include(GNUInstallDirs)
 
 set(PROJECT_VERSION 1.9.4)
 set(API_VERSION 1)
 set(RAYLIB raylib)    # Name of the generated library
 
+include("CMakeOptions.txt")
+configure_file(config.h.in ${CMAKE_BINARY_DIR}/cmake/config.h)
+include_directories(${CMAKE_BINARY_DIR})
+
+include("../utils.cmake")
+
 # Get the sources together
 file(GLOB raylib_sources *.c)
+
 if(glfw3_FOUND)
   list(REMOVE_ITEM raylib_sources ${CMAKE_CURRENT_SOURCE_DIR}/rglfw.c)
 else()
   include_directories(external/glfw/include)
 endif()
-
-include("CMakeOptions.txt")
 
 if(USE_AUDIO)
   file(GLOB stb_vorbis external/stb_vorbis.c)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,36 +7,6 @@ set(PROJECT_VERSION 1.9.4)
 set(API_VERSION 1)
 set(RAYLIB raylib)    # Name of the generated library
 
-### Config options ###
-# Shared library is always PIC. Static library should be PIC too if linked into a shared library
-option(WITH_PIC "Compile static library as position-independent code" OFF)
-# Build a static and/or shared raylib?
-option(SHARED "Build raylib as a dynamic library" OFF)
-option(STATIC "Build raylib as a static library" ON)
-option(USE_AUDIO "Build raylib with audio module" ON)
-option(MACOS_FATLIB  "Build fat library for both i386 and x86_64 on macOS" ON)
-
-if(NOT (STATIC OR SHARED))
-  message(FATAL_ERROR "Nothing to do if both -DSHARED=OFF and -DSTATIC=OFF...")
-endif()
-
-if(DEFINED SHARED_RAYLIB)
-  set(SHARED ${SHARED_RAYLIB})
-  message(DEPRECATION "-DSHARED_RAYLIB is deprecated. Please use -DSHARED instead.")
-endif()
-if(DEFINED STATIC_RAYLIB)
-  set(STATIC ${STATIC_RAYLIB})
-  message(DEPRECATION "-DSTATIC_RAYLIB is deprecated. Please use -DSTATIC instead.")
-endif()
-
-# Platform
-set(PLATFORM "Desktop" CACHE STRING "Platform to build for.")
-set_property(CACHE PLATFORM PROPERTY STRINGS "Desktop" "Web" "Android" "Raspberry Pi")
-
-# OpenGL version
-set(OPENGL_VERSION "3.3" CACHE STRING "OpenGL Version to build raylib with")
-set_property(CACHE OPENGL_VERSION PROPERTY STRINGS "3.3" "2.1" "1.1" "ES 2.0")
-
 # Get the sources together
 file(GLOB raylib_sources *.c)
 if(glfw3_FOUND)
@@ -45,12 +15,14 @@ else()
   include_directories(external/glfw/include)
 endif()
 
+include("CMakeOptions.txt")
+
 if(USE_AUDIO)
   file(GLOB stb_vorbis external/stb_vorbis.c)
   file(GLOB mini_al external/mini_al.c ${stb_vorbis})
   set(sources ${raylib_sources} ${mini_al})
 else()
-  set(INCLUDE_AUDIO_MODULE 0) 
+  set(INCLUDE_AUDIO_MODULE 0)
   list(REMOVE_ITEM raylib_sources ${CMAKE_CURRENT_SOURCE_DIR}/audio.c)
   set(sources ${raylib_sources})
 endif()

--- a/src/CMakeOptions.txt
+++ b/src/CMakeOptions.txt
@@ -1,17 +1,77 @@
 ### Config options ###
+include(CMakeDependentOption)
 
 # Shared library is always PIC. Static library should be PIC too if linked into a shared library
 option(WITH_PIC "Compile static library as position-independent code" OFF)
 option(SHARED "Build raylib as a dynamic library" OFF)
 option(STATIC "Build raylib as a static library" ON)
-option(USE_AUDIO "Build raylib with audio module" ON)
 option(MACOS_FATLIB  "Build fat library for both i386 and x86_64 on macOS" ON)
+option(USE_AUDIO "Build raylib with audio module" ON)
+cmake_dependent_option(USE_OPENAL_BACKEND "Link raylib with openAL instead of mini-al" OFF "USE_AUDIO" OFF)
+set(USE_EXTERNAL_GLFW  OFF  CACHE STRING "Link raylib against system GLFW instead of embedded one")
+set_property(CACHE USE_EXTERNAL_GLFW PROPERTY STRINGS ON OFF IF_POSSIBLE)
+if(UNIX AND NOT APPLE)
+    option(USE_WAYLAND "Use Wayland for window creation" OFF)
+endif()
+
 
 set(PLATFORM "Desktop" CACHE STRING "Platform to build for.")
 set_property(CACHE PLATFORM PROPERTY STRINGS "Desktop" "Web" "Android" "Raspberry Pi")
 
 set(OPENGL_VERSION "3.3" CACHE STRING "OpenGL Version to build raylib with")
 set_property(CACHE OPENGL_VERSION PROPERTY STRINGS "3.3" "2.1" "1.1" "ES 2.0")
+
+# core.c
+option(SUPPORT_BUSY_WAIT_LOOP "Use busy wait loop for timing sync instead of a high-resolution timer" ON)
+option(SUPPORT_CAMERA_SYSTEM "Provide camera module (camera.h) with multiple predefined cameras: free, 1st/3rd person, orbital" ON)
+option(SUPPORT_DEFAULT_FONT "Default font is loaded on window initialization to be available for the user to render simple text. If enabled, uses external module functions to load default raylib font (module: text)" ON)
+option(SUPPORT_GIF_RECORDING "Allow automatic gif recording of current screen pressing CTRL+F12, defined in KeyCallback()" ON)
+option(SUPPORT_GESTURES_SYSTEM "Gestures module is included (gestures.h) to support gestures detection: tap, hold, swipe, drag" ON)
+option(SUPPORT_MOUSE_GESTURES "Mouse gestures are directly mapped like touches and processed by gestures system" ON)
+
+# rlgl.c
+option(SUPPORT_VR_SIMULATOR "Support VR simulation functionality (stereo rendering)" ON)
+option(SUPPORT_DISTORTION_SHADER "Include stereo rendering distortion shader (shader_distortion.h)" ON)
+
+# models.c
+option(SUPPORT_FILEFORMAT_OBJ "Support loading OBJ file format" ON)
+option(SUPPORT_FILEFORMAT_MTL "Support loading MTL file format" ON)
+option(SUPPORT_MESH_GENERATION "Support procedural mesh generation functions, uses external par_shapes.h library. NOTE: Some generated meshes DO NOT include generated texture coordinates" ON)
+
+# textures.c
+option(SUPPORT_IMAGE_GENERATION "Support proedural image generation functionality (gradient, spot, perlin-noise, cellular)" ON)
+option(SUPPORT_FILEFORMAT_PNG "Support loading PNG as textures" ON)
+option(SUPPORT_FILEFORMAT_DDS "Support loading DDS as textures" ON)
+option(SUPPORT_FILEFORMAT_HDR "Support loading HDR as textures" ON)
+option(SUPPORT_FILEFORMAT_KTX "Support loading KTX as textures" ON)
+option(SUPPORT_FILEFORMAT_ASTC "Support loading ASTC as  textures" ON)
+option(SUPPORT_FILEFORMAT_BMP "Support loading BMP as textures" OFF)
+option(SUPPORT_FILEFORMAT_TGA "Support loading TGA as textures" OFF)
+option(SUPPORT_FILEFORMAT_JPG "Support loading JPG as textures" OFF)
+option(SUPPORT_FILEFORMAT_GIF "Support loading GIF as textures" OFF)
+option(SUPPORT_FILEFORMAT_PSD "Support loading PSD as textures" OFF)
+option(SUPPORT_FILEFORMAT_PKM "Support loading PKM as textures" OFF)
+option(SUPPORT_FILEFORMAT_PVR "Support loading PVR as textures" OFF)
+
+# audio.c
+option(SUPPORT_FILEFORMAT_WAV  "Support loading WAV for sound" ON)
+option(SUPPORT_FILEFORMAT_OGG  "Support loading OGG for sound" ON)
+option(SUPPORT_FILEFORMAT_XM   "Support loading XM for sound" ON)
+option(SUPPORT_FILEFORMAT_MOD  "Support loading MOD for sound" ON)
+option(SUPPORT_FILEFORMAT_FLAC "Support loading FLAC for sound" OFF)
+
+# shapes.c
+option(USE_DEFAULT_FONT_TEXTURE "Draw rectangle shapes using font texture white character instead of default white texture. Allows drawing rectangles and text with a single draw call, very useful for GUI systems!" ON)
+
+# utils.c
+option(SUPPORT_SAVE_PNG "Support saving image data in PNG file format" ON)
+option(SUPPORT_SAVE_BMP "Support saving image data in BMP file format" OFF)
+option(SUPPORT_TRACELOG "Show TraceLog() output messages. NOTE: By default LOG_DEBUG traces not shown" ON)
+
+option(SUPPORT_FILEFORMAT_FNT "Support loading fonts in FNT format" ON)
+option(SUPPORT_FILEFORMAT_TTF "Support loading font in TTF format" ON)
+
+option(SUPPORT_IMAGE_MANIPULATION "Support multiple image editing functions to scale, adjust colors, flip, draw on images, crop... If not defined only three image editing functions supported: ImageFormat(), ImageAlphaMask(), ImageToPOT()" ON)
 
 if(NOT (STATIC OR SHARED))
   message(FATAL_ERROR "Nothing to do if both -DSHARED=OFF and -DSTATIC=OFF...")

--- a/src/CMakeOptions.txt
+++ b/src/CMakeOptions.txt
@@ -1,0 +1,29 @@
+### Config options ###
+
+# Shared library is always PIC. Static library should be PIC too if linked into a shared library
+option(WITH_PIC "Compile static library as position-independent code" OFF)
+option(SHARED "Build raylib as a dynamic library" OFF)
+option(STATIC "Build raylib as a static library" ON)
+option(USE_AUDIO "Build raylib with audio module" ON)
+option(MACOS_FATLIB  "Build fat library for both i386 and x86_64 on macOS" ON)
+
+set(PLATFORM "Desktop" CACHE STRING "Platform to build for.")
+set_property(CACHE PLATFORM PROPERTY STRINGS "Desktop" "Web" "Android" "Raspberry Pi")
+
+set(OPENGL_VERSION "3.3" CACHE STRING "OpenGL Version to build raylib with")
+set_property(CACHE OPENGL_VERSION PROPERTY STRINGS "3.3" "2.1" "1.1" "ES 2.0")
+
+if(NOT (STATIC OR SHARED))
+  message(FATAL_ERROR "Nothing to do if both -DSHARED=OFF and -DSTATIC=OFF...")
+endif()
+
+if(DEFINED SHARED_RAYLIB)
+  set(SHARED ${SHARED_RAYLIB})
+  message(DEPRECATION "-DSHARED_RAYLIB is deprecated. Please use -DSHARED instead.")
+endif()
+if(DEFINED STATIC_RAYLIB)
+  set(STATIC ${STATIC_RAYLIB})
+  message(DEPRECATION "-DSTATIC_RAYLIB is deprecated. Please use -DSTATIC instead.")
+endif()
+
+# vim: ft=cmake

--- a/src/audio.c
+++ b/src/audio.c
@@ -11,7 +11,7 @@
 *       - Manage raw audio context
 *
 *   CONFIGURATION:
-*   
+*
 *   #define AUDIO_STANDALONE
 *       Define to use the module as standalone library (independently of raylib).
 *       Required types and functions are defined in the same module.
@@ -24,7 +24,7 @@
 *   #define SUPPORT_FILEFORMAT_XM
 *   #define SUPPORT_FILEFORMAT_MOD
 *   #define SUPPORT_FILEFORMAT_FLAC
-*       Selected desired fileformats to be supported for loading. Some of those formats are 
+*       Selected desired fileformats to be supported for loading. Some of those formats are
 *       supported by default, to remove support, just comment unrequired #define in this module
 *
 *   LIMITATIONS (only OpenAL Soft):
@@ -72,13 +72,7 @@
 *
 **********************************************************************************************/
 
-// Default configuration flags (supported features)
-//-------------------------------------------------
-#define SUPPORT_FILEFORMAT_WAV
-#define SUPPORT_FILEFORMAT_OGG
-#define SUPPORT_FILEFORMAT_XM
-#define SUPPORT_FILEFORMAT_MOD
-//-------------------------------------------------
+#include "config.h"
 
 #if !defined(USE_OPENAL_BACKEND)
     #define USE_MINI_AL 1       // Set to 1 to use mini_al; 0 to use OpenAL.

--- a/src/config.h
+++ b/src/config.h
@@ -1,0 +1,74 @@
+/* Edit to control what features raylib is compiled with. */
+
+// text.c
+/* Default font is loaded on window initialization to be available for the user to render simple text. NOTE: If enabled, uses external module functions to load default raylib font (module: text) */
+#define SUPPORT_DEFAULT_FONT 1
+/* Selected desired fileformats to be supported for loading.  */
+#define SUPPORT_FILEFORMAT_FNT 1
+#define SUPPORT_FILEFORMAT_TTF 1
+
+// textures.c
+/* Selecte desired fileformats to be supported for image data loading. */
+#define SUPPORT_FILEFORMAT_PNG 1
+#define SUPPORT_FILEFORMAT_DDS 1
+#define SUPPORT_FILEFORMAT_HDR 1
+#define SUPPORT_FILEFORMAT_KTX 1
+#define SUPPORT_FILEFORMAT_ASTC 1
+/* #undef SUPPORT_FILEFORMAT_BMP */
+/* #undef SUPPORT_FILEFORMAT_TGA */
+/* #undef SUPPORT_FILEFORMAT_JPG */
+/* #undef SUPPORT_FILEFORMAT_GIF */
+/* #undef SUPPORT_FILEFORMAT_PSD */
+/* #undef SUPPORT_FILEFORMAT_PKM */
+/* #undef SUPPORT_FILEFORMAT_PVR */
+
+/* Support multiple image editing functions to scale, adjust colors, flip, draw on images, crop... If not defined only three image editing functions supported: ImageFormat(), ImageAlphaMask(), ImageToPOT() */
+#define SUPPORT_IMAGE_MANIPULATION 1
+
+/* Support proedural image generation functionality (gradient, spot, perlin-noise, cellular) */
+#define SUPPORT_IMAGE_GENERATION 1
+
+// rlgl.c
+/* Support VR simulation functionality (stereo rendering) */
+#define SUPPORT_VR_SIMULATOR 1
+/* Include stereo rendering distortion shader (shader_distortion.h) */
+#define SUPPORT_DISTORTION_SHADER 1
+
+// core.c
+/* Camera module is included (camera.h) and multiple predefined cameras are available: free, 1st/3rd person, orbital */
+#define SUPPORT_CAMERA_SYSTEM 1
+/* Gestures module is included (gestures.h) to support gestures detection: tap, hold, swipe, drag */
+#define SUPPORT_GESTURES_SYSTEM 1
+/* Mouse gestures are directly mapped like touches and processed by gestures system. */
+#define SUPPORT_MOUSE_GESTURES 1
+/* Use busy wait loop for timing sync, if not defined, a high-resolution timer is setup and used */
+#define SUPPORT_BUSY_WAIT_LOOP 1
+/* Allow automatic gif recording of current screen pressing CTRL+F12, defined in KeyCallback() */
+#define SUPPORT_GIF_RECORDING 1
+
+// audio.c
+/* Desired fileformats to be supported for loading. */
+#define SUPPORT_FILEFORMAT_WAV 1
+#define SUPPORT_FILEFORMAT_OGG 1
+#define SUPPORT_FILEFORMAT_XM 1
+#define SUPPORT_FILEFORMAT_MOD 1
+/* #undef SUPPORT_FILEFORMAT_FLAC */
+
+// models.c
+/* Selected desired fileformats to be supported for loading. */
+#define SUPPORT_FILEFORMAT_OBJ 1
+#define SUPPORT_FILEFORMAT_MTL 1
+
+/* Support procedural mesh generation functions, uses external par_shapes.h library
+ * NOTE: Some generated meshes DO NOT include generated texture coordinates
+ */
+#define SUPPORT_MESH_GENERATION 1
+
+// utils.c
+/* Show TraceLog() output messages. NOTE: By default LOG_DEBUG traces not shown */
+#define SUPPORT_TRACELOG 1
+
+/* Support saving image data as PNG fileformat. NOTE: Requires stb_image_write library */
+#define SUPPORT_SAVE_PNG 1
+/* Support saving image data as PMP fileformat. NOTE: Requires stb_image_write library */
+/* #undef SUPPORT_SAVE_BMP */

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -1,78 +1,74 @@
-/* Edit to control what features Makefile'd raylib is compiled with. */
-#ifdef RAYLIB_CMAKE /* Edit CMakeOptions.txt for CMake instead! */
-#include "cmake/config.h"
-#else
+/* config.h.in */
+
 // text.c
 /* Default font is loaded on window initialization to be available for the user to render simple text. NOTE: If enabled, uses external module functions to load default raylib font (module: text) */
-#define SUPPORT_DEFAULT_FONT 1
+#cmakedefine SUPPORT_DEFAULT_FONT 1
 /* Selected desired fileformats to be supported for loading.  */
-#define SUPPORT_FILEFORMAT_FNT 1
-#define SUPPORT_FILEFORMAT_TTF 1
+#cmakedefine SUPPORT_FILEFORMAT_FNT 1
+#cmakedefine SUPPORT_FILEFORMAT_TTF 1
 
 // textures.c
 /* Selecte desired fileformats to be supported for image data loading. */
-#define SUPPORT_FILEFORMAT_PNG 1
-#define SUPPORT_FILEFORMAT_DDS 1
-#define SUPPORT_FILEFORMAT_HDR 1
-#define SUPPORT_FILEFORMAT_KTX 1
-#define SUPPORT_FILEFORMAT_ASTC 1
-/* #undef SUPPORT_FILEFORMAT_BMP */
-/* #undef SUPPORT_FILEFORMAT_TGA */
-/* #undef SUPPORT_FILEFORMAT_JPG */
-/* #undef SUPPORT_FILEFORMAT_GIF */
-/* #undef SUPPORT_FILEFORMAT_PSD */
-/* #undef SUPPORT_FILEFORMAT_PKM */
-/* #undef SUPPORT_FILEFORMAT_PVR */
+#cmakedefine SUPPORT_FILEFORMAT_PNG 1
+#cmakedefine SUPPORT_FILEFORMAT_DDS 1
+#cmakedefine SUPPORT_FILEFORMAT_HDR 1
+#cmakedefine SUPPORT_FILEFORMAT_KTX 1
+#cmakedefine SUPPORT_FILEFORMAT_ASTC 1
+#cmakedefine SUPPORT_FILEFORMAT_BMP 1
+#cmakedefine SUPPORT_FILEFORMAT_TGA 1
+#cmakedefine SUPPORT_FILEFORMAT_JPG 1
+#cmakedefine SUPPORT_FILEFORMAT_GIF 1
+#cmakedefine SUPPORT_FILEFORMAT_PSD 1
+#cmakedefine SUPPORT_FILEFORMAT_PKM 1
+#cmakedefine SUPPORT_FILEFORMAT_PVR 1
 
 /* Support multiple image editing functions to scale, adjust colors, flip, draw on images, crop... If not defined only three image editing functions supported: ImageFormat(), ImageAlphaMask(), ImageToPOT() */
-#define SUPPORT_IMAGE_MANIPULATION 1
+#cmakedefine SUPPORT_IMAGE_MANIPULATION 1
 
 /* Support proedural image generation functionality (gradient, spot, perlin-noise, cellular) */
-#define SUPPORT_IMAGE_GENERATION 1
+#cmakedefine SUPPORT_IMAGE_GENERATION 1
 
 // rlgl.c
 /* Support VR simulation functionality (stereo rendering) */
-#define SUPPORT_VR_SIMULATOR 1
+#cmakedefine SUPPORT_VR_SIMULATOR 1
 /* Include stereo rendering distortion shader (shader_distortion.h) */
-#define SUPPORT_DISTORTION_SHADER 1
+#cmakedefine SUPPORT_DISTORTION_SHADER 1
 
 // core.c
 /* Camera module is included (camera.h) and multiple predefined cameras are available: free, 1st/3rd person, orbital */
-#define SUPPORT_CAMERA_SYSTEM 1
+#cmakedefine SUPPORT_CAMERA_SYSTEM 1
 /* Gestures module is included (gestures.h) to support gestures detection: tap, hold, swipe, drag */
-#define SUPPORT_GESTURES_SYSTEM 1
+#cmakedefine SUPPORT_GESTURES_SYSTEM 1
 /* Mouse gestures are directly mapped like touches and processed by gestures system. */
-#define SUPPORT_MOUSE_GESTURES 1
+#cmakedefine SUPPORT_MOUSE_GESTURES 1
 /* Use busy wait loop for timing sync, if not defined, a high-resolution timer is setup and used */
-#define SUPPORT_BUSY_WAIT_LOOP 1
+#cmakedefine SUPPORT_BUSY_WAIT_LOOP 1
 /* Allow automatic gif recording of current screen pressing CTRL+F12, defined in KeyCallback() */
-#define SUPPORT_GIF_RECORDING 1
+#cmakedefine SUPPORT_GIF_RECORDING 1
 
 // audio.c
 /* Desired fileformats to be supported for loading. */
-#define SUPPORT_FILEFORMAT_WAV 1
-#define SUPPORT_FILEFORMAT_OGG 1
-#define SUPPORT_FILEFORMAT_XM 1
-#define SUPPORT_FILEFORMAT_MOD 1
-/* #undef SUPPORT_FILEFORMAT_FLAC */
+#cmakedefine SUPPORT_FILEFORMAT_WAV 1
+#cmakedefine SUPPORT_FILEFORMAT_OGG 1
+#cmakedefine SUPPORT_FILEFORMAT_XM 1
+#cmakedefine SUPPORT_FILEFORMAT_MOD 1
+#cmakedefine SUPPORT_FILEFORMAT_FLAC 1
 
 // models.c
 /* Selected desired fileformats to be supported for loading. */
-#define SUPPORT_FILEFORMAT_OBJ 1
-#define SUPPORT_FILEFORMAT_MTL 1
+#cmakedefine SUPPORT_FILEFORMAT_OBJ 1
+#cmakedefine SUPPORT_FILEFORMAT_MTL 1
 
 /* Support procedural mesh generation functions, uses external par_shapes.h library
  * NOTE: Some generated meshes DO NOT include generated texture coordinates
  */
-#define SUPPORT_MESH_GENERATION 1
+#cmakedefine SUPPORT_MESH_GENERATION 1
 
 // utils.c
 /* Show TraceLog() output messages. NOTE: By default LOG_DEBUG traces not shown */
-#define SUPPORT_TRACELOG 1
+#cmakedefine SUPPORT_TRACELOG 1
 
 /* Support saving image data as PNG fileformat. NOTE: Requires stb_image_write library */
-#define SUPPORT_SAVE_PNG 1
+#cmakedefine SUPPORT_SAVE_PNG 1
 /* Support saving image data as PMP fileformat. NOTE: Requires stb_image_write library */
-/* #undef SUPPORT_SAVE_BMP */
-
-#endif
+#cmakedefine SUPPORT_SAVE_BMP 1

--- a/src/core.c
+++ b/src/core.c
@@ -48,7 +48,7 @@
 *       Mouse gestures are directly mapped like touches and processed by gestures system.
 *
 *   #define SUPPORT_BUSY_WAIT_LOOP
-*       Use busy wait loop for timming sync, if not defined, a high-resolution timer is setup and used
+*       Use busy wait loop for timing sync, if not defined, a high-resolution timer is setup and used
 *
 *   #define SUPPORT_GIF_RECORDING
 *       Allow automatic gif recording of current screen pressing CTRL+F12, defined in KeyCallback()
@@ -81,15 +81,7 @@
 *
 **********************************************************************************************/
 
-// Default configuration flags (supported features)
-//-------------------------------------------------
-#define SUPPORT_DEFAULT_FONT
-#define SUPPORT_MOUSE_GESTURES
-#define SUPPORT_CAMERA_SYSTEM
-#define SUPPORT_GESTURES_SYSTEM
-#define SUPPORT_BUSY_WAIT_LOOP
-#define SUPPORT_GIF_RECORDING
-//-------------------------------------------------
+#include "config.h"
 
 #include "raylib.h"
 

--- a/src/models.c
+++ b/src/models.c
@@ -36,12 +36,7 @@
 *
 **********************************************************************************************/
 
-// Default configuration flags (supported features)
-//-------------------------------------------------
-#define SUPPORT_FILEFORMAT_OBJ
-#define SUPPORT_FILEFORMAT_MTL
-#define SUPPORT_MESH_GENERATION
-//-------------------------------------------------
+#include "config.h"
 
 #include "raylib.h"
 

--- a/src/rlgl.c
+++ b/src/rlgl.c
@@ -54,11 +54,7 @@
 *
 **********************************************************************************************/
 
-// Default configuration flags (supported features)
-//-------------------------------------------------
-#define SUPPORT_VR_SIMULATOR
-#define SUPPORT_DISTORTION_SHADER
-//-------------------------------------------------
+#include "config.h"
 
 #include "rlgl.h"
 

--- a/src/rlgl.h
+++ b/src/rlgl.h
@@ -24,7 +24,7 @@
 *   #define RLGL_STANDALONE
 *       Use rlgl as standalone library (no raylib dependency)
 *
-*   #define SUPPORT_VR_SIMULATION / SUPPORT_STEREO_RENDERING
+*   #define SUPPORT_VR_SIMULATOR
 *       Support VR simulation functionality (stereo rendering)
 *
 *   #define SUPPORT_DISTORTION_SHADER

--- a/src/shapes.c
+++ b/src/shapes.c
@@ -4,12 +4,6 @@
 *
 *   CONFIGURATION:
 *
-*   #define SUPPORT_QUADS_ONLY
-*       Draw shapes using only QUADS, vertex are accumulated in QUADS arrays (like textures)
-*
-*   #define SUPPORT_TRIANGLES_ONLY
-*       Draw shapes using only TRIANGLES, vertex are accumulated in TRIANGLES arrays
-*
 *   #define USE_DEFAULT_FONT_TEXTURE
 *       Draw rectangle shapes using font texture white character instead of default white texture
 *       Allows drawing rectangles and text with a single draw call, very useful for GUI systems!
@@ -36,7 +30,7 @@
 *
 **********************************************************************************************/
 
-#define USE_DEFAULT_FONT_TEXTURE
+#include "config.h"
 
 #include "raylib.h"
 

--- a/src/text.c
+++ b/src/text.c
@@ -6,7 +6,7 @@
 *
 *   #define SUPPORT_FILEFORMAT_FNT
 *   #define SUPPORT_FILEFORMAT_TTF
-*       Selected desired fileformats to be supported for loading. Some of those formats are 
+*       Selected desired fileformats to be supported for loading. Some of those formats are
 *       supported by default, to remove support, just comment unrequired #define in this module
 *
 *   #define SUPPORT_DEFAULT_FONT
@@ -36,12 +36,7 @@
 *
 **********************************************************************************************/
 
-// Default supported features
-//-------------------------------------
-#define SUPPORT_DEFAULT_FONT
-#define SUPPORT_FILEFORMAT_FNT
-#define SUPPORT_FILEFORMAT_TTF
-//-------------------------------------
+#include "config.h"
 
 #include "raylib.h"
 

--- a/src/textures.c
+++ b/src/textures.c
@@ -52,17 +52,7 @@
 *     3. This notice may not be removed or altered from any source distribution.
 *
 **********************************************************************************************/
-
-// Default configuration flags (supported features)
-//-------------------------------------------------
-#define SUPPORT_FILEFORMAT_PNG
-#define SUPPORT_FILEFORMAT_DDS
-#define SUPPORT_FILEFORMAT_HDR
-#define SUPPORT_FILEFORMAT_KTX
-#define SUPPORT_FILEFORMAT_ASTC
-#define SUPPORT_IMAGE_MANIPULATION
-#define SUPPORT_IMAGE_GENERATION
-//-------------------------------------------------
+#include "config.h"
 
 #include "raylib.h"
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -41,7 +41,7 @@
 *
 **********************************************************************************************/
 
-#define SUPPORT_TRACELOG            // Output tracelog messages
+#include "config.h"
 
 #include "raylib.h"                 // WARNING: Required for: LogType enum
 #include "utils.h"

--- a/src/utils.h
+++ b/src/utils.h
@@ -32,7 +32,9 @@
     #include <android/asset_manager.h>      // Required for: AAssetManager
 #endif
 
-#define SUPPORT_SAVE_PNG
+#ifndef SUPPORT_SAVE_PNG
+#define SUPPORT_SAVE_PNG 1
+#endif
 
 //----------------------------------------------------------------------------------
 // Some basic Defines

--- a/utils.cmake
+++ b/utils.cmake
@@ -1,12 +1,7 @@
 # All sorts of things that we need cross project
 cmake_minimum_required(VERSION 2.8.0)
 
-set(USE_EXTERNAL_GLFW  OFF  CACHE STRING "Link raylib against system GLFW instead of embedded one")
-set_property(CACHE USE_EXTERNAL_GLFW PROPERTY STRINGS ON OFF IF_POSSIBLE)
-
-if(UNIX AND NOT APPLE)
-    option(USE_WAYLAND "Use Wayland for window creation" OFF)
-endif()
+add_definitions("-DRAYLIB_CMAKE=1")
 
 # Linking for OS X -framework options
 # Will do nothing on other OSes
@@ -29,7 +24,7 @@ else()
   endif()
 
   find_library(pthread NAMES pthread)
-  find_package(OpenGL)
+  find_package(OpenGL QUIET)
   if ("${OPENGL_LIBRARIES}" STREQUAL "")
     if(NOT USE_WAYLAND)
       # CFLAGS=-m32 cmake on Linux fails for some reason, so fallback to hardcoding
@@ -69,7 +64,7 @@ endif()
 if(USE_EXTERNAL_GLFW STREQUAL "ON")
     find_package(glfw3 3.2.1 REQUIRED)
 elseif(USE_EXTERNAL_GLFW STREQUAL "IF_POSSIBLE")
-    find_package(glfw3 3.2.1)
+    find_package(glfw3 3.2.1 QUIET)
 endif()
 if (glfw3_FOUND)
   set(LIBS_PRIVATE ${LIBS_PRIVATE} glfw)
@@ -114,4 +109,3 @@ function(link_libraries_to_executable executable)
     target_link_libraries(${executable} raylib ${__PKG_CONFIG_LIBS_PRIVATE})
   endif()
 endfunction()
-


### PR DESCRIPTION
Instead of requiring users to manually edit or add `#define SUPPORT_*`s to the appropriate source file, centralize all library configuration to an internal `config.h` file.

This file is generated at configuration time from CMake options and hardcoded for the Makefile and other build systems.