### PR TITLE
appveyor: configure for Release with Debug Info

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,7 +39,7 @@ before_build:
   - cd build
 
 build_script:
-  - cmake -G %GENERATOR% -DSTATIC=ON -DSHARED=ON -DBUILD_EXAMPLES=%examples% -DBUILD_GAMES=%examples% -DINCLUDE_EVERYTHING=ON ..
+  - cmake -G %GENERATOR% -DCMAKE_BUILD_TYPE=RelWithDebInfo -DSTATIC=ON -DSHARED=ON -DBUILD_EXAMPLES=%examples% -DBUILD_GAMES=%examples% -DINCLUDE_EVERYTHING=ON ..
   - cmake --build . --target install
 
 after_build:

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -263,6 +263,11 @@ file(COPY "raymath.h" DESTINATION ".")
 file(COPY "raudio.h" DESTINATION ".")
 
 # Print the flags for the user
+if (DEFINED CMAKE_BUILD_TYPE)
+  message(STATUS "Generated build type: ${CMAKE_BUILD_TYPE}")
+else()
+  message(STATUS "Generated config types: ${CMAKE_CONFIGURATION_TYPES}")
+endif()
 message(STATUS "Compiling with the flags:")
 message(STATUS "  PLATFORM=" ${PLATFORM_CPP})
 message(STATUS "  GRAPHICS=" ${GRAPHICS})


### PR DESCRIPTION
We build the library as debug with AppVeyor and package it this way,
which is unfortunate, because on Windows it's linked against debug
variants of the C runtime. Fix this by build RelWithDebInfo instead

Fixes #1128.