### PR TITLE
Makefile: Remove unnecessary -no-pie for older GCC support

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -215,7 +215,7 @@ ifeq ($(PLATFORM),PLATFORM_DESKTOP)
             #CC = clang
         endif
         ifeq ($(RAYLIB_LIBTYPE),STATIC)
-        CFLAGS += -no-pie -D_DEFAULT_SOURCE
+        CFLAGS += -D_DEFAULT_SOURCE
         endif
         ifeq ($(RAYLIB_LIBTYPE),SHARED)
         # Explicitly enable runtime link to libraylib.so

--- a/games/Makefile
+++ b/games/Makefile
@@ -163,7 +163,7 @@ ifeq ($(PLATFORM),PLATFORM_DESKTOP)
         CFLAGS += $(RAYLIB_PATH)/src/raylib_icon -Wl,--subsystem,windows
     endif
     ifeq ($(PLATFORM_OS),LINUX)
-        CFLAGS += -no-pie -D_DEFAULT_SOURCE
+        CFLAGS += -D_DEFAULT_SOURCE
     endif
 endif
 ifeq ($(PLATFORM),PLATFORM_RPI)

--- a/games/drturtle/Makefile
+++ b/games/drturtle/Makefile
@@ -163,7 +163,7 @@ ifeq ($(PLATFORM),PLATFORM_DESKTOP)
         CFLAGS += $(RAYLIB_PATH)/src/raylib_icon -Wl,--subsystem,windows
     endif
     ifeq ($(PLATFORM_OS),LINUX)
-        CFLAGS += -no-pie -D_DEFAULT_SOURCE
+        CFLAGS += -D_DEFAULT_SOURCE
     endif
 endif
 ifeq ($(PLATFORM),PLATFORM_RPI)

--- a/games/just_do/Makefile
+++ b/games/just_do/Makefile
@@ -163,7 +163,7 @@ ifeq ($(PLATFORM),PLATFORM_DESKTOP)
         CFLAGS += $(RAYLIB_PATH)/src/raylib_icon -Wl,--subsystem,windows
     endif
     ifeq ($(PLATFORM_OS),LINUX)
-        CFLAGS += -no-pie -D_DEFAULT_SOURCE
+        CFLAGS += -D_DEFAULT_SOURCE
     endif
 endif
 ifeq ($(PLATFORM),PLATFORM_RPI)

--- a/games/koala_seasons/Makefile
+++ b/games/koala_seasons/Makefile
@@ -163,7 +163,7 @@ ifeq ($(PLATFORM),PLATFORM_DESKTOP)
         CFLAGS += $(RAYLIB_PATH)/src/raylib_icon -Wl,--subsystem,windows
     endif
     ifeq ($(PLATFORM_OS),LINUX)
-        CFLAGS += -no-pie -D_DEFAULT_SOURCE
+        CFLAGS += -D_DEFAULT_SOURCE
     endif
 endif
 ifeq ($(PLATFORM),PLATFORM_RPI)

--- a/games/light_my_ritual/Makefile
+++ b/games/light_my_ritual/Makefile
@@ -163,7 +163,7 @@ ifeq ($(PLATFORM),PLATFORM_DESKTOP)
         CFLAGS += $(RAYLIB_PATH)/src/raylib_icon -Wl,--subsystem,windows
     endif
     ifeq ($(PLATFORM_OS),LINUX)
-        CFLAGS += -no-pie -D_DEFAULT_SOURCE
+        CFLAGS += -D_DEFAULT_SOURCE
     endif
 endif
 ifeq ($(PLATFORM),PLATFORM_RPI)

--- a/games/skully_escape/Makefile
+++ b/games/skully_escape/Makefile
@@ -163,7 +163,7 @@ ifeq ($(PLATFORM),PLATFORM_DESKTOP)
         CFLAGS += $(RAYLIB_PATH)/src/raylib_icon -Wl,--subsystem,windows
     endif
     ifeq ($(PLATFORM_OS),LINUX)
