### PR TITLE
build: increment API_VERSION after release

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,7 +4,7 @@ include(GNUInstallDirs)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake")
 
 set(PROJECT_VERSION 2.5.0)
-set(API_VERSION 2)
+set(API_VERSION 251)
 
 include("CMakeOptions.txt")
 include(BuildType)

--- a/src/Makefile
+++ b/src/Makefile
@@ -43,7 +43,7 @@
 
 # Define required raylib variables
 RAYLIB_VERSION     = 2.5.0
-RAYLIB_API_VERSION = 2
+RAYLIB_API_VERSION = 251
 
 # See below for alternatives.
 RAYLIB_PATH        = ..


### PR DESCRIPTION
With v2.5.0 out, increment API_VERSION, so binaries dynamically linked against
the released raylib aren't accidentally paired with a development or later
released raylib that may be incompatible.

---

Issues was discussed multiple time in the past (see #613 for an example).
The intention here is not to change raylib's versioning scheme, just the compatibility/API version evaluated by the dynamic loader.