### PR TITLE
GenImageFontAtlas prototype in raylib.h is incorrect.

### DIFF
--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1075,7 +1075,7 @@ RLAPI Font GetFontDefault(void);                                                
 RLAPI Font LoadFont(const char *fileName);                                                  // Load font from file into GPU memory (VRAM)
 RLAPI Font LoadFontEx(const char *fileName, int fontSize, int charsCount, int *fontChars);  // Load font from file with extended parameters
 RLAPI CharInfo *LoadFontData(const char *fileName, int fontSize, int *fontChars, int charsCount, int type); // Load font data for further use
-RLAPI Image GenImageFontAtlas(CharInfo *chars, int fontSize, int charsCount, int padding, int packMethod);  // Generate image font atlas using chars info
+RLAPI Image GenImageFontAtlas(CharInfo *chars, int charsCount, int fontSize, int padding, int packMethod);  // Generate image font atlas using chars info
 RLAPI void UnloadFont(Font font);                                                           // Unload Font from GPU memory (VRAM)
 
 // Text drawing functions


### PR DESCRIPTION
The prototype of GenImageFontAtlas() in the main raylib.h header has a set of swapped parameter names.
Going through the usage of the function within raylib itself, it appears as if the correct order is:
1) charsCount
2) fontSize

However, it's exposed to the world as the other way around, which may cause some major confusion.