### PR TITLE
Fix rlgl.h to be used as a standalone

### DIFF
--- a/src/rlgl.h
+++ b/src/rlgl.h
@@ -66,6 +66,7 @@
 
 #if defined(RLGL_STANDALONE)
     #define RAYMATH_STANDALONE
+    #define RAYMATH_HEADER_ONLY
 #else
     #include "raylib.h"         // Required for: Model, Shader, Texture2D, TraceLog()
 #endif


### PR DESCRIPTION
Even though we are not compiling `rlgl_standalone` in Travis CI, users should be able to compile it separately. I tried to do so manually running
```
gcc -o rlgl_standalone -Isrc examples/others/rlgl_standalone.c build/release/external/glfw/src/libglfw3.a -framework Cocoa -framework IOKit -framework CoreFoundation -framework
 CoreVideo -framework OpenGL
```
and got:
```
Undefined symbols for architecture x86_64:                                                                                                                                                                                       [183/36228]
  "_MatrixFrustum", referenced from:
      _rlFrustum in rlgl_standalone-e6fe05.o
  "_MatrixIdentity", referenced from:
      _rlLoadIdentity in rlgl_standalone-e6fe05.o
      _rlRotatef in rlgl_standalone-e6fe05.o
      _rlglInit in rlgl_standalone-e6fe05.o
      _GetMatrixModelview in rlgl_standalone-e6fe05.o
      _ToggleVrMode in rlgl_standalone-e6fe05.o
      _EndVrDrawing in rlgl_standalone-e6fe05.o
      _main in rlgl_standalone-e6fe05.o
      ...
  "_MatrixInvert", referenced from:
      _rlUnproject in rlgl_standalone-e6fe05.o
  "_MatrixLookAt", referenced from:
      _GenTextureCubemap in rlgl_standalone-e6fe05.o
      _GenTextureIrradiance in rlgl_standalone-e6fe05.o
      _GenTexturePrefilter in rlgl_standalone-e6fe05.o
      _main in rlgl_standalone-e6fe05.o
  "_MatrixMultiply", referenced from:
      _rlTranslatef in rlgl_standalone-e6fe05.o
      _rlRotatef in rlgl_standalone-e6fe05.o
      _rlScalef in rlgl_standalone-e6fe05.o
      _rlMultMatrixf in rlgl_standalone-e6fe05.o
      _rlFrustum in rlgl_standalone-e6fe05.o
      _rlOrtho in rlgl_standalone-e6fe05.o
      _DrawBuffersDefault in rlgl_standalone-e6fe05.o
      ...
  "_MatrixOrtho", referenced from:
      _rlOrtho in rlgl_standalone-e6fe05.o
      _ToggleVrMode in rlgl_standalone-e6fe05.o
      _EndVrDrawing in rlgl_standalone-e6fe05.o
      _main in rlgl_standalone-e6fe05.o
  "_MatrixPerspective", referenced from:
      _GenTextureCubemap in rlgl_standalone-e6fe05.o
      _GenTextureIrradiance in rlgl_standalone-e6fe05.o
      _GenTexturePrefilter in rlgl_standalone-e6fe05.o
      _SetStereoConfig in rlgl_standalone-e6fe05.o
      _main in rlgl_standalone-e6fe05.o
  "_MatrixRotate", referenced from:
      _rlRotatef in rlgl_standalone-e6fe05.o
  "_MatrixScale", referenced from:
      _rlScalef in rlgl_standalone-e6fe05.o
  "_MatrixToFloatV", referenced from:
      _DrawBuffersDefault in rlgl_standalone-e6fe05.o
      _rlDrawMesh in rlgl_standalone-e6fe05.o
      _SetShaderValueMatrix in rlgl_standalone-e6fe05.o
  "_MatrixTranslate", referenced from:
      _rlTranslatef in rlgl_standalone-e6fe05.o
      _SetStereoConfig in rlgl_standalone-e6fe05.o
        "_QuaternionTransform", referenced from:
      _rlUnproject in rlgl_standalone-e6fe05.o
  "_Vector3Normalize", referenced from:
      _rlRotatef in rlgl_standalone-e6fe05.o
  "_Vector3Transform", referenced from:
      _rlEnd in rlgl_standalone-e6fe05.o
  "_Vector3Zero", referenced from:
      _rlglInit in rlgl_standalone-e6fe05.o
ld: symbol(s) not found for architecture x86_64
```

This PR ensures the methods in `raymath.h` are inlined