### PR TITLE
Updated VSCode project to support OSX building / debugging.

### DIFF
--- a/projects/README.md
+++ b/projects/README.md
@@ -12,6 +12,6 @@ IDE | Platform | Template type | State
 [Notepad++](https://notepad-plus-plus.org/) | Windows | source/example compiling | DONE
 [VS2015](https://www.visualstudio.com) | Windows | source/example compiling | DONE
 [VS2017](https://www.visualstudio.com) | Windows | source/example compiling | DONE
-[VSCode](https://code.visualstudio.com/) | Windows | - | INCOMPLETE
+[VSCode](https://code.visualstudio.com/) | Windows, macOS | - | INCOMPLETE
 
  *New IDEs config files are welcome!*

--- a/projects/VSCode/.vscode/c_cpp_properties.json
+++ b/projects/VSCode/.vscode/c_cpp_properties.json
@@ -17,6 +17,27 @@
             "cStandard": "c11",
             "cppStandard": "c++14",
             "intelliSenseMode": "clang-x64"
+        },
+        {
+            "name": "Mac",
+            "includePath": [
+                "<path_to_raylib>/src/**",
+                "${workspaceFolder}/**"
+            ],
+            "defines": [
+                "_DEBUG",
+                "UNICODE",
+                "_UNICODE",
+                "GRAPHICS_API_OPENGL_33",
+                "PLATFORM_DESKTOP"
+            ],
+            "macFrameworkPath": [
+                "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/System/Library/Frameworks"
+            ],
+            "compilerPath": "/usr/bin/clang",
+            "cStandard": "c11",
+            "cppStandard": "c++14",
+            "intelliSenseMode": "clang-x64"
         }
     ],
     "version": 4

--- a/projects/VSCode/.vscode/launch.json
+++ b/projects/VSCode/.vscode/launch.json
@@ -5,7 +5,7 @@
         "version": "0.2.0",
         "configurations": [
           {
-            "name": "Debug",
+            "name": "(WIN) Debug",
             "type": "cppdbg",
             "request": "launch",
             "program": "${workspaceFolder}/game.exe",
@@ -23,10 +23,10 @@
                 "ignoreFailures": false
               }
             ],
-            "preLaunchTask": "build debug"
+            "preLaunchTask": "(WIN) build debug"
           },
           {
-            "name": "Run",
+            "name": "(WIN) Run",
             "type": "cppdbg",
             "request": "launch",
             "program": "${workspaceFolder}/game.exe",
@@ -44,7 +44,25 @@
                 "ignoreFailures": false
               }
             ],
-            "preLaunchTask": "build release"
+            "preLaunchTask": "(WIN) build release"
+          },
+          {
+            "name": "(OSX) Debug",
+            "type": "lldb",
+            "request": "launch",
+            "program": "${workspaceFolder}/game",
+            "args": [],
+            "cwd": "${workspaceFolder}",
+            "preLaunchTask": "(OSX) build debug"
+          },
+          {
+            "name": "(OSX) Run",
+            "type": "lldb",
+            "request": "launch",
+            "program": "${workspaceFolder}/game",
+            "args": [],
+            "cwd": "${workspaceFolder}",
+            "preLaunchTask": "(OSX) build release"
           },
         ]
       }

--- a/projects/VSCode/.vscode/tasks.json
+++ b/projects/VSCode/.vscode/tasks.json
@@ -4,30 +4,49 @@
     "version": "2.0.0",
     "tasks": [
         {
-            "label": "build release",
+            "label": "(WIN) build release",
             "type": "process",
             "command": "C:/raylib/mingw/bin/mingw32-make.exe",
             "args": [
                 "PLATFORM=PLATFORM_DESKTOP",
                 "RAYLIB_PATH=C:/raylib/raylib",
-                "PROJECT_NAME=game",
             ],
             "group": "build"
         },
         {
-            "label": "build debug",
+            "label": "(WIN) build debug",
             "type": "process",
             "command": "C:/raylib/mingw/bin/mingw32-make.exe",
             "args": [
                 "PLATFORM=PLATFORM_DESKTOP",
                 "RAYLIB_PATH=C:/raylib/raylib",
-                "PROJECT_NAME=game",
-                "DEBUGGING=TRUE",
+                "DEBUGGING=TRUE"
+            ],
+            "group": "build"
+        },
+        {
+            "label": "(OSX) build debug",
+            "type": "process",
+            "command": "make",
+            "args": [
+                "PLATFORM=PLATFORM_DESKTOP",
+                "RAYLIB_PATH=<path_to_raylib>",
+                "DEBUGGING=TRUE"
             ],
             "group": {
                 "kind": "build",
                 "isDefault": true
             }
+        },
+        {
+            "label": "(OSX) build release",
+            "type": "process",
+            "command": "make",
+            "args": [
+                "PLATFORM=PLATFORM_DESKTOP",
+                "RAYLIB_PATH=<path_to_raylib>",
+            ],
+            "group": "build"
         }
     ]
 }

--- a/projects/VSCode/Makefile
+++ b/projects/VSCode/Makefile
@@ -254,7 +254,7 @@ ifeq ($(PLATFORM),PLATFORM_DESKTOP)
     ifeq ($(PLATFORM_OS),OSX)
         # Libraries for OSX 10.9 desktop compiling
         # NOTE: Required packages: libopenal-dev libegl1-mesa-dev
-        LDLIBS = -lraylib -framework OpenGL -framework OpenAL -framework Cocoa
+        LDLIBS = -lraylib -framework OpenGL -framework Cocoa -framework IOKit -framework CoreFoundation -framework CoreVideo
     endif
     ifeq ($(PLATFORM_OS),BSD)
         # Libraries for FreeBSD, OpenBSD, NetBSD, DragonFly desktop compiling


### PR DESCRIPTION
Previously the project was insufficient for running raylib on OSX. This will be the first official project that actually supports building, running, and debugging on the platform.

There are some things to keep in mind:
- This project requires that the user specify the path to their installation of raylib in a few places. It might be a good course of action to work towards having a similar situation to the Windows side of things, where we can be more certain of the direct path to raylib on OSX.
- The wiki needs to be updated to explain better how to run raylib on OSX. Perhaps directing people to use VSCode and linking that project is the best course of action?