### PR TITLE
UpdateMusicStream takes pointer

### DIFF
--- a/examples/audio/audio_module_playing.c
+++ b/examples/audio/audio_module_playing.c
@@ -70,7 +70,7 @@ int main(void)
         // Restart music playing (stop and play)
         if (IsKeyPressed(KEY_SPACE))
         {
-            StopMusicStream(xm);
+            StopMusicStream(&xm);
             PlayMusicStream(xm);
         }
 

--- a/examples/audio/audio_module_playing.c
+++ b/examples/audio/audio_module_playing.c
@@ -65,7 +65,7 @@ int main(void)
     {
         // Update
         //----------------------------------------------------------------------------------
-        UpdateMusicStream(xm);        // Update music buffer with new stream data
+        UpdateMusicStream(&xm);        // Update music buffer with new stream data
 
         // Restart music playing (stop and play)
         if (IsKeyPressed(KEY_SPACE))

--- a/examples/audio/audio_music_stream.c
+++ b/examples/audio/audio_music_stream.c
@@ -37,7 +37,7 @@ int main(void)
     {
         // Update
         //----------------------------------------------------------------------------------
-        UpdateMusicStream(music);   // Update music buffer with new stream data
+        UpdateMusicStream(&music);   // Update music buffer with new stream data
 
         // Restart music playing (stop and play)
         if (IsKeyPressed(KEY_SPACE))

--- a/examples/audio/audio_music_stream.c
+++ b/examples/audio/audio_music_stream.c
@@ -42,7 +42,7 @@ int main(void)
         // Restart music playing (stop and play)
         if (IsKeyPressed(KEY_SPACE))
         {
-            StopMusicStream(music);
+            StopMusicStream(&music);
             PlayMusicStream(music);
         }
 

--- a/examples/audio/audio_music_stream.c
+++ b/examples/audio/audio_music_stream.c
@@ -58,7 +58,7 @@ int main(void)
         // Get timePlayed scaled to bar dimensions (400 pixels)
         timePlayed = GetMusicTimePlayed(music)/GetMusicTimeLength(music)*400;
 
-        if (timePlayed > 400) StopMusicStream(music);
+        if (timePlayed > 400) StopMusicStream(&music);
         //----------------------------------------------------------------------------------
 
         // Draw

--- a/examples/others/raudio_standalone.c
+++ b/examples/others/raudio_standalone.c
@@ -124,7 +124,7 @@ int main()
             key = 0;
         }
 
-        UpdateMusicStream(music);
+        UpdateMusicStream(&music);
     }
 
     // De-Initialization

--- a/src/raudio.c
+++ b/src/raudio.c
@@ -1378,32 +1378,32 @@ void ResumeMusicStream(Music music)
 }
 
 // Stop music playing (close stream)
-void StopMusicStream(Music music)
+void StopMusicStream(Music* music)
 {
-    StopAudioStream(music.stream);
+    StopAudioStream(music->stream);
 
     // Restart music context
-    switch (music.ctxType)
+    switch (music->ctxType)
     {
 #if defined(SUPPORT_FILEFORMAT_OGG)
-        case MUSIC_AUDIO_OGG: stb_vorbis_seek_start((stb_vorbis *)music.ctxData); break;
+        case MUSIC_AUDIO_OGG: stb_vorbis_seek_start((stb_vorbis *)music->ctxData); break;
 #endif
 #if defined(SUPPORT_FILEFORMAT_FLAC)
         case MUSIC_AUDIO_FLAC: /* TODO: Restart FLAC context */ break;
 #endif
 #if defined(SUPPORT_FILEFORMAT_MP3)
-        case MUSIC_AUDIO_MP3: drmp3_seek_to_pcm_frame((drmp3 *)music.ctxData, 0); break;
+        case MUSIC_AUDIO_MP3: drmp3_seek_to_pcm_frame((drmp3 *)music->ctxData, 0); break;
 #endif
 #if defined(SUPPORT_FILEFORMAT_XM)
-        case MUSIC_MODULE_XM: jar_xm_reset((jar_xm_context_t *)music.ctxData); break;
+        case MUSIC_MODULE_XM: jar_xm_reset((jar_xm_context_t *)music->ctxData); break;
 #endif
 #if defined(SUPPORT_FILEFORMAT_MOD)
-        case MUSIC_MODULE_MOD: jar_mod_seek_start((jar_mod_context_t *)music.ctxData); break;
+        case MUSIC_MODULE_MOD: jar_mod_seek_start((jar_mod_context_t *)music->ctxData); break;
 #endif
         default: break;
     }
 
-    music.sampleLeft = music.sampleCount;
+    music->sampleLeft = music->sampleCount;
 }
 
 // Update (re-fill) music buffers if data already processed
