### PR TITLE
Revert "Always use latest raylib version for cmake"

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -96,7 +96,7 @@ endif()
 include_directories(BEFORE SYSTEM others/external/include)
 
 if (NOT TARGET raylib)
-  find_package(raylib REQUIRED)
+  find_package(raylib 2.0 REQUIRED)
 endif()
 
 # Do each example

--- a/games/CMakeLists.txt
+++ b/games/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Setup the project and settings
 project(games)
 
-# Get the source together
+# Get the source toegher
 file(GLOB sources *.c)
 
 set(OUTPUT_EXT)
@@ -18,7 +18,7 @@ if(${PLATFORM} MATCHES "Web")
 endif()
 
 if (NOT TARGET raylib)
-  find_package(raylib REQUIRED)
+  find_package(raylib 2.0 REQUIRED)
 endif()
 
 # Do each game

--- a/games/drturtle/CMakeLists.txt
+++ b/games/drturtle/CMakeLists.txt
@@ -4,7 +4,7 @@ project(drturtle)
 # Executable & linking
 add_executable(${PROJECT_NAME} 06_drturtle_final.c)
 if (NOT TARGET raylib)
-  find_package(raylib REQUIRED)
+  find_package(raylib 2.0 REQUIRED)
 endif()
 target_link_libraries(${PROJECT_NAME} raylib)
 

--- a/games/just_do/CMakeLists.txt
+++ b/games/just_do/CMakeLists.txt
@@ -7,7 +7,7 @@ file(GLOB screen_sources "screens/*.c")
 # Executable & linking
 add_executable(${PROJECT_NAME} ${PROJECT_NAME}.c ${screen_sources})
 if (NOT TARGET raylib)
-  find_package(raylib REQUIRED)
+  find_package(raylib 2.0 REQUIRED)
 endif()
 target_link_libraries(${PROJECT_NAME} raylib)
 

--- a/games/koala_seasons/CMakeLists.txt
+++ b/games/koala_seasons/CMakeLists.txt
@@ -7,7 +7,7 @@ file(GLOB screen_sources "screens/*.c")
 # Executable & linking
 add_executable(${PROJECT_NAME} ${PROJECT_NAME}.c ${screen_sources})
 if (NOT TARGET raylib)
-  find_package(raylib REQUIRED)
+  find_package(raylib 2.0 REQUIRED)
 endif()
 target_link_libraries(${PROJECT_NAME} raylib)
 

--- a/games/light_my_ritual/CMakeLists.txt
+++ b/games/light_my_ritual/CMakeLists.txt
@@ -7,7 +7,7 @@ file(GLOB screen_sources "screens/*.c")
 # Executable & linking
 add_executable(${PROJECT_NAME} ${PROJECT_NAME}.c ${screen_sources})
 if (NOT TARGET raylib)
-  find_package(raylib REQUIRED)
+  find_package(raylib 2.0 REQUIRED)
 endif()
 target_link_libraries(${PROJECT_NAME} raylib)
 

--- a/games/skully_escape/CMakeLists.txt
+++ b/games/skully_escape/CMakeLists.txt
@@ -7,7 +7,7 @@ file(GLOB screen_sources "screens/*.c")
 # Executable & linking
 add_executable(${PROJECT_NAME} skully_escape.c player.c monster.c ${screen_sources})
 if (NOT TARGET raylib)
-  find_package(raylib REQUIRED)
+  find_package(raylib 2.0 REQUIRED)
 endif()
 target_link_libraries(${PROJECT_NAME} raylib)
 

--- a/games/wave_collector/CMakeLists.txt
+++ b/games/wave_collector/CMakeLists.txt
@@ -7,7 +7,7 @@ file(GLOB screen_sources "screens/*.c")
 # Executable & linking
 add_executable(${PROJECT_NAME} ${PROJECT_NAME}.c ${screen_sources})
 if (NOT TARGET raylib)
-  find_package(raylib REQUIRED)
+  find_package(raylib 2.0 REQUIRED)
 endif()
 target_link_libraries(${PROJECT_NAME} raylib)
 

--- a/projects/CMake/CMakeLists.txt
+++ b/projects/CMake/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.11) # FetchContent is available in 3.11+
 project(example)
 
 # Set this to the minimal version you want to support
-find_package(raylib QUIET) # Let CMake search for a raylib-config.cmake
+find_package(raylib 2.5 QUIET) # Let CMake search for a raylib-config.cmake
 
 # You could change the QUIET above to REQUIRED and remove this if() clause
 # This part downloads raylib and builds it if it's not installed on your system


### PR DESCRIPTION
 We didn't use the latest version, but a compatible version, which is established by  [`raylib-config-version.cmake`](https://github.com/raysan5/raylib/blob/master/cmake/raylib-config-version.cmake).

It's ok to have a minimal version, so revert the raysan5/raylib#1123.