### PR TITLE
add `LoadImageBuffer`

### DIFF
--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1098,6 +1098,7 @@ RLAPI bool CheckCollisionPointTriangle(Vector2 point, Vector2 p1, Vector2 p2, Ve
 
 // Image/Texture2D data loading/unloading/saving functions
 RLAPI Image LoadImage(const char *fileName);                                                             // Load image from file into CPU memory (RAM)
+RLAPI Image LoadImageBuffer(const char *extension, const void *data, const unsigned int length);         // Load image from file already in memory
 RLAPI Image LoadImageEx(Color *pixels, int width, int height);                                           // Load image from Color array data (RGBA - 32bit)
 RLAPI Image LoadImagePro(void *data, int width, int height, int format);                                 // Load image from raw data with parameters
 RLAPI Image LoadImageRaw(const char *fileName, int width, int height, int format, int headerSize);       // Load image from RAW file data

--- a/src/textures.c
+++ b/src/textures.c
@@ -299,7 +299,7 @@ Image LoadImage(const char *fileName)
     return image;
 }
 
-// Load image from file in memory
+// Load image from file already in memory
 Image LoadImageBuffer(const char *extension, const void *data, const unsigned int length)
 {
     Image image = { 0 };


### PR DESCRIPTION
`LoadImageBuffer` allows the user to load an image from data that already exists in memory, such as raw PNG data they have embedded into their application.

I also have a version of this for raylib 2.6, but is there any reason to backport it? Does raylib 2.6 support any platforms that raylib 3.0 will not?