### PR TITLE
Fix for short non-looping sounds

### DIFF
--- a/src/raudio.c
+++ b/src/raudio.c
@@ -324,6 +324,12 @@ static void OnSendAudioDataToDevice(ma_device *pDevice, void *pFramesOut, const 
                         framesToRead -= framesJustRead;
                         framesRead += framesJustRead;
                     }
+                    
+                    if (!audioBuffer->playing)
+                    {
+                        framesRead = frameCount;
+                        break;
+                    }
 
                     // If we weren't able to read all the frames we requested, break
                     if (framesJustRead < framesToReadRightNow)


### PR DESCRIPTION
Short non-looping sounds can sometimes think they need to keep playing and will output their first few frames again. This helps to break out of all the loops instead of just this one.