### PR TITLE
Fix camera not working problem at align z direction. #924

### DIFF
--- a/src/camera.h
+++ b/src/camera.h
@@ -243,9 +243,9 @@ void SetCameraMode(Camera camera, int mode)
 
     cameraTargetDistance = sqrtf(dx*dx + dy*dy + dz*dz);
 
-	// Camera angle calculation
-	cameraAngle.x = atan2f(dx, dz);                   // Camera angle in plane XZ (0 aligned with Z, move positive CCW)
-	cameraAngle.y = atan2f(dy, sqrtf(dx*dx + dz*dz)); // Camera angle in plane XY (0 aligned with X, move positive CW)
+    // Camera angle calculation
+    cameraAngle.x = atan2f(dx, dz);                   // Camera angle in plane XZ (0 aligned with Z, move positive CCW)
+    cameraAngle.y = atan2f(dy, sqrtf(dx*dx + dz*dz)); // Camera angle in plane XY (0 aligned with X, move positive CW)
 
     playerEyesPosition = camera.position.y;
 
@@ -382,9 +382,9 @@ void UpdateCamera(Camera *camera)
             }
 
             // Update camera position with changes
-			camera->position.x = -sinf(cameraAngle.x)*cameraTargetDistance*cosf(cameraAngle.y) + camera->target.x;
-			camera->position.y = -sinf(cameraAngle.y)*cameraTargetDistance + camera->target.y;
-			camera->position.z = -cosf(cameraAngle.x)*cameraTargetDistance*cosf(cameraAngle.y) + camera->target.z;
+            camera->position.x = -sinf(cameraAngle.x)*cameraTargetDistance*cosf(cameraAngle.y) + camera->target.x;
+            camera->position.y = -sinf(cameraAngle.y)*cameraTargetDistance + camera->target.y;
+            camera->position.z = -cosf(cameraAngle.x)*cameraTargetDistance*cosf(cameraAngle.y) + camera->target.z;
         } break;
         case CAMERA_ORBITAL:
         {

--- a/src/camera.h
+++ b/src/camera.h
@@ -243,13 +243,9 @@ void SetCameraMode(Camera camera, int mode)
 
     cameraTargetDistance = sqrtf(dx*dx + dy*dy + dz*dz);
 
-    Vector2 distance = { 0.0f, 0.0f };
-    distance.x = sqrtf(dx*dx + dz*dz);
-    distance.y = sqrtf(dx*dx + dy*dy);
-
-    // Camera angle calculation
-    cameraAngle.x = asinf( (float)fabs(dx)/distance.x);  // Camera angle in plane XZ (0 aligned with Z, move positive CCW)
-    cameraAngle.y = -asinf( (float)fabs(dy)/distance.y); // Camera angle in plane XY (0 aligned with X, move positive CW)
+	// Camera angle calculation
+	cameraAngle.x = atan2f(dx, dz);                   // Camera angle in plane XZ (0 aligned with Z, move positive CCW)
+	cameraAngle.y = atan2f(dy, sqrtf(dx*dx + dz*dz)); // Camera angle in plane XY (0 aligned with X, move positive CW)
 
     playerEyesPosition = camera.position.y;
 
@@ -379,17 +375,16 @@ void UpdateCamera(Camera *camera)
                 else
                 {
                     // Camera panning
-                    camera->target.x += ((mousePositionDelta.x*-CAMERA_FREE_MOUSE_SENSITIVITY)*cosf(cameraAngle.x) + (mousePositionDelta.y*CAMERA_FREE_MOUSE_SENSITIVITY)*sinf(cameraAngle.x)*sinf(cameraAngle.y))*(cameraTargetDistance/CAMERA_FREE_PANNING_DIVIDER);
+                    camera->target.x += ((mousePositionDelta.x*CAMERA_FREE_MOUSE_SENSITIVITY)*cosf(cameraAngle.x) + (mousePositionDelta.y*CAMERA_FREE_MOUSE_SENSITIVITY)*sinf(cameraAngle.x)*sinf(cameraAngle.y))*(cameraTargetDistance/CAMERA_FREE_PANNING_DIVIDER);
                     camera->target.y += ((mousePositionDelta.y*CAMERA_FREE_MOUSE_SENSITIVITY)*cosf(cameraAngle.y))*(cameraTargetDistance/CAMERA_FREE_PANNING_DIVIDER);
-                    camera->target.z += ((mousePositionDelta.x*CAMERA_FREE_MOUSE_SENSITIVITY)*sinf(cameraAngle.x) + (mousePositionDelta.y*CAMERA_FREE_MOUSE_SENSITIVITY)*cosf(cameraAngle.x)*sinf(cameraAngle.y))*(cameraTargetDistance/CAMERA_FREE_PANNING_DIVIDER);
+                    camera->target.z += ((mousePositionDelta.x*-CAMERA_FREE_MOUSE_SENSITIVITY)*sinf(cameraAngle.x) + (mousePositionDelta.y*CAMERA_FREE_MOUSE_SENSITIVITY)*cosf(cameraAngle.x)*sinf(cameraAngle.y))*(cameraTargetDistance/CAMERA_FREE_PANNING_DIVIDER);
                 }
             }
 
             // Update camera position with changes
