### PR TITLE
CMake: Don't create symlinks on unsupporting file systems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,7 +98,7 @@ project/vs2015.UWP/*.db
 !project/vs2015.UWP/*.sln
 !project/vs2015.UWP/raylib.App.UWP/*.vcxproj
 
-# Web examples 
+# Web examples
 docs/examples/web/*.html
 docs/examples/web/*/*.html
 !docs/examples/web/loader.html
@@ -116,6 +116,7 @@ CMakeCache.txt
 CMakeFiles
 CMakeScripts
 Testing
+TestingIfSymlinkWorks
 cmake_install.cmake
 install_manifest.txt
 compile_commands.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,18 @@ add_if_flag_works(-Werror=implicit-function-declaration CMAKE_C_FLAGS)
 # src/external/jar_xm.h does shady stuff
 add_if_flag_works(-fno-strict-aliasing CMAKE_C_FLAGS)
 
+message(STATUS "Check for symlink support in file system")
+execute_process(
+  COMMAND ${CMAKE_COMMAND} -E create_symlink CMakeLists.txt "${CMAKE_CURRENT_BINARY_DIR}/TestingIfSymlinkWorks"
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    RESULT_VARIABLE FILESYSTEM_LACKS_SYMLINKS
+)
+If (FILESYSTEM_LACKS_SYMLINKS)
+  message(STATUS "Testing if file system supports symlinks -- unsupported")
+else()
+  message(STATUS "Testing if file system supports symlinks -- supported")
+endif()
+
 if (ENABLE_ASAN)
     add_if_flag_works(-fno-omit-frame-pointer CMAKE_C_FLAGS CMAKE_LINKER_FLAGS)
     add_if_flag_works(-fsanitize=address CMAKE_C_FLAGS CMAKE_LINKER_FLAGS)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -101,9 +101,15 @@ if(${PLATFORM} MATCHES "PLATFORM_DESKTOP")
     set(CMAKE_MACOSX_RPATH ON)
 
     target_link_libraries(${RAYLIB}_shared ${LIBS_PRIVATE})
+    if (UNIX AND ${FILESYSTEM_LACKS_SYMLINKS})
+      MESSAGE(WARNING "Can't version UNIX shared library on file system without symlink support")
+    else()
+        set_target_properties(${RAYLIB}_shared PROPERTIES
+            VERSION   ${PROJECT_VERSION}
+            SOVERSION ${API_VERSION}
+        )
+    endif()
     set_target_properties(${RAYLIB}_shared PROPERTIES
-        VERSION   ${PROJECT_VERSION}
-        SOVERSION ${API_VERSION}
         PUBLIC_HEADER "raylib.h"
     )
     if(WIN32)


### PR DESCRIPTION
Panders to the idiosyncrasies of my work flow:
I have my raylib build directory mounted as a VirtualBox vboxfs for use
with my Linux VM, but vboxfs doesn't support symlinks, while raylib shared
library versioning on Unix expects symlinks to work.
If this happens, library versioning is now disabled on Unix with
an error message instead of just failing the build.