### PR TITLE
Fix config.h flags

### DIFF
--- a/src/models.c
+++ b/src/models.c
@@ -655,12 +655,16 @@ Mesh LoadMesh(const char *fileName)
     TraceLog(LOG_WARNING, "[%s] Mesh fileformat not supported, it can't be loaded", fileName);
 #endif
 
+#if defined(SUPPORT_MESH_GENERATION)
     if (mesh.vertexCount == 0)
     {
         TraceLog(LOG_WARNING, "Mesh could not be loaded! Let's load a cube to replace it!");
         mesh = GenMeshCube(1.0f, 1.0f, 1.0f);
     }
     else rlLoadMesh(&mesh, false);  // Upload vertex data to GPU (static mesh)
+#else
+    rlLoadMesh(&mesh, false);  // Upload vertex data to GPU (static mesh)
+#endif
 
     return mesh;
 }

--- a/src/raudio.c
+++ b/src/raudio.c
@@ -767,7 +767,11 @@ Wave LoadWave(const char *fileName)
 {
     Wave wave = { 0 };
 
+#if defined(SUPPORT_FILEFORMAT_WAV)
     if (IsFileExtension(fileName, ".wav")) wave = LoadWAV(fileName);
+#else
+    if (false) {}
+#endif
 #if defined(SUPPORT_FILEFORMAT_OGG)
     else if (IsFileExtension(fileName, ".ogg")) wave = LoadOGG(fileName);
 #endif
@@ -887,7 +891,11 @@ void ExportWave(Wave wave, const char *fileName)
 {
     bool success = false;
 
+#if defined(SUPPORT_FILEFORMAT_WAV)
     if (IsFileExtension(fileName, ".wav")) success = SaveWAV(wave, fileName);
+#else
+    if (false) {}
+#endif
     else if (IsFileExtension(fileName, ".raw"))
     {
         // Export raw sample data (without header)
@@ -1087,6 +1095,7 @@ Music LoadMusicStream(const char *fileName)
     Music music = (MusicData *)malloc(sizeof(MusicData));
     bool musicLoaded = true;
 
+#if defined(SUPPORT_FILEFORMAT_OGG)
     if (IsFileExtension(fileName, ".ogg"))
     {
         // Open ogg audio stream
@@ -1110,6 +1119,9 @@ Music LoadMusicStream(const char *fileName)
             TraceLog(LOG_DEBUG, "[%s] OGG memory required: %i", fileName, info.temp_memory_required);
         }
     }
+#else
+    if (false) {}
+#endif
 #if defined(SUPPORT_FILEFORMAT_FLAC)
     else if (IsFileExtension(fileName, ".flac"))
     {
@@ -1202,7 +1214,11 @@ Music LoadMusicStream(const char *fileName)
 
     if (!musicLoaded)
     {
+    #if defined(SUPPORT_FILEFORMAT_OGG)
         if (music->ctxType == MUSIC_AUDIO_OGG) stb_vorbis_close(music->ctxOgg);
+    #else
+        if (false) {}
+    #endif
     #if defined(SUPPORT_FILEFORMAT_FLAC)
         else if (music->ctxType == MUSIC_AUDIO_FLAC) drflac_free(music->ctxFlac);
     #endif
@@ -1232,7 +1248,11 @@ void UnloadMusicStream(Music music)
     
     CloseAudioStream(music->stream);
 
+#if defined(SUPPORT_FILEFORMAT_OGG)
     if (music->ctxType == MUSIC_AUDIO_OGG) stb_vorbis_close(music->ctxOgg);
+#else
+    if (false) {}
+#endif
 #if defined(SUPPORT_FILEFORMAT_FLAC)
     else if (music->ctxType == MUSIC_AUDIO_FLAC) drflac_free(music->ctxFlac);
 #endif
@@ -1297,7 +1317,9 @@ void StopMusicStream(Music music)
     // Restart music context
     switch (music->ctxType)
     {
+#if defined(SUPPORT_FILEFORMAT_OGG)
         case MUSIC_AUDIO_OGG: stb_vorbis_seek_start(music->ctxOgg); break;
+#endif
 #if defined(SUPPORT_FILEFORMAT_FLAC)
         case MUSIC_AUDIO_FLAC: /* TODO: Restart FLAC context */ break;
 #endif
@@ -1339,12 +1361,14 @@ void UpdateMusicStream(Music music)
         // TODO: Really don't like ctxType thingy...
         switch (music->ctxType)
         {
+        #if defined(SUPPORT_FILEFORMAT_OGG)
             case MUSIC_AUDIO_OGG:
             {
                 // NOTE: Returns the number of samples to process (be careful! we ask for number of shorts!)
                 stb_vorbis_get_samples_short_interleaved(music->ctxOgg, music->stream.channels, (short *)pcm, samplesCount);
 
             } break;
+        #endif
         #if defined(SUPPORT_FILEFORMAT_FLAC)
             case MUSIC_AUDIO_FLAC:
             {

--- a/src/shapes.c
+++ b/src/shapes.c
@@ -742,7 +742,7 @@ static Texture2D GetShapesTexture(void)
         recTexShapes = (Rectangle){ rec.x + 1, rec.y + 1, rec.width - 2, rec.height - 2 };
 #else
         texShapes = GetTextureDefault();                // Use default white texture
-        recTexShapes = { 0.0f, 0.0f, 1.0f, 1.0f };
+        recTexShapes = (Rectangle){ 0.0f, 0.0f, 1.0f, 1.0f };
 #endif
     }
 

--- a/src/text.c
+++ b/src/text.c
@@ -309,6 +309,7 @@ Font LoadFontEx(const char *fileName, int fontSize, int *fontChars, int charsCou
     font.charsCount = (charsCount > 0) ? charsCount : 95;
     font.chars = LoadFontData(fileName, font.baseSize, fontChars, font.charsCount, FONT_DEFAULT);
 
+#if defined(SUPPORT_FILEFORMAT_TTF)
     if (font.chars != NULL)
     {
         Image atlas = GenImageFontAtlas(font.chars, font.charsCount, font.baseSize, 2, 0);
@@ -316,6 +317,9 @@ Font LoadFontEx(const char *fileName, int fontSize, int *fontChars, int charsCou
         UnloadImage(atlas);
     }
     else font = GetFontDefault();
+#else
+    font = GetFontDefault();
+#endif
 
     return font;
 }
@@ -449,6 +453,7 @@ CharInfo *LoadFontData(const char *fileName, int fontSize, int *fontChars, int c
 
     CharInfo *chars = NULL;
 
+#if defined(SUPPORT_FILEFORMAT_TTF)
     // Load font data (including pixel data) from TTF file
     // NOTE: Loaded information should be enough to generate font image atlas,
     // using any packaging method
@@ -537,12 +542,16 @@ CharInfo *LoadFontData(const char *fileName, int fontSize, int *fontChars, int c
         if (genFontChars) free(fontChars);
     }
     else TraceLog(LOG_WARNING, "[%s] TTF file could not be opened", fileName);
+#else
+    TraceLog(LOG_WARNING, "[%s] TTF support is disabled", fileName);
+#endif
 
     return chars;
 }
 
 // Generate image font atlas using chars info
 // NOTE: Packing method: 0-Default, 1-Skyline
+#if defined(SUPPORT_FILEFORMAT_TTF)
 Image GenImageFontAtlas(CharInfo *chars, int charsCount, int fontSize, int padding, int packMethod)
 {
     Image atlas = { 0 };
@@ -667,6 +676,7 @@ Image GenImageFontAtlas(CharInfo *chars, int charsCount, int fontSize, int paddi
 
     return atlas;
 }
+#endif
 
 // Unload Font from GPU memory (VRAM)
 void UnloadFont(Font font)

--- a/src/textures.c
+++ b/src/textures.c
@@ -182,7 +182,11 @@ Image LoadImage(const char *fileName)
 {
     Image image = { 0 };
 
+#if defined(SUPPORT_FILEFORMAT_PNG)
     if ((IsFileExtension(fileName, ".png"))
+#else
+    if ((false)
+#endif
 #if defined(SUPPORT_FILEFORMAT_BMP)
         || (IsFileExtension(fileName, ".bmp"))
 #endif
@@ -825,14 +829,27 @@ void ExportImage(Image image, const char *fileName)
 {
     int success = 0;
 
+#if defined(SUPPORT_IMAGE_EXPORT)
     // NOTE: Getting Color array as RGBA unsigned char values
     unsigned char *imgData = (unsigned char *)GetImageData(image);
 
+#if defined(SUPPORT_FILEFORMAT_PNG)
     if (IsFileExtension(fileName, ".png")) success = stbi_write_png(fileName, image.width, image.height, 4, imgData, image.width*4);
+#else
+    if (false) {}
+#endif
+#if defined(SUPPORT_FILEFORMAT_BMP)
     else if (IsFileExtension(fileName, ".bmp")) success = stbi_write_bmp(fileName, image.width, image.height, 4, imgData);
+#endif
+#if defined(SUPPORT_FILEFORMAT_TGA)
     else if (IsFileExtension(fileName, ".tga")) success = stbi_write_tga(fileName, image.width, image.height, 4, imgData);
+#endif
+#if defined(SUPPORT_FILEFORMAT_JPG)
     else if (IsFileExtension(fileName, ".jpg")) success = stbi_write_jpg(fileName, image.width, image.height, 4, imgData, 80);  // JPG quality: between 1 and 100
+#endif
+#if defined(SUPPORT_FILEFORMAT_KTX)
     else if (IsFileExtension(fileName, ".ktx")) success = SaveKTX(image, fileName);
+#endif
     else if (IsFileExtension(fileName, ".raw"))
     {
         // Export raw pixel data (without header)
@@ -842,10 +859,11 @@ void ExportImage(Image image, const char *fileName)
         fclose(rawFile);
     }
 
+    free(imgData);
+#endif
+
     if (success != 0) TraceLog(LOG_INFO, "Image exported successfully: %s", fileName);
     else TraceLog(LOG_WARNING, "Image could not be exported.");
-
-    free(imgData);
 }
 
 // Export image as code file (.h) defining an array of bytes
@@ -2146,7 +2164,6 @@ void ImageColorReplace(Image *image, Color color, Color replace)
 }
 #endif      // SUPPORT_IMAGE_MANIPULATION
 
-#if defined(SUPPORT_IMAGE_GENERATION)
 // Generate image: plain color
 Image GenImageColor(int width, int height, Color color)
 {
@@ -2161,6 +2178,7 @@ Image GenImageColor(int width, int height, Color color)
     return image;
 }
 
+#if defined(SUPPORT_IMAGE_GENERATION)
 // Generate image: vertical gradient
 Image GenImageGradientV(int width, int height, Color top, Color bottom)
 {


### PR DESCRIPTION
Related to issue #752.
This PR currently contains fixes to most of the configuration flags. I'm making this PR now since I need some advice on how to continue.

Issues when `SUPPORT_IMAGE_MANIPULATION` is disabled:
- `LoadTextureCubemap` calls `ImageDraw`, which is now undefined. `ImageDraw` then seems to depend on `ImageCrop` and `ImageResize`, and `ImageResize` depends on `stbir_resize_uint8`. Should `LoadTextureCubemap` depend on `SUPPORT_IMAGE_MANIPULATION`, or should something more sophisticated be done?
- `ImageFormat` calls `ImageMipmaps`, which is now undefined. Is it safe to just not call `ImageMipmaps` if this flag is not enabled?
- `ImageAlphaCrop` calls `ImageCrop`, I'm guessing it should be under this flag as well.

A few notes on the changes I made already:
- If I understood correctly, GenImageFontAtlas is only used internally, and only used with TTF fonts. Based on this, and the fact that it exploded with errors once the flag was disabled, I made it depend on the `SUPPORT_FILEFORMAT_TTF` flag.
- Moved GenImageColor out of the `SUPPORT_IMAGE_GENERATION` block, since it's called from four different places outside of it, so modifying the callers would probably cause more problems.