### PR TITLE
SNES-like GAMEPAD Support added for Android, Makefile has optional support for 32bit

### DIFF
--- a/release/include/raylib.h
+++ b/release/include/raylib.h
@@ -241,6 +241,24 @@
 #define GAMEPAD_XBOX_BUTTON_LEFT    13
 #define GAMEPAD_XBOX_BUTTON_HOME    8
 
+// 8BitDo Gamepad SNES CLASSIC
+#define GAMEPAD_SNES_DPAD_UP        19
+#define GAMEPAD_SNES_DPAD_DOWN      20
+#define GAMEPAD_SNES_DPAD_LEFT      21
+#define GAMEPAD_SNES_DPAD_RIGHT     22
+#define GAMEPAD_SNES_DPAD_CENTER    23
+
+#define GAMEPAD_SNES_BUTTON_A       96
+#define GAMEPAD_SNES_BUTTON_B       97
+#define GAMEPAD_SNES_BUTTON_C       98
+#define GAMEPAD_SNES_BUTTON_X       99
+#define GAMEPAD_SNES_BUTTON_Y       100
+#define GAMEPAD_SNES_BUTTON_Z       101
+#define GAMEPAD_SNES_BUTTON_L1      102
+#define GAMEPAD_SNES_BUTTON_R1      103
+#define GAMEPAD_SNES_BUTTON_L2      104
+#define GAMEPAD_SNES_BUTTON_R2      105
+
 // Xbox360 USB Controller Axis
 // NOTE: For Raspberry Pi, axis must be reconfigured
 #if defined(PLATFORM_RPI)
