### PR TITLE
Improve code readability

### DIFF
--- a/src/shapes.c
+++ b/src/shapes.c
@@ -1298,7 +1298,7 @@ void DrawTriangleStrip(Vector2 *points, int pointsCount, Color color)
 void DrawPoly(Vector2 center, int sides, float radius, float rotation, Color color)
 {
     if (sides < 3) sides = 3;
-    float internalAngle = 360.0f/(float)sides;
+    float centralAngle = 0.0f;
 
     if (rlCheckBufferLimit(4*(360/sides))) rlglDraw();
 
@@ -1318,14 +1318,14 @@ void DrawPoly(Vector2 center, int sides, float radius, float rotation, Color col
                 rlVertex2f(0, 0);
 
                 rlTexCoord2f(recTexShapes.x/texShapes.width, (recTexShapes.y + recTexShapes.height)/texShapes.height);
-                rlVertex2f(sinf(DEG2RAD*internalAngle)*radius, cosf(DEG2RAD*internalAngle)*radius);
+                rlVertex2f(sinf(DEG2RAD*centralAngle)*radius, cosf(DEG2RAD*centralAngle)*radius);
 
                 rlTexCoord2f((recTexShapes.x + recTexShapes.width)/texShapes.width, (recTexShapes.y + recTexShapes.height)/texShapes.height);
-                rlVertex2f(sinf(DEG2RAD*internalAngle)*radius, cosf(DEG2RAD*internalAngle)*radius);
+                rlVertex2f(sinf(DEG2RAD*centralAngle)*radius, cosf(DEG2RAD*centralAngle)*radius);
 
-                internalAngle += 360.0f/(float)sides;
+                centralAngle += 360.0f/(float)sides;
                 rlTexCoord2f((recTexShapes.x + recTexShapes.width)/texShapes.width, recTexShapes.y/texShapes.height);
-                rlVertex2f(sinf(DEG2RAD*internalAngle)*radius, cosf(DEG2RAD*internalAngle)*radius);
+                rlVertex2f(sinf(DEG2RAD*centralAngle)*radius, cosf(DEG2RAD*centralAngle)*radius);
             }
         rlEnd();
         rlDisableTexture();
@@ -1336,10 +1336,10 @@ void DrawPoly(Vector2 center, int sides, float radius, float rotation, Color col
                 rlColor4ub(color.r, color.g, color.b, color.a);
 
                 rlVertex2f(0, 0);
-                rlVertex2f(sinf(DEG2RAD*internalAngle)*radius, cosf(DEG2RAD*internalAngle)*radius);
+                rlVertex2f(sinf(DEG2RAD*centralAngle)*radius, cosf(DEG2RAD*centralAngle)*radius);
 
-                internalAngle += 360.0f/(float)sides;
-                rlVertex2f(sinf(DEG2RAD*internalAngle)*radius, cosf(DEG2RAD*internalAngle)*radius);
+                centralAngle += 360.0f/(float)sides;
+                rlVertex2f(sinf(DEG2RAD*centralAngle)*radius, cosf(DEG2RAD*centralAngle)*radius);
             }
         rlEnd();
 #endif


### PR DESCRIPTION
Thanks ray for accepting my bug fix! ([#972](https://github.com/raysan5/raylib/pull/972))
I would like to make some minor changes, mostly to improve code legibility.
In the src/shapes.c the DrawPoly() function:

- Change the variable name from internalAngle to centralAngle, since technically, the geometric definition of internal angle is [this](https://en.wikipedia.org/wiki/Internal_and_external_angles), and of central angle is [this](https://en.wikipedia.org/wiki/Central_angle).
- The centralAngle can be initialized with the value of zero. Although the functionality remains the same (as long as it is initialized with a 360/sides multiple), it makes more sense this way, and it also minimizes unnecessary computations.