### PR TITLE
Fix font cannot be narrowed to type 'int'

### DIFF
--- a/src/text.c
+++ b/src/text.c
@@ -113,7 +113,7 @@ extern void LoadDefaultFont(void)
     // Default font is directly defined here (data generated from a sprite font image)
     // This way, we reconstruct Font without creating large global variables
     // This data is automatically allocated to Stack and automatically deallocated at the end of this function
-    int defaultFontData[512] = {
+    unsigned int defaultFontData[512] = {
         0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00200020, 0x0001b000, 0x00000000, 0x00000000, 0x8ef92520, 0x00020a00, 0x7dbe8000, 0x1f7df45f,
         0x4a2bf2a0, 0x0852091e, 0x41224000, 0x10041450, 0x2e292020, 0x08220812, 0x41222000, 0x10041450, 0x10f92020, 0x3efa084c, 0x7d22103c, 0x107df7de,
         0xe8a12020, 0x08220832, 0x05220800, 0x10450410, 0xa4a3f000, 0x08520832, 0x05220400, 0x10450410, 0xe2f92020, 0x0002085e, 0x7d3e0281, 0x107df41f,


### PR DESCRIPTION
Getting the following strict error....

```
src/text.c:117:105: error: constant expression evaluates to 2398692640 which
      cannot be narrowed to type 'int' [-Wc++11-narrowing]
...0x00000000, 0x00000000, 0x00200020, 0x0001b000, 0x00000000, 0x00000000, 0x8ef92520, 0x00020a00...
                                                                             ^~~~~~~~~~
```

Switching it to an unsigned int fixes it.