### PR TITLE
Add SUPPORT_HIGH_DPI to CMakeOptions.txt

### DIFF
--- a/src/CMakeOptions.txt
+++ b/src/CMakeOptions.txt
@@ -31,6 +31,7 @@ option(SUPPORT_SCREEN_CAPTURE "Allow automatic screen capture of current screen 
 option(SUPPORT_GIF_RECORDING "Allow automatic gif recording of current screen pressing CTRL+F12, defined in KeyCallback()" ON)
 option(SUPPORT_GESTURES_SYSTEM "Gestures module is included (gestures.h) to support gestures detection: tap, hold, swipe, drag" ON)
 option(SUPPORT_MOUSE_GESTURES "Mouse gestures are directly mapped like touches and processed by gestures system" ON)
+option(SUPPORT_HIGH_DPI "Support high DPI displays" OFF)
 
 # rlgl.h
 option(SUPPORT_VR_SIMULATOR "Support VR simulation functionality (stereo rendering)" ON)

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -15,6 +15,8 @@
 #cmakedefine SUPPORT_SCREEN_CAPTURE 1
 /* Allow automatic gif recording of current screen pressing CTRL+F12, defined in KeyCallback() */
 #cmakedefine SUPPORT_GIF_RECORDING 1
+/* Support high DPI displays */
+#cmakedefine SUPPORT_HIGH_DPI 1
 
 // rlgl.h
 /* Support VR simulation functionality (stereo rendering) */


### PR DESCRIPTION
Hi! ^ ^

This change allows the recently-added option to be toggled in CMake. The wiki page "CMake Build Options" needs to be updated as well.

On a side note, is it desirable that such options default to different values depending on the platform, e.g. `SUPPORT_HIGH_DPI=ON` on macOS (as almost all recent models have a Retina display), and `SUPPORT_BUSY_WAIT_LOOP=OFF` on systems with `nanosleep()`? Because with current master 0b2bad4 and default value `SUPPORT_HIGH_DPI=OFF`, the macOS build draws on only 1/4 of the window.

![asteroids](https://user-images.githubusercontent.com/45892908/57121427-04912600-6daa-11e9-9d42-d7f6c9dce9de.png)

