### PR TITLE
A more intuitive Camera2D behavior

### DIFF
--- a/examples/core/core_2d_camera.c
+++ b/examples/core/core_2d_camera.c
@@ -42,7 +42,7 @@ int main(void)
 
     Camera2D camera = { 0 };
     camera.target = (Vector2){ player.x + 20, player.y + 20 };
-    camera.offset = (Vector2){ 0, 0 };
+    camera.offset = (Vector2){ screenWidth / 2, screenHeight / 2 };
     camera.rotation = 0.0f;
     camera.zoom = 1.0f;
 
@@ -57,12 +57,10 @@ int main(void)
         if (IsKeyDown(KEY_RIGHT))
         {
             player.x += 2;              // Player movement
-            camera.offset.x -= 2;       // Camera displacement with player movement
         }
         else if (IsKeyDown(KEY_LEFT))
         {
             player.x -= 2;              // Player movement
-            camera.offset.x += 2;       // Camera displacement with player movement
         }
 
         // Camera target follows player

--- a/src/core.c
+++ b/src/core.c
@@ -1251,11 +1251,24 @@ void BeginMode2D(Camera2D camera)
     rlLoadIdentity();                   // Reset current matrix (MODELVIEW)
     rlMultMatrixf(MatrixToFloat(screenScaling)); // Apply screen scaling if required
 
-    // Camera rotation and scaling is always relative to target
+    //The camera in world-space is set by
+    //1. Move it to target
+    //2. Rotate by -rotation and scale by (1/zoom)
+    //      When setting higher scale, it's more intuitive for the world to become bigger (= camera become smaller),
+    //      not for the camera getting bigger, hence the invert. Same deal with rotation.
+    //3. Move it by (-offset);
+    //      Offset defines target transform relative to screen, but since we're effectively "moving" screen (camera)
+    //      we need to do it into opposite direction (inverse transform)
+    //
+    //Having camera transform in world-space, inverse of it gives the modelview transform.
+    //Since (A*B*C)' = C'*B'*A', the modelview is
+    //1. Move to offset
+    //2. Rotate and Scale
+    //3. Move by -target
     Matrix matOrigin = MatrixTranslate(-camera.target.x, -camera.target.y, 0.0f);
     Matrix matRotation = MatrixRotate((Vector3){ 0.0f, 0.0f, 1.0f }, camera.rotation*DEG2RAD);
     Matrix matScale = MatrixScale(camera.zoom, camera.zoom, 1.0f);
-    Matrix matTranslation = MatrixTranslate(camera.offset.x + camera.target.x, camera.offset.y + camera.target.y, 0.0f);
+    Matrix matTranslation = MatrixTranslate(camera.offset.x, camera.offset.y, 0.0f);
 
     Matrix matTransform = MatrixMultiply(MatrixMultiply(matOrigin, MatrixMultiply(matScale, matRotation)), matTranslation);
 


### PR DESCRIPTION
Currently when working with Camera2D, you have to constantly change both offset and target when following the player. This isn't intuitive; when following player with camera, generally only one vector - player's position - changes every frame, and thus to update camera one would expect to also only change one field.

This pull request removes camera transformation by target at the end of camera world-space transformation, which means user doesn't have to add this value himself to the offset anymore. In effect, this makes offset to be not relative to world coordinates, but to screen, and thus the value doesn't have to be updated when the position of the followed object changes.

Illustration of new camera behavior

![image](https://user-images.githubusercontent.com/15849668/63055643-0c0ab400-beef-11e9-8d85-6e4752efe243.png)
