### PR TITLE
Android: Set CORE.display.[width, height] before screen size check

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -3191,9 +3191,6 @@ static bool InitGraphicsDevice(int width, int height)
 #if defined(PLATFORM_ANDROID)
     EGLint displayFormat;
 
-    CORE.Window.display.width = ANativeWindow_getWidth(CORE.Android.app->window);
-    CORE.Window.display.height = ANativeWindow_getHeight(CORE.Android.app->window);
-
     // EGL_NATIVE_VISUAL_ID is an attribute of the EGLConfig that is guaranteed to be accepted by ANativeWindow_setBuffersGeometry()
     // As soon as we picked a EGLConfig, we can safely reconfigure the ANativeWindow buffers to match, using EGL_NATIVE_VISUAL_ID
     eglGetConfigAttrib(CORE.Window.device, CORE.Window.config, EGL_NATIVE_VISUAL_ID, &displayFormat);
@@ -4160,6 +4157,9 @@ static void AndroidCommandCallback(struct android_app *app, int32_t cmd)
                 }
                 else
                 {
+                    CORE.Window.display.width  = ANativeWindow_getWidth(CORE.Android.app->window);
+                    CORE.Window.display.height = ANativeWindow_getHeight(CORE.Android.app->window);
+
                     // Init graphics device (display device and OpenGL context)
                     InitGraphicsDevice(CORE.Window.screen.width, CORE.Window.screen.height);
 


### PR DESCRIPTION
In `InitGraphicsDevice(...)`, the Android section has a screen security check
like other platforms- but CORE.display.width, CORE.display.height are
not set yet, so the security check sets it to 0. So ensure we query the
device's screen width and height before the screen size security check.

This also gives you the ability to run a proper full-screen application
on Android without any scaling and guess work on the target device by
setting screen width and height to 0 in `InitWindow(...)` and using
`GetScreen[Width|Height]()` to get the actual values.