### PR TITLE
Fixed height bug in DrawTextRecEx()

### DIFF
--- a/src/text.c
+++ b/src/text.c
@@ -897,7 +897,7 @@ void DrawTextRecEx(Font font, const char *text, Rectangle rec, float fontSize, f
                     textOffsetX = 0;
                 }
 
-                if ((textOffsetY + (int)((font.baseSize + font.baseSize/2)*scaleFactor)) > rec.height) break;
+                if ((textOffsetY + (int)(font.baseSize*scaleFactor)) > rec.height) break;
 
                 //draw selected
                 bool isGlyphSelected = false;


### PR DESCRIPTION
Small error that prevented rendering the text inside a rectangle with sufficient height.
Sorry i didn't catch this earlier!