### PR TITLE
Convert window render sizes to floats

### DIFF
--- a/examples/shaders/resources/shaders/glsl100/swirl.fs
+++ b/examples/shaders/resources/shaders/glsl100/swirl.fs
@@ -13,8 +13,8 @@ uniform vec4 colDiffuse;
 // NOTE: Add here your custom variables
 
 // NOTE: Render size values should be passed from code
-const float renderWidth = 800;
-const float renderHeight = 450;
+const float renderWidth = 800.0;
+const float renderHeight = 450.0;
 
 float radius = 250.0;
 float angle = 0.8;


### PR DESCRIPTION
GLSL 1.10 is typesafe ([PDF specs](https://www.khronos.org/registry/OpenGL/specs/gl/GLSLangSpec.1.10.pdf), page 22), so this shader will not load properly during build triggering a type mismatch error.

It's not a super important change, but I came across it while playing with the examples on my pi.