### PR TITLE
Added SetMouseOffset

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -333,7 +333,7 @@ static int defaultKeyboardMode;                 // Used to store default keyboar
 
 // Mouse states
 static Vector2 mousePosition;                   // Mouse position on screen
-static Vector2 mouseScale = { 1.0f };               // Mouse default scale
+static Vector2 mouseScale = { 1.0f, 1.0f };     // Mouse default scale
 static bool cursorHidden = false;               // Track if cursor is hidden
 static bool cursorOnScreen = false;             // Tracks if cursor is inside client area
 static Vector2 touchPosition[MAX_TOUCH_POINTS]; // Touch position on screen
@@ -2114,7 +2114,7 @@ void SetMousePosition(Vector2 position)
 void SetMouseScale(float scale)
 {
 #if !defined(PLATFORM_ANDROID)
-	mouseScale = (Vector2){ scale };
+	mouseScale = (Vector2){ scale, scale };
 #endif
 }
 

--- a/src/core.c
+++ b/src/core.c
@@ -334,6 +334,7 @@ static int defaultKeyboardMode;                 // Used to store default keyboar
 // Mouse states
 static Vector2 mousePosition;                   // Mouse position on screen
 static Vector2 mouseScale = { 1.0f, 1.0f };     // Mouse default scale
+static Vector2 mouseOffset = { 0.0f, 0.0f };    // Mouse default scale
 static bool cursorHidden = false;               // Track if cursor is hidden
 static bool cursorOnScreen = false;             // Tracks if cursor is inside client area
 static Vector2 touchPosition[MAX_TOUCH_POINTS]; // Touch position on screen
@@ -2075,7 +2076,7 @@ int GetMouseX(void)
 #if defined(PLATFORM_ANDROID)
     return (int)touchPosition[0].x;
 #else
-    return (int)(mousePosition.x*mouseScale.x);
+    return (int)((mousePosition.x+mouseOffset.x)*mouseScale.x);
 #endif
 }
 
@@ -2085,7 +2086,7 @@ int GetMouseY(void)
 #if defined(PLATFORM_ANDROID)
     return (int)touchPosition[0].x;
 #else
-    return (int)(mousePosition.y*mouseScale.y);
+    return (int)((mousePosition.y+mouseOffset.y)*mouseScale.y);
 #endif
 }
 
@@ -2095,7 +2096,7 @@ Vector2 GetMousePosition(void)
 #if defined(PLATFORM_ANDROID)
     return GetTouchPosition(0);
 #else
-    return (Vector2){ mousePosition.x*mouseScale.x, mousePosition.y*mouseScale.y };
+    return (Vector2){ (mousePosition.x+mouseOffset.x)*mouseScale.x, (mousePosition.y+mouseOffset.y)*mouseScale.y };
 #endif
 }
 
@@ -2111,14 +2112,14 @@ void SetMousePosition(Vector2 position)
 
 // Set mouse scaling
 // NOTE: Useful when rendering to different size targets
-void SetMouseScale(float scale)
+void SetMouseScale(Vector2 scale)
 {
 #if !defined(PLATFORM_ANDROID)
-	mouseScale = (Vector2){ scale, scale };
+	mouseScale = scale;
 #endif
 }
 
-// Set mouse scaling
+// Set mouse offset
 // NOTE: Useful when rendering to different size targets
 void SetMouseOffset(Vector2 offset)
 {
@@ -4237,7 +4238,7 @@ static void *EventThread(void *arg)
             if (mousePosition.x > screenWidth/mouseScale.x) mousePosition.x = screenWidth/mouseScale.x;
 
             if (mousePosition.y < 0) mousePosition.y = 0;
-            if (mousePosition.y > screenHeight/mouseScale) mousePosition.y = screenHeight/mouseScale.y;
+            if (mousePosition.y > screenHeight/mouseScale.y) mousePosition.y = screenHeight/mouseScale.y;
 
             // Gesture update
             if (GestureNeedsUpdate)

--- a/src/core.c
+++ b/src/core.c
@@ -333,7 +333,7 @@ static int defaultKeyboardMode;                 // Used to store default keyboar
 
 // Mouse states
 static Vector2 mousePosition;                   // Mouse position on screen
-static float mouseScale = 1.0f;                 // Mouse default scale
+static Vector2 mouseScale = { 1.0f };               // Mouse default scale
 static bool cursorHidden = false;               // Track if cursor is hidden
 static bool cursorOnScreen = false;             // Tracks if cursor is inside client area
 static Vector2 touchPosition[MAX_TOUCH_POINTS]; // Touch position on screen
@@ -2075,7 +2075,7 @@ int GetMouseX(void)
 #if defined(PLATFORM_ANDROID)
     return (int)touchPosition[0].x;
 #else
-    return (int)(mousePosition.x*mouseScale);
+    return (int)(mousePosition.x*mouseScale.x);
 #endif
 }
 
