### PR TITLE
Complete Hidpi support

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -2877,7 +2877,7 @@ static bool InitGraphicsDevice(int width, int height)
 // Set viewport parameters
 static void SetupViewport(void)
 {
-#if defined(__APPLE__)
+#if defined(PLATFORM_DESKTOP)
     // Get framebuffer size of current window
     // NOTE: Required to handle HighDPI display correctly on OSX because framebuffer
     // is automatically reasized to adapt to new DPI.


### PR DESCRIPTION
This should complete HIDPI support in Raylib with the inclusion of the previously committed GLFW flag.

Tested on Linux and Windows with both HIDPI and Regular monitors.  

Windows actually works really well.  I kept changing the DPI and the Raylib window would automatically update while it was running.  