### PR TITLE
Check for single apostrophe in OpenURL()

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -1828,24 +1828,10 @@ void OpenURL(const char *url)
 {
     // Small security check trying to avoid (partially) malicious code... 
     // sorry for the inconvenience when you hit this point...
-    bool validUrl = true;
-    int len = strlen(url);
-    
-    for (int i = 0; i < len; i++) 
+    if (strchr(url, '\'') != NULL)
     {
-        if ((url[i] == ';') || 
-            (url[i] == '?') || 
-            (url[i] == ':') || 
-            (url[i] == '=') || 
-            (url[i] == '&')) 
-        {
-            validUrl = false;
-            break;
-        }
-    }
-    
-    if (validUrl)
-    {
+        TraceLog(LOG_WARNING, "Provided URL does not seem to be valid.");
+    } else {
         char *cmd = calloc(strlen(url) + 10, sizeof(char));
 
 #if defined(_WIN32)
@@ -1856,10 +1842,9 @@ void OpenURL(const char *url)
         sprintf(cmd, "open '%s'", url);
 #endif
         system(cmd);
-    
+
         free(cmd);
     }
-    else TraceLog(LOG_WARNING, "Provided URL does not seem to be valid.");
 }
 
 //----------------------------------------------------------------------------------


### PR DESCRIPTION
When doing a8dffc63fbe3926498ecb905428f454d0afbe526 I was not aware that
printing a warning and not executing the code would be an option. I only
learned that through 618f220851570f2bb9ea0bb354a65e92c6d06968.

So I propose that we allow all URLs except if the string contains a `'`.
Which could end the URL and call another command via `system()`.

Related to https://github.com/raysan5/raylib/issues/686