-        CFLAGS += -no-pie -D_DEFAULT_SOURCE
+        CFLAGS += -D_DEFAULT_SOURCE
     endif
 endif
 ifeq ($(PLATFORM),PLATFORM_RPI)

--- a/games/transmission/Makefile
+++ b/games/transmission/Makefile
@@ -163,7 +163,7 @@ ifeq ($(PLATFORM),PLATFORM_DESKTOP)
         CFLAGS += $(RAYLIB_PATH)/src/raylib_icon -Wl,--subsystem,windows
     endif
     ifeq ($(PLATFORM_OS),LINUX)
-        CFLAGS += -no-pie -D_DEFAULT_SOURCE
+        CFLAGS += -D_DEFAULT_SOURCE
     endif
 endif
 ifeq ($(PLATFORM),PLATFORM_RPI)

--- a/games/wave_collector/Makefile
+++ b/games/wave_collector/Makefile
@@ -163,7 +163,7 @@ ifeq ($(PLATFORM),PLATFORM_DESKTOP)
         CFLAGS += $(RAYLIB_PATH)/src/raylib_icon -Wl,--subsystem,windows
     endif
     ifeq ($(PLATFORM_OS),LINUX)
-        CFLAGS += -no-pie -D_DEFAULT_SOURCE
+        CFLAGS += -D_DEFAULT_SOURCE
     endif
 endif
 ifeq ($(PLATFORM),PLATFORM_RPI)

--- a/templates/advance_game/Makefile
+++ b/templates/advance_game/Makefile
@@ -163,7 +163,7 @@ ifeq ($(PLATFORM),PLATFORM_DESKTOP)
         CFLAGS += $(RAYLIB_PATH)/src/raylib_icon -Wl,--subsystem,windows
     endif
     ifeq ($(PLATFORM_OS),LINUX)
-        CFLAGS += -no-pie -D_DEFAULT_SOURCE
+        CFLAGS += -D_DEFAULT_SOURCE
     endif
 endif
 ifeq ($(PLATFORM),PLATFORM_RPI)

--- a/templates/simple_game/Makefile
+++ b/templates/simple_game/Makefile
@@ -163,7 +163,7 @@ ifeq ($(PLATFORM),PLATFORM_DESKTOP)
         CFLAGS += $(RAYLIB_PATH)/src/raylib_icon -Wl,--subsystem,windows
     endif
     ifeq ($(PLATFORM_OS),LINUX)
-        CFLAGS += -no-pie -D_DEFAULT_SOURCE
+        CFLAGS += -D_DEFAULT_SOURCE
     endif
 endif
 ifeq ($(PLATFORM),PLATFORM_RPI)

--- a/templates/standard_game/Makefile
+++ b/templates/standard_game/Makefile
@@ -163,7 +163,7 @@ ifeq ($(PLATFORM),PLATFORM_DESKTOP)
         CFLAGS += $(RAYLIB_PATH)/src/raylib_icon -Wl,--subsystem,windows
     endif
     ifeq ($(PLATFORM_OS),LINUX)
-        CFLAGS += -no-pie -D_DEFAULT_SOURCE
+        CFLAGS += -D_DEFAULT_SOURCE
     endif
 endif
 ifeq ($(PLATFORM),PLATFORM_RPI)


### PR DESCRIPTION
Currently, if:
* GCC doesn't supports `-no-pie`: Build error
* GCC supports `-no-pie`
    * GCC is not configured with `--enable-default-pie`: No-op
    * GCC is configured with `--enable-default-pie`:
            Slightly worse performance because we still generate `-fpie` code
            (`-pie` affects linker, `-fpie` affects compiler)

So instead of probing for existence of `-fno-pie -no-pie`, remove it altogether.

Fixes #540: Build breakage on Debian 8 with gcc 4.9.