### PR TITLE
Add project/scripts

### DIFF
--- a/projects/scripts/README.md
+++ b/projects/scripts/README.md
@@ -1,0 +1,68 @@
+Here are dependency-less build scripts for raylib projects.
+
+## Dependencies
+The scripts, as mentioned above, do not have dependencies. There's one
+exception to this however, and that is Windows, because Windows
+doesn't have a built-in C compiler. On Windows, you'll need to install
+[Visual Studio][visual-studio] or the [build tools][vs-tools]. If you
+didn't install them in the default location, write your changes around
+line 101 of [`windows-build.bat`](windows-build.bat).
+
+## Script customization
+First of all, the scripts have a few variables at the very top, which
+are supposed to be configured for each project separately:
+- `GAME_NAME` variable is used for the executable name.
+- `SOURCES` is a list of .c source files, divided by spaces, which are
+  going to be compiled and linked with raylib to create the final
+  executable. You can use wildcards, so if you have all your .c files
+  in a directory called `src`, you can just set `SOURCES` to
+  `../../src/*.c`. Note: the paths should be either absolute, or
+  relative to `builds/platform`, hence `../../`.
+- `RAYLIB_SRC` should point to the raylib/src directory. In this case,
+  it's `../../src`, but as with the `SOURCES`, if the path is
+  relative, it should be relative to `temp/debug`, so it's actually
+  `../../../../src`.
+
+## Compilation flags
+- `-Os` (`/O1` with MSVC, `-O2` with clang\*) is used for release
+  builds, to save space. Since it's a good practice to make your games
+  run on the slowest possible systems, only a few games would benefit
+  from additional runtime performance on almost all systems. Other
+  flags: `-flto` (`/GL` and `/LTCG` for MSVC) in release builds, `-O0
+  -g` (`/Od /Zi` for MSVC) in debug builds.
+- `-Wall -Wextra -Wpedantic` (`/Wall` for MSVC) are used for warnings.
+
+\* Clang 7.0.1 seems to have problems compiling with `-flto` and `-Os`
+enabled at the same time, so `-Os` is replaced with `-O2` for clang.
+
+## Command line arguments
+The build scripts accept some flags, which can be given either one at
+a time (`-d -c -r`) or in bunches (`-dcr`). Here's a description of
+all of the flags.
+- `-h` Describes all the flags, and a few example commands
+- `-d` Faster builds that have debug symbols, and enable warnings
+- `-u` Run upx\* on the executable after compilation (before -r)
+- `-r` Run the executable after compilation
+- `-c` Remove the temp/(debug|release) directory, ie. full recompile
+- `-q` Suppress this script's informational prints
+- `-qq` Suppress all prints, complete silence
+- `-v` cl.exe normally prints out a lot of superficial information, as
+  well as the MSVC build environment activation scripts, but these are
+  mostly suppressed by default. If you do want to see everything, use
+  this flag.
+
+\* This is mostly here to make building simple "shipping" versions
+   easier, and it's a very small bit in the build scripts. The option
+   requires that you have upx installed and on your path, of course.
+
+#### Examples
+| What the command does                                       | Command                   |
+|-------------------------------------------------------------|---------------------------|
+| Build a release build, on Windows                           | `windows-build.bat`       |
+| Build a release build, full recompile, on Linux             | `./linux-build.sh -c`     |
+| Build a debug build and run, on macOS                       | `./osx-build.sh -d -r`    |
+| Build in debug, run, don't print at all, on Linux with `sh` | `sh linux-build.sh -drqq` |
+
+
+[visual-studio]: https://visualstudio.microsoft.com/downloads/#visual-studio-community-2017
+[vs-tools]: https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2017

