### PR TITLE
fix problem when compiling with MSVC 2017, error C2177

### DIFF
--- a/examples/models/models_mesh_picking.c
+++ b/examples/models/models_mesh_picking.c
@@ -13,7 +13,7 @@
 #include "raylib.h"
 #include "raymath.h"
 
-#define FLT_MAX     340282346638528859811704183484516925440.0     // Maximum value of a float, from bit pattern 01111111011111111111111111111111
+#define FLT_MAX     340282346638528859811704183484516925440.0f     // Maximum value of a float, from bit pattern 01111111011111111111111111111111
 
 int main()
 {

--- a/examples/models/models_mesh_picking.c
+++ b/examples/models/models_mesh_picking.c
@@ -13,7 +13,7 @@
 #include "raylib.h"
 #include "raymath.h"
 
-#define FLT_MAX     3.40282347E+38F     // Maximum value of a float, defined in <float.h>
+#define FLT_MAX     340282346638528859811704183484516925440.0     // Maximum value of a float, from bit pattern 01111111011111111111111111111111
 
 int main()
 {


### PR DESCRIPTION
(I'm not sure if the built-in CMake makes any difference)

The old FLT_MAX constant seems to be too big for MSVC, resulting in error C2177. I could have just used as defined in float.h that comes with MSVC. But I thought why not just go all the way and use the bit-by-bit correct constant as defined here: https://stackoverflow.com/questions/16350955/interpreting-the-bit-pattern-of-flt-max