### PR TITLE
examples makefile not deleting examples in Linux

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -471,7 +471,7 @@ ifeq ($(PLATFORM),PLATFORM_DESKTOP)
 		del *.o *.exe /s
     endif
     ifeq ($(PLATFORM_OS),LINUX)
-	find -type f -executable | xargs file -i | grep -E 'x-object|x-archive|x-sharedlib|x-executable' | rev | cut -d ':' -f 2- | rev | xargs rm -fv
+	find -type f -executable | xargs file -i | grep -E 'x-object|x-archive|x-sharedlib|x-executable|x-pie-executable' | rev | cut -d ':' -f 2- | rev | xargs rm -fv
     endif
     ifeq ($(PLATFORM_OS),OSX)
 		find . -type f -perm +ugo+x -delete


### PR DESCRIPTION
I'm not sure why the clean command is so complex (especially given that find -type f -executable | xargs rm -fv works!)
but I fixed the version as is, to support x-pie-executable which was preventing it deleting anything on my system...