### PR TITLE
Changed `if` to `else if`.

### DIFF
--- a/src/textures.c
+++ b/src/textures.c
@@ -3118,7 +3118,7 @@ static Image LoadDDS(const char *fileName)
                     }
                 }
             }
-            if (ddsHeader.ddspf.flags == 0x40 && ddsHeader.ddspf.rgbBitCount == 24)   // DDS_RGB, no compressed
+            else if (ddsHeader.ddspf.flags == 0x40 && ddsHeader.ddspf.rgbBitCount == 24)   // DDS_RGB, no compressed
             {
                 // NOTE: not sure if this case exists...
                 image.data = (unsigned char *)RL_MALLOC(image.width*image.height*3*sizeof(unsigned char));


### PR DESCRIPTION
I think that the `if` statement on line `3121` should be `else if` because it would cause a memory leak if both branches could be hit in the same call because they both do an allocation stored in `image.data`.