### PR TITLE
[rlgl] `LoadText()` fix

### DIFF
--- a/src/rlgl.h
+++ b/src/rlgl.h
@@ -3013,8 +3013,10 @@ char *LoadText(const char *fileName)
                 if (count < size)
                 {
                     text = RL_REALLOC(text, count + 1);
-                    text[count] = '\0';
                 }
+                
+                // zero-terminate the string
+                text[count] = '\0';
             }
 
             fclose(textFile);


### PR DESCRIPTION
This fix guarantees the string loaded from a file is zero-terminated. The old code:
```C
// WARNING: \r\n is converted to \n on reading, so,
// read bytes count gets reduced by the number of lines
if (count < size)
{
    text = RL_REALLOC(text, count + 1);
    text[count] = '\0';
}
```
does not zero-terminate the string if `count == size`, which can very well be the case if the text file was written in an editor that uses `\n` instead of `\r\n` (basically every text editor on Linux).