-            camera->position.x = sinf(cameraAngle.x)*cameraTargetDistance*cosf(cameraAngle.y) + camera->target.x;
-            camera->position.y = ((cameraAngle.y <= 0.0f)? 1 : -1)*sinf(cameraAngle.y)*cameraTargetDistance*sinf(cameraAngle.y) + camera->target.y;
-            camera->position.z = cosf(cameraAngle.x)*cameraTargetDistance*cosf(cameraAngle.y) + camera->target.z;
-
+			camera->position.x = -sinf(cameraAngle.x)*cameraTargetDistance*cosf(cameraAngle.y) + camera->target.x;
+			camera->position.y = -sinf(cameraAngle.y)*cameraTargetDistance + camera->target.y;
+			camera->position.z = -cosf(cameraAngle.x)*cameraTargetDistance*cosf(cameraAngle.y) + camera->target.z;
         } break;
         case CAMERA_ORBITAL:
         {


### PR DESCRIPTION
Hi, about https://github.com/raysan5/raylib/issues/924
I fix the camera behavior. I noticed additional camera issues.
I think that there are 3 problems.

1. z-direction camera at initialization is not working. it is caused by SetCameraMode(camera, CAMERA_FREE); Because "cameraAngle.y" was nan after this function.

```
	Camera camera = { 0 };
	camera.position = Vector3 { 0.0f, 0.0f, 0.0f };
	camera.target = Vector3 { 0.0f, 0.0f, 10.0f };
	camera.up = Vector3 { 0.0f, 1.0f, 0.0f };
	camera.fovy = 45.0f;
	camera.type = CAMERA_PERSPECTIVE;
```

2. Camera rotation by mouse.y movement has a non-linear behavior when a camera angle close to align xz plane.

3. camera.position at start is not zero. it was flip 180 degrees unexpectedly.

```
	Camera camera = { 0 };
	camera.position = Vector3 { 0.0f, 0.0f, 0.0f };
	camera.target = Vector3 { 0.0f, 0.0f, 10.0f };
	camera.up = Vector3 { 0.0f, 1.0f, 0.0f };
	camera.fovy = 45.0f;
	camera.type = CAMERA_PERSPECTIVE;
```

So I fixed these issues.
https://pastebin.com/FTRGTAQR
by Dacode45 
start working by this fix.

# additional tips
For camera consistent behavior, the following code should work. 
It is good for debugging.

```
	// Main game loop
	while (!WindowShouldClose()) // Detect window close button or ESC key
	{
		// SetCameraMode(camera, CAMERA_FREE);
		// Update
		//----------------------------------------------------------------------------------
		SetCameraMode(camera, CAMERA_FREE);
		UpdateCamera(&camera); // Update camera
        ....
```