### PR TITLE
Remove `raylib-rust`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,7 +71,6 @@ Some people ported raylib to other languages in form of bindings or wrappers to 
  - [RaylibSharp](https://github.com/TheLumaio/RaylibSharp) : raylib **C#** binding
  - [raylib-ruby-ffi](https://github.com/D3nX/raylib-ruby-ffi) : raylib **Ruby** binding
  - [raylib-rs](https://github.com/deltaphc/raylib-rs) : raylib **Rust** binding
- - [raylib-rust](https://github.com/dtcristo/raylib-rust) : raylib **Rust** binding
  - [raylib-py](https://github.com/overdev/raylib-py) : raylib **Python** binding
  - [raylib-haskell](https://github.com/DevJac/raylib-haskell) : raylib **Haskell** binding
  - [raylib-java](https://github.com/XoanaIO/raylib-java) : raylib **Java** binding


### PR DESCRIPTION
I've deprecated [raylib-rust](https://github.com/dtcristo/raylib-rust) in favour of [raylib-rs](https://github.com/deltaphc/raylib-rs) which is more feature complete. Therefore feel free to remove this link as I'm not maintaining the bindings anymore.