### PR TITLE
Fixes memory leak in text.c

### DIFF
--- a/src/text.c
+++ b/src/text.c
@@ -527,6 +527,7 @@ Image GenImageFontAtlas(CharInfo *chars, int charsCount, int fontSize, int paddi
             else TraceLog(LOG_WARNING, "Character could not be packed: %i", i);
         }
 
+        free(rects);
         free(nodes);
         free(context);
     }


### PR DESCRIPTION
GenImageFontAtlas() allocates an array of stbrp_rect for the packing functions, but it never frees them.