### PR TITLE
Update shapes.c for smoother collision detection

### DIFF
--- a/src/shapes.c
+++ b/src/shapes.c
@@ -1392,8 +1392,8 @@ bool CheckCollisionRecs(Rectangle rec1, Rectangle rec2)
 {
     bool collision = false;
 
-    if ((rec1.x <= (rec2.x + rec2.width) && (rec1.x + rec1.width) >= rec2.x) &&
-        (rec1.y <= (rec2.y + rec2.height) && (rec1.y + rec1.height) >= rec2.y)) collision = true;
+    if ((rec1.x < (rec2.x + rec2.width) && (rec1.x + rec1.width) > rec2.x) &&
+        (rec1.y < (rec2.y + rec2.height) && (rec1.y + rec1.height) > rec2.y)) collision = true;
 
     return collision;
 }


### PR DESCRIPTION
By removing the equal sign, if the 2 rects are right next to each other and are not overlapping, there will be no collision detection. This is what a majority of other game libraries do and would make it easier to implement collisions for tile based games.