### PR TITLE
CMake: pkg-config: fix usage for RedHat-like systems

### DIFF
--- a/raylib.pc.in
+++ b/raylib.pc.in
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
-libdir=${exec_prefix}/lib
-includedir=${prefix}/include
+libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
 
 Name: raylib
 Description: Simple and easy-to-use library to enjoy videogames programming


### PR DESCRIPTION
$prefix/lib isn't in pc_path on Fedora 28:

    [root@fedora-28 ~]# pkg-config --variable=pc_path pkg-config
    /usr/lib64/pkgconfig:/usr/share/pkgconfig

This has the effect that the raylib.pc file is written to the
correct location but `pkg-config --libs raylib` doesn't output
the correct library path. This fixes this problem by substituting
the directory names into raylib.pc, same as we do with the CMakeLists.txt
since #518.

This issue popped up during the automated test of the Perl bindings:
	athreef/Alien-raylib#3