### PR TITLE
Add GetRaylibVersionString() to core.c and raylib.h

### DIFF
--- a/examples/core/core_basic_window.c
+++ b/examples/core/core_basic_window.c
@@ -20,6 +20,7 @@
 ********************************************************************************************/
 
 #include "raylib.h"
+#include <stdio.h>
 
 int main(void)
 {
@@ -27,7 +28,9 @@ int main(void)
     //--------------------------------------------------------------------------------------
     const int screenWidth = 800;
     const int screenHeight = 450;
+    char raylib_info[1024];
 
+    sprintf(raylib_info, "Using raylib %s", GetRaylibVersionString());
     InitWindow(screenWidth, screenHeight, "raylib [core] example - basic window");
 
     SetTargetFPS(60);               // Set our game to run at 60 frames-per-second
@@ -48,6 +51,7 @@ int main(void)
             ClearBackground(RAYWHITE);
 
             DrawText("Congrats! You created your first window!", 190, 200, 20, LIGHTGRAY);
+            DrawText(raylib_info, 190, 240, 20, LIGHTGRAY);
 
         EndDrawing();
         //----------------------------------------------------------------------------------

--- a/src/core.c
+++ b/src/core.c
@@ -534,6 +534,16 @@ static void *GamepadThread(void *arg);                  // Mouse reading thread
 #endif
 
 //----------------------------------------------------------------------------------
+// Misc Functions Definition - Raylib info
+//----------------------------------------------------------------------------------
+
+// Returns the current version string, for example: "2.6"
+const char *GetRaylibVersionString(void)
+{
+    return RAYLIB_VERSION;
+}
+
+//----------------------------------------------------------------------------------
 // Module Functions Definition - Window and OpenGL Context Functions
 //----------------------------------------------------------------------------------
 

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -856,6 +856,13 @@ extern "C" {            // Prevents name mangling of functions
 // It's lonely here...
 
 //------------------------------------------------------------------------------------
+// Misc Functions (Module: core)
+//------------------------------------------------------------------------------------
+
+// Raylib info
+RLAPI const char *GetRaylibVersionString(void);                   // Returns the current version string, for example: "2.6"
+
+//------------------------------------------------------------------------------------
 // Window and Graphics Device Functions (Module: core)
 //------------------------------------------------------------------------------------
 


### PR DESCRIPTION
While writing my [raylib-ruby](https://github.com/a0/raylib-ruby) wrapper, I was thinking it would be useful to programatically get the current raylib version, but there was no function like that in the API. So I wrote this one.

```c
RLAPI const char*GetRaylibVersionString();
// returns "2.5" from RAYLIB_VERSION #define
```

I'm not sure the name of functions is the best, but I guess is enough to start. There is a sample in examples/core_basic_window.c