### PR TITLE
Fix generation of web examples

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -85,9 +85,12 @@ elseif(${PLATFORM} MATCHES "Web")
   # Since WASM is used, ALLOW_MEMORY_GROWTH has no extra overheads
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -s ALLOW_MEMORY_GROWTH=1 --no-heap-copy")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --shell-file ${CMAKE_SOURCE_DIR}/src/shell.html")
-
   set(OUTPUT_EXT ".html")
 
+  # Remove the -rdynamic flag because otherwise emscripten
+  # does not generate HTML+JS+WASM files, only a non-working
+  # and fat HTML
+  string(REPLACE "-rdynamic" "" CMAKE_SHARED_LIBRARY_LINK_C_FLAGS ${CMAKE_SHARED_LIBRARY_LINK_C_FLAGS})
 endif()
 
 include_directories(BEFORE SYSTEM others/external/include)

--- a/games/CMakeLists.txt
+++ b/games/CMakeLists.txt
@@ -10,6 +10,11 @@ if(${PLATFORM} MATCHES "Web")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Os -s USE_GLFW=3 -s ASSERTIONS=1 -s WASM=1 -s EMTERPRETIFY=1 -s EMTERPRETIFY_ASYNC=1")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --shell-file ${CMAKE_SOURCE_DIR}/src/shell.html")
   set(OUTPUT_EXT ".html")
+
+  # Remove the -rdynamic flag because otherwise emscripten
+  # does not generate HTML+JS+WASM files, only a non-working
+  # and fat HTML
+  string(REPLACE "-rdynamic" "" CMAKE_SHARED_LIBRARY_LINK_C_FLAGS ${CMAKE_SHARED_LIBRARY_LINK_C_FLAGS})
 endif()
 
 if (NOT TARGET raylib)


### PR DESCRIPTION
At least on Linux, CMake seems to add automatically
the '-rdynamic' flag. As a result, Emscripten
generates a fat HTML file that does not work.
Removing it allows HTML+JS+WASM generation.