@@ -1488,17 +1488,13 @@ void UpdateMusicStream(Music* music)
     // Reset audio stream for looping
     if (streamEnding)
     {
-        StopMusicStream(*music);        // Stop music (and reset)
+        StopMusicStream(music);        // Stop music (and reset)
 
         // Decrease loopCount to stop when required
         if (music->loopCount > 1)
         {
             music->loopCount--;        // Decrease loop count
             PlayMusicStream(*music);    // Play again
-        }
-        else
-        {
-            if (music->loopCount == 0) PlayMusicStream(*music);
         }
     }
     else

--- a/src/raudio.h
+++ b/src/raudio.h
@@ -167,7 +167,7 @@ float *GetWaveData(Wave wave);                                  // Get samples d
 Music LoadMusicStream(const char *fileName);                    // Load music stream from file
 void UnloadMusicStream(Music music);                            // Unload music stream
 void PlayMusicStream(Music music);                              // Start music playing
-void UpdateMusicStream(Music music);                            // Updates buffers for music streaming
+void UpdateMusicStream(Music* music);                            // Updates buffers for music streaming
 void StopMusicStream(Music music);                              // Stop music playing
 void PauseMusicStream(Music music);                             // Pause music playing
 void ResumeMusicStream(Music music);                            // Resume playing paused music

--- a/src/raudio.h
+++ b/src/raudio.h
@@ -168,7 +168,7 @@ Music LoadMusicStream(const char *fileName);                    // Load music st
 void UnloadMusicStream(Music music);                            // Unload music stream
 void PlayMusicStream(Music music);                              // Start music playing
 void UpdateMusicStream(Music* music);                            // Updates buffers for music streaming
-void StopMusicStream(Music music);                              // Stop music playing
+void StopMusicStream(Music* music);                              // Stop music playing
 void PauseMusicStream(Music music);                             // Pause music playing
 void ResumeMusicStream(Music music);                            // Resume playing paused music
 bool IsMusicPlaying(Music music);                               // Check if music is playing

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1378,7 +1378,7 @@ RLAPI Music LoadMusicStream(const char *fileName);                    // Load mu
 RLAPI void UnloadMusicStream(Music music);                            // Unload music stream
 RLAPI void PlayMusicStream(Music music);                              // Start music playing
 RLAPI void UpdateMusicStream(Music* music);                            // Updates buffers for music streaming
-RLAPI void StopMusicStream(Music music);                              // Stop music playing
+RLAPI void StopMusicStream(Music* music);                              // Stop music playing
 RLAPI void PauseMusicStream(Music music);                             // Pause music playing
 RLAPI void ResumeMusicStream(Music music);                            // Resume playing paused music
 RLAPI bool IsMusicPlaying(Music music);                               // Check if music is playing

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1377,7 +1377,7 @@ RLAPI float *GetWaveData(Wave wave);                                  // Get sam
 RLAPI Music LoadMusicStream(const char *fileName);                    // Load music stream from file
 RLAPI void UnloadMusicStream(Music music);                            // Unload music stream
 RLAPI void PlayMusicStream(Music music);                              // Start music playing
-RLAPI void UpdateMusicStream(Music music);                            // Updates buffers for music streaming
+RLAPI void UpdateMusicStream(Music* music);                            // Updates buffers for music streaming
 RLAPI void StopMusicStream(Music music);                              // Stop music playing
 RLAPI void PauseMusicStream(Music music);                             // Pause music playing
 RLAPI void ResumeMusicStream(Music music);                            // Resume playing paused music


### PR DESCRIPTION
`GetMusicTimePlayed(music)` always returns 0. This is reproducible with the `audio_music_stream` example.

I've investigated this and found out that while `GetMusicTimePlayed` makes use of `music.sampleLeft`, that field itself is supposed to be counted down by `UpdateMusicStream` as the samples are played. However, `UpdateMusicStream`, like all the other related functions, takes the `MusicStream` struct as an argument and not a pointer to it. Of course, the struct ends up being passed by value and the modifications made to the `sampleLeft` never leaves the function, causing `sampleLeft` to never tick down, `IsMusicPlaying` to never return false once `PlayMusicStream` has been called, and other problems.

This PR **changes the API** to make `UpdateMusicStream` take a pointer instead, and modify the underlying struct, making the aforementioned functionality work again. There are probably ways to solve this without having to change the API, but I wanted to make this PR to bring this issue to your attention more than anything.

I've also modified the audio-related examples to work properly.