### PR TITLE
[Core] Added ColorFromNormalized which is the reverse of ColorNormalize.

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -1616,6 +1616,19 @@ Vector4 ColorNormalize(Color color)
     return result;
 }
 
+// Returns color from normalized values [0..1]
+Color ColorFromNormalized(Vector4 normalized)
+{
+    Color result;
+
+    result.r = normalized.x*255.0f;
+    result.g = normalized.y*255.0f;
+    result.b = normalized.z*255.0f;
+    result.a = normalized.w*255.0f;
+
+    return result;
+}
+
 // Returns HSV values for a Color
 // NOTE: Hue is returned as degrees [0..360]
 Vector3 ColorToHSV(Color color)

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -924,6 +924,7 @@ RLAPI double GetTime(void);                                       // Returns ela
 // Color-related functions
 RLAPI int ColorToInt(Color color);                                // Returns hexadecimal value for a Color
 RLAPI Vector4 ColorNormalize(Color color);                        // Returns color normalized as float [0..1]
+RLAPI Color ColorFromNormalized(Vector4 normalized);              // Returns color from normalized values [0..1]
 RLAPI Vector3 ColorToHSV(Color color);                            // Returns HSV values for a Color
 RLAPI Color ColorFromHSV(Vector3 hsv);                            // Returns a Color from HSV values
 RLAPI Color GetColor(int hexValue);                               // Returns a Color struct from hexadecimal value


### PR DESCRIPTION
I based the name from `ColorFromHSV`. Not sure if it is the best name for it. 

Example usage
```c
Color color = ColorFromNormalized((Vector4){0.5f, 0.1f, 0.1f, 1.0f});
```

I am not sure if a cast should be added for converting the float to unsigned char.