### PR TITLE
Makes tracker music files (mod, xm) play to completion and loop in the right spot, fixes #989 

### DIFF
--- a/src/raudio.c
+++ b/src/raudio.c
@@ -1481,8 +1481,19 @@ void UpdateMusicStream(Music music)
 
     // Reset audio stream for looping
     if (streamEnding)
-    {
-        StopMusicStream(music);        // Stop music (and reset)
+    {	
+		// is this a tracker format or a streamed one (ogg, wav, etc.)	
+		if (!((music.ctxType == MUSIC_MODULE_XM) || (music.ctxType == MUSIC_MODULE_MOD)))
+		{
+			// streamed - stop the music and reset it.
+			StopMusicStream(music);
+		}
+		else
+		{
+			// tracker - don't reset it, but remember that we have hit 
+			// the loop point and are playing normally again.
+			streamEnding = false;
+		}
 
         // Decrease loopCount to stop when required
         if (music.loopCount > 1)


### PR DESCRIPTION
This fixes #989 by changing the end-of-stream logic for tracker music formats. 

Because the samples are generated on the fly, rather than coming from a stream, we don't need stop and reset playing audio if we've hit what we think is the end and want to loop; if we 'blindly' keep playing, the module player will continue to generate the samples one would expect to hear, no buffer underruns or crashing occur, etc.

This seems like a hacky way of fixing it (and I welcome any suggestions on how to improve it) - there might be a more elegant solution - but it does stop the problem from happening.