### PR TITLE
Remove sqrt() from CheckCollisionSpheres()

### DIFF
--- a/src/models.c
+++ b/src/models.c
@@ -2472,7 +2472,7 @@ void DrawBoundingBox(BoundingBox box, Color color)
 // Detect collision between two spheres
 bool CheckCollisionSpheres(Vector3 centerA, float radiusA, Vector3 centerB, float radiusB)
 {
-    return Vector3DotProduct(Vector3Subtract(B,A),Vector3Subtract(B,A))<=(RadA+RadB)*(RadA+RadB);
+    return Vector3DotProduct(Vector3Subtract(centerB,centerA),Vector3Subtract(centerB,centerA))<=(radiusA+radiusB)*(radiusA+radiusB);
 }
 
 // Detect collision between two boxes


### PR DESCRIPTION
Square root calls are computationally expensive.  In this function, it can be avoided.  Instead of checking whether distance<(radiusA+radiusB), we can check whether distance squared < (radiusA+radiusB) squared.

I used the existing Vector functions, but perhaps the code is less readable that way.  The Vector3DotProduct of centerB-centerA with itself gives the distance squared.