### PR TITLE
[physac] Fix physac's fixed time step

### DIFF
--- a/examples/physac/physics_restitution.c
+++ b/examples/physac/physics_restitution.c
@@ -51,6 +51,9 @@ int main()
     circleC->restitution = 1;
     
     SetTargetFPS(60);
+
+    // Restitution demo needs a very tiny physics time step for a proper simulation
+    SetPhysicsTimeStep(1.0/60.0/100 * 1000);
     //--------------------------------------------------------------------------------------
 
     // Main game loop

--- a/src/physac.h
+++ b/src/physac.h
@@ -96,8 +96,6 @@
 #define     PHYSAC_MAX_VERTICES             24
 #define     PHYSAC_CIRCLE_VERTICES          24
 
-#define     PHYSAC_DESIRED_DELTATIME        1.0/60.0
-#define     PHYSAC_MAX_TIMESTEP             0.02
 #define     PHYSAC_COLLISION_ITERATIONS     100
 #define     PHYSAC_PENETRATION_ALLOWANCE    0.05f
 #define     PHYSAC_PENETRATION_CORRECTION   0.4f
@@ -197,6 +195,7 @@ extern "C" {                                    // Prevents name mangling of fun
 //----------------------------------------------------------------------------------
 PHYSACDEF void InitPhysics(void);                                                                           // Initializes physics values, pointers and creates physics loop thread
 PHYSACDEF void RunPhysicsStep(void);                                                                        // Run physics step, to be used if PHYSICS_NO_THREADS is set in your main loop
+PHYSACDEF void SetPhysicsTimeStep(double delta);                                                            // Sets physics fixed time step in milliseconds. 1.666666 by default
 PHYSACDEF bool IsPhysicsEnabled(void);                                                                      // Returns true if physics thread is currently enabled
 PHYSACDEF void SetPhysicsGravity(float x, float y);                                                         // Sets physics global gravity force
 PHYSACDEF PhysicsBody CreatePhysicsBodyCircle(Vector2 pos, float radius, float density);                    // Creates a new circle physics body with generic parameters
@@ -279,16 +278,15 @@ static pthread_t physicsThreadId;                           // Physics thread id
 #endif
 static unsigned int usedMemory = 0;                         // Total allocated dynamic memory
 static bool physicsThreadEnabled = false;                   // Physics thread enabled state
-
 static double baseTime = 0.0;                               // Offset time for MONOTONIC clock
 static double startTime = 0.0;                              // Start time in milliseconds
-static double deltaTime = 0.0;                              // Delta time used for physics steps
+static double deltaTime = 1.0/60.0/10.0 * 1000;             // Delta time used for physics steps, in milliseconds
 static double currentTime = 0.0;                            // Current time in milliseconds
 static uint64_t frequency = 0;                              // Hi-res clock frequency
 
 static double accumulator = 0.0;                            // Physics time step delta time accumulator
 static unsigned int stepsCount = 0;                         // Total physics steps processed
-static Vector2 gravityForce = { 0.0f, 9.81f/1000 };         // Physics world gravity force
+static Vector2 gravityForce = { 0.0f, 9.81f };              // Physics world gravity force
 static PhysicsBody bodies[PHYSAC_MAX_BODIES];               // Physics bodies pointers array
 static unsigned int physicsBodiesCount = 0;                 // Physics world current bodies counter
 static PhysicsManifold contacts[PHYSAC_MAX_MANIFOLDS];      // Physics bodies pointers array
@@ -322,13 +320,12 @@ static bool BiasGreaterThan(float valueA, float valueB);                        
 static Vector2 TriangleBarycenter(Vector2 v1, Vector2 v2, Vector2 v3);                                      // Returns the barycenter of a triangle given by 3 points
 
 static void InitTimer(void);                                                                                // Initializes hi-resolution MONOTONIC timer
-static uint64_t GetTimeCount(void);                                                                         // Get hi-res MONOTONIC time measure in seconds
-static double GetCurrentTime(void);                                                                         // // Get hi-res MONOTONIC time measure in seconds
+static uint64_t GetTimeCount(void);                                                                         // Get hi-res MONOTONIC time measure in mseconds
+static double GetCurrentTime(void);                                                                         // Get current time measure in milliseconds
 
 static int GetRandomNumber(int min, int max);                                                               // Returns a random number between min and max (both included)
 
 // Math functions
-static void MathClamp(double *value, double min, double max);                                               // Clamp a value in a range
 static Vector2 MathCross(float value, Vector2 vector);                                                      // Returns the cross product of a vector and a value
 static float MathCrossVector2(Vector2 v1, Vector2 v2);                                                      // Returns the cross product of two vectors
 static float MathLenSqr(Vector2 vector);                                                                    // Returns the len square root of a vector
@@ -363,6 +360,8 @@ PHYSACDEF void InitPhysics(void)
     #if defined(PHYSAC_DEBUG)
         printf("[PHYSAC] physics module initialized successfully\n");
     #endif
+
+    accumulator = 0.0;
 }
 
 // Returns true if physics thread is currently enabled
