### PR TITLE
updated RayMarching Demo

### DIFF
--- a/examples/shaders/resources/shaders/glsl100/raymarching.fs
+++ b/examples/shaders/resources/shaders/glsl100/raymarching.fs
@@ -8,8 +8,6 @@ varying vec4 fragColor;
 
 uniform vec3 viewEye;
 uniform vec3 viewCenter; 
-uniform vec3 viewUp;
-uniform float deltaTime;
 uniform float runTime;
 uniform vec2 resolution;
 

--- a/examples/shaders/resources/shaders/glsl330/raymarching.fs
+++ b/examples/shaders/resources/shaders/glsl330/raymarching.fs
@@ -9,8 +9,6 @@ out vec4 finalColor;
 
 uniform vec3 viewEye;
 uniform vec3 viewCenter; 
-uniform vec3 viewUp;
-uniform float deltaTime;
 uniform float runTime;
 uniform vec2 resolution;
 

--- a/examples/shaders/shaders_raymarching.c
+++ b/examples/shaders/shaders_raymarching.c
@@ -59,7 +59,7 @@ int main(void)
 
     float runTime = 0.0f;
 
-    SetTargetFPS(60);
+    SetTargetFPS(60);                       // Set our game to run at 60 frames-per-second
     //--------------------------------------------------------------------------------------
 
     // Main game loop
@@ -100,7 +100,7 @@ int main(void)
             // We only draw a white full-screen rectangle,
             // frame is generated in shader using raymarching
             BeginShaderMode(shader);
-                DrawRectangle(0, 0, screenWidth, screenHeight, RAYWHITE);
+                DrawRectangle(0, 0, screenWidth, screenHeight, WHITE);
             EndShaderMode();
 
             DrawText("(c) Raymarching shader by Iñigo Quilez. MIT License.", screenWidth - 280, screenHeight - 20, 10, BLACK);

--- a/examples/shaders/shaders_raymarching.c
+++ b/examples/shaders/shaders_raymarching.c
@@ -18,6 +18,8 @@
 
 #include "raylib.h"
 
+#define PLATFORM_DESKTOP // comment this out if you are not compiling this for desktop.
+
 #if defined(PLATFORM_DESKTOP)
     #define GLSL_VERSION            330
 #else   // PLATFORM_RPI, PLATFORM_ANDROID, PLATFORM_WEB
@@ -28,9 +30,10 @@ int main(void)
 {
     // Initialization
     //--------------------------------------------------------------------------------------
-    const int screenWidth = 800;
-    const int screenHeight = 450;
+    int screenWidth = 800;
+    int screenHeight = 450;
 
+    SetConfigFlags(FLAG_WINDOW_RESIZABLE);
     InitWindow(screenWidth, screenHeight, "raylib [shaders] example - raymarching shapes");
 
     Camera camera = { 0 };
@@ -48,29 +51,36 @@ int main(void)
     // Get shader locations for required uniforms
     int viewEyeLoc = GetShaderLocation(shader, "viewEye");
     int viewCenterLoc = GetShaderLocation(shader, "viewCenter");
-    int viewUpLoc = GetShaderLocation(shader, "viewUp");
-    int deltaTimeLoc = GetShaderLocation(shader, "deltaTime");
     int runTimeLoc = GetShaderLocation(shader, "runTime");
     int resolutionLoc = GetShaderLocation(shader, "resolution");
 
-    float resolution[2] = { screenWidth, screenHeight };
+    float resolution[2] = { (float)screenWidth, (float)screenHeight };
     SetShaderValue(shader, resolutionLoc, resolution, UNIFORM_VEC2);
 
     float runTime = 0.0f;
 
-    SetTargetFPS(60);                       // Set our game to run at 60 frames-per-second
+    SetTargetFPS(60);
     //--------------------------------------------------------------------------------------
 
     // Main game loop
     while (!WindowShouldClose())            // Detect window close button or ESC key
     {
+        // Check if screen is resized
+        //----------------------------------------------------------------------------------
+        if(IsWindowResized())
+        {
+            screenWidth = GetScreenWidth();
+            screenHeight = GetScreenHeight();
+            float resolution[2] = { (float)screenWidth, (float)screenHeight };
+            SetShaderValue(shader, resolutionLoc, resolution, UNIFORM_VEC2);
+        }
+
         // Update
         //----------------------------------------------------------------------------------
         UpdateCamera(&camera);              // Update camera
 
         float cameraPos[3] = { camera.position.x, camera.position.y, camera.position.z };
         float cameraTarget[3] = { camera.target.x, camera.target.y, camera.target.z };
-        float cameraUp[3] = { camera.up.x, camera.up.y, camera.up.z };
 
         float deltaTime = GetFrameTime();
         runTime += deltaTime;
@@ -78,8 +88,6 @@ int main(void)
         // Set shader required uniform values
         SetShaderValue(shader, viewEyeLoc, cameraPos, UNIFORM_VEC3);
         SetShaderValue(shader, viewCenterLoc, cameraTarget, UNIFORM_VEC3);
-        SetShaderValue(shader, viewUpLoc, cameraUp, UNIFORM_VEC3);
-        SetShaderValue(shader, deltaTimeLoc, &deltaTime, UNIFORM_FLOAT);
         SetShaderValue(shader, runTimeLoc, &runTime, UNIFORM_FLOAT);
         //----------------------------------------------------------------------------------
 
@@ -92,10 +100,10 @@ int main(void)
             // We only draw a white full-screen rectangle,
             // frame is generated in shader using raymarching
             BeginShaderMode(shader);
-                DrawRectangle(0, 0, screenWidth, screenHeight, WHITE);
+                DrawRectangle(0, 0, screenWidth, screenHeight, RAYWHITE);
             EndShaderMode();
 
-            DrawText("(c) Raymarching shader by Iñigo Quilez. MIT License.", screenWidth - 280, screenHeight - 20, 10, GRAY);
+            DrawText("(c) Raymarching shader by Iñigo Quilez. MIT License.", screenWidth - 280, screenHeight - 20, 10, BLACK);
 
         EndDrawing();
         //----------------------------------------------------------------------------------

--- a/examples/shaders/shaders_raymarching.c
+++ b/examples/shaders/shaders_raymarching.c
@@ -18,8 +18,6 @@
 
 #include "raylib.h"
 
-#define PLATFORM_DESKTOP // comment this out if you are not compiling this for desktop.
-
 #if defined(PLATFORM_DESKTOP)
     #define GLSL_VERSION            330
 #else   // PLATFORM_RPI, PLATFORM_ANDROID, PLATFORM_WEB


### PR DESCRIPTION
  Added   - #define PLATFORM_DESKTOP line for desktop users.
            This now will correctly find the proper glsl version for the raymarching.fs file.
  Removed - Uniforms --> deltaTime and viewUp. Including the code that was setting them.
            They were never used and they were triggering a log warning.
  Removed - The const from both screenWidth and screenHeight.
            Now they can be used to update the shader resolution when screen is resized.
            NOTE : This is a quick fix and probably not the best idea.
  Added   - IsWindowResized() to check if screen is resized.
            If window is resized then width, height and shader resolution are updated.
  Changed - MIT tag at bottom right color value to BLACK. Now it's easier to see.