### PR TITLE
CMake - Fix usage of GLFW. Use static library instead of object files.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -35,9 +35,6 @@ if(NOT glfw3_FOUND AND NOT USE_EXTERNAL_GLFW STREQUAL "ON" AND "${PLATFORM}" MAT
   set(GLFW_USE_WAYLAND ${USE_WAYLAND} CACHE BOOL "" FORCE)
 
   add_subdirectory(external/glfw)
-
-  list(APPEND raylib_sources $<TARGET_OBJECTS:glfw_objlib>)
-  include_directories(BEFORE SYSTEM external/glfw/include)
 else()
   MESSAGE(STATUS "Using external GLFW")
   set(GLFW_PKG_DEPS glfw3)


### PR DESCRIPTION
Should fix the: $<TARGET_OBJECTS:glfw_objlib> issue