### PR TITLE
Comments

### DIFF
--- a/src/raylib.h
+++ b/src/raylib.h
@@ -620,8 +620,7 @@ typedef enum {
 } GamepadNumber;
 
 // Gamepad Buttons
-typedef enum
-{
+typedef enum {
     // This is here just for error checking
     GAMEPAD_BUTTON_UNKNOWN = 0,
 
@@ -647,9 +646,9 @@ typedef enum
     GAMEPAD_BUTTON_RIGHT_TRIGGER_2,
 
     // These are buttons in the center of the gamepad
-    GAMEPAD_BUTTON_MIDDLE_LEFT,  //PS3 Select
-    GAMEPAD_BUTTON_MIDDLE,       //PS Button/XBOX Button
-    GAMEPAD_BUTTON_MIDDLE_RIGHT, //PS3 Start
+    GAMEPAD_BUTTON_MIDDLE_LEFT,     //PS3 Select
+    GAMEPAD_BUTTON_MIDDLE,          //PS Button/XBOX Button
+    GAMEPAD_BUTTON_MIDDLE_RIGHT,    //PS3 Start
 
     // These are the joystick press in buttons
     GAMEPAD_BUTTON_LEFT_THUMB,

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -620,18 +620,21 @@ typedef enum {
 } GamepadNumber;
 
 // Gamepad Buttons
-typedef enum {
+typedef enum
+{
     // This is here just for error checking
     GAMEPAD_BUTTON_UNKNOWN = 0,
 
-    // This is normally [A,B,X,Y]/[Circle,Triangle,Square,Cross]
-    // No support for 6 button controllers though..
+    // This is normally a DPAD
     GAMEPAD_BUTTON_LEFT_FACE_UP,
     GAMEPAD_BUTTON_LEFT_FACE_RIGHT,
     GAMEPAD_BUTTON_LEFT_FACE_DOWN,
     GAMEPAD_BUTTON_LEFT_FACE_LEFT,
 
-    // This is normally a DPAD
+    // This normally corresponds with PlayStation and Xbox controllers
+    // XB: [Y,X,A,B]
+    // PS: [Triangle,Square,Cross,Circle]
+    // No support for 6 button controllers though..
     GAMEPAD_BUTTON_RIGHT_FACE_UP,
     GAMEPAD_BUTTON_RIGHT_FACE_RIGHT,
     GAMEPAD_BUTTON_RIGHT_FACE_DOWN,
@@ -644,9 +647,9 @@ typedef enum {
     GAMEPAD_BUTTON_RIGHT_TRIGGER_2,
 
     // These are buttons in the center of the gamepad
-    GAMEPAD_BUTTON_MIDDLE_LEFT,     //PS3 Select
-    GAMEPAD_BUTTON_MIDDLE,          //PS Button/XBOX Button
-    GAMEPAD_BUTTON_MIDDLE_RIGHT,    //PS3 Start
+    GAMEPAD_BUTTON_MIDDLE_LEFT,  //PS3 Select
+    GAMEPAD_BUTTON_MIDDLE,       //PS Button/XBOX Button
+    GAMEPAD_BUTTON_MIDDLE_RIGHT, //PS3 Start
 
     // These are the joystick press in buttons
     GAMEPAD_BUTTON_LEFT_THUMB,

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -631,8 +631,8 @@ typedef enum {
     GAMEPAD_BUTTON_LEFT_FACE_LEFT,
 
     // This normally corresponds with PlayStation and Xbox controllers
-    // XB: [Y,X,A,B]
-    // PS: [Triangle,Square,Cross,Circle]
+    // XBOX: [Y,X,A,B]
+    // PS3: [Triangle,Square,Cross,Circle]
     // No support for 6 button controllers though..
     GAMEPAD_BUTTON_RIGHT_FACE_UP,
     GAMEPAD_BUTTON_RIGHT_FACE_RIGHT,


### PR DESCRIPTION
While setting up input recognition I realized that the comments for the face buttons were flipped. So I flipped them around.

Also reorganized the PS3 and XBOX symbols to be in the same order, corresponding with the order of the enums.