@@ -2085,7 +2085,7 @@ int GetMouseY(void)
 #if defined(PLATFORM_ANDROID)
     return (int)touchPosition[0].x;
 #else
-    return (int)(mousePosition.y*mouseScale);
+    return (int)(mousePosition.y*mouseScale.y);
 #endif
 }
 
@@ -2095,7 +2095,7 @@ Vector2 GetMousePosition(void)
 #if defined(PLATFORM_ANDROID)
     return GetTouchPosition(0);
 #else
-    return (Vector2){ mousePosition.x*mouseScale, mousePosition.y*mouseScale };
+    return (Vector2){ mousePosition.x*mouseScale.x, mousePosition.y*mouseScale.y };
 #endif
 }
 
@@ -2114,7 +2114,16 @@ void SetMousePosition(Vector2 position)
 void SetMouseScale(float scale)
 {
 #if !defined(PLATFORM_ANDROID)
-    mouseScale = scale;
+	mouseScale = (Vector2){ scale };
+#endif
+}
+
+// Set mouse scaling
+// NOTE: Useful when rendering to different size targets
+void SetMouseOffset(Vector2 offset)
+{
+#if !defined(PLATFORM_ANDROID)
+    mouseScale = offset;
 #endif
 }
 
@@ -4225,10 +4234,10 @@ static void *EventThread(void *arg)
 
             // Screen confinement
             if (mousePosition.x < 0) mousePosition.x = 0;
-            if (mousePosition.x > screenWidth/mouseScale) mousePosition.x = screenWidth/mouseScale;
+            if (mousePosition.x > screenWidth/mouseScale.x) mousePosition.x = screenWidth/mouseScale.x;
 
             if (mousePosition.y < 0) mousePosition.y = 0;
-            if (mousePosition.y > screenHeight/mouseScale) mousePosition.y = screenHeight/mouseScale;
+            if (mousePosition.y > screenHeight/mouseScale) mousePosition.y = screenHeight/mouseScale.y;
 
             // Gesture update
             if (GestureNeedsUpdate)

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -941,8 +941,8 @@ RLAPI int GetMouseX(void);                                    // Returns mouse p
 RLAPI int GetMouseY(void);                                    // Returns mouse position Y
 RLAPI Vector2 GetMousePosition(void);                         // Returns mouse position XY
 RLAPI void SetMousePosition(Vector2 position);                // Set mouse position XY
-RLAPI void SetMouseScale(float scale);                        // Set mouse scaling
-RLAPI void SetMouseOffset(Vector2 scale);                     // Set mouse scaling XY
+RLAPI void SetMouseScale(Vector2 scale);                      // Set mouse scaling
+RLAPI void SetMouseOffset(Vector2 scale);                     // Set mouse offset
 RLAPI int GetMouseWheelMove(void);                            // Returns mouse wheel movement Y
 
 // Input-related functions: touch

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -942,6 +942,7 @@ RLAPI int GetMouseY(void);                                    // Returns mouse p
 RLAPI Vector2 GetMousePosition(void);                         // Returns mouse position XY
 RLAPI void SetMousePosition(Vector2 position);                // Set mouse position XY
 RLAPI void SetMouseScale(float scale);                        // Set mouse scaling
+RLAPI void SetMouseOffset(Vector2 scale);                     // Set mouse scaling XY
 RLAPI int GetMouseWheelMove(void);                            // Returns mouse wheel movement Y
 
 // Input-related functions: touch


### PR DESCRIPTION
Needed mouseScale to be seperate for x and y so it works when the width and height are different.
For example works with a size of 500x500 but not when using 1024x600.

Solved by addding `SetMouseOffset` to set the scale with a Vector2.
Default scale is 1.0f for both x and y and `SetMouseScale` sets both aswell.

### Example
```c
Vector2 size = { GetScreenWidth(), GetScreenHeight() };
Vector2 offset = { 1920.0f / size.x, 1080 / size.y };
SetMouseOffset(offset);
```