@@ -966,7 +984,7 @@ RLAPI void DrawTexturePro(Texture2D texture, Rectangle sourceRec, Rectangle dest
 //------------------------------------------------------------------------------------
 
 // Font loading/unloading functions
-RLAPI Font GetFontDefault(void);                                                          // Get the default Font
+RLAPI Font GetFontDefault(void);                                                            // Get the default Font
 RLAPI Font LoadFont(const char *fileName);                                                  // Load font from file into GPU memory (VRAM)
 RLAPI Font LoadFontEx(const char *fileName, int fontSize, int charsCount, int *fontChars);  // Load font from file with extended parameters
 RLAPI CharInfo *LoadFontData(const char *fileName, int fontSize, int *fontChars, int charsCount, bool sdf); // Load font data for further use

--- a/src/Makefile
+++ b/src/Makefile
@@ -208,6 +208,9 @@ ifeq ($(PLATFORM),PLATFORM_ANDROID)
     ifeq ($(ANDROID_ARCH),ARM64)
         RAYLIB_RELEASE_PATH = $(RAYLIB_PATH)/release/libs/android/arm64-v8a
     endif
+    ifeq ($(ANDROID_ARCH),ARM)
+        RAYLIB_RELEASE_PATH = $(RAYLIB_PATH)/release/libs/android/armeabi-v7a
+    endif
 endif
 
 # Define raylib graphics api depending on selected platform
@@ -261,6 +264,9 @@ ifeq ($(PLATFORM),PLATFORM_ANDROID)
     ifeq ($(ANDROID_ARCH),ARM64)
         CC = $(ANDROID_TOOLCHAIN)/bin/aarch64-linux-android-clang
     endif
+    ifeq ($(ANDROID_ARCH),ARM)
+        CC = $(ANDROID_TOOLCHAIN)/bin/arm-linux-androideabi-clang
+    endif
 endif
 
 # Default archiver program to pack libraries
@@ -278,6 +284,9 @@ endif
 ifeq ($(PLATFORM),PLATFORM_ANDROID)
     ifeq ($(ANDROID_ARCH),ARM64)
         AR = $(ANDROID_TOOLCHAIN)/bin/aarch64-linux-android-ar
+    endif
+    ifeq ($(ANDROID_ARCH),ARM)
+        AR = $(ANDROID_TOOLCHAIN)/bin/arm-linux-androideabi-ar
     endif
 endif
 
@@ -317,8 +326,12 @@ ifeq ($(PLATFORM),PLATFORM_WEB)
 endif
 ifeq ($(PLATFORM),PLATFORM_ANDROID)
     # Compiler flags for arquitecture (only ARM, not ARM64)
-    #CFLAGS += -march=armv7-a -mfloat-abi=softfp -mfpu=vfpv3-d16
-    CFLAGS += -target aarch64 -mfix-cortex-a53-835769
+    ifeq ($(ANDROID_ARCH),ARM64)
+		CFLAGS += -target aarch64 -mfix-cortex-a53-835769
+	endif
+    ifeq ($(ANDROID_ARCH),ARM)
+		CFLAGS += -march=armv7-a -mfloat-abi=softfp -mfpu=vfpv3-d16
+	endif
     # Compilation functions attributes options
     CFLAGS += -ffunction-sections -funwind-tables -fstack-protector-strong -fPIE -fPIC
     # Compiler options for the linker
@@ -438,6 +451,9 @@ generate_android_toolchain:
 ifeq ($(PLATFORM),PLATFORM_ANDROID)
     ifeq ($(ANDROID_ARCH),ARM64)
 		$(ANDROID_NDK)/build/tools/make-standalone-toolchain.sh --platform=android-21 --toolchain=aarch64-linux-androideabi-4.9 --use-llvm --install-dir=$(ANDROID_TOOLCHAIN)
+    endif
+    ifeq ($(ANDROID_ARCH),ARM)
+		$(ANDROID_NDK)/build/tools/make-standalone-toolchain.sh --platform=android-21 --toolchain=arm-linux-androideabi-4.9 --use-llvm --install-dir=$(ANDROID_TOOLCHAIN)
     endif
 endif
 

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -241,6 +241,24 @@
 #define GAMEPAD_XBOX_BUTTON_LEFT    13
 #define GAMEPAD_XBOX_BUTTON_HOME    8
 
+// 8BitDo Gamepad SNES CLASSIC
+#define GAMEPAD_SNES_DPAD_UP        19
+#define GAMEPAD_SNES_DPAD_DOWN      20
+#define GAMEPAD_SNES_DPAD_LEFT      21
+#define GAMEPAD_SNES_DPAD_RIGHT     22
+#define GAMEPAD_SNES_DPAD_CENTER    23
+
+#define GAMEPAD_SNES_BUTTON_A       96
+#define GAMEPAD_SNES_BUTTON_B       97
+#define GAMEPAD_SNES_BUTTON_C       98
+#define GAMEPAD_SNES_BUTTON_X       99
+#define GAMEPAD_SNES_BUTTON_Y       100
+#define GAMEPAD_SNES_BUTTON_Z       101
+#define GAMEPAD_SNES_BUTTON_L1      102
+#define GAMEPAD_SNES_BUTTON_R1      103
+#define GAMEPAD_SNES_BUTTON_L2      104
+#define GAMEPAD_SNES_BUTTON_R2      105
+
 // Xbox360 USB Controller Axis
 // NOTE: For Raspberry Pi, axis must be reconfigured
 #if defined(PLATFORM_RPI)


### PR DESCRIPTION
#567 

This is my first ever significant pull request! I love that that raylib is so easy to comprehend.

Note that in getting the gamepad feature to work, I had to abort before the gestures system could be handled. I tried some methods for ignoring gestures only when gamepad input was detected, however the system seems really glitchy (pointerCount seems to go all over the place), and I had to give up. Perhaps someone who is doing gesture stuff can step in here and try to re-enable it. 

The gamepad feature is really simple, all I had to do was capture the keycode when motion was detected, no axis needed for this one. 

I've tested this with Android, wasn't able to test elsewhere right now. Won't be offended if this is rejected for that reason! Was a great experience solving this myself, I'm so glad I'm using a code base that I can actually reason about!

Seth