@@ -917,6 +916,18 @@ PHYSACDEF void ClosePhysics(void)
     #if !defined(PHYSAC_NO_THREADS)
         pthread_join(physicsThreadId, NULL);
     #endif
+
+    // Unitialize physics manifolds dynamic memory allocations
+    for (int i = physicsManifoldsCount - 1; i >= 0; i--) DestroyPhysicsManifold(contacts[i]);
+
+    // Unitialize physics bodies dynamic memory allocations
+    for (int i = physicsBodiesCount - 1; i >= 0; i--) DestroyPhysicsBody(bodies[i]);
+
+    #if defined(PHYSAC_DEBUG)
+        if (physicsBodiesCount > 0 || usedMemory != 0) printf("[PHYSAC] physics module closed with %i still allocated bodies [MEMORY: %i bytes]\n", physicsBodiesCount, usedMemory);
+        else if (physicsManifoldsCount > 0 || usedMemory != 0) printf("[PHYSAC] physics module closed with %i still allocated manifolds [MEMORY: %i bytes]\n", physicsManifoldsCount, usedMemory);
+        else printf("[PHYSAC] physics module closed successfully\n");
+    #endif
 }
 
 //----------------------------------------------------------------------------------
@@ -1011,25 +1022,12 @@ static void *PhysicsLoop(void *arg)
 
     // Initialize physics loop thread values
     physicsThreadEnabled = true;
-    accumulator = 0;
 
     // Physics update loop
     while (physicsThreadEnabled)
     {
         RunPhysicsStep();
     }
-
-    // Unitialize physics manifolds dynamic memory allocations
-    for (int i = physicsManifoldsCount - 1; i >= 0; i--) DestroyPhysicsManifold(contacts[i]);
-
-    // Unitialize physics bodies dynamic memory allocations
-    for (int i = physicsBodiesCount - 1; i >= 0; i--) DestroyPhysicsBody(bodies[i]);
-
-    #if defined(PHYSAC_DEBUG)
-        if (physicsBodiesCount > 0 || usedMemory != 0) printf("[PHYSAC] physics module closed with %i still allocated bodies [MEMORY: %i bytes]\n", physicsBodiesCount, usedMemory);
-        else if (physicsManifoldsCount > 0 || usedMemory != 0) printf("[PHYSAC] physics module closed with %i still allocated manifolds [MEMORY: %i bytes]\n", physicsManifoldsCount, usedMemory);
-        else printf("[PHYSAC] physics module closed successfully\n");
-    #endif
 
     return NULL;
 }
@@ -1147,23 +1145,29 @@ PHYSACDEF void RunPhysicsStep(void)
     currentTime = GetCurrentTime();
 
     // Calculate current delta time
-    deltaTime = currentTime - startTime;
+    const double delta = currentTime - startTime;
 
     // Store the time elapsed since the last frame began
-    accumulator += deltaTime;
-
-    // Clamp accumulator to max time step to avoid bad performance
-    MathClamp(&accumulator, 0.0, PHYSAC_MAX_TIMESTEP);
+    accumulator += delta;
 
     // Fixed time stepping loop
-    while (accumulator >= PHYSAC_DESIRED_DELTATIME)
+    while (accumulator >= deltaTime)
     {
+#ifdef PHYSAC_DEBUG
+        //printf("currentTime %f, startTime %f, accumulator-pre %f, accumulator-post %f, delta %f, deltaTime %f\n",
+        //       currentTime, startTime, accumulator, accumulator-deltaTime, delta, deltaTime);
+#endif
         PhysicsStep();
         accumulator -= deltaTime;
     }
 
     // Record the starting of this frame
     startTime = currentTime;
+}
+
+PHYSACDEF void SetPhysicsTimeStep(double delta)
+{
+    deltaTime = delta;
 }
 
 // Finds a valid index for a new manifold initialization
@@ -1557,8 +1561,8 @@ static void IntegratePhysicsForces(PhysicsBody body)
 
     if (body->useGravity)
     {
-        body->velocity.x += gravityForce.x*(deltaTime/2.0);
-        body->velocity.y += gravityForce.y*(deltaTime/2.0);
+        body->velocity.x += gravityForce.x*(deltaTime/1000/2.0);
+        body->velocity.y += gravityForce.y*(deltaTime/1000/2.0);
     }
 
     if (!body->freezeOrient) body->angularVelocity += body->torque*body->inverseInertia*(deltaTime/2.0);
@@ -1592,7 +1596,7 @@ static void InitializePhysicsManifolds(PhysicsManifold manifold)
 
         // Determine if we should perform a resting collision or not;
         // The idea is if the only thing moving this object is gravity, then the collision should be performed without any restitution
