### PR TITLE
Fixed regular polygon shape rendering

### DIFF
--- a/src/shapes.c
+++ b/src/shapes.c
@@ -1183,7 +1183,7 @@ void DrawRectangleRoundedLines(Rectangle rec, float roundness, int segments, int
 void DrawTriangle(Vector2 v1, Vector2 v2, Vector2 v3, Color color)
 {
     if (rlCheckBufferLimit(4)) rlglDraw();
-    
+
 #if defined(SUPPORT_QUADS_DRAW_MODE)
     rlEnableTexture(GetShapesTexture().id);
 
@@ -1219,7 +1219,7 @@ void DrawTriangle(Vector2 v1, Vector2 v2, Vector2 v3, Color color)
 void DrawTriangleLines(Vector2 v1, Vector2 v2, Vector2 v3, Color color)
 {
     if (rlCheckBufferLimit(6)) rlglDraw();
-    
+
     rlBegin(RL_LINES);
         rlColor4ub(color.r, color.g, color.b, color.a);
         rlVertex2f(v1.x, v1.y);
@@ -1298,6 +1298,7 @@ void DrawTriangleStrip(Vector2 *points, int pointsCount, Color color)
 void DrawPoly(Vector2 center, int sides, float radius, float rotation, Color color)
 {
     if (sides < 3) sides = 3;
+    float internalAngle = 360.0f/(float)sides;
 
     if (rlCheckBufferLimit(4*(360/sides))) rlglDraw();
 
@@ -1309,7 +1310,7 @@ void DrawPoly(Vector2 center, int sides, float radius, float rotation, Color col
         rlEnableTexture(GetShapesTexture().id);
 
         rlBegin(RL_QUADS);
-            for (int i = 0; i < 360; i += 360/sides)
+            for (int i = 0; i < sides; i++)
             {
                 rlColor4ub(color.r, color.g, color.b, color.a);
 
@@ -1317,25 +1318,28 @@ void DrawPoly(Vector2 center, int sides, float radius, float rotation, Color col
                 rlVertex2f(0, 0);
 
                 rlTexCoord2f(recTexShapes.x/texShapes.width, (recTexShapes.y + recTexShapes.height)/texShapes.height);
-                rlVertex2f(sinf(DEG2RAD*i)*radius, cosf(DEG2RAD*i)*radius);
+                rlVertex2f(sinf(DEG2RAD*internalAngle)*radius, cosf(DEG2RAD*internalAngle)*radius);
 
                 rlTexCoord2f((recTexShapes.x + recTexShapes.width)/texShapes.width, (recTexShapes.y + recTexShapes.height)/texShapes.height);
-                rlVertex2f(sinf(DEG2RAD*i)*radius, cosf(DEG2RAD*i)*radius);
+                rlVertex2f(sinf(DEG2RAD*internalAngle)*radius, cosf(DEG2RAD*internalAngle)*radius);
 
+                internalAngle += 360.0f/(float)sides;
                 rlTexCoord2f((recTexShapes.x + recTexShapes.width)/texShapes.width, recTexShapes.y/texShapes.height);
-                rlVertex2f(sinf(DEG2RAD*(i + 360/sides))*radius, cosf(DEG2RAD*(i + 360/sides))*radius);
+                rlVertex2f(sinf(DEG2RAD*internalAngle)*radius, cosf(DEG2RAD*internalAngle)*radius);
             }
         rlEnd();
         rlDisableTexture();
 #else
         rlBegin(RL_TRIANGLES);
-            for (int i = 0; i < 360; i += 360/sides)
+            for (int i = 0; i < sides; i++)
             {
                 rlColor4ub(color.r, color.g, color.b, color.a);
 
                 rlVertex2f(0, 0);
-                rlVertex2f(sinf(DEG2RAD*i)*radius, cosf(DEG2RAD*i)*radius);
-                rlVertex2f(sinf(DEG2RAD*(i + 360/sides))*radius, cosf(DEG2RAD*(i + 360/sides))*radius);
+                rlVertex2f(sinf(DEG2RAD*internalAngle)*radius, cosf(DEG2RAD*internalAngle)*radius);
+
+                internalAngle += 360.0f/(float)sides;
+                rlVertex2f(sinf(DEG2RAD*internalAngle)*radius, cosf(DEG2RAD*internalAngle)*radius);
             }
         rlEnd();
 #endif
@@ -1511,9 +1515,9 @@ Rectangle GetCollisionRec(Rectangle rec1, Rectangle rec2)
 static float EaseCubicInOut(float t, float b, float c, float d)
 {
     if ((t /= 0.5f*d) < 1) return 0.5f*c*t*t*t + b;
-    
+
     t -= 2;
-    
+
     return 0.5f*c*(t*t*t + 2.0f) + b;
 }
 


### PR DESCRIPTION
Hi, I think I have fixed a bug.
In the moudle: _shapes_, the function: _void DrawPoly(Vector2 center, int sides, float radius, float rotation, Color color);_ Its implementation is wrong.

![polygons2](https://user-images.githubusercontent.com/28542484/65370737-cb782600-dc64-11e9-8b4b-afd6b81afec5.jpg)

There are problems with rendering polygons, with number of sides not divisible by 360.
The 360/sides is integer division, and as a result a  non divisible by 360 number will render sides+x sides. Sub-cases:
- If the lower bound of (360/sides) is not divisible by 360 there will be an overlap and it will create an artifact (more visible when rendering transparent). (Example sides: 7, 11, 13, 14...)

![polygons1](https://user-images.githubusercontent.com/28542484/65370730-c0bd9100-dc64-11e9-9c3b-aa9e5626e7f1.jpg)

- If the lower bound of (360/sides) is divisible by 360 there will be no overlap but there are still going to be rendered more edges. For example if you request a polygon with 23 sides, there will be rendered one with 24, or if you want one with 28 or 29 sides there will be rendered 30!
- If the lower bound of (360/sides) is 0 (side count higher than 360), the function is going to create infinitely many polygons (quads/triangles) since it will be stuck in an infinite loop, until there will be a buffer/memory overflow.

Fix: Have a separate from the side counting variable "i" floating point value, that represents the internal angle of the polygon.

In case my explanation was bad, here is some sample code: (controls Z, X, C)
```C
#include"raylib.h"

#define WIDTH  1000
#define HEIGHT 1000

int main(void)
{
    InitWindow(WIDTH, HEIGHT, "Regular polygons bug");
    SetTargetFPS(60);

    /* Default case */
    BeginDrawing();
    ClearBackground((Color){ 20, 20, 20, 255 });
    DrawPoly((Vector2){ WIDTH/2, HEIGHT/2 }, 7, 470.0f, 0.0f, (Color){ 30, 255, 30, 120 });
    EndDrawing();

    while (!WindowShouldClose())
    {
        BeginDrawing();
        if (IsKeyPressed(KEY_Z))
        {
            ClearBackground((Color){ 20, 20, 20, 255 });
            DrawPoly((Vector2){ WIDTH/2, HEIGHT/2 }, 7, 470.0f, 0.0f, (Color){ 30, 255, 30, 120 });   /* Has artifact (better visible with alpha) */
        }
        else if (IsKeyPressed(KEY_X))
        {
            ClearBackground((Color){ 20, 20, 20, 255 });
            DrawPoly((Vector2){ WIDTH/2, HEIGHT/2 }, 13, 470.0f, 0.0f, (Color){ 30, 255, 30, 120 });  /* Has artifact (better visible with alpha) */
        }
        else if (IsKeyPressed(KEY_C))
        {
            ClearBackground((Color){ 20, 20, 20, 255 });
            DrawPoly((Vector2){ WIDTH/2, HEIGHT/2 }, 23, 470.0f, 0.0f, (Color){ 30, 255, 30, 120 });  /* Has 24 instead of 23 sides */
        }
        EndDrawing();
    }
    CloseWindow();
    return 0;
}
```