### PR TITLE
Fix memory leak in LoadGLTF()

### DIFF
--- a/src/models.c
+++ b/src/models.c
@@ -3459,6 +3459,7 @@ static Model LoadGLTF(const char *fileName)
                         ImageColorTint(&image, tint);
                         texture = LoadTextureFromImage(image);
                         UnloadImage(image);
+                        RL_FREE(texturePath);
                     }
                 }
                 else if (img->buffer_view)


### PR DESCRIPTION
Free texturePath in LoadGLTF()