### PR TITLE
Fix cannot find -lX11

### DIFF
--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -53,6 +53,11 @@ if(${PLATFORM} MATCHES "Desktop")
   endif()
 endif()
 
+# Ugly crutch. Temporary workaround for #551
+if("${CMAKE_SYSTEM_NAME}" MATCHES "(Free|Net|Open)BSD")
+    link_directories("/usr/local/lib")
+endif()
+
 if(CMAKE_SYSTEM_NAME STREQUAL Linux)
   set(LINUX TRUE)
   set(LIBS_PRIVATE dl ${LIBS_PRIVATE})


### PR DESCRIPTION
Fixed bug in utill.cmake on FreeBSD (cannot find -X11 libraries) for issue https://github.com/raysan5/raylib/issues/551