### PR TITLE
LoadBMFont filepath fix

### DIFF
--- a/src/text.c
+++ b/src/text.c
@@ -1406,6 +1406,10 @@ static Font LoadBMFont(const char *fileName)
     char *lastSlash = NULL;
 
     lastSlash = strrchr(fileName, '/');
+	if (lastSlash == NULL)
+	{
+		lastSlash = strrchr(fileName, '\\');
+	}
 
     // NOTE: We need some extra space to avoid memory corruption on next allocations!
     texPath = malloc(strlen(fileName) - strlen(lastSlash) + strlen(texFileName) + 4);


### PR DESCRIPTION
Fixed as issue where `strrchr` in `LoadBMFont` would only look for forward slashes, instead of backslashes causing `strlen` to fail on a null string formatted like so:

> R"(..\Resources\fonts\example.fnt)"