### PR TITLE
[games] Prevent GLFW changing working dir to 'Resources'

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -1869,6 +1869,10 @@ static bool InitGraphicsDevice(int width, int height)
 #if defined(PLATFORM_DESKTOP) || defined(PLATFORM_WEB)
     glfwSetErrorCallback(ErrorCallback);
 
+#if defined(__APPLE__)
+    glfwInitHint(GLFW_COCOA_CHDIR_RESOURCES, GLFW_FALSE);
+#endif
+
     if (!glfwInit())
     {
         TraceLog(LOG_WARNING, "Failed to initialize GLFW");

--- a/src/rglfw.c
+++ b/src/rglfw.c
@@ -42,7 +42,6 @@
 #endif
 #if defined(__APPLE__)
     #define _GLFW_COCOA
-    #define _GLFW_USE_CHDIR         // To chdir to the Resources subdirectory of the application bundle during glfwInit
     #define _GLFW_USE_MENUBAR       // To create and populate the menu bar when the first window is created
     #define _GLFW_USE_RETINA        // To have windows use the full resolution of Retina displays
 #endif


### PR DESCRIPTION
GLFW was changing the working directory to `Resources` by default. We should prevent this in order to run successfully the games examples that load stuff from `resources/[whatever]`.