-        if (MathLenSqr(radiusV) < (MathLenSqr((Vector2){ gravityForce.x*deltaTime, gravityForce.y*deltaTime }) + PHYSAC_EPSILON)) manifold->restitution = 0;
+        if (MathLenSqr(radiusV) < (MathLenSqr((Vector2){ gravityForce.x*deltaTime/1000, gravityForce.y*deltaTime/1000 }) + PHYSAC_EPSILON)) manifold->restitution = 0;
     }
 }
 
@@ -1951,13 +1955,6 @@ static int GetRandomNumber(int min, int max)
     }
 
     return (rand()%(abs(max - min) + 1) + min);
-}
-
-// Clamp a value in a range
-static inline void MathClamp(double *value, double min, double max)
-{
-    if (*value < min) *value = min;
-    else if (*value > max) *value = max;
 }
 
 // Returns the cross product of a vector and a value


### PR DESCRIPTION
This PR aims to fix some details that https://github.com/raysan5/raylib/pull/609 left unsolved. When I gave support for running physac from main thread I assumed it already had the logic to handle the physics step being called with different time deltas. This doesn't seem to be the case. Please @victorfisac take a look and correct me if I am wrong. This is what I've found in the original implementation within the physics loop that looks wrong:

```
PHYSACDEF void RunPhysicsStep(void)
{
    // Calculate current time
    currentTime = GetCurrentTime();

    // Calculate current delta time
    deltaTime = currentTime - startTime;

    // Store the time elapsed since the last frame began
    accumulator += deltaTime;

    // Clamp accumulator to max time step to avoid bad performance
    MathClamp(&accumulator, 0.0, PHYSAC_MAX_TIMESTEP);

    // Fixed time stepping loop
    while (accumulator >= PHYSAC_DESIRED_DELTATIME)
    {
        PhysicsStep();
        accumulator -= deltaTime;
    }

    // Record the starting of this frame
    startTime = currentTime;
}
```

1. `deltaTime` which is used for the physics formulas is measured in milliseconds. This comes from the substraction of two values taken from `GetCurrentTime()`, which returns milliseconds. My guess is that this method previously returned seconds and hence the confusion.
2. `accumulator` was increased with `deltaTime` (ms) but compared against `PHYSAC_MAX_TIMESTEP` (1.0/60.0=0.016, hence seconds). So, since `deltaTime` in ms was more than likely to be > 0.016 (seconds), `MathClamp` was basically making sure that `accumulator` always had the `PHYSAC_MAX_TIMESTEP` value (0.02, in seconds?). In the end, this mechanism basically was making that the fixed time step loop was always executed at least once and only once. Only once because even if the `accumulator` value was clamped, we were subtracting `deltaTime`(remember, in ms) from it. So, `accumulator` would take a negative number.
3. The result of this is that `PhysicsStep` was called always once with a `deltaTime` in ms that was quite small since there's a loop in a dedicated physics thread that it just runs this. The easiest way to prove that the fixed time step loop is not fixed at all is by introducing an `usleep` call with different values in the physics thread after each `RunPhysicsStep()` call.

So, these changes just make sure that the fixed time step is actually fixed and it runs in consistent steps of `deltaTime` value. I consolidated all time values to ms since it's what was used the most. I have found that `deltaTime` value needs to be quite small for the physics simulation to be accurate. It even turns out that for one example (`physics_restitution`, we even need to decrease the time step for it to perform well. However, if we used such a tiny value to run physics for every demo, it would perform very badly with multiple objects due to the number of collisions that need to be checked. Hence, I decided to use a default value that works well for all demos and create a new API called `SetPhysicsTimeStep` to set another value for the `physics_restitution` example.

I took some quick gifs so that you can see the difference. Take into account that I exported them with 10 FPS to avoid bloating this page, so the quality is not very good.

Before
![demo_bad](https://user-images.githubusercontent.com/3248441/46487916-8663a580-c801-11e8-8750-aff4c7df08d0.gif)
After
![demo_good](https://user-images.githubusercontent.com/3248441/46487932-8d8ab380-c801-11e8-961b-a8b0be951487.gif)

Before
![friction_bad](https://user-images.githubusercontent.com/3248441/46487940-94192b00-c801-11e8-8482-d1f8afdb3f97.gif)
After
![friction_good](https://user-images.githubusercontent.com/3248441/46487944-97141b80-c801-11e8-8b56-d67bd258ba7d.gif)

Before
![restitution_bad](https://user-images.githubusercontent.com/3248441/46487954-9e3b2980-c801-11e8-96c1-7a5395a8e046.gif)
After
![restitution_good](https://user-images.githubusercontent.com/3248441/46487960-a1361a00-c801-11e8-9525-3a649d245343.gif)
