### PR TITLE
Use typedef rather than #define in order to avoid issues in applicati…

### DIFF
--- a/src/raylib.h
+++ b/src/raylib.h
@@ -278,7 +278,7 @@ typedef struct Camera3D {
     int type;               // Camera type, defines projection type: CAMERA_PERSPECTIVE or CAMERA_ORTHOGRAPHIC
 } Camera3D;
 
-#define Camera Camera3D     // Camera type fallback, defaults to Camera3D
+typedef Camera3D Camera;    // Camera type fallback, defaults to Camera3D
 
 // Camera2D type, defines a 2d camera
 typedef struct Camera2D {


### PR DESCRIPTION
The typedef is nicer because it is scope-aware and does not globally deny the use of the 'Camera' typename. User code may very well have a Camera class/struct inside a namespace, for example.