### PR TITLE
Defined PI (#822)

### DIFF
--- a/src/easings.h
+++ b/src/easings.h
@@ -91,6 +91,7 @@
 #endif
 
 #include <math.h>       // Required for: sin(), cos(), sqrt(), pow()
+#define PI 3.14159265358979323846 //Required as PI is not always defined in math.h
 
 #ifdef __cplusplus
 extern "C" {            // Prevents name mangling of functions

--- a/src/easings.h
+++ b/src/easings.h
@@ -91,7 +91,10 @@
 #endif
 
 #include <math.h>       // Required for: sin(), cos(), sqrt(), pow()
-#define PI 3.14159265358979323846 //Required as PI is not always defined in math.h
+
+#ifndef PI
+    #define PI 3.14159265358979323846f //Required as PI is not always defined in math.h
+#endif
 
 #ifdef __cplusplus
 extern "C" {            // Prevents name mangling of functions


### PR DESCRIPTION
PI is not always defined in math.h, thus it must be defined in this header