### PR TITLE
Fixed text selection in DrawTextRecEx()

### DIFF
--- a/src/text.c
+++ b/src/text.c
@@ -900,7 +900,7 @@ void DrawTextRecEx(Font font, const char *text, Rectangle rec, float fontSize, f
     int startLine = -1;   // Index where to begin drawing (where a line begins)
     int endLine = -1;     // Index where to stop drawing (where a line ends)
 
-    for (int i = 0; i < length; i++)
+    for (int i = 0, k = 0; i < length; i++, k++)
     {
         int glyphWidth = 0;
         int next = 1;
@@ -979,7 +979,7 @@ void DrawTextRecEx(Font font, const char *text, Rectangle rec, float fontSize, f
 
                 //draw selected
                 bool isGlyphSelected = false;
-                if ((selectStart >= 0) && (i >= selectStart) && (i < (selectStart + selectLength)))
+                if ((selectStart >= 0) && (k >= selectStart) && (k < (selectStart + selectLength)))
                 {
                     Rectangle strec = {rec.x + textOffsetX-1, rec.y + textOffsetY, glyphWidth, (font.baseSize + font.baseSize/4)*scaleFactor };
                     DrawRectangleRec(strec, selectBack);


### PR DESCRIPTION
Since the unicode patch, text selection didn't work as expected (see below), so i fixed it(easy fix :D).
![comp](https://user-images.githubusercontent.com/27865535/56687158-59fc7180-66de-11e9-8519-726b26852fa7.png)


Working on raygui textbox now so i'll probably find all the bugs related to drawing unicode text, if there are any... Lucky me!