### PR TITLE
 CMake: Reuse libraries found by glfw CMake config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -96,6 +96,7 @@ script:
   - if [[ "$ARCH" != *-android && "$ARCH" != html5 ]]; then
       pkg-config --static --libs raylib;
       nm -g release/libraylib.a | grep glfwGetProcAddress || (echo "libraylib.a doesn't contain GLFW symbols! Aborting..." && false);
+      ctest --output-on-failure;
     fi
 
 deploy:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,3 +50,5 @@ endif()
 if (${BUILD_GAMES})
   add_subdirectory(games)
 endif()
+
+enable_testing()

--- a/cmake/test-pkgconfig.sh
+++ b/cmake/test-pkgconfig.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+# Test if including/linking/running an installed raylib works
+
+set -x
+export LD_RUN_PATH=/usr/local/lib
+
+CFLAGS="-Wall -Wextra -Werror $CFLAGS"
+if [ "$ARCH" = "i386" ]; then
+CFLAGS="-m32 $CLFAGS"
+fi
+
+cat << EOF | ${CC:-cc} -otest -xc - $(pkg-config --libs --cflags $@ raylib.pc) $CFLAGS && exec ./test
+#include <stdlib.h>
+#include <raylib.h>
+
+int main(void)
+{
+    int num = GetRandomValue(42, 1337);
+    return 42 <= num && num <= 1337 ? EXIT_SUCCESS : EXIT_FAILURE;
+}
+EOF

--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -11,13 +11,8 @@ if(${PLATFORM} MATCHES "Android")
 elseif(${PLATFORM} MATCHES "Web")
 elseif(APPLE)
   find_library(OPENGL_LIBRARY OpenGL)
-  find_library(COCOA_LIBRARY Cocoa)
-  find_library(IOKIT_LIBRARY IOKit)
-  find_library(COREFOUNDATION_LIBRARY CoreFoundation)
-  find_library(COREVIDEO_LIBRARY CoreVideo)
 
-  set(LIBS_PRIVATE ${OPENGL_LIBRARY} ${COCOA_LIBRARY}
-                   ${IOKIT_LIBRARY} ${COREFOUNDATION_LIBRARY} ${COREVIDEO_LIBRARY})
+  set(LIBS_PRIVATE ${OPENGL_LIBRARY})
 elseif(WIN32)
   # no pkg-config --static on Windows yet...
 else()
@@ -34,12 +29,6 @@ else()
   endif()
 
   set(LIBS_PRIVATE m pthread ${OPENGL_LIBRARIES} ${OSS_LIBRARY})
-  # TODO: maybe read those out of glfw's cmake config?
-  if(USE_WAYLAND)
-    set(LIBS_PRIVATE ${LIBS_PRIVATE} wayland-client wayland-cursor wayland-egl)
-  else()
-    set(LIBS_PRIVATE ${LIBS_PRIVATE} X11 Xrandr Xinerama Xi Xxf86vm Xcursor)
-  endif()
 endif()
 
 if(${PLATFORM} MATCHES "Desktop")
@@ -53,14 +42,8 @@ if(${PLATFORM} MATCHES "Desktop")
   endif()
 endif()
 
-# Ugly crutch. Temporary workaround for #551
-if("${CMAKE_SYSTEM_NAME}" MATCHES "(Free|Net|Open)BSD|DragonFly")
-    link_directories("${CMAKE_INSTALL_PREFIX}/lib")
-endif()
-
 if(CMAKE_SYSTEM_NAME STREQUAL Linux)
   set(LINUX TRUE)
-  set(LIBS_PRIVATE dl ${LIBS_PRIVATE})
 endif()
 
 foreach(L ${LIBS_PRIVATE})

--- a/raylib.pc.in
+++ b/raylib.pc.in
@@ -9,5 +9,5 @@ URL: http://github.com/raysan5/raylib
 Version: @PROJECT_VERSION@
 Libs: -L${libdir} -lraylib
 Libs.private: @PKG_CONFIG_LIBS_PRIVATE@
-Requires.private:
+Requires.private: @GLFW_PKG_DEPS@
 Cflags: -I${includedir}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -144,6 +144,8 @@ if(${SHARED})
       PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
     )
   endif()
+
+  add_test("pkg-config" ${PROJECT_SOURCE_DIR}/../cmake/test-pkgconfig.sh)
 endif(${SHARED})
 
 if(${STATIC})
@@ -167,6 +169,8 @@ if(${STATIC})
     ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
     PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
   )
+
+  add_test("pkg-config--static" ${PROJECT_SOURCE_DIR}/../cmake/test-pkgconfig.sh --static)
 endif(${STATIC})
 
 configure_file(../raylib.pc.in raylib.pc @ONLY)
