### PR TITLE
Small fix in GetMouseY()

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -2324,7 +2324,7 @@ int GetMouseX(void)
 int GetMouseY(void)
 {
 #if defined(PLATFORM_ANDROID)
-    return (int)touchPosition[0].x;
+    return (int)touchPosition[0].y;
 #else
     return (int)((mousePosition.y + mouseOffset.y)*mouseScale.y);
 #endif


### PR DESCRIPTION
This is a single small fix to an apparent copy-paste error in the `GetMouseY()` function present when building for the Android platform.