### PR TITLE
Fix jar_xm_reset

### DIFF
--- a/src/external/jar_xm.h
+++ b/src/external/jar_xm.h
@@ -2670,7 +2670,7 @@ void jar_xm_reset(jar_xm_context_t* ctx)
         jar_xm_cut_note(&ctx->channels[i]);
     }
     ctx->current_row = 0;
-    ctx->current_table_index = 1;
+    ctx->current_table_index = ctx->module.restart_position;
     ctx->current_tick = 0;
 }
 


### PR DESCRIPTION
See #850 
The function didn't work for some .xm files ([one](https://modarchive.org/index.php?request=view_by_moduleid&query=59963) [two](https://modarchive.org/index.php?request=view_by_moduleid&query=43516)) so I fixed it.