### PR TITLE
[Clean] Should fix RL_WRAP_MIRROR_CLAMP issue

### DIFF
--- a/src/rlgl.h
+++ b/src/rlgl.h
@@ -1292,10 +1292,15 @@ void rlTextureParameters(unsigned int id, int param, int value)
             if (value == RL_WRAP_MIRROR_CLAMP)
             {
 #if !defined(GRAPHICS_API_OPENGL_11)
-                if (!texMirrorClampSupported) TraceLog(LOG_WARNING, "Clamp mirror wrap mode not supported");
+                if (!texMirrorClampSupported) {
+                    TraceLog(LOG_WARNING, "Clamp mirror wrap mode not supported");
+                    break;
+                }
+#else
+                break;
 #endif
             }
-            else glTexParameteri(GL_TEXTURE_2D, param, value);
+            glTexParameteri(GL_TEXTURE_2D, param, value);
         } break;
         case RL_TEXTURE_MAG_FILTER:
         case RL_TEXTURE_MIN_FILTER: glTexParameteri(GL_TEXTURE_2D, param, value); break;


### PR DESCRIPTION
* This is the clean version, without CLion's junk *

This should fix a logic error which would mean that, even if it was supported, texture wrapping mode RL_WRAP_MIRROR_CLAMP would never be applied. Below is an image of where the issue occurred.

![Issue](https://cdn.discordapp.com/attachments/427518168995725317/604293971266633768/unknown.png)

This PR assumes that OpenGl 1.1 is incapable of using this extension regardless of whether or not the supported flag is true. If this is wrong, please correct me.