### PR TITLE
Fix HTML5 examples and games using CMake

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -35,6 +35,7 @@ endforeach()
 
 include(CheckIncludeFiles)
 list(REMOVE_ITEM example_sources ${CMAKE_CURRENT_SOURCE_DIR}/others/standard_lighting.c)
+set(OUTPUT_EXT)
 
 if(${PLATFORM} MATCHES "Android")
   list(REMOVE_ITEM example_sources ${CMAKE_CURRENT_SOURCE_DIR}/others/rlgl_standalone.c)
@@ -56,7 +57,10 @@ if(${PLATFORM} MATCHES "Android")
   list(REMOVE_ITEM example_sources ${CMAKE_CURRENT_SOURCE_DIR}/shaders/shaders_custom_uniform.c)
   list(REMOVE_ITEM example_sources ${CMAKE_CURRENT_SOURCE_DIR}/shaders/shaders_model_shader.c)
   list(REMOVE_ITEM example_sources ${CMAKE_CURRENT_SOURCE_DIR}/shaders/shaders_postprocessing.c)
-  
+elseif(${PLATFORM} MATCHES "Web")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Os -s USE_GLFW=3 -s ASSERTIONS=1 -s WASM=1 -s EMTERPRETIFY=1 -s EMTERPRETIFY_ASYNC=1")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --shell-file ${CMAKE_SOURCE_DIR}/templates/web_shell/shell.html")
+  set(OUTPUT_EXT ".html")
 endif()
 
 
@@ -64,7 +68,7 @@ endif()
 foreach(example_source ${example_sources})
   # Create the basename for the example
   get_filename_component(example_name ${example_source} NAME)
-  string(REPLACE ".c" "" example_name ${example_name})
+  string(REPLACE ".c" "${OUTPUT_EXT}" example_name ${example_name})
 
   # Setup the example
   add_executable(${example_name} ${example_source})

--- a/games/CMakeLists.txt
+++ b/games/CMakeLists.txt
@@ -11,11 +11,21 @@ include_directories("../build/release")
 # Get the source toegher
 file(GLOB sources *.c)
 
+message("PLATFORM = ${PLATFORM}")
+set(OUTPUT_EXT)
+
+if(${PLATFORM} MATCHES "Web")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Os -s USE_GLFW=3 -s ASSERTIONS=1 -s WASM=1 -s EMTERPRETIFY=1 -s EMTERPRETIFY_ASYNC=1")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --shell-file ${CMAKE_SOURCE_DIR}/templates/web_shell/shell.html")
+  set(OUTPUT_EXT ".html")
+endif()
+
+
 # Do each game
 foreach(game_source ${sources})
   # Create the basename for the game
   get_filename_component(game_name ${game_source} NAME)
-  string(REPLACE ".c" "" game_name ${game_name})
+  string(REPLACE ".c" "${OUTPUT_EXT}" game_name ${game_name})
   
   # Setup the game
   add_executable(${game_name} ${game_source})


### PR DESCRIPTION
I found that examples and games using CMake were not compiled correctly. The output was LLVM IR bitcode instead of html + js. I introduced the changes needed for their `CMakeLists.txt` mimicking what's done in the Makefiles.