### PR TITLE
Fix `IsMouseButtonReleased()` when press/release events come too fast

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -3903,6 +3903,7 @@ static void KeyCallback(GLFWwindow *window, int key, int scancode, int action, i
 // GLFW3 Mouse Button Callback, runs on mouse button pressed
 static void MouseButtonCallback(GLFWwindow *window, int button, int action, int mods)
 {
+    previousMouseState[button] = currentMouseState[button];
     currentMouseState[button] = action;
 
 #if defined(SUPPORT_GESTURES_SYSTEM) && defined(SUPPORT_MOUSE_GESTURES)


### PR DESCRIPTION
If press/release events for a mouse button come too fast, then using
`IsMouseButtonReleased()` does not work. This has been noticed when
using a touchpad on Linux when tapping with two fingers two emulate
right mouse button click.

The situation looks like this:

```
BeginDrawing           <-- current==released, previous==released
Pressed                <-- current=pressed
Released               <-- current=released
IsMouseButtonReleased  <-- returns false because current==previous
EndDrawing             <-- previous=released
```

The fix is to update the previous mouse button state in addition to
current mouse button state when `MouseButtonCallback()` is called by
glfw. Now the situation is as follows:

```
BeginDrawing           <-- current==released, previous==released
Pressed                <-- current=pressed, previous=released
Released               <-- current=released, previous=pressed
IsMouseButtonReleased  <-- returns true because current!=previous
EndDrawing             <-- previous=released
```

Fixes #1017 