### PR TITLE
Fix compiler warnings

### DIFF
--- a/examples/textures/textures_image_processing.c
+++ b/examples/textures/textures_image_processing.c
@@ -59,7 +59,7 @@ int main()
 
     Rectangle selectRecs[NUM_PROCESSES];
     
-    for (int i = 0; i < NUM_PROCESSES; i++) selectRecs[i] = (Rectangle){ 40, 50 + 32*i, 150, 30 };
+    for (int i = 0; i < NUM_PROCESSES; i++) selectRecs[i] = (Rectangle){ 40.0f, (float)(50 + 32*i), 150.0f, 30.0f };
     
     SetTargetFPS(60);
     //---------------------------------------------------------------------------------------
@@ -123,7 +123,7 @@ int main()
             {
                 DrawRectangleRec(selectRecs[i], (i == currentProcess) ? SKYBLUE : LIGHTGRAY);
                 DrawRectangleLines(selectRecs[i].x, selectRecs[i].y, selectRecs[i].width, selectRecs[i].height, (i == currentProcess) ? BLUE : GRAY);
-                DrawText(processText[i], selectRecs[i].x + selectRecs[i].width/2 - MeasureText(processText[i], 10)/2, selectRecs[i].y + 11, 10, (i == currentProcess) ? DARKBLUE : DARKGRAY);
+                DrawText(processText[i], selectRecs[i].x + selectRecs[i].width/2 - MeasureText(processText[i], 10)/2, selectRecs[i].y + 11, 10.0f, (i == currentProcess) ? DARKBLUE : DARKGRAY);
             }
 
             DrawTexture(texture, screenWidth - texture.width - 60, screenHeight/2 - texture.height/2, WHITE);

--- a/examples/textures/textures_image_processing.c
+++ b/examples/textures/textures_image_processing.c
@@ -122,8 +122,8 @@ int main()
             for (int i = 0; i < NUM_PROCESSES; i++)
             {
                 DrawRectangleRec(selectRecs[i], (i == currentProcess) ? SKYBLUE : LIGHTGRAY);
-                DrawRectangleLines(selectRecs[i].x, selectRecs[i].y, selectRecs[i].width, selectRecs[i].height, (i == currentProcess) ? BLUE : GRAY);
-                DrawText(processText[i], selectRecs[i].x + selectRecs[i].width/2 - MeasureText(processText[i], 10)/2, selectRecs[i].y + 11, 10.0f, (i == currentProcess) ? DARKBLUE : DARKGRAY);
+                DrawRectangleLines((int)selectRecs[i].x, (int) selectRecs[i].y, (int) selectRecs[i].width, (int) selectRecs[i].height, (i == currentProcess) ? BLUE : GRAY);
+                DrawText( processText[i], (int)( selectRecs[i].x + selectRecs[i].width/2 - MeasureText(processText[i], 10)/2), (int) selectRecs[i].y + 11, 10, (i == currentProcess) ? DARKBLUE : DARKGRAY);
             }
 
             DrawTexture(texture, screenWidth - texture.width - 60, screenHeight/2 - texture.height/2, WHITE);

--- a/examples/textures/textures_image_text.c
+++ b/examples/textures/textures_image_text.c
@@ -26,12 +26,12 @@ int main()
     Image parrots = LoadImage("resources/parrots.png"); // Load image in CPU memory (RAM)
 
     // Draw over image using custom font
-    ImageDrawTextEx(&parrots, (Vector2){ 20, 20 }, font, "[Parrots font drawing]", font.baseSize, 0, WHITE);
+    ImageDrawTextEx(&parrots, (Vector2){ 20.0f, 20.0f }, font, "[Parrots font drawing]", (float)font.baseSize, 0.0f, WHITE);
 
     Texture2D texture = LoadTextureFromImage(parrots);  // Image converted to texture, uploaded to GPU memory (VRAM)
     UnloadImage(parrots);   // Once image has been converted to texture and uploaded to VRAM, it can be unloaded from RAM
     
-    Vector2 position = { screenWidth/2 - texture.width/2, screenHeight/2 - texture.height/2 - 20 };
+    Vector2 position = { (float)(screenWidth/2 - texture.width/2), (float)(screenHeight/2 - texture.height/2 - 20) };
     
     bool showFont = false;
 
@@ -60,7 +60,7 @@ int main()
                 
                 // Draw text directly using sprite font
                 DrawTextEx(font, "[Parrots font drawing]", (Vector2){ position.x + 20, 
-                           position.y + 20 + 280 }, font.baseSize, 0, WHITE);
+                           position.y + 20 + 280 }, (float)font.baseSize, 0.0f, WHITE);
             }
             else DrawTexture(font.texture, screenWidth/2 - font.texture.width/2, 50, BLACK);
             