@@ -203,3 +207,5 @@ SET(CPACK_RESOURCE_FILE_LICENSE "${PROJECT_SOURCE_DIR}/../LICENSE.md")
 SET(CPACK_PACKAGE_FILE_NAME "raylib-${PROJECT_VERSION}$ENV{RAYLIB_PACKAGE_SUFFIX}")
 SET(CPACK_GENERATOR "ZIP;TGZ") # Remove this, if you want the NSIS installer on Windows
 include(CPack)
+
+enable_testing()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,6 +33,8 @@ if(NOT glfw3_FOUND AND NOT USE_EXTERNAL_GLFW STREQUAL "ON" AND "${PLATFORM}" MAT
   include_directories(external/glfw/include)
 
   list(APPEND raylib_sources $<TARGET_OBJECTS:glfw_objlib>)
+else()
+  set(GLFW_PKG_DEPS glfw)
 endif()
 
 include(utils)
@@ -92,7 +94,7 @@ elseif(${PLATFORM} MATCHES "Android")
   add_if_flag_compiles(-Wa,--noexecstack CMAKE_C_FLAGS)
   add_if_flag_compiles(-no-canonical-prefixes CMAKE_C_FLAGS)
   add_definitions(-DANDROID -D__ANDROID_API__=21)
-  include_directories(external/android/native_app_glue )
+  include_directories(external/android/native_app_glue)
   set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--exclude-libs,libatomic.a -Wl,--build-id -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now -Wl,--warn-shared-textrel -Wl,--fatal-warnings -uANativeActivity_onCreate")
 
 elseif(${PLATFORM} MATCHES "Raspberry Pi")
@@ -114,8 +116,8 @@ if(${SHARED})
   set(CMAKE_MACOSX_RPATH ON)
 
   target_link_libraries(${RAYLIB}_shared ${LIBS_PRIVATE})
-  if (${PLATFORM} MATCHES "Desktop")
-    target_link_libraries(${RAYLIB}_shared glfw ${GLFW_LIBRARIES})
+  if (${PLATFORM} MATCHES "PLATFORM_DESKTOP")
+    target_link_libraries(${RAYLIB}_shared glfw)
   endif()
   if (UNIX AND ${FILESYSTEM_LACKS_SYMLINKS})
     MESSAGE(WARNING "Can't version UNIX shared library on file system without symlink support")
@@ -151,8 +153,9 @@ if(${STATIC})
 
   add_library(${RAYLIB} STATIC ${sources})
 
-  set(PKG_CONFIG_LIBS_PRIVATE ${__PKG_CONFIG_LIBS_PRIVATE})
-  if (${PLATFORM} MATCHES "Desktop")
+  set(PKG_CONFIG_LIBS_PRIVATE ${__PKG_CONFIG_LIBS_PRIVATE} ${GLFW_PKG_LIBS})
+  string (REPLACE ";" " " PKG_CONFIG_LIBS_PRIVATE "${PKG_CONFIG_LIBS_PRIVATE}")
+  if (${PLATFORM} MATCHES "PLATFORM_DESKTOP")
     target_link_libraries(${RAYLIB} glfw ${GLFW_LIBRARIES})
   endif()
 

--- a/src/external/glfw/CMakeLists.txt
+++ b/src/external/glfw/CMakeLists.txt
@@ -327,10 +327,10 @@ endif()
 # Export GLFW library dependencies
 #--------------------------------------------------------------------
 foreach(arg ${glfw_PKG_DEPS})
-    set(GLFW_PKG_DEPS "${GLFW_PKG_DEPS} ${arg}")
+    set(GLFW_PKG_DEPS "${GLFW_PKG_DEPS} ${arg}" PARENT_SCOPE)
 endforeach()
 foreach(arg ${glfw_PKG_LIBS})
-    set(GLFW_PKG_LIBS "${GLFW_PKG_LIBS} ${arg}")
+    set(GLFW_PKG_LIBS "${GLFW_PKG_LIBS} ${arg}" PARENT_SCOPE)
 endforeach()
 
 #--------------------------------------------------------------------


### PR DESCRIPTION
```
if (${PLATFORM} MATCHES "Desktop")
  target_link_libraries(${RAYLIB}_shared glfw ${GLFW_LIBRARIES})
```

was never true because `PLATFORM STREQUAL "PLATFORM_DESKTOP"`...

This fixes #551 and makes the changes suggested in #552 (commited as 965cc8a)
unnecessary.

Also adds a simple CTest test case as a sanity check that the resulting raylib.pc file can be used to compile a simple application.