### PR TITLE
Raymath dllexport fix

### DIFF
--- a/src/raymath.h
+++ b/src/raymath.h
@@ -60,7 +60,11 @@
 #endif
 
 #ifdef RAYMATH_IMPLEMENTATION
-    #define RMDEF __declspec(dllexport) extern inline // Provide external definition
+    #if defined(_WIN32)
+        #define RMDEF __declspec(dllexport) extern inline // Provide external definition
+    #else
+        #define RMDEF extern inline
+    #endif
 #elif defined RAYMATH_HEADER_ONLY
     #define RMDEF static inline // Functions may be inlined, no external out-of-line definition
 #else

--- a/src/raymath.h
+++ b/src/raymath.h
@@ -60,7 +60,7 @@
 #endif
 
 #ifdef RAYMATH_IMPLEMENTATION
-    #define RMDEF extern inline // Provide external definition
+    #define RMDEF __declspec(dllexport) extern inline // Provide external definition
 #elif defined RAYMATH_HEADER_ONLY
     #define RMDEF static inline // Functions may be inlined, no external out-of-line definition
 #else

--- a/src/raymath.h
+++ b/src/raymath.h
@@ -60,10 +60,12 @@
 #endif
 
 #ifdef RAYMATH_IMPLEMENTATION
-    #if defined(_WIN32)
-        #define RMDEF __declspec(dllexport) extern inline // Provide external definition
+    #if defined(_WIN32) && defined(BUILD_LIBTYPE_SHARED)
+        #define RMDEF __declspec(dllexport) extern inline // We are building raylib as a Win32 shared library (.dll).
+    #elif defined(_WIN32) && defined(USE_LIBTYPE_SHARED) 
+        #define RLAPI __declspec(dllimport)         // We are using raylib as a Win32 shared library (.dll)
     #else
-        #define RMDEF extern inline
+        #define RMDEF extern inline // Provide external definition
     #endif
 #elif defined RAYMATH_HEADER_ONLY
     #define RMDEF static inline // Functions may be inlined, no external out-of-line definition


### PR DESCRIPTION
- Added __declspec(dllexport) to RMDEF in raymath.h. This allows them to be accessed when importing from raylib.dll.