### PR TITLE
[physac] Fix Physac examples to be run without creating new thread

### DIFF
--- a/examples/physac/physics_demo.c
+++ b/examples/physac/physics_demo.c
@@ -17,6 +17,7 @@
 #include "raylib.h"
 
 #define PHYSAC_IMPLEMENTATION
+#define PHYSAC_NO_THREADS
 #include "physac.h"
 
 int main()
@@ -54,6 +55,8 @@ int main()
         // Update
         //----------------------------------------------------------------------------------
         // Delay initialization of variables due to physics reset async
+        RunPhysicsStep();
+
         if (needsReset)
         {
             floor = CreatePhysicsBodyRectangle((Vector2){ screenWidth/2, screenHeight }, 500, 100, 10);
@@ -61,6 +64,8 @@ int main()
 
             circle = CreatePhysicsBodyCircle((Vector2){ screenWidth/2, screenHeight/2 }, 45, 10);
             circle->enabled = false;
+
+            needsReset = false;
         }
 
         // Reset physics input
@@ -134,4 +139,3 @@ int main()
 
     return 0;
 }
-

--- a/examples/physac/physics_friction.c
+++ b/examples/physac/physics_friction.c
@@ -17,6 +17,7 @@
 #include "raylib.h"
 
 #define PHYSAC_IMPLEMENTATION
+#define PHYSAC_NO_THREADS
 #include "physac.h"
 
 int main()
@@ -71,6 +72,8 @@ int main()
     {
         // Update
         //----------------------------------------------------------------------------------
+        RunPhysicsStep();
+
         if (IsKeyPressed('R'))    // Reset physics input
         {
             // Reset dynamic physics bodies position, velocity and rotation
@@ -141,4 +144,3 @@ int main()
 
     return 0;
 }
-

--- a/examples/physac/physics_movement.c
+++ b/examples/physac/physics_movement.c
@@ -17,6 +17,7 @@
 #include "raylib.h"
 
 #define PHYSAC_IMPLEMENTATION
+#define PHYSAC_NO_THREADS
 #include "physac.h"
 
 #define VELOCITY    0.5f
@@ -64,6 +65,8 @@ int main()
     {
         // Update
         //----------------------------------------------------------------------------------
+        RunPhysicsStep();
+
         if (IsKeyPressed('R'))    // Reset physics input
         {
             // Reset movement physics body position, velocity and rotation
@@ -127,4 +130,3 @@ int main()
 
     return 0;
 }
-

--- a/examples/physac/physics_restitution.c
+++ b/examples/physac/physics_restitution.c
@@ -17,6 +17,7 @@
 #include "raylib.h"
 
 #define PHYSAC_IMPLEMENTATION
+#define PHYSAC_NO_THREADS
 #include "physac.h"
 
 int main()
@@ -57,6 +58,8 @@ int main()
     {
         // Update
         //----------------------------------------------------------------------------------
+        RunPhysicsStep();
+
         if (IsKeyPressed('R'))    // Reset physics input
         {
             // Reset circles physics bodies position and velocity
@@ -120,4 +123,3 @@ int main()
 
     return 0;
 }
-

--- a/examples/physac/physics_shatter.c
+++ b/examples/physac/physics_shatter.c
@@ -17,7 +17,8 @@
 #include "raylib.h"
 
 #define PHYSAC_IMPLEMENTATION
-#include "physac.h" 
+#define PHYSAC_NO_THREADS
+#include "physac.h"
 
 int main()
 {
@@ -48,12 +49,15 @@ int main()
     while (!WindowShouldClose())    // Detect window close button or ESC key
     {
         // Update
+        RunPhysicsStep();
+
         //----------------------------------------------------------------------------------
         // Delay initialization of variables due to physics reset asynchronous
         if (needsReset)
         {
             // Create random polygon physics body to shatter
             CreatePhysicsBodyPolygon((Vector2){ screenWidth/2, screenHeight/2 }, GetRandomValue(80, 200), GetRandomValue(3, 8), 10);
+            needsReset = false;
         }
 
         if (IsKeyPressed('R'))    // Reset physics input
@@ -118,4 +122,3 @@ int main()
 
     return 0;
 }
-


### PR DESCRIPTION
This PR addresses https://github.com/raysan5/raylib/issues/592

To start with, both `physics_demo` and `physics_shatter` had a bug because they were never setting `needsReset` back to `false`.

Then, as discussed in https://github.com/raysan5/raylib/issues/592, I thought it would be much simpler to avoid `physac` creating any threads rather than making the library thread-safe. I feel it's much simpler for beginners and newcomers to simply call `RunPhysicsStep` themselves within their main loop rather than learning concurrency all of the sudden. For this reason, I believe `PHYSAC_NO_THREADS` should be the default. I would actually rename it to do the opposite: `PHYSAC_CREATE_THREAD` or similar.

I had to fix refactor `PhysicsLoop` slightly and created `PhysicsRunStep` to be able to run `PhysicsStep` when being called from the user end since it relied on the timing values collected there.

I'd appreciate very much if @victorfisac reviewed this since it's his creation and I'm also modifying his library within this PR. Should I open a different PR if this gets accepted in https://github.com/victorfisac/Physac to keep them in sync or is @raysan5 doing that from time to time?
