### PR TITLE
Fix unitialized struct member bug (#848)

### DIFF
--- a/src/models.c
+++ b/src/models.c
@@ -3044,7 +3044,7 @@ static Model LoadIQM(const char *fileName)
     fread(imesh, sizeof(IQMMesh)*iqm.num_meshes, 1, iqmFile);
 
     model.meshCount = iqm.num_meshes;
-    model.meshes = RL_MALLOC(model.meshCount*sizeof(Mesh));
+    model.meshes = RL_CALLOC(model.meshCount, sizeof(Mesh));
 
     char name[MESH_NAME_LENGTH];
 


### PR DESCRIPTION
In the `LoadIQM` function, the `vaoId` of the meshes is never initialized to 0. So when `LoadModel` calls `rlLoadMesh`, if `vaoId` is positive then the mesh is never uploaded to the GPU ([see here](https://github.com/raysan5/raylib/blob/master/src/rlgl.h#L2349)).

The fix is simply to initialize all the struct members to 0.

Fixes #848 