--- a/projects/scripts/core_basic_window.c
+++ b/projects/scripts/core_basic_window.c
@@ -1,0 +1,62 @@
+/*******************************************************************************************
+*
+*   raylib [core] example - Basic window
+*
+*   Welcome to raylib!
+*
+*   To test examples, just press F6 and execute raylib_compile_execute script
+*   Note that compiled executable is placed in the same folder as .c file
+*
+*   You can find all basic examples on C:\raylib\raylib\examples folder or
+*   raylib official webpage: www.raylib.com
+*
+*   Enjoy using raylib. :)
+*
+*   This example has been created using raylib 1.0 (www.raylib.com)
+*   raylib is licensed under an unmodified zlib/libpng license (View raylib.h for details)
+*
+*   Copyright (c) 2013-2016 Ramon Santamaria (@raysan5)
+*
+********************************************************************************************/
+
+#include "raylib.h"
+
+int main()
+{
+    // Initialization
+    //--------------------------------------------------------------------------------------
+    int screenWidth = 800;
+    int screenHeight = 450;
+
+    InitWindow(screenWidth, screenHeight, "raylib [core] example - basic window");
+    
+    SetTargetFPS(60);
+    //--------------------------------------------------------------------------------------
+
+    // Main game loop
+    while (!WindowShouldClose())    // Detect window close button or ESC key
+    {
+        // Update
+        //----------------------------------------------------------------------------------
+        // TODO: Update your variables here
+        //----------------------------------------------------------------------------------
+
+        // Draw
+        //----------------------------------------------------------------------------------
+        BeginDrawing();
+
+            ClearBackground(RAYWHITE);
+
+            DrawText("Congrats! You created your first window!", 190, 200, 20, LIGHTGRAY);
+
+        EndDrawing();
+        //----------------------------------------------------------------------------------
+    }
+
+    // De-Initialization
+    //--------------------------------------------------------------------------------------   
+    CloseWindow();        // Close window and OpenGL context
+    //--------------------------------------------------------------------------------------
+
+    return 0;
+}

