### PR TITLE
Added ColorFromHSV()

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -1445,6 +1445,41 @@ Vector3 ColorToHSV(Color color)
     return hsv;
 }
 
+// Returns a Color from HSV values
+// NOTE: Color->HSV->Color conversion will not yield exactly the same color due to rounding errors
+Color ColorFromHSV(Vector3 hsv, unsigned char alpha) 
+{
+    // implementation details at https://en.wikipedia.org/wiki/HSL_and_HSV#Alternative_HSV_conversion
+    float h = hsv.x, s=hsv.y, v=hsv.z;
+    Color color = {0,0,0,alpha};
+    
+    //red
+    float k = fmod((5.+h/60.),6);
+    float t = 4.-k;
+    k = t<k?t:k;
+    k = k<1?k:1;
+    k = k>0?k:0;
+    color.r = (v-v*s*k)*255;
+
+    //green
+    k = fmod((3.+h/60.),6);
+    t = 4.-k;
+    k = t<k?t:k;
+    k = k<1?k:1;
+    k = k>0?k:0;
+    color.g =(v-v*s*k)*255;
+    
+    //blue
+    k = fmod((1.+h/60.),6);
+    t = 4.-k;
+    k = t<k?t:k;
+    k = k<1?k:1;
+    k = k>0?k:0;
+    color.b = (v-v*s*k)*255;
+	
+    return color;
+}
+
 // Returns a Color struct from hexadecimal value
 Color GetColor(int hexValue)
 {

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -891,6 +891,7 @@ RLAPI double GetTime(void);                                       // Returns ela
 RLAPI int ColorToInt(Color color);                                // Returns hexadecimal value for a Color
 RLAPI Vector4 ColorNormalize(Color color);                        // Returns color normalized as float [0..1]
 RLAPI Vector3 ColorToHSV(Color color);                            // Returns HSV values for a Color
+RLAPI Color ColorFromHSV(Vector3 hsv, unsigned char alpha);       // Returns a Color from HSV values (NOTE: some precision is lost due to rounding errors)
 RLAPI Color GetColor(int hexValue);                               // Returns a Color struct from hexadecimal value
 RLAPI Color Fade(Color color, float alpha);                       // Color fade-in or fade-out, alpha goes from 0.0f to 1.0f
 


### PR DESCRIPTION
Implemented from https://en.wikipedia.org/wiki/HSL_and_HSV#Alternative_HSV_conversion. 

When converting back and forth from **Color** to **HSV** some precision will be lost and the initial color won't be exactly the same but this cannot be avoided. I put a note in the source!