### PR TITLE
Physac.h fix for variable array size declaration.

### DIFF
--- a/src/physac.h
+++ b/src/physac.h
@@ -606,7 +606,7 @@ PHYSACDEF void PhysicsShatter(PhysicsBody body, Vector2 position, float force)
             {
                 int count = vertexData.vertexCount;
                 Vector2 bodyPos = body->position;
-                Vector2 vertices[count];
+                Vector2 *vertices = (Vector2*)malloc(sizeof(Vector2) * count);
                 Mat2 trans = body->shape.transform;
                 for (int i = 0; i < count; i++) vertices[i] = vertexData.positions[i];
 
@@ -698,6 +698,8 @@ PHYSACDEF void PhysicsShatter(PhysicsBody body, Vector2 position, float force)
                     // Apply force to new physics body
                     PhysicsAddForce(newBody, forceDirection);
                 }
+
+                free(vertices);
             }
         }
     }


### PR DESCRIPTION
Generating the projects using CMake, targeting VS2017, results in an error when compiling.
This is due to physac.h trying to make a 'vertices' array of size 'int count', making it const does not work, either.

This changes the static declaration to a malloc/free combo.

Tested using the physics-demo.