### PR TITLE
Update Builder example

### DIFF
--- a/projects/Builder/README.md
+++ b/projects/Builder/README.md
@@ -21,6 +21,3 @@ In the provided file we assume that the build file is located at the root folder
 
 Check out the `examples` directory for a simple example on how to use this template.
 You can also look at [raymario](https://github.com/jubalh/raymario) for a slightly more complex example which also installs resource files.
-
-# Notice
-The files provided link against glfw3 and openAL because the latest stable version of raylib is version 1.8, which still needs this. For later versions these two dependencies are not necessary anymore.

--- a/projects/Builder/examples/meson.build
+++ b/projects/Builder/examples/meson.build
@@ -9,9 +9,7 @@ project('core_basic_window', 'c', version: '1.0',
 cc = meson.get_compiler('c')
 
 # Find dependencies
-glfw_dep = dependency('glfw3')
 gl_dep = dependency('gl')
-openal_dep = dependency('openal')
 m_dep = cc.find_library('m', required : false)
 raylib_dep = cc.find_library('raylib', required : false)
 
@@ -23,5 +21,5 @@ source_c = [
 # Build executable
 core_basic_window = executable('core_basic_window',
   source_c,
-  dependencies : [ raylib_dep, glfw_dep, gl_dep, openal_dep, m_dep ],
+  dependencies : [ raylib_dep, gl_dep, m_dep ],
   install : true)

--- a/projects/Builder/meson.build
+++ b/projects/Builder/meson.build
@@ -9,10 +9,7 @@ project('projectname', 'c', version: '1.0',
 cc = meson.get_compiler('c')
 
 # Find dependencies
-# glfw3 and openal are not needed for raylib > 1.8.0
-glfw_dep = dependency('glfw3')
 gl_dep = dependency('gl')
-openal_dep = dependency('openal')
 m_dep = cc.find_library('m', required : false)
 raylib_dep = cc.find_library('raylib', required : false)
 
@@ -24,5 +21,5 @@ source_c = [
 # Build executable
 projectname = executable('projectname',
   source_c,
-  dependencies : [ raylib_dep, glfw_dep, gl_dep, openal_dep, m_dep ],
+  dependencies : [ raylib_dep, gl_dep, m_dep ],
   install : true)


### PR DESCRIPTION
Update Builder example for raylib 2.0.0.
External OpenAL and GLFW are not required anymore.