### PR TITLE
Editing the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ raylib is heavily inspired by the Borland Graphics Interface and the XNA Framewo
 raylib is especially well suited for prototyping, tooling, graphical applications, embedded systems and education.
 
 > NOTE for ADVENTURERS: raylib is a *programming library* for *enjoying videogames programming*.
-There will never be a fancy interface, visual helpers, auto-debugging, or anything else that detracts from the art and practice of programming videogames. raylib augments your C or C++ runtime with [a comprehensive API](https://www.raylib.com/cheatsheet/cheatsheet.html) that makes it easy to build games from scratch.
+There will never be a fancy interface, visual helpers, auto-debugging, or anything else that detracts from the art and practice of programming videogames. raylib augments your C or C++ runtime with [a comprehensive API](https://www.raylib.com/cheatsheet/cheatsheet.html) that makes it easy to build videogames from scratch.
 
 Ready to learn? Jump to [the code examples](http://www.raylib.com/examples.html)!
 
@@ -22,26 +22,26 @@ Features
 
   - **No external dependencies**. All required libraries are bundled into raylib.
   - Crossplatform. Supports **Windows, Linux, MacOS, Android... and many more!**
-  - Written in plain C code. Uses C99 with PascalCase/camelCase notation.
+  - Written in plain C code. Uses C99, with PascalCase/camelCase notation.
   - Hardware accelerated with OpenGL (**1.1, 2.1, 3.3 or ES 2.0**).
-  - **Unique OpenGL abstraction layer** (usable as standalone module): [rlgl](https://github.com/raysan5/raylib/blob/master/src/rlgl.h).
+  - **Unique OpenGL abstraction layer** (usable as a standalone module): [rlgl](https://github.com/raysan5/raylib/blob/master/src/rlgl.h).
   - Multiple font format support (XNA fonts, AngelCode fonts and TTF).
   - Outstanding texture formats support, including compressed formats (DXT, ETC and ASTC).
   - **Full 3D support**, including 3D Shapes, Models, Billboards, Heightmaps and more! 
   - Flexible materials system, supporting classic maps and **PBR maps**.
   - Custom shaders, including model and postprocessing shaders.
-  - **Powerful math module** for vector, matrix and quaternion operations: [raymath](https://github.com/raysan5/raylib/blob/master/src/raymath.h)
-  - Support for loading and playing and streaming audio (WAV, OGG, MP3, FLAC, XM and MOD).
-  - **VR stereo rendering** support, with configurable HMD device parameters.
+  - **Powerful math module** for vector, matrix and quaternion operations: [raymath](https://github.com/raysan5/raylib/blob/master/src/raymath.h).
+  - Support for loading, playing and streaming audio (WAV, OGG, MP3, FLAC, XM and MOD).
+  - **VR stereo rendering** support with configurable HMD device parameters.
   - Language bindings for **Lua** ([raylib-lua](https://github.com/raysan5/raylib-lua)), **Go** ([raylib-go](https://github.com/gen2brain/raylib-go)) and [more](https://github.com/raysan5/raylib/blob/master/CONTRIBUTING.md#raylib-bindings)!
 
 raylib has its own [core](https://github.com/raysan5/raylib/blob/master/src/core.c) module (derived from the outstanding [GLFW3](http://www.glfw.org/) library), bundled with raylib as the [rglfw](https://github.com/raysan5/raylib/blob/master/src/rglfw.c) module (avoiding external dependencies).
 
-raylib also has its own [audio](https://github.com/raysan5/raylib/blob/master/src/raudio.c) module, based on the amazing [mini_al](https://github.com/dr-soft/mini_al) audio library, provided as a single file, (header-only), and supporting multiple platforms and various audio backends.
+raylib also has its own [audio](https://github.com/raysan5/raylib/blob/master/src/raudio.c) module, based on the amazing [mini_al](https://github.com/dr-soft/mini_al) audio library, provided as a single file (header-only), and supporting multiple platforms and various audio backends.
 
-raylib is internally relient on multiple single-file, header-only libraries to support loading and saving multiple file formats. All of those libraries are bundled with raylib, and are available in the `[src/external](https://github.com/raysan5/raylib/tree/master/src/external)` directory.
+raylib relies internally on multiple single-file, header-only libraries that support loading and saving multiple file formats. All of those libraries are bundled with raylib, and are available in the [`src/external`](https://github.com/raysan5/raylib/tree/master/src/external) directory.
 
-*On Android, `native_app_glue module` (provided by the Android NDK) and native Android libraries are used to manage the window and context, inputs and the activity life cycle.*
+*On Android, the `native_app_glue module` (provided by the Android NDK) and native Android libraries are used to manage the window and context, inputs and the activity life cycle.*
 
 *On Raspberry Pi, the `Videocore API` and `EGL` libraries are used for window and context management, and for reading raw inputs.*
 
@@ -50,7 +50,7 @@ Building and Installation
 
 Binary releases for Windows, Linux and macOS are available at [the Github Releases page](https://github.com/raysan5/raylib/releases). raylib is also available via multiple package managers, across multiple OS distributions. For more info, check [the raylib Wiki](https://github.com/raysan5/raylib/wiki).
 
-If you wish to build raylib yourself, [the raylib Wiki](https://github.com/raysan5/raylib/wiki) also contains detailed instructions on how to achieve that.
+If you wish to build raylib yourself, [the raylib Wiki](https://github.com/raysan5/raylib/wiki) also contains detailed instructions on how to approach that.
 
 raylib has been developed exclusively using two tools:
 
@@ -71,9 +71,9 @@ Contact
    * Discord: [https://discord.gg/raylib](https://discord.gg/VkzNHUE)
    * YouTube: [https://www.youtube.com/channel/raylib](https://www.youtube.com/channel/UC8WIBkhYb5sBNqXO1mZ7WSQ)
 
-If you are using raylib and enjoy it, please [let me know][raysan5].
+If you use raylib and enjoy it, please [let me know][raysan5].
 
-If you are able to contribute, then please, [helpme](http://www.raylib.com/helpme.html)!
+If you are able to contribute, then please [helpme](http://www.raylib.com/helpme.html)!
 
 License
 -------

--- a/README.md
+++ b/README.md
@@ -1,14 +1,15 @@
 <img align="left" src="https://github.com/raysan5/raylib/blob/master/logo/raylib_256x256.png" width=256>
 
-**raylib is a simple and easy-to-use library to enjoy videogames programming.**
+**raylib is a simple and accessible library that makes videogames programming enjoyable.**
 
-raylib is highly inspired by Borland BGI graphics lib and by XNA framework.
+raylib is heavily inspired by the Borland Graphics Interface and the XNA Framework.
 
-raylib could be useful for prototyping, tools development, graphic applications, embedded systems and education.
+raylib is especially well suited for prototyping, tooling, graphical applications, embedded systems and education.
 
-NOTE for ADVENTURERS: raylib is a programming library to enjoy videogames programming; 
-no fancy interface, no visual helpers, no auto-debugging... just coding in the most 
-pure spartan-programmers way. Are you ready to learn? Jump to [code examples!](http://www.raylib.com/examples.html)
+> NOTE for ADVENTURERS: raylib is a *programming library* for *enjoying videogames programming*.
+There will never be a fancy interface, visual helpers, auto-debugging, or anything else that detracts from the art and practice of programming videogames. raylib augments your C or C++ runtime with [a comprehensive API](https://www.raylib.com/cheatsheet/cheatsheet.html) that makes it easy to build games from scratch.
+
+Ready to learn? Jump to [the code examples](http://www.raylib.com/examples.html)!
 
 [![Build Status](https://travis-ci.org/raysan5/raylib.svg?branch=master)](https://travis-ci.org/raysan5/raylib)
 [![https://ci.appveyor.com/api/projects/status/github/raysan5/raylib?svg=true](https://ci.appveyor.com/api/projects/status/github/raysan5/raylib?svg=true)](https://ci.appveyor.com/project/raysan5/raylib)
@@ -16,48 +17,49 @@ pure spartan-programmers way. Are you ready to learn? Jump to [code examples!](h
 [![License](https://img.shields.io/badge/license-zlib%2Flibpng-blue.svg)](LICENSE.md)
 [![Twitter URL](https://img.shields.io/twitter/url/http/shields.io.svg?style=social&label=Follow)](https://twitter.com/raysan5)
 
-features
+Features
 --------
-  - **NO external dependencies**, all required libraries included with raylib
-  - Multiple platforms supported: **Windows, Linux, MacOS, Android... and many more!**
-  - Written in plain C code (C99) in PascalCase/camelCase notation
-  - Hardware accelerated with OpenGL (**1.1, 2.1, 3.3 or ES 2.0**)
-  - **Unique OpenGL abstraction layer** (usable as standalone module): [rlgl](https://github.com/raysan5/raylib/blob/master/src/rlgl.h)
-  - Multiple Fonts formats supported (XNA fonts, AngelCode fonts, TTF)
-  - Outstanding texture formats support, including compressed formats (DXT, ETC, ASTC)
-  - **Full 3d support** for 3d Shapes, Models, Billboards, Heightmaps and more! 
-  - Flexible Materials system, supporting classic maps and **PBR maps**
-  - Shaders support, including Model shaders and Postprocessing shaders
-  - **Powerful math module** for Vector, Matrix and Quaternion operations: [raymath](https://github.com/raysan5/raylib/blob/master/src/raymath.h)
-  - Audio loading and playing with streaming support (WAV, OGG, MP3, FLAC, XM, MOD)
-  - **VR stereo rendering** support with configurable HMD device parameters
-  - Bindings to **Lua** ([raylib-lua](https://github.com/raysan5/raylib-lua)), **Go** ([raylib-go](https://github.com/gen2brain/raylib-go)) and [more](https://github.com/raysan5/raylib/blob/master/CONTRIBUTING.md#raylib-bindings)!
 
-raylib uses on its [core](https://github.com/raysan5/raylib/blob/master/src/core.c) module the outstanding [GLFW3](http://www.glfw.org/) library, embedded inside raylib in the form of [rglfw](https://github.com/raysan5/raylib/blob/master/src/rglfw.c) module, avoiding that way external dependencies.
+  - **No external dependencies**. All required libraries are bundled into raylib.
+  - Crossplatform. Supports **Windows, Linux, MacOS, Android... and many more!**
+  - Written in plain C code. Uses C99 with PascalCase/camelCase notation.
+  - Hardware accelerated with OpenGL (**1.1, 2.1, 3.3 or ES 2.0**).
+  - **Unique OpenGL abstraction layer** (usable as standalone module): [rlgl](https://github.com/raysan5/raylib/blob/master/src/rlgl.h).
+  - Multiple font format support (XNA fonts, AngelCode fonts and TTF).
+  - Outstanding texture formats support, including compressed formats (DXT, ETC and ASTC).
+  - **Full 3D support**, including 3D Shapes, Models, Billboards, Heightmaps and more! 
+  - Flexible materials system, supporting classic maps and **PBR maps**.
+  - Custom shaders, including model and postprocessing shaders.
+  - **Powerful math module** for vector, matrix and quaternion operations: [raymath](https://github.com/raysan5/raylib/blob/master/src/raymath.h)
+  - Support for loading and playing and streaming audio (WAV, OGG, MP3, FLAC, XM and MOD).
+  - **VR stereo rendering** support, with configurable HMD device parameters.
+  - Language bindings for **Lua** ([raylib-lua](https://github.com/raysan5/raylib-lua)), **Go** ([raylib-go](https://github.com/gen2brain/raylib-go)) and [more](https://github.com/raysan5/raylib/blob/master/CONTRIBUTING.md#raylib-bindings)!
 
-raylib uses on its [audio](https://github.com/raysan5/raylib/blob/master/src/raudio.c) module, the amazing [mini_al](https://github.com/dr-soft/mini_al) audio library, single-file header-only and supporting multiple platforms and multiple audio backends.
+raylib has its own [core](https://github.com/raysan5/raylib/blob/master/src/core.c) module (derived from the outstanding [GLFW3](http://www.glfw.org/) library), bundled with raylib as the [rglfw](https://github.com/raysan5/raylib/blob/master/src/rglfw.c) module (avoiding external dependencies).
 
-raylib uses internally multiple single-file header-only libraries to support multiple fileformats loading and saving, all those libraries are embedded with raylib and available in [src/external](https://github.com/raysan5/raylib/tree/master/src/external) directory.
+raylib also has its own [audio](https://github.com/raysan5/raylib/blob/master/src/raudio.c) module, based on the amazing [mini_al](https://github.com/dr-soft/mini_al) audio library, provided as a single file, (header-only), and supporting multiple platforms and various audio backends.
 
-*On Android, `native_app_glue module` (provided by Android NDK) and native Android libraries are used to manage window/context, inputs and activity life cycle.*
+raylib is internally relient on multiple single-file, header-only libraries to support loading and saving multiple file formats. All of those libraries are bundled with raylib, and are available in the `[src/external](https://github.com/raysan5/raylib/tree/master/src/external)` directory.
 
-*On Raspberry Pi, `Videocore API` and `EGL` libraries are used for window/context management and raw inputs reading.*
+*On Android, `native_app_glue module` (provided by the Android NDK) and native Android libraries are used to manage the window and context, inputs and the activity life cycle.*
 
-build and installation
-----------------------
+*On Raspberry Pi, the `Videocore API` and `EGL` libraries are used for window and context management, and for reading raw inputs.*
 
-Binary releases for Windows, Linux and macOS are available at the [Github Releases](https://github.com/raysan5/raylib/releases) page. raylib is also available via multiple package managers on multiple OS distributions. For more info check [raylib Wiki](https://github.com/raysan5/raylib/wiki).
+Building and Installation
+-------------------------
 
-To build raylib yourself, check out also the [raylib Wiki](https://github.com/raysan5/raylib/wiki) for detailed instructions.
+Binary releases for Windows, Linux and macOS are available at [the Github Releases page](https://github.com/raysan5/raylib/releases). raylib is also available via multiple package managers, across multiple OS distributions. For more info, check [the raylib Wiki](https://github.com/raysan5/raylib/wiki).
 
-raylib has been developed using exclusively two tools: 
+If you wish to build raylib yourself, [the raylib Wiki](https://github.com/raysan5/raylib/wiki) also contains detailed instructions on how to achieve that.
 
-   * Notepad++ (text editor) - [http://notepad-plus-plus.org/](http://notepad-plus-plus.org/)
-   * MinGW (GCC compiler) - [http://www.mingw.org/](http://www.mingw.org/)
-   
-Those are the tools recommended to develop with raylib, in fact, those are the tools my students use. 
+raylib has been developed exclusively using two tools:
 
-contact
+   * Notepad++ (text editor) - [http://notepad-plus-plus.org](http://notepad-plus-plus.org/)
+   * MinGW (GCC compiler) - [http://www.mingw.org](http://www.mingw.org/)
+
+Those tools are recommended for raylib development, and are the tools that my students use.
+
+Contact
 -------
 
    * Webpage: [http://www.raylib.com](http://www.raylib.com)
@@ -69,14 +71,13 @@ contact
    * Discord: [https://discord.gg/raylib](https://discord.gg/VkzNHUE)
    * YouTube: [https://www.youtube.com/channel/raylib](https://www.youtube.com/channel/UC8WIBkhYb5sBNqXO1mZ7WSQ)
 
-If you are using raylib and you enjoy it, please, [let me know][raysan5].
+If you are using raylib and enjoy it, please [let me know][raysan5].
 
-If you feel you can help, then, [helpme!](http://www.raylib.com/helpme.html)
+If you are able to contribute, then please, [helpme](http://www.raylib.com/helpme.html)!
 
-license
+License
 -------
 
-raylib is licensed under an unmodified zlib/libpng license, which is an OSI-certified, BSD-like license that allows static linking with closed source software. Check [LICENSE](LICENSE.md) for further details.
+raylib is licensed under an unmodified zlib/libpng license, which is an OSI-certified, BSD-like license that allows static linking with closed source software. See [the LICENSE file](LICENSE.md) for further details.
 
 [raysan5]: mailto:ray@raylib.com "Ramon Santamaria - Ray San"
-


### PR DESCRIPTION
I spent a little while editing the README, and ended up making quite a large number of small improvements. I haven't changed anything too substantial. The content was already good, so I stuck to fixing a bunch of minor grammatical issues.

There was one part that confused me, where I'm worried that I may have changed the meaning. It's the two lines that follow the bullet points. They used to say:

> raylib uses on its core module the outstanding GLFW3 library, embedded inside raylib in the form of rglfw module, avoiding that way external dependencies.

> raylib uses on its audio module, the amazing mini_al audio library, single-file header-only and supporting multiple platforms and multiple audio backends.

They now say:

> raylib has its own core module (derived from the outstanding GLFW3 library), bundled with raylib as the rglfw module (avoiding external dependencies).

> raylib also has its own audio module, based on the amazing mini_al audio library, provided as a single file (header-only), and supporting multiple platforms and various audio backends.

I'm new to raylib, and didn't understand those two lines properly.