### PR TITLE
Added GetLastWriteTime to allow for file reloading

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -123,6 +123,7 @@
 #include <string.h>         // Required for: strrchr(), strcmp()
 //#include <errno.h>          // Macros for reporting and retrieving error conditions through error codes
 #include <ctype.h>          // Required for: tolower() [Used in IsFileExtension()]
+#include <sys/stat.h>       // Required for stat() [Used in GetLastWriteTime()]
 
 #if defined(_MSC_VER)
     #include "external/dirent.h"    // Required for: DIR, opendir(), closedir() [Used in GetDirectoryFiles()]
@@ -1679,6 +1680,18 @@ void ClearDroppedFiles(void)
         dropFilesCount = 0;
     }
 #endif
+}
+
+// Get the last write time of a file
+long GetLastWriteTime(const char *fileName)
+{
+    struct stat result = {0}; 
+    if (stat(fileName, &result) == 0)
+    {
+        time_t mod = result.st_mtime;
+        return mod;
+    }
+    return 0;
 }
 
 // Save integer value to storage file (to defined position)

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -880,6 +880,7 @@ RLAPI bool ChangeDirectory(const char *dir);                      // Change work
 RLAPI bool IsFileDropped(void);                                   // Check if a file has been dropped into window
 RLAPI char **GetDroppedFiles(int *count);                         // Get dropped files names (memory should be freed)
 RLAPI void ClearDroppedFiles(void);                               // Clear dropped files paths buffer (free memory)
+RLAPI long GetLastWriteTime(const char *fileName);                // Get last write time of a file
 
 // Persistent storage management
 RLAPI void StorageSaveValue(int position, int value);             // Save integer value to storage file (to defined position)


### PR DESCRIPTION
Added a function to get the last write time of a file. I used this so I can reload files or resources if the time since they were last loaded changes.

### Example
```
char *path1 = "test1.txt";
char *path2 = "test2.txt";

long mod1 = GetLastWriteTime(path1);
long mod2 = GetLastWriteTime(path2);
TraceLog(LOG_INFO, "last write time %ld %ld", mod1, mod2);
```
