### PR TITLE
Trace log failing on other

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -112,6 +112,7 @@ void TraceLog(int msgType, const char *text, ...)
         case LOG_ERROR: strcpy(buffer, "ERROR: "); break;
         case LOG_WARNING: strcpy(buffer, "WARNING: "); break;
         case LOG_DEBUG: strcpy(buffer, "DEBUG: "); break;
+        case LOG_OTHER: strcpy(buffer, "OTHER: "); break;
         default: break;
     }
 
@@ -125,6 +126,7 @@ void TraceLog(int msgType, const char *text, ...)
         case LOG_WARNING: if (logTypeFlags & LOG_WARNING) __android_log_vprint(ANDROID_LOG_WARN, "raylib", buffer, args); break;
         case LOG_ERROR: if (logTypeFlags & LOG_ERROR) __android_log_vprint(ANDROID_LOG_ERROR, "raylib", buffer, args); break;
         case LOG_DEBUG: if (logTypeFlags & LOG_DEBUG) __android_log_vprint(ANDROID_LOG_DEBUG, "raylib", buffer, args); break;
+        case LOG_OTHER: if (logTypeFlags & LOG_OTHER) __android_log_vprint(ANDROID_LOG_VERBOSE, "raylib", buffer, args); break;
         default: break;
     }
 #else
@@ -134,6 +136,7 @@ void TraceLog(int msgType, const char *text, ...)
         case LOG_WARNING: if (logTypeFlags & LOG_WARNING) vprintf(buffer, args); break;
         case LOG_ERROR: if (logTypeFlags & LOG_ERROR) vprintf(buffer, args); break;
         case LOG_DEBUG: if (logTypeFlags & LOG_DEBUG) vprintf(buffer, args); break;
+        case LOG_OTHER: if (logTypeFlags & LOG_OTHER) vprintf(buffer, args); break;
         default: break;
     }
 #endif

--- a/src/utils.c
+++ b/src/utils.c
@@ -46,6 +46,8 @@
 #include <stdarg.h>                 // Required for: va_list, va_start(), vfprintf(), va_end()
 #include <string.h>                 // Required for: strlen(), strrchr(), strcmp()
 
+#define MAX_TRACELOG_BUFFER_SIZE    128 // Max length of a trace-log message.
+
 //----------------------------------------------------------------------------------
 // Global Variables Definition
 //----------------------------------------------------------------------------------
@@ -93,7 +95,7 @@ void SetTraceLogCallback(TraceLogCallback callback)
 void TraceLog(int msgType, const char *text, ...)
 {
 #if defined(SUPPORT_TRACELOG)
-    static char buffer[128];
+    char buffer[MAX_TRACELOG_BUFFER_SIZE];
     va_list args;
     va_start(args, text);
 


### PR DESCRIPTION
Here it is, a small fix that issue the `LOG_OTHER` log-type not properly handled.
