### PR TITLE
update: fix wrong color assignment

### DIFF
--- a/src/raylib.h
+++ b/src/raylib.h
@@ -130,8 +130,8 @@
 #define PINK       CLITERAL{ 255, 109, 194, 255 }   // Pink
 #define RED        CLITERAL{ 230, 41, 55, 255 }     // Red
 #define MAROON     CLITERAL{ 190, 33, 55, 255 }     // Maroon
-#define GREEN      CLITERAL{ 0, 228, 48, 255 }      // Green
-#define LIME       CLITERAL{ 0, 158, 47, 255 }      // Lime
+#define GREEN      CLITERAL{ 0, 158, 47, 255 }      // Green
+#define LIME       CLITERAL{ 0, 228, 48, 255 }      // Lime
 #define DARKGREEN  CLITERAL{ 0, 117, 44, 255 }      // Dark Green
 #define SKYBLUE    CLITERAL{ 102, 191, 255, 255 }   // Sky Blue
 #define BLUE       CLITERAL{ 0, 121, 241, 255 }     // Blue


### PR DESCRIPTION
I believe the color `lime` should be brighter than the color `green`
```c
/* ... */

while (!WindowShouldClose()) {
    BeginDrawing();
    
    {
        ClearBackground(BLACK);
        
        DrawText("color_green", 40, 40, 80, GREEN);
        DrawText("color_lime", 40, 140, 80, LIME);
        DrawText("color_dark_green", 40, 240, 80, DARKGREEN);
    }

    EndDrawing();
}

/* ... */
```
![comparison](https://user-images.githubusercontent.com/28700668/59546646-8c9f4980-8f6c-11e9-8a2f-4878e4458cbc.png)
