### PR TITLE
Update core.c

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -1170,7 +1170,9 @@ void BeginTextureMode(RenderTexture2D target)
 
     rlEnableRenderTexture(target.id);   // Enable render target
 
-    rlClearScreenBuffers();             // Clear render texture buffers
+    // Some projects need the buffer to not be empited when drawing to
+    // the render texture.
+    //rlClearScreenBuffers();             // Clear render texture buffers
 
     // Set viewport to framebuffer size
     rlViewport(0, 0, target.texture.width, target.texture.height);


### PR DESCRIPTION
Some projects need the buffer to not be empited when drawing to the render texture. I would suggest making maybe a variation of the function if you'd like to keep backwards compatibility, maybe like: BeginTextureModeNoClear() ?