### PR TITLE
Changed minimum vertices for circle shapes from 4 to 3 to allow drawing of triangles

### DIFF
--- a/src/shapes.c
+++ b/src/shapes.c
@@ -215,7 +215,7 @@ void DrawCircleSector(Vector2 center, float radius, int startAngle, int endAngle
         endAngle = tmp;
     }
 
-    if (segments < 4)
+    if (segments < 3)
     {
         // Calculate how many segments we need to draw a smooth circle, taken from https://stackoverflow.com/a/2244088
         #define CIRCLE_ERROR_RATE  0.5f
@@ -307,7 +307,7 @@ void DrawCircleSectorLines(Vector2 center, float radius, int startAngle, int end
         endAngle = tmp;
     }
 
-    if (segments < 4)
+    if (segments < 3)
     {
         // Calculate how many segments we need to draw a smooth circle, taken from https://stackoverflow.com/a/2244088
         #ifndef CIRCLE_ERROR_RATE


### PR DESCRIPTION
This PR reduces the minimum vertices of circles from 4 (square) to 3 (triangle) to allow drawing of triangle primitives (filled and outline)