### PR TITLE
[text] `TextFormat()` caching

### DIFF
--- a/src/text.c
+++ b/src/text.c
@@ -1102,9 +1102,16 @@ unsigned int TextLength(const char *text)
 }
 
 // Formatting of text with variables to 'embed'
+// WARNING: the string returned will expire after this function is called MAX_TEXT_BUFFERS times
 const char *TextFormat(const char *text, ...)
 {
-    static char buffer[MAX_TEXT_BUFFER_LENGTH] = { 0 };
+    #define MAX_TEXT_BUFFERS 8
+    // We create an array of buffers so strings don't expire until MAX_TEXT_BUFFERS invocations
+    static char cache[MAX_TEXT_BUFFERS][MAX_TEXT_BUFFER_LENGTH] = { 0 };
+    static int  index = 0;
+    char       *buffer = cache[index];
+    index += 1;
+    index %= MAX_TEXT_BUFFERS;
 
     va_list args;
     va_start(args, text);
@@ -1112,6 +1119,7 @@ const char *TextFormat(const char *text, ...)
     va_end(args);
 
     return buffer;
+    #undef MAX_TEXT_BUFFERS
 }
 
 // Get a piece of a text string


### PR DESCRIPTION
I was playing around with `shaders_model_shader.c`:
```C
// Load shader for model
// NOTE: Defining 0 (NULL) for vertex shader forces usage of internal default vertex shader
Shader shader = LoadShader(0, TextFormat("resources/shaders/glsl%i/grayscale.fs", GLSL_VERSION));
```
The original code above suggests we can do this:
```C
// Load shader for model
Shader shader =
LoadShader(
   TextFormat("resources/shaders/glsl%i/base.vs", GLSL_VERSION)
   , TextFormat("resources/shaders/glsl%i/grayscale.fs", GLSL_VERSION)
);
```
Unfortunately, we cannot. This was causing the runtime error `gl_Position: undeclared identifier`, the kind of error we get when attempting to compile a vertex shader as a fragment shader. What was going on?

Adding some basic output to `LoadShader()` revealed the following:
```
vsFileName = 'resources/shaders/glsl330/base.vs'
fsFileName = 'resources/shaders/glsl330/base.vs'
```
`TextFormat()` was isolated as the culprit. Why? The explanation lies within C's evaluation order. 

From the C99 standard:
 > 6.5.2.2 Function calls
 >
 > 10/ The order of evaluation of the function designator, the actual arguments, and subexpressions within the actual arguments is unspecified, but there is a sequence point before the actual call.
 > 
 > 6.5 Expressions
 >
 > 2/ Between the previous and next sequence point an object shall have its stored value modified at most once by the evaluation of an expression. Furthermore, the prior value shall be read only to determine the value to be stored.

Not only was the evaluation order of these function calls unspecified: they were also modifying the same data within the same sequence point, which will undoubtedly cause undefined behavior.


One option would have been to call `strdup(TextFormat(...))`, leaving two never-freed blocks of memory behind.

Another option:
```C
// Get shader paths
char *vs = strdup(TextFormat("resources/shaders/glsl%i/base.vs", GLSL_VERSION));
char *fs = strdup(TextFormat("resources/shaders/glsl%i/grayscale.fs", GLSL_VERSION));

// Load shader for model
Shader shader = LoadShader(vs, fs);

// Free shader paths
free(vs);
free(fs);
```

But this verbosity goes against the spirit of raylib's short, simple, self-documenting examples, and updating all the examples would be far from ideal.

The solution I concocted is as follows:

Instead of `TextFormat()` constantly modifying one string, it now caches eight* strings. Now it modifies a different string between up to eight invocations before rolling over to the start of the cache, greatly reducing the chances of the same data being modified within the same sequence point, as well as guaranteeing a generated string will not expire during a subsequent call to `TextFormat()`.

\* I have set the default to eight because I doubt that many different `TextFormat()`'d strings will ever be used as function arguments simultaneously.