### PR TITLE
RaspberryPi Mouse and touch overhaul

### DIFF
--- a/src/raylib.h
+++ b/src/raylib.h
@@ -223,7 +223,7 @@
 #define MOUSE_MIDDLE_BUTTON   2
 
 // Touch points registered
-#define MAX_TOUCH_POINTS      2
+#define MAX_TOUCH_POINTS      10
 
 // Gamepad Number
 #define GAMEPAD_PLAYER1       0


### PR DESCRIPTION
1) Now all '/dev/input/event*' devices are used for input(Mouse no longer used). They are scanned trough on startup, devices that are mice or touchscreens are given reading threads. This allows for an unlimited number of simultaneously working mice. Keyboard and gamepad continue to use existing methods.
2) Multitouch is now supported on RPi with 10 point multitouch
3 Touchscreens now get scaling factors from '/dev/input/event*' by ioctl 
4) Fixed bugs with IsMouseButtonPressed(Used to constantly fire when holding button) and GetMouseWheelMove(Did not work)
5) Fixed exesive CPU usage of GamepadThread

Relates to issue: https://github.com/raysan5/raylib/issues/666