### PR TITLE
Remove non-Windows includes from Makefile

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -339,9 +339,12 @@ endif
 
 # Define include paths for required headers
 # NOTE: Several external required libraries (stb and others)
-INCLUDE_PATHS = -I. -Iexternal -Iexternal/glfw/include
+INCLUDE_PATHS = -I. -Iexternal/glfw/include
 
 ifeq ($(PLATFORM),PLATFORM_DESKTOP)
+    ifeq ($(PLATFORM_OS),WINDOWS)
+        INCLUDE_PATHS += -Iexternal
+    endif
     ifeq ($(PLATFORM_OS),BSD)
         INCLUDE_PATHS += -I/usr/local/include
         LDFLAGS += -L. -Lsrc -L/usr/local/lib -L$(RAYLIB_RELEASE_PATH)


### PR DESCRIPTION
Removed -Iexternal from the base include path, added it back conditionally for Windows only. This allows non-Windows platforms to compile raylib as discussed in https://github.com/raysan5/raylib/issues/667.

