### PR TITLE
Android: Track touch motion across screen

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -4272,54 +4272,6 @@ static int32_t AndroidInputCallback(struct android_app *app, AInputEvent *event)
             // Stop processing gamepad buttons
             return 1;
         }
-
-        int32_t action = AMotionEvent_getAction(event);
-        unsigned int flags = action & AMOTION_EVENT_ACTION_MASK;
-
-        // Simple touch position
-        if (flags == AMOTION_EVENT_ACTION_DOWN)
-        {
-            // Get first touch position
-            CORE.Input.Touch.position[0].x = AMotionEvent_getX(event, 0);
-            CORE.Input.Touch.position[0].y = AMotionEvent_getY(event, 0);
-        }
-
-#if defined(SUPPORT_GESTURES_SYSTEM)
-        GestureEvent gestureEvent;
-
-        // Register touch actions
-        if (flags == AMOTION_EVENT_ACTION_DOWN) gestureEvent.touchAction = TOUCH_DOWN;
-        else if (flags == AMOTION_EVENT_ACTION_UP) gestureEvent.touchAction = TOUCH_UP;
-        else if (flags == AMOTION_EVENT_ACTION_MOVE) gestureEvent.touchAction = TOUCH_MOVE;
-
-        // Register touch points count
-        // NOTE: Documentation says pointerCount is Always >= 1,
-        // but in practice it can be 0 or over a million
-        gestureEvent.pointCount = AMotionEvent_getPointerCount(event);
-
-        // Only enable gestures for 1-3 touch points
-        if ((gestureEvent.pointCount > 0) && (gestureEvent.pointCount < 4))
-        {
-            // Register touch points id
-            // NOTE: Only two points registered
-            gestureEvent.pointerId[0] = AMotionEvent_getPointerId(event, 0);
-            gestureEvent.pointerId[1] = AMotionEvent_getPointerId(event, 1);
-
-            // Register touch points position
-            gestureEvent.position[0] = (Vector2){ AMotionEvent_getX(event, 0), AMotionEvent_getY(event, 0) };
-            gestureEvent.position[1] = (Vector2){ AMotionEvent_getX(event, 1), AMotionEvent_getY(event, 1) };
-
-            // Normalize gestureEvent.position[x] for screenWidth and screenHeight
-            gestureEvent.position[0].x /= (float)GetScreenWidth();
-            gestureEvent.position[0].y /= (float)GetScreenHeight();
-
-            gestureEvent.position[1].x /= (float)GetScreenWidth();
-            gestureEvent.position[1].y /= (float)GetScreenHeight();
-
-            // Gesture data is sent to gestures system for processing
-            ProcessGestureEvent(gestureEvent);
-        }
-#endif
     }
     else if (type == AINPUT_EVENT_TYPE_KEY)
     {
@@ -4360,26 +4312,14 @@ static int32_t AndroidInputCallback(struct android_app *app, AInputEvent *event)
         return 0;
     }
 
+    CORE.Input.Touch.position[0].x = AMotionEvent_getX(event, 0);
+    CORE.Input.Touch.position[0].y = AMotionEvent_getY(event, 0);
+
+#if defined(SUPPORT_GESTURES_SYSTEM)
     int32_t action = AMotionEvent_getAction(event);
     unsigned int flags = action & AMOTION_EVENT_ACTION_MASK;
 
-    // Support only simple touch position
-    if (flags == AMOTION_EVENT_ACTION_DOWN)
-    {
-        // Get first touch position
-        CORE.Input.Touch.position[0].x = AMotionEvent_getX(event, 0);
-        CORE.Input.Touch.position[0].y = AMotionEvent_getY(event, 0);
-    }
-    else if (flags == AMOTION_EVENT_ACTION_UP)
-    {
-        // Get first touch position
-        CORE.Input.Touch.position[0].x = 0;
-        CORE.Input.Touch.position[0].y = 0;
-    }
-    else return 0; // TODO: Not sure what else should be handled
-
-#if defined(SUPPORT_GESTURES_SYSTEM)
-    GestureEvent gestureEvent = { 0 };
+    GestureEvent gestureEvent;
 
     // Register touch actions
     if (flags == AMOTION_EVENT_ACTION_DOWN) gestureEvent.touchAction = TOUCH_DOWN;
@@ -4403,7 +4343,7 @@ static int32_t AndroidInputCallback(struct android_app *app, AInputEvent *event)
         gestureEvent.position[0] = (Vector2){ AMotionEvent_getX(event, 0), AMotionEvent_getY(event, 0) };
         gestureEvent.position[1] = (Vector2){ AMotionEvent_getX(event, 1), AMotionEvent_getY(event, 1) };
 
-        // Normalize gestureEvent.position[x] for CORE.Window.screen.width and CORE.Window.screen.height
+        // Normalize gestureEvent.position[x] for screenWidth and screenHeight
         gestureEvent.position[0].x /= (float)GetScreenWidth();
         gestureEvent.position[0].y /= (float)GetScreenHeight();
 


### PR DESCRIPTION
This was working in 2.6 but no longer does in current git tree.
It appears touch position is only tracked on
AMOTION_EVENT_ACTION_[DOWN|UP], which only registers the initial touch
on the screen. Subsequent movement is not tracked into CORE.

Touch position and the Gesture System appears to be updated twice in
AndroidInputCallback in what looks like perhaps a copy paste error (code
is identical) with the exception of tracking AMOTION_EVENT_ACTION_UP in
the 2nd copy of the code (but this is not necessary to track).

If you need to track the first touch or release touch position, you can
do so with checking IsMouseButton[Pressed|Released] on the same frame.

This patch makes it so the touch position is always updated, and merges the
duplicated code into 1 singular code path.