--- a/projects/scripts/linux-build.sh
+++ b/projects/scripts/linux-build.sh
@@ -1,0 +1,158 @@
+#!/bin/sh
+# Change your executable name here
+GAME_NAME="game"
+
+# Set your sources here (relative to the ./builds/linux directory)
+# Example with two source folders:
+# SOURCES="../../src/*.c ../../src/submodule/*.c"
+SOURCES="../../core_basic_window.c"
+
+# Set your raylib/src location here, relative to the ./temp/x directory
+RAYLIB_SRC="../../../../src"
+
+# About this build script: it does many things, but in essence, it's
+# very simple. It has 3 compiler invocations: building raylib (which
+# is not done always, see logic by searching "Build raylib"), building
+# src/*.c files, and linking together those two. Each invocation is
+# wrapped in an if statement to make the -qq flag work, it's pretty
+# verbose, sorry.
+
+# Get arguments
+while getopts ":hdurcq" opt; do
+    case $opt in
+        h)
+            echo "Usage: ./linux-build.sh [-hdurcqq]"
+            echo " -h  Show this information"
+            echo " -d  Faster builds that have debug symbols, and enable warnings"
+            echo " -u  Run upx* on the executable after compilation (before -r)"
+            echo " -r  Run the executable after compilation"
+            echo " -c  Remove the temp/(debug|release) directory, ie. full recompile"
+            echo " -q  Suppress this script's informational prints"
+            echo " -qq Suppress all prints, complete silence (> /dev/null 2>&1)"
+            echo ""
+            echo "* This is mostly here to make building simple \"shipping\" versions"
+            echo "  easier, and it's a very small bit in the build scripts. The option"
+            echo "  requires that you have upx installed and on your path, of course."
+            echo ""
+            echo "Examples:"
+            echo " Build a release build:                    ./linux-build.sh"
+            echo " Build a release build, full recompile:    ./linux-build.sh -c"
+            echo " Build a debug build and run:              ./linux-build.sh -d -r"
+            echo " Build in debug, run, don't print at all:  ./linux-build.sh -drqq"
+            exit 0
+            ;;
+        d)
+            BUILD_DEBUG="1"
+            ;;
+        u)
+            UPX_IT="1"
+            ;;
+        r)
+            RUN_AFTER_BUILD="1"
+            ;;
+        c)
+            BUILD_ALL="1"
+            ;;
+        q)
+            if [ -n "$QUIET" ]; then
+                REALLY_QUIET="1"
+            else
+                QUIET="1"
+            fi
+            ;;
+        \?)
+            echo "Invalid option: -$OPTARG" >&2
+            exit 1
+            ;;
+    esac
+done
+
+# Set CC if it's not set already
+if [ -z "$CC" ]; then
+    CC=cc
+fi
+
+# Flags
+OUTPUT_DIR="builds/linux"
+COMPILATION_FLAGS="-std=c99 -Os -flto"
+if [ "$CC" = "clang" ]; then
+    # Clang 7.0.1 fails to compile with -Os, possibly the same bug as this:
+    # https://www.mail-archive.com/llvm-bugs@lists.llvm.org/msg25771.html
+    COMPILATION_FLAGS="-std=c99 -O2 -flto"
+    [ -z "$QUIET" ] && echo "COMPILE-WARNING: \$CC is clang, using -O2 instead of -Os."
+fi
+FINAL_COMPILE_FLAGS="-s"
+WARNING_FLAGS="-Wall -Wextra -Wpedantic"
+LINK_FLAGS="-lm -ldl -lpthread -lX11 -lxcb -lGL -lGLX -lXext -lGLdispatch -lXau -lXdmcp"
+# Debug changes to flags
+if [ -n "$BUILD_DEBUG" ]; then
+    OUTPUT_DIR="builds-debug/linux"
+    COMPILATION_FLAGS="-std=c99 -O0 -g"
+    FINAL_COMPILE_FLAGS=""
+fi
+
+# Display what we're doing
+if [ -n "$BUILD_DEBUG" ]; then
+    [ -z "$QUIET" ] && echo "COMPILE-INFO: Compiling in debug mode. ($COMPILATION_FLAGS $WARNING_FLAGS)"
+else
+    [ -z "$QUIET" ] && echo "COMPILE-INFO: Compiling in release mode. ($COMPILATION_FLAGS $FINAL_COMPILE_FLAGS)"
+fi
+
+# Create the raylib cache directory
+ROOT_DIR=$(pwd)
+TEMP_DIR="temp/release"
+if [ -n "$BUILD_DEBUG" ]; then
+    TEMP_DIR="temp/debug"
+fi
+# If there's a -c flag, remove the cache
+if [ -d "$TEMP_DIR" ] && [ -n "$BUILD_ALL" ]; then
+    [ -z "$QUIET" ] && echo "COMPILE-INFO: Found cached raylib, rebuilding."
+    rm -r "$TEMP_DIR"
+fi
+# If temp directory doesn't exist, build raylib
+if [ ! -d "$TEMP_DIR" ]; then
+    mkdir -p $TEMP_DIR
+    cd $TEMP_DIR
+    RAYLIB_DEFINES="-D_DEFAULT_SOURCE -DPLATFORM_DESKTOP -DGRAPHICS_API_OPENGL_33"
+    RAYLIB_C_FILES="$RAYLIB_SRC/core.c $RAYLIB_SRC/shapes.c $RAYLIB_SRC/textures.c $RAYLIB_SRC/text.c $RAYLIB_SRC/models.c $RAYLIB_SRC/utils.c $RAYLIB_SRC/audio.c $RAYLIB_SRC/rglfw.c $RAYLIB_SRC/external/mini_al.c"
+    RAYLIB_INCLUDE_FLAGS="-I$RAYLIB_SRC -I$RAYLIB_SRC/external/glfw/include"
+
+    if [ -n "$REALLY_QUIET" ]; then
+        $CC -c $RAYLIB_DEFINES $RAYLIB_INCLUDE_FLAGS $COMPILATION_FLAGS $RAYLIB_C_FILES > /dev/null 2>&1
+    else
+        $CC -c $RAYLIB_DEFINES $RAYLIB_INCLUDE_FLAGS $COMPILATION_FLAGS $RAYLIB_C_FILES
+    fi
+    [ -z "$QUIET" ] && echo "COMPILE-INFO: Raylib compiled into object files in: $TEMP_DIR/"
+    cd $ROOT_DIR
+fi
+
+# Build the actual game
+mkdir -p $OUTPUT_DIR
+cd $OUTPUT_DIR
+[ -z "$QUIET" ] && echo "COMPILE-INFO: Compiling game code."
+if [ -n "$REALLY_QUIET" ]; then
+    $CC -c -o main.o -I$RAYLIB_SRC $COMPILATION_FLAGS $WARNING_FLAGS $SOURCES > /dev/null 2>&1
+    $CC -o $GAME_NAME $ROOT_DIR/$TEMP_DIR/*.o main.o $LINK_FLAGS > /dev/null 2>&1
+else
+    $CC -c -o main.o -I$RAYLIB_SRC $COMPILATION_FLAGS $WARNING_FLAGS $SOURCES
+    $CC -o $GAME_NAME $ROOT_DIR/$TEMP_DIR/*.o main.o $LINK_FLAGS
+fi
+rm main.o
+[ -z "$QUIET" ] && echo "COMPILE-INFO: Game compiled into an executable in: $OUTPUT_DIR/"
+
+if [ -n "$UPX_IT" ]; then
+    [ -z "$QUIET" ] && echo "COMPILE-INFO: Packing $GAME_NAME with upx."
+    upx $GAME_NAME > /dev/null 2>&1
+fi
+
+if [ -n "$RUN_AFTER_BUILD" ]; then
+    [ -z "$QUIET" ] && echo "COMPILE-INFO: Running."
+    if [ -n "$REALLY_QUIET" ]; then
+        ./$GAME_NAME > /dev/null 2>&1
+    else
+        ./$GAME_NAME
+    fi
+fi
+cd $ROOT_DIR
+
+[ -z "$QUIET" ] && echo "COMPILE-INFO: All done."

--- a/projects/scripts/osx-build.sh
+++ b/projects/scripts/osx-build.sh
@@ -1,0 +1,154 @@
+#!/bin/sh
+# Change your executable name here
+GAME_NAME="game"
+
+# Set your sources here (relative to the ./builds/osx directory)
+# Example with two source folders:
+# SOURCES="../../src/*.c ../../src/submodule/*.c"
+SOURCES="../../core_basic_window.c"
+
+# Set your raylib/src location here, relative to the ./temp/x directory
+RAYLIB_SRC="../../../../src"
+
+# About this build script: it does many things, but in essence, it's
+# very simple. It has 3 compiler invocations: building raylib (which
+# is not done always, see logic by searching "Build raylib"), building
+# src/*.c files, and linking together those two. Each invocation is
+# wrapped in an if statement to make the -qq flag work, it's pretty
+# verbose, sorry.
+
+# Get arguments
+while getopts ":hdurcq" opt; do
+    case $opt in
+        h)
+            echo "Usage: ./osx-build.sh [-hdurcqq]"
+            echo " -h  Show this information"
+            echo " -d  Faster builds that have debug symbols, and enable warnings"
+            echo " -u  Run upx* on the executable after compilation (before -r)"
+            echo " -r  Run the executable after compilation"
+            echo " -c  Remove the temp/(debug|release) directory, ie. full recompile"
+            echo " -q  Suppress this script's informational prints"
+            echo " -qq Suppress all prints, complete silence (> /dev/null 2>&1)"
+            echo ""
+            echo "* This is mostly here to make building simple \"shipping\" versions"
+            echo "  easier, and it's a very small bit in the build scripts. The option"
+            echo "  requires that you have upx installed and on your path, of course."
+            echo ""
+            echo "Examples:"
+            echo " Build a release build:                    ./osx-build.sh"
+            echo " Build a release build, full recompile:    ./osx-build.sh -c"
+            echo " Build a debug build and run:              ./osx-build.sh -d -r"
+            echo " Build in debug, run, don't print at all:  ./osx-build.sh -drqq"
+            exit 0
+            ;;
+        d)
+            BUILD_DEBUG="1"
+            ;;
+        u)
+            UPX_IT="1"
+            ;;
+        r)
+            RUN_AFTER_BUILD="1"
+            ;;
+        c)
+            BUILD_ALL="1"
+            ;;
+        q)
+            if [ -n "$QUIET" ]; then
+                REALLY_QUIET="1"
+            else
+                QUIET="1"
+            fi
+            ;;
+        \?)
+            echo "Invalid option: -$OPTARG" >&2
+            exit 1
+            ;;
+    esac
+done
+
+# Set CC if it's not set already
+if [ -z "$CC" ]; then
+    CC=cc
+fi
+
+# Flags
+OUTPUT_DIR="builds/osx"
+COMPILATION_FLAGS="-std=c99 -O2 -flto"
+FINAL_COMPILE_FLAGS="-s"
+WARNING_FLAGS="-Wall -Wextra -Wpedantic"
+LINK_FLAGS="-framework OpenGL -framework OpenAL -framework IOKit -framework CoreVideo -framework Cocoa"
+# Debug changes to flags
+if [ -n "$BUILD_DEBUG" ]; then
+    OUTPUT_DIR="builds-debug/osx"
+    COMPILATION_FLAGS="-std=c99 -O0 -g"
+    FINAL_COMPILE_FLAGS=""
+fi
+
+# Display what we're doing
+if [ -n "$BUILD_DEBUG" ]; then
+    [ -z "$QUIET" ] && echo "COMPILE-INFO: Compiling in debug mode. ($COMPILATION_FLAGS $WARNING_FLAGS)"
+else
+    [ -z "$QUIET" ] && echo "COMPILE-INFO: Compiling in release mode. ($COMPILATION_FLAGS $FINAL_COMPILE_FLAGS)"
+fi
+
+# Create the raylib cache directory
+ROOT_DIR=$(pwd)
+TEMP_DIR="temp/release"
+if [ -n "$BUILD_DEBUG" ]; then
+    TEMP_DIR="temp/debug"
+fi
+# If there's a -c flag, remove the cache
+if [ -d "$TEMP_DIR" ] && [ -n "$BUILD_ALL" ]; then
+    [ -z "$QUIET" ] && echo "COMPILE-INFO: Found cached raylib, rebuilding."
+    rm -r "$TEMP_DIR"
+fi
+# If temp directory doesn't exist, build raylib
+if [ ! -d "$TEMP_DIR" ]; then
+    mkdir -p $TEMP_DIR
+    cd $TEMP_DIR
+    RAYLIB_DEFINES="-D_DEFAULT_SOURCE -DPLATFORM_DESKTOP -DGRAPHICS_API_OPENGL_33"
+    RAYLIB_C_FILES="$RAYLIB_SRC/core.c $RAYLIB_SRC/shapes.c $RAYLIB_SRC/textures.c $RAYLIB_SRC/text.c $RAYLIB_SRC/models.c $RAYLIB_SRC/utils.c $RAYLIB_SRC/audio.c $RAYLIB_SRC/external/mini_al.c"
+    RAYLIB_INCLUDE_FLAGS="-I$RAYLIB_SRC -I$RAYLIB_SRC/external/glfw/include"
+
+    if [ -n "$REALLY_QUIET" ]; then
+        $CC -c $RAYLIB_DEFINES $RAYLIB_INCLUDE_FLAGS $COMPILATION_FLAGS -x objective-c $RAYLIB_SRC/rglfw.c > /dev/null 2>&1
+        $CC -c $RAYLIB_DEFINES $RAYLIB_INCLUDE_FLAGS $COMPILATION_FLAGS $RAYLIB_C_FILES > /dev/null 2>&1
+    else
+        $CC -c $RAYLIB_DEFINES $RAYLIB_INCLUDE_FLAGS $COMPILATION_FLAGS -x objective-c $RAYLIB_SRC/rglfw.c
+        $CC -c $RAYLIB_DEFINES $RAYLIB_INCLUDE_FLAGS $COMPILATION_FLAGS $RAYLIB_C_FILES
+    fi
+    [ -z "$QUIET" ] && echo "COMPILE-INFO: Raylib compiled into object files in: $TEMP_DIR/"
+    cd $ROOT_DIR
+fi
+
+# Build the actual game
+mkdir -p $OUTPUT_DIR
+cd $OUTPUT_DIR
+[ -z "$QUIET" ] && echo "COMPILE-INFO: Compiling game code."
+if [ -n "$REALLY_QUIET" ]; then
+    $CC -c -o main.o -I$RAYLIB_SRC $COMPILATION_FLAGS $WARNING_FLAGS $SOURCES > /dev/null 2>&1
+    $CC -o $GAME_NAME $ROOT_DIR/$TEMP_DIR/*.o main.o $LINK_FLAGS > /dev/null 2>&1
+else
+    $CC -c -o main.o -I$RAYLIB_SRC $COMPILATION_FLAGS $WARNING_FLAGS $SOURCES
+    $CC -o $GAME_NAME $ROOT_DIR/$TEMP_DIR/*.o main.o $LINK_FLAGS
+fi
+rm main.o
+[ -z "$QUIET" ] && echo "COMPILE-INFO: Game compiled into an executable in: $OUTPUT_DIR/"
+
+if [ -n "$UPX_IT" ]; then
+    [ -z "$QUIET" ] && echo "COMPILE-INFO: Packing $GAME_NAME with upx."
+    upx $GAME_NAME > /dev/null 2>&1
+fi
+
+if [ -n "$RUN_AFTER_BUILD" ]; then
+    [ -z "$QUIET" ] && echo "COMPILE-INFO: Running."
+    if [ -n "$REALLY_QUIET" ]; then
+        ./$GAME_NAME > /dev/null 2>&1
+    else
+        ./$GAME_NAME
+    fi
+fi
+cd $ROOT_DIR
+
+[ -z "$QUIET" ] && echo "COMPILE-INFO: All done."

--- a/projects/scripts/windows-build.bat
+++ b/projects/scripts/windows-build.bat
@@ -1,0 +1,211 @@
+@echo off
+REM Change your executable name here
+set GAME_NAME=game.exe
+
+REM Set your sources here (relative to the builds\windows directory)
+REM Example with two source folders:
+REM set SOURCES=..\..\src\*.c ..\..\src\submodule\*.c
+set SOURCES=..\..\core_basic_window.c
+
+REM Set your raylib/src location here, relative to the ./temp/x directory
+set RAYLIB_SRC=..\..\..\..\src
+
+REM About this build script: it does many things, but in essence, it's
+REM very simple. It has 3 compiler invocations: building raylib (which
+REM is not done always, see logic by searching "Build raylib"), building
+REM src/*.c files, and linking together those two. Each invocation is
+REM wrapped in an if statement to make the -qq flag work, it's pretty
+REM verbose, sorry.
+
+REM To skip to the actual building part of the script, search for ":BUILD"
+
+REM For the ! variable notation
+setlocal EnableDelayedExpansion
+REM For shifting, which the command line argument parsing needs
+setlocal EnableExtensions
+
+
+:ARG_LOOP
+set ARG=%1
+if "!ARG!" == "" ( goto PREPARE )
+IF NOT "x!ARG!" == "x!ARG:h=!" (
+  goto HELP
+)
+IF NOT "x!ARG!" == "x!ARG:d=!" (
+  set BUILD_DEBUG=1
+)
+IF NOT "x!ARG!" == "x!ARG:u=!" (
+  set UPX_IT=1
+)
+IF NOT "x!ARG!" == "x!ARG:r=!" (
+  set RUN_AFTER_BUILD=1
+)
+IF NOT "x!ARG!" == "x!ARG:c=!" (
+  set BUILD_ALL=1
+)
+IF NOT "x!ARG!" == "x!ARG:qq=!" (
+  set QUIET=1
+  set REALLY_QUIET=1
+) ELSE IF NOT "x!ARG!" == "x!ARG:q=!" (
+  IF DEFINED QUIET (
+    set REALLY_QUIET=1
+  ) ELSE (
+    set QUIET=1
+  )
+)
+IF NOT "x!ARG!" == "x!ARG:v=!" (
+  set VERBOSE=1
+)
+IF NOT "%1" == "" (
+  shift /1
+  goto ARG_LOOP
+)
+
+
+:HELP
+echo Usage: windows-build.bat [-hdurcqqv]
+echo  -h  Show this information
+echo  -d  Faster builds that have debug symbols, and enable warnings
+echo  -u  Run upx* on the executable after compilation (before -r)
+echo  -r  Run the executable after compilation
+echo  -c  Remove the temp\{debug,release} directory, ie. full recompile
+echo  -q  Suppress this script's informational prints
+echo  -qq Suppress all prints, complete silence
+echo  -v  cl.exe normally prints out a lot of superficial information, as
+echo      well as the MSVC build environment activation scripts, but these are
+echo      mostly suppressed by default. If you do want to see everything, use
+echo      this flag.
+echo.
+echo * This is mostly here to make building simple "shipping" versions
+echo   easier, and it's a very small bit in the build scripts. The option
+echo   requires that you have upx installed and on your path, of course.
+echo.
+echo Examples:
+echo  Build a release build:                    windows-build.bat
+echo  Build a release build, full recompile:    windows-build.bat -c
+echo  Build a debug build and run:              windows-build.bat -d -r
+echo  Build in debug, run, don't print at all:  windows-build.bat -drqq
+exit /B
+
+
+:PREPARE
+REM Activate the msvc build environment
+IF EXIST "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" (
+  set VC_INIT="C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat"
+) ELSE IF EXIST "C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\VC\Auxiliary\Build\vcvarsall.bat" (
+  set VC_INIT="C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\VC\Auxiliary\Build\vcvarsall.bat"
+) ELSE IF EXIST "C:\Program Files (x86)\Microsoft Visual C++ Build Tools\vcbuildtools.bat" (
+  set VC_INIT="C:\Program Files (x86)\Microsoft Visual C++ Build Tools\vcbuildtools.bat"
+) ELSE (
+  REM Initialize your vc environment here if the defaults don't work
+  REM  set VC_INIT="C:\your\path\here\vcvarsall.bat"
+  REM And then remove/comment out the following two lines
+  echo "Couldn't find vcvarsall.bat or vcbuildtools.bat, please set it manually."
+  exit /B
+)
+IF DEFINED VERBOSE (
+  call !VC_INIT! x86
+) ELSE (
+  call !VC_INIT! x86 > NUL 2>&1
+)
+
+
+:BUILD
+REM Flags
+set OUTPUT_FLAG=/Fe: "!GAME_NAME!"
+set COMPILATION_FLAGS=/O1 /GL
+set WARNING_FLAGS=
+set SUBSYSTEM_FLAGS=/SUBSYSTEM:WINDOWS /ENTRY:mainCRTStartup
+set LINK_FLAGS=/link /LTCG kernel32.lib user32.lib shell32.lib winmm.lib gdi32.lib opengl32.lib
+set OUTPUT_DIR=builds\windows
+REM Debug changes to flags
+IF DEFINED BUILD_DEBUG (
+  set OUTPUT_FLAG=/Fe: "!GAME_NAME!"
+  set COMPILATION_FLAGS=/Od /Zi
+  set WARNING_FLAGS=/Wall
+  set SUBSYSTEM_FLAGS=
+  set LINK_FLAGS=/link kernel32.lib user32.lib shell32.lib winmm.lib gdi32.lib opengl32.lib
+  set OUTPUT_DIR=builds-debug\windows
+)
+IF NOT DEFINED VERBOSE (
+  set VERBOSITY_FLAG=/nologo
+)
+
+REM Display what we're doing
+IF DEFINED BUILD_DEBUG (
+  IF NOT DEFINED QUIET echo COMPILE-INFO: Compiling in debug mode, flags: !COMPILATION_FLAGS! !WARNING_FLAGS!
+) ELSE (
+  IF NOT DEFINED QUIET echo COMPILE-INFO: Compiling in release mode, flags: !COMPILATION_FLAGS! /link /LTCG
+)
+
+REM Create the temp directory for raylib
+set "ROOT_DIR=%CD%"
+set "TEMP_DIR=temp\release"
+IF DEFINED BUILD_DEBUG (
+  set "TEMP_DIR=temp\debug"
+)
+
+IF DEFINED BUILD_ALL (
+  IF EXIST !TEMP_DIR!\ (
+    IF NOT DEFINED QUIET echo COMPILE-INFO: Found cached raylib, rebuilding.
+    del /Q !TEMP_DIR!
+    rmdir !TEMP_DIR!
+  )
+)
+
+REM Build raylib if it hasn't been cached in TEMP_DIR
+IF NOT EXIST !TEMP_DIR!\ (
+  mkdir !TEMP_DIR!
+  cd !TEMP_DIR!
+  REM Raylib's src folder
+  set "RAYLIB_DEFINES=/D_DEFAULT_SOURCE /DPLATFORM_DESKTOP /DGRAPHICS_API_OPENGL_33"
+  set RAYLIB_C_FILES="!RAYLIB_SRC!\core.c" "!RAYLIB_SRC!\shapes.c" "!RAYLIB_SRC!\textures.c" "!RAYLIB_SRC!\text.c" "!RAYLIB_SRC!\models.c" "!RAYLIB_SRC!\utils.c" "!RAYLIB_SRC!\audio.c" "!RAYLIB_SRC!\rglfw.c" "!RAYLIB_SRC!\external\mini_al.c"
+  set RAYLIB_INCLUDE_FLAGS=/I"!RAYLIB_SRC!" /I"!RAYLIB_SRC!\external\glfw\include"
+
+  IF DEFINED REALLY_QUIET (
+    cl.exe /w /c !RAYLIB_DEFINES! !RAYLIB_INCLUDE_FLAGS! !COMPILATION_FLAGS! !RAYLIB_C_FILES! > NUL 2>&1
+  ) ELSE (
+    cl.exe /w /c !VERBOSITY_FLAG! !RAYLIB_DEFINES! !RAYLIB_INCLUDE_FLAGS! !COMPILATION_FLAGS! !RAYLIB_C_FILES!
+  )
+  IF NOT DEFINED QUIET echo COMPILE-INFO: Raylib compiled into object files in: !TEMP_DIR!\
+
+  REM Out of the temp directory
+  cd !ROOT_DIR!
+)
+
+REM Move to the build directory
+IF NOT EXIST !OUTPUT_DIR! mkdir !OUTPUT_DIR!
+cd !OUTPUT_DIR!
+
+REM Build the actual game
+IF NOT DEFINED QUIET echo COMPILE-INFO: Compiling game code.
+IF DEFINED REALLY_QUIET (
+  cl.exe !VERBOSITY_FLAG! /Fo"main.obj" !COMPILATION_FLAGS! !WARNING_FLAGS! /c /I"!RAYLIB_SRC!" !SOURCES! > NUL 2>&1
+  cl.exe !VERBOSITY_FLAG! !OUTPUT_FLAG! "!ROOT_DIR!\!TEMP_DIR!\*.obj" main.obj !LINK_FLAGS! !SUBSYSTEM_FLAGS! > NUL 2>&1
+) ELSE (
+  cl.exe !VERBOSITY_FLAG! /Fo"main.obj" !COMPILATION_FLAGS! !WARNING_FLAGS! /c /I"!RAYLIB_SRC!" !SOURCES!
+  cl.exe !VERBOSITY_FLAG! !OUTPUT_FLAG! "!ROOT_DIR!\!TEMP_DIR!\*.obj" main.obj !LINK_FLAGS! !SUBSYSTEM_FLAGS!
+)
+del main.obj
+IF NOT DEFINED QUIET echo COMPILE-INFO: Game compiled into an executable in: !OUTPUT_DIR!\
+
+REM Run upx
+IF DEFINED UPX_IT (
+  IF NOT DEFINED QUIET echo COMPILE-INFO: Packing !GAME_NAME! with upx.
+  upx !GAME_NAME! > NUL 2>&1
+)
+
+REM Finally, run the produced executable
+IF DEFINED RUN_AFTER_BUILD (
+  IF NOT DEFINED QUIET echo COMPILE-INFO: Running.
+  IF DEFINED REALLY_QUIET (
+    !GAME_NAME! > NUL 2>&1
+  ) ELSE (
+    !GAME_NAME!
+  )
+)
+
+REM Back to development directory
+cd !ROOT_DIR!
+
+IF NOT DEFINED QUIET echo COMPILE-INFO: All done.


### PR DESCRIPTION
Some people might want to build projects without make systems or such, so here's three build scripts I wrote to build raylib applications without those. Only the three main desktop platforms sadly, but they were the easiest to write and test. I've ran them all successfully on Windows 8.1, Arch Linux (gcc) and a pretty up-to-date macOS, but additional testing would probably be nice if possible.