### PR TITLE
Added rlglDraw() to SetShaderValueV()

### DIFF
--- a/src/rlgl.h
+++ b/src/rlgl.h
@@ -3092,7 +3092,9 @@ void SetShaderValueV(Shader shader, int uniformLoc, const void *value, int unifo
 {
 #if defined(GRAPHICS_API_OPENGL_33) || defined(GRAPHICS_API_OPENGL_ES2)
     glUseProgram(shader.id);
-
+    
+    rlglDraw(); // Force draw
+    
     switch (uniformType)
     {
         case UNIFORM_FLOAT: glUniform1fv(uniformLoc, count, (float *)value); break;


### PR DESCRIPTION
I had a problem while working on a palette switching shader, where changing shader values between BeginShaderMode(shader) and EndShaderMode() only takes effect after BeginShaderMode(). By adding an rlglDraw() in the SetShaderValueV() function, you can change the shader between draw calls.

I've tested the performance a bit, and _without drawing_, the function can be called about 150,000 times per frame while the framerate stays at 60FPS. If something is drawn every single time the function is called, then the number is about 512 times a frame, at which point the framerate drops to about 50FPS (but that's on my 2011 thinkpad). This, however, can be greatly optimized, like in the following example:

I have a sprite struct which has a position, and a palette. The position ranges in the x and y position from 0, 0 to the screen borders. The palette can be 0-31. Both values are random.
I also have a sprite sheet, which is 64x64 pixels and made up of four grayscale colors.
There is also a shader, which has a uniform vec4 array of 4 colors. It's job is to map the palette colors to the grayscale color of the sprites. It's a very basic palette-swap shader.
Ok, so let's draw something. First I make an array of a certain number of sprite structs. Then, in the draw loop, I loop over them. First I call the SetShaderValueV function and set the shader's color array to the sprite's palette. Then I draw the sprite. I do this for every sprite in the sprite array. In the end, we have a bunch of sprites, and they are all colored by the shader. Without the rlglDraw() in the SetShaderValueV function, they would all be drawn with the last sprite's palette, because the shader is only applied when drawing. So, how many can we draw like this, without tanking the framerate. On my machine it is about 512.
Now let's try to optimize it. First of all, there is usually much more sprites then there are palettes, to two sprites drawn one after the other might use the same palette, and if they do, we don't have to change the shader value. We can do this with a simple lastPalette variable. But now we opened ourselves to yet another optimization. 
If we don't update the shader when the last palette was the same, we can ensure that we call it as little as possible by sorting the sprites by their palette value. This way we only have to call the SetShaderValueV() once for every palette. 
But this is a problem now, because we don't want to draw all sprites of a certain palette on top always. We want to be able to pick which sprites are in front and which are in the back. No problemo, we can just add a layer variable to our sprite struct, and sort them by their layer after sorting by palette. This does impact performance a bit, but it let's us choose which sprites we want to draw first, which last, and which in the middle. 
So how many sprites can we draw now without tanking the framerate? It's not 512. It's not 1024. It's not 4096. It's not 16,384. I can draw about _32,768 sprites per frame_ while the framerate barely dips below 50FPS.

(Please tell me if I messed something up I am not that good at this :) )