--- a/examples/textures/textures_particles_blending.c
+++ b/examples/textures/textures_particles_blending.c
@@ -42,7 +42,7 @@ int main()
         mouseTail[i].color = (Color){ GetRandomValue(0, 255), GetRandomValue(0, 255), GetRandomValue(0, 255), 255 };
         mouseTail[i].alpha = 1.0f;
         mouseTail[i].size = (float)GetRandomValue(1, 30)/20.0f;
-        mouseTail[i].rotation = GetRandomValue(0, 360);
+        mouseTail[i].rotation = (float) GetRandomValue(0, 360);
         mouseTail[i].active = false;
     }
     
@@ -107,9 +107,9 @@ int main()
                 // Draw active particles
                 for (int i = 0; i < MAX_PARTICLES; i++)
                 {
-                    if (mouseTail[i].active) DrawTexturePro(smoke, (Rectangle){ 0, 0, smoke.width, smoke.height }, 
+                    if (mouseTail[i].active) DrawTexturePro(smoke, (Rectangle){ 0.0f, 0.0f, (float) smoke.width, (float) smoke.height }, 
                                                            (Rectangle){ mouseTail[i].position.x, mouseTail[i].position.y, smoke.width*mouseTail[i].size, smoke.height*mouseTail[i].size },
-                                                           (Vector2){ smoke.width*mouseTail[i].size/2, smoke.height*mouseTail[i].size/2 }, mouseTail[i].rotation,
+                                                           (Vector2){ (float) (smoke.width*mouseTail[i].size/2.0f), (float)(smoke.height*mouseTail[i].size/2.0f) }, mouseTail[i].rotation,
                                                            Fade(mouseTail[i].color, mouseTail[i].alpha));
                 }
             

--- a/examples/textures/textures_srcrec_dstrec.c
+++ b/examples/textures/textures_srcrec_dstrec.c
@@ -27,13 +27,13 @@ int main()
     int frameHeight = scarfy.height;
     
     // NOTE: Source rectangle (part of the texture to use for drawing)
-    Rectangle sourceRec = { 0, 0, frameWidth, frameHeight };
+    Rectangle sourceRec = { 0.0f, 0.0f, (float)frameWidth, (float)frameHeight };
 
     // NOTE: Destination rectangle (screen rectangle where drawing part of texture)
-    Rectangle destRec = { screenWidth/2, screenHeight/2, frameWidth*2, frameHeight*2 };
+    Rectangle destRec = { (float) screenWidth/2, (float)screenHeight/2, (float)frameWidth*2, (float)frameHeight*2 };
 
     // NOTE: Origin of the texture (rotation/scale point), it's relative to destination rectangle size
-    Vector2 origin = { frameWidth, frameHeight };
+    Vector2 origin = { (float) frameWidth, (float) frameHeight };
     
     int rotation = 0;
     
@@ -59,10 +59,10 @@ int main()
             // destRec defines the rectangle where our texture part will fit (scaling it to fit)
             // origin defines the point of the texture used as reference for rotation and scaling
             // rotation defines the texture rotation (using origin as rotation point)
-            DrawTexturePro(scarfy, sourceRec, destRec, origin, rotation, WHITE);
+            DrawTexturePro(scarfy, sourceRec, destRec, origin, (float)rotation, WHITE);
 
-            DrawLine(destRec.x, 0, destRec.x, screenHeight, GRAY);
-            DrawLine(0, destRec.y, screenWidth, destRec.y, GRAY);
+            DrawLine((int) destRec.x, 0, (int) destRec.x, screenHeight, GRAY);
+            DrawLine(0, (int)destRec.y, screenWidth, (int)destRec.y, GRAY);
             
             DrawText("(c) Scarfy sprite by Eiden Marsal", screenWidth - 200, screenHeight - 20, 10, GRAY);
 

--- a/src/camera.h
+++ b/src/camera.h
@@ -244,8 +244,8 @@ void SetCameraMode(Camera camera, int mode)
     distance.y = sqrtf(dx*dx + dy*dy);
     
     // Camera angle calculation
-    cameraAngle.x = asinf(fabs(dx)/distance.x);  // Camera angle in plane XZ (0 aligned with Z, move positive CCW)
-    cameraAngle.y = -asinf(fabs(dy)/distance.y); // Camera angle in plane XY (0 aligned with X, move positive CW)
+    cameraAngle.x = (float)asinf(fabs(dx)/distance.x);  // Camera angle in plane XZ (0 aligned with Z, move positive CCW)
+    cameraAngle.y = (float)-asinf(fabs(dy)/distance.y); // Camera angle in plane XY (0 aligned with X, move positive CW)
     
     // NOTE: Just testing what cameraAngle means
     //cameraAngle.x = 0.0f*DEG2RAD;       // Camera angle in plane XZ (0 aligned with Z, move positive CCW)

--- a/src/camera.h
+++ b/src/camera.h
@@ -244,8 +244,8 @@ void SetCameraMode(Camera camera, int mode)
     distance.y = sqrtf(dx*dx + dy*dy);
     
     // Camera angle calculation
-    cameraAngle.x = (float)asinf(fabs(dx)/distance.x);  // Camera angle in plane XZ (0 aligned with Z, move positive CCW)
-    cameraAngle.y = (float)-asinf(fabs(dy)/distance.y); // Camera angle in plane XY (0 aligned with X, move positive CW)
+    cameraAngle.x = asinf( (float)fabs(dx)/distance.x);  // Camera angle in plane XZ (0 aligned with Z, move positive CCW)
+    cameraAngle.y = -asinf( (float)fabs(dy)/distance.y); // Camera angle in plane XY (0 aligned with X, move positive CW)
     
     // NOTE: Just testing what cameraAngle means
     //cameraAngle.x = 0.0f*DEG2RAD;       // Camera angle in plane XZ (0 aligned with Z, move positive CCW)

--- a/src/core.c
+++ b/src/core.c
@@ -886,7 +886,7 @@ void EndDrawing(void)
     // Wait for some milliseconds...
     if (frameTime < targetTime)
     {
-        Wait((targetTime - frameTime)*1000.0f);
+        Wait( (float)(targetTime - frameTime)*1000.0f);
 
         currentTime = GetTime();
         double extraTime = currentTime - previousTime;
@@ -2510,7 +2510,7 @@ static void SetupFramebufferSize(int displayWidth, int displayHeight)
 // Initialize hi-resolution timer
 static void InitTimer(void)
 {
-    srand(time(NULL));              // Initialize random seed
+    srand((unsigned int)time(NULL));              // Initialize random seed
     
 #if !defined(SUPPORT_BUSY_WAIT_LOOP) && defined(_WIN32)
     timeBeginPeriod(1);             // Setup high-resolution timer to 1ms (granularity of 1-2 ms)

--- a/src/models.c
+++ b/src/models.c
@@ -1771,7 +1771,7 @@ void DrawModelWiresEx(Model model, Vector3 position, Vector3 rotationAxis, float
 // Draw a billboard
 void DrawBillboard(Camera camera, Texture2D texture, Vector3 center, float size, Color tint)
 {
-    Rectangle sourceRec = { 0, 0, texture.width, texture.height };
+    Rectangle sourceRec = { 0.0f, 0.0f, (float)texture.width, (float)texture.height };
 
     DrawBillboardRec(camera, texture, sourceRec, center, size, tint);
 }
@@ -1837,9 +1837,9 @@ void DrawBoundingBox(BoundingBox box, Color color)
 {
     Vector3 size;
 
-    size.x = fabs(box.max.x - box.min.x);
-    size.y = fabs(box.max.y - box.min.y);
-    size.z = fabs(box.max.z - box.min.z);
+    size.x = (float)fabs(box.max.x - box.min.x);
+    size.y = (float)fabs(box.max.y - box.min.y);
+    size.z = (float)fabs(box.max.z - box.min.z);
 
     Vector3 center = { box.min.x + size.x/2.0f, box.min.y + size.y/2.0f, box.min.z + size.z/2.0f };
 
@@ -2206,9 +2206,9 @@ void MeshBinormals(Mesh *mesh)
         Vector3 tangent = { mesh->tangents[i*4 + 0], mesh->tangents[i*4 + 1], mesh->tangents[i*4 + 2] };
         float tangentW = mesh->tangents[i*4 + 3];
     
-        Vector3 binormal = Vector3Multiply(Vector3CrossProduct(normal, tangent), tangentW);
         
         // TODO: Register computed binormal in mesh->binormal ?
+        // Vector3 binormal = Vector3Multiply( Vector3CrossProduct( normal, tangent ), tangentW );
     }
 }
 

--- a/src/raymath.h
+++ b/src/raymath.h
@@ -296,12 +296,12 @@ RMDEF Vector3 Vector3Perpendicular(Vector3 v)
 {
     Vector3 result = { 0 };
 
-    float min = fabs(v.x);
+    float min = (float) fabs(v.x);
     Vector3 cardinalAxis = {1.0f, 0.0f, 0.0f};
 
     if (fabs(v.y) < min)
     {
-        min = fabs(v.y);
+        min = (float) fabs(v.y);
         Vector3 tmp = {0.0f, 1.0f, 0.0f};
         cardinalAxis = tmp;
     }
@@ -840,28 +840,28 @@ RMDEF Matrix MatrixFrustum(double left, double right, double bottom, double top,
 {
     Matrix result = { 0 };
 
-    float rl = (right - left);
-    float tb = (top - bottom);
-    float fn = (far - near);
+    float rl = (float)(right - left);
+    float tb = (float)(top - bottom);
+    float fn = (float)(far - near);
 
-    result.m0 = (near*2.0f)/rl;
+    result.m0 = ((float) near*2.0f)/rl;
     result.m1 = 0.0f;
     result.m2 = 0.0f;
     result.m3 = 0.0f;
 
     result.m4 = 0.0f;
-    result.m5 = (near*2.0f)/tb;
+    result.m5 = ((float) near*2.0f)/tb;
     result.m6 = 0.0f;
     result.m7 = 0.0f;
 
-    result.m8 = (right + left)/rl;
-    result.m9 = (top + bottom)/tb;
-    result.m10 = -(far + near)/fn;
+    result.m8 = ((float)right + (float)left)/rl;
+    result.m9 = ((float)top + (float)bottom)/tb;
+    result.m10 = -((float)far + (float)near)/fn;
     result.m11 = -1.0f;
 
     result.m12 = 0.0f;
     result.m13 = 0.0f;
-    result.m14 = -(far*near*2.0f)/fn;
+    result.m14 = -((float)far*(float)near*2.0f)/fn;
     result.m15 = 0.0f;
 
     return result;
@@ -899,9 +899,9 @@ RMDEF Matrix MatrixOrtho(double left, double right, double bottom, double top, d
     result.m9 = 0.0f;
     result.m10 = -2.0f/fn;
     result.m11 = 0.0f;
-    result.m12 = -(left + right)/rl;
-    result.m13 = -(top + bottom)/tb;
-    result.m14 = -(far + near)/fn;
+    result.m12 = -((float)left + (float)right)/rl;
+    result.m13 = -((float)top + (float)bottom)/tb;
+    result.m14 = -((float)far + (float)near)/fn;
     result.m15 = 1.0f;
 
     return result;

--- a/src/raymath.h
+++ b/src/raymath.h
@@ -883,9 +883,9 @@ RMDEF Matrix MatrixOrtho(double left, double right, double bottom, double top, d
 {
     Matrix result = { 0 };
 
-    float rl = (right - left);
-    float tb = (top - bottom);
-    float fn = (far - near);
+    float rl = (float)(right - left);
+    float tb = (float)(top - bottom);
+    float fn = (float)(far - near);
 
     result.m0 = 2.0f/rl;
     result.m1 = 0.0f;
@@ -980,7 +980,7 @@ RMDEF Quaternion QuaternionIdentity(void)
 // Computes the length of a quaternion
 RMDEF float QuaternionLength(Quaternion q)
 {
-    float result = sqrt(q.x*q.x + q.y*q.y + q.z*q.z + q.w*q.w);
+    float result = (float)sqrt(q.x*q.x + q.y*q.y + q.z*q.z + q.w*q.w);
     return result;
 }
 
@@ -1071,8 +1071,8 @@ RMDEF Quaternion QuaternionSlerp(Quaternion q1, Quaternion q2, float amount)
     else if (cosHalfTheta > 0.95f) result = QuaternionNlerp(q1, q2, amount);
     else
     {
-        float halfTheta = acos(cosHalfTheta);
-        float sinHalfTheta = sqrt(1.0f - cosHalfTheta*cosHalfTheta);
+        float halfTheta = (float) acos(cosHalfTheta);
+        float sinHalfTheta = (float) sqrt(1.0f - cosHalfTheta*cosHalfTheta);
 
         if (fabs(sinHalfTheta) < 0.001f)
         {

--- a/src/rlgl.h
+++ b/src/rlgl.h
@@ -3306,8 +3306,8 @@ Texture2D GenTexturePrefilter(Shader shader, Texture2D cubemap, int size)
     for (unsigned int mip = 0; mip < MAX_MIPMAP_LEVELS; mip++)
     {
         // Resize framebuffer according to mip-level size.
-        unsigned int mipWidth  = size*powf(0.5f, mip);
-        unsigned int mipHeight = size*powf(0.5f, mip);
+        unsigned int mipWidth  = size*(int) powf(0.5f, mip);
+        unsigned int mipHeight = size* (int) powf(0.5f, mip);
 
         glBindRenderbuffer(GL_RENDERBUFFER, rbo);
         glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT24, mipWidth, mipHeight);
@@ -3633,15 +3633,15 @@ void EndVrDrawing(void)
 
                 // Bottom-right corner for texture and quad
                 rlTexCoord2f(0.0f, 0.0f);
-                rlVertex2f(0.0f, vrConfig.stereoFbo.texture.height);
+                rlVertex2f(0.0f, (float)vrConfig.stereoFbo.texture.height);
 
                 // Top-right corner for texture and quad
                 rlTexCoord2f(1.0f, 0.0f);
-                rlVertex2f(vrConfig.stereoFbo.texture.width, vrConfig.stereoFbo.texture.height);
+                rlVertex2f( (float)vrConfig.stereoFbo.texture.width, (float)vrConfig.stereoFbo.texture.height);
 
                 // Top-left corner for texture and quad
                 rlTexCoord2f(1.0f, 1.0f);
-                rlVertex2f(vrConfig.stereoFbo.texture.width, 0.0f);
+                rlVertex2f( (float)vrConfig.stereoFbo.texture.width, 0.0f);
             rlEnd();
         rlPopMatrix();
 
@@ -4502,7 +4502,7 @@ static void SetStereoConfig(VrDeviceInfo hmd)
 
     // Compute distortion scale parameters
     // NOTE: To get lens max radius, lensShift must be normalized to [-1..1]
-    float lensRadius = fabs(-1.0f - 4.0f*lensShift);
+    float lensRadius = (float)fabs(-1.0f - 4.0f*lensShift);
     float lensRadiusSq = lensRadius*lensRadius;
     float distortionScale = hmd.lensDistortionValues[0] +
                             hmd.lensDistortionValues[1]*lensRadiusSq +
@@ -4553,8 +4553,8 @@ static void SetStereoConfig(VrDeviceInfo hmd)
     vrConfig.eyesViewOffset[1] = MatrixTranslate(hmd.interpupillaryDistance*0.5f, 0.075f, 0.045f);
 
     // Compute eyes Viewports
-    vrConfig.eyesViewport[0] = (Rectangle){ 0, 0, hmd.hResolution/2, hmd.vResolution };
-    vrConfig.eyesViewport[1] = (Rectangle){ hmd.hResolution/2, 0, hmd.hResolution/2, hmd.vResolution };
+    vrConfig.eyesViewport[0] = (Rectangle){ 0.0f, 0.0f, (float)hmd.hResolution/2, (float)hmd.vResolution };
+    vrConfig.eyesViewport[1] = (Rectangle){ hmd.hResolution/2.0f, 0.0f, (float)hmd.hResolution/2, (float) hmd.vResolution };
 }
 
 // Set internal projection and modelview matrix depending on eyes tracking data

--- a/src/rlgl.h
+++ b/src/rlgl.h
@@ -3306,8 +3306,8 @@ Texture2D GenTexturePrefilter(Shader shader, Texture2D cubemap, int size)
     for (unsigned int mip = 0; mip < MAX_MIPMAP_LEVELS; mip++)
     {
         // Resize framebuffer according to mip-level size.
-        unsigned int mipWidth  = size*(int) powf(0.5f, mip);
-        unsigned int mipHeight = size* (int) powf(0.5f, mip);
+        unsigned int mipWidth  = size*(int) powf(0.5f, (float) mip);
+        unsigned int mipHeight = size* (int) powf(0.5f, (float) mip);
 
         glBindRenderbuffer(GL_RENDERBUFFER, rbo);
         glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT24, mipWidth, mipHeight);

--- a/src/shapes.c
+++ b/src/shapes.c
@@ -153,9 +153,9 @@ void DrawLineBezier(Vector2 startPos, Vector2 endPos, float thick, Color color)
     for (int i = 1; i <= LINE_DIVISIONS; i++)
     {
         // Cubic easing in-out
-        // NOTE: Easing is calcutated only for y position value 
-        current.y = EaseCubicInOut(i, startPos.y, endPos.y - startPos.y, LINE_DIVISIONS);
-        current.x = previous.x + (endPos.x - startPos.x)/LINE_DIVISIONS;
+        // NOTE: Easing is calculated only for y position value 
+        current.y = EaseCubicInOut(i, startPos.y, endPos.y - startPos.y, (float) LINE_DIVISIONS);
+        current.x = previous.x + (endPos.x - startPos.x)/ (float) LINE_DIVISIONS;
         
         DrawLineEx(previous, current, thick, color);
         
@@ -324,7 +324,7 @@ void DrawRectangleV(Vector2 position, Vector2 size, Color color)
 // Draw a color-filled rectangle
 void DrawRectangleRec(Rectangle rec, Color color)
 {
-    DrawRectangle(rec.x, rec.y, rec.width, rec.height, color);
+    DrawRectangle((int)rec.x, (int)rec.y, (int)rec.width, (int)rec.height, color);
 }
 
 void DrawRectanglePro(Rectangle rec, Vector2 origin, float rotation, Color color)
@@ -354,14 +354,14 @@ void DrawRectanglePro(Rectangle rec, Vector2 origin, float rotation, Color color
 // NOTE: Gradient goes from bottom (color1) to top (color2)
 void DrawRectangleGradientV(int posX, int posY, int width, int height, Color color1, Color color2)
 {
-    DrawRectangleGradientEx((Rectangle){ posX, posY, width, height }, color1, color2, color2, color1);
+    DrawRectangleGradientEx((Rectangle){ (float)posX, (float)posY, (float)width, (float)height }, color1, color2, color2, color1);
 }
 
 // Draw a horizontal-gradient-filled rectangle
 // NOTE: Gradient goes from bottom (color1) to top (color2)
 void DrawRectangleGradientH(int posX, int posY, int width, int height, Color color1, Color color2)
 {
-    DrawRectangleGradientEx((Rectangle){ posX, posY, width, height }, color1, color1, color2, color2);
+    DrawRectangleGradientEx((Rectangle){ (float)posX, (float)posY, (float)width, (float)height }, color1, color1, color2, color2);
 }
 
 // Draw a gradient-filled rectangle

--- a/src/shapes.c
+++ b/src/shapes.c
@@ -154,7 +154,7 @@ void DrawLineBezier(Vector2 startPos, Vector2 endPos, float thick, Color color)
     {
         // Cubic easing in-out
         // NOTE: Easing is calculated only for y position value 
-        current.y = EaseCubicInOut(i, startPos.y, endPos.y - startPos.y, (float) LINE_DIVISIONS);
+        current.y = EaseCubicInOut((float)i, startPos.y, endPos.y - startPos.y, (float) LINE_DIVISIONS);
         current.x = previous.x + (endPos.x - startPos.x)/ (float) LINE_DIVISIONS;
         
         DrawLineEx(previous, current, thick, color);
@@ -457,14 +457,14 @@ void DrawRectangleLinesEx(Rectangle rec, int lineThick, Color color)
 {   
     if (lineThick > rec.width || lineThick > rec.height)
     {
-        if(rec.width > rec.height) lineThick = rec.height/2;
-        else if (rec.width < rec.height) lineThick = rec.width/2;
+        if(rec.width > rec.height) lineThick = (int)rec.height/2;
+        else if (rec.width < rec.height) lineThick = (int)rec.width/2;
     }        
     
-    DrawRectangle(rec.x, rec.y, rec.width, lineThick, color);
-    DrawRectangle(rec.x - lineThick + rec.width, rec.y + lineThick, lineThick, rec.height - lineThick*2, color);
-    DrawRectangle(rec.x, rec.y + rec.height - lineThick, rec.width, lineThick, color);
-    DrawRectangle(rec.x, rec.y + lineThick, lineThick, rec.height - lineThick*2, color);
+    DrawRectangle( (int)rec.x, (int)rec.y, (int)rec.width, lineThick, color);
+    DrawRectangle( (int)(rec.x - lineThick + rec.width), (int)(rec.y + lineThick), lineThick, (int)(rec.height - lineThick*2.0f), color);
+    DrawRectangle( (int)rec.x, (int)(rec.y + rec.height - lineThick), (int)rec.width, lineThick, color);
+    DrawRectangle( (int)rec.x, (int)(rec.y + lineThick), lineThick, (int)(rec.height - lineThick*2), color);
 }
 
 // Draw a triangle
@@ -648,8 +648,8 @@ bool CheckCollisionRecs(Rectangle rec1, Rectangle rec2)
 {
     bool collision = false;
 
-    float dx = fabs((rec1.x + rec1.width/2) - (rec2.x + rec2.width/2));
-    float dy = fabs((rec1.y + rec1.height/2) - (rec2.y + rec2.height/2));
+    float dx = (float)fabs((rec1.x + rec1.width/2) - (rec2.x + rec2.width/2));
+    float dy = (float)fabs((rec1.y + rec1.height/2) - (rec2.y + rec2.height/2));
 
     if ((dx <= (rec1.width/2 + rec2.width/2)) && ((dy <= (rec1.height/2 + rec2.height/2)))) collision = true;
 
@@ -675,11 +675,11 @@ bool CheckCollisionCircles(Vector2 center1, float radius1, Vector2 center2, floa
 // NOTE: Reviewed version to take into account corner limit case
 bool CheckCollisionCircleRec(Vector2 center, float radius, Rectangle rec)
 {
-    int recCenterX = rec.x + rec.width/2;
-    int recCenterY = rec.y + rec.height/2;
+    int recCenterX = (int)(rec.x + rec.width/2.0f);
+    int recCenterY = (int)(rec.y + rec.height/2.0f);
     
-    float dx = fabs(center.x - recCenterX);
-    float dy = fabs(center.y - recCenterY);
+    float dx = (float)fabs(center.x - recCenterX);
+    float dy = (float)fabs(center.y - recCenterY);
 
     if (dx > (rec.width/2.0f + radius)) { return false; }
     if (dy > (rec.height/2.0f + radius)) { return false; }
@@ -700,8 +700,8 @@ Rectangle GetCollisionRec(Rectangle rec1, Rectangle rec2)
 
     if (CheckCollisionRecs(rec1, rec2))
     {
-        float dxx = fabs(rec1.x - rec2.x);
-        float dyy = fabs(rec1.y - rec2.y);
+        float dxx = (float)fabs(rec1.x - rec2.x);
+        float dyy = (float)fabs(rec1.y - rec2.y);
 
         if (rec1.x <= rec2.x)
         {
@@ -768,8 +768,8 @@ Rectangle GetCollisionRec(Rectangle rec1, Rectangle rec2)
 // NOTE: Required for DrawLineBezier()
 static float EaseCubicInOut(float t, float b, float c, float d) 
 { 
-    if ((t /= 0.5*d) < 1)
-        return 0.5*c*t*t*t + b;
+    if ((t /= 0.5f*d) < 1)
+        return 0.5f*c*t*t*t + b;
     t -= 2;
-    return 0.5*c*(t*t*t + 2) + b;
+    return 0.5f*c*(t*t*t + 2.0f) + b;
 }

--- a/src/text.c
+++ b/src/text.c
@@ -220,12 +220,12 @@ extern void LoadDefaultFont(void)
     {
         defaultFont.chars[i].value = 32 + i;  // First char is 32
 
-        defaultFont.chars[i].rec.x = currentPosX;
-        defaultFont.chars[i].rec.y = charsDivisor + currentLine*(charsHeight + charsDivisor);
-        defaultFont.chars[i].rec.width = charsWidth[i];
-        defaultFont.chars[i].rec.height = charsHeight;
+        defaultFont.chars[i].rec.x = (float) currentPosX;
+        defaultFont.chars[i].rec.y = (float) charsDivisor + currentLine*(charsHeight + charsDivisor);
+        defaultFont.chars[i].rec.width = (float) charsWidth[i];
+        defaultFont.chars[i].rec.height = (float) charsHeight;
 
-        testPosX += (defaultFont.chars[i].rec.width + charsDivisor);
+        testPosX += (int) (defaultFont.chars[i].rec.width + (float) charsDivisor);
 
         if (testPosX >= defaultFont.texture.width)
         {
@@ -233,8 +233,8 @@ extern void LoadDefaultFont(void)
             currentPosX = 2*charsDivisor + charsWidth[i];
             testPosX = currentPosX;
 
-            defaultFont.chars[i].rec.x = charsDivisor;
-            defaultFont.chars[i].rec.y = charsDivisor + currentLine*(charsHeight + charsDivisor);
+            defaultFont.chars[i].rec.x = (float)charsDivisor;
+            defaultFont.chars[i].rec.y = (float)charsDivisor + currentLine*(charsHeight + charsDivisor);
         }
         else currentPosX = testPosX;
 
@@ -244,7 +244,7 @@ extern void LoadDefaultFont(void)
         defaultFont.chars[i].advanceX = 0;
     }
 
-    defaultFont.baseSize = defaultFont.chars[0].rec.height;
+    defaultFont.baseSize = (int) defaultFont.chars[0].rec.height;
     
     TraceLog(LOG_INFO, "[TEX ID %i] Default font loaded successfully", defaultFont.texture.id);
 }
@@ -361,14 +361,14 @@ CharInfo *LoadFontData(const char *fileName, int fontSize, int *fontChars, int c
     if (!stbtt_InitFont(&fontInfo, fontBuffer, 0)) TraceLog(LOG_WARNING, "Failed to init font!");
 
     // Calculate font scale factor
-    float scaleFactor = stbtt_ScaleForPixelHeight(&fontInfo, fontSize);
+    float scaleFactor = stbtt_ScaleForPixelHeight(&fontInfo, (float) fontSize);
 
     // Calculate font basic metrics
     // NOTE: ascent is equivalent to font baseline
     int ascent, descent, lineGap;
     stbtt_GetFontVMetrics(&fontInfo, &ascent, &descent, &lineGap);
-    ascent *= scaleFactor;
-    descent *= scaleFactor;
+    ascent *= (int) scaleFactor;
+    descent *= (int) scaleFactor;
     
     // Fill fontChars in case not provided externally
     // NOTE: By default we fill charsCount consecutevely, starting at 32 (Space)
@@ -407,7 +407,7 @@ CharInfo *LoadFontData(const char *fileName, int fontSize, int *fontChars, int c
         TraceLog(LOG_DEBUG, "Character offsetY: %i", ascent + chY1);
 
         stbtt_GetCodepointHMetrics(&fontInfo, ch, &chars[i].advanceX, NULL);
-        chars[i].advanceX *= scaleFactor;
+        chars[i].advanceX *= (int) scaleFactor;
     }
     
     free(fontBuffer);
@@ -460,8 +460,8 @@ Image GenImageFontAtlas(CharInfo *chars, int charsCount, int fontSize, int paddi
                 }
             }
             
-            chars[i].rec.x = offsetX;
-            chars[i].rec.y = offsetY;
+            chars[i].rec.x = (float) offsetX;
+            chars[i].rec.y = (float) offsetY;
             
             // Move atlas position X for next character drawing
             offsetX += ((int)chars[i].rec.width + 2*padding);
@@ -502,8 +502,8 @@ Image GenImageFontAtlas(CharInfo *chars, int charsCount, int fontSize, int paddi
         
         for (int i = 0; i < charsCount; i++)
         {
-            chars[i].rec.x = rects[i].x + padding;
-            chars[i].rec.y = rects[i].y + padding;
+            chars[i].rec.x = rects[i].x + (float) padding;
+            chars[i].rec.y = rects[i].y + (float) padding;
             
             if (rects[i].was_packed)
             {
@@ -834,15 +834,15 @@ static Font LoadImageFont(Image image, Color key, int firstChar)
         {
             tempCharValues[index] = firstChar + index;
 
-            tempCharRecs[index].x = xPosToRead;
-            tempCharRecs[index].y = lineSpacing + lineToRead*(charHeight + lineSpacing);
-            tempCharRecs[index].height = charHeight;
+            tempCharRecs[index].x = (float) xPosToRead;
+            tempCharRecs[index].y = (float) (lineSpacing + lineToRead*(charHeight + lineSpacing));
+            tempCharRecs[index].height = (float) charHeight;
 
             int charWidth = 0;
 
             while (!COLOR_EQUAL(pixels[(lineSpacing + (charHeight+lineSpacing)*lineToRead)*image.width + xPosToRead + charWidth], key)) charWidth++;
 
-            tempCharRecs[index].width = charWidth;
+            tempCharRecs[index].width = (float) charWidth;
 
             index++;
 
@@ -887,7 +887,7 @@ static Font LoadImageFont(Image image, Color key, int firstChar)
         spriteFont.chars[i].advanceX = 0;
     }
 
-    spriteFont.baseSize = spriteFont.chars[0].rec.height;
+    spriteFont.baseSize = (int) spriteFont.chars[0].rec.height;
 
     TraceLog(LOG_INFO, "Image file loaded correctly as Font");
 
@@ -996,7 +996,7 @@ static Font LoadBMFont(const char *fileName)
 
         // Save data properly in sprite font
         font.chars[i].value = charId;
-        font.chars[i].rec = (Rectangle){ charX, charY, charWidth, charHeight };
+        font.chars[i].rec = (Rectangle){ (float) charX, (float) charY, (float) charWidth, (float) charHeight };
         font.chars[i].offsetX = charOffsetX;
         font.chars[i].offsetY = charOffsetY;
         font.chars[i].advanceX = charAdvanceX;


### PR DESCRIPTION
Thanks a lot for the great library. I just fixed some compiler warnings which are caused by forat to int, int to float or double to float casts, which are not explicitely marked as explicit casts.