### PR TITLE
Add MP3 config to config.h.in

### DIFF
--- a/src/config.h.in
+++ b/src/config.h.in
@@ -74,6 +74,7 @@
 #cmakedefine SUPPORT_FILEFORMAT_XM 1
 #cmakedefine SUPPORT_FILEFORMAT_MOD 1
 #cmakedefine SUPPORT_FILEFORMAT_FLAC 1
+#cmakedefine SUPPORT_FILEFORMAT_MP3 1
 
 // utils.c
 /* Show TraceLog() output messages. NOTE: By default LOG_DEBUG traces not shown */


### PR DESCRIPTION
config.h.in is missing an MP3 flag which stops MP3 audio from working on cmake projects unless this is overcome/overriden.