### PR TITLE
Fixed DrawTextRecEx() selection when wordwrap is ON (again)

### DIFF
--- a/src/text.c
+++ b/src/text.c
@@ -973,6 +973,7 @@ void DrawTextRecEx(Font font, const char *text, Rectangle rec, float fontSize, f
                 startLine = endLine;
                 endLine = -1;
                 glyphWidth = 0;
+                selectStart += lastk - k;
                 k = lastk;
 
                 state = !state;


### PR DESCRIPTION
Selection index didn't account for change in k value after a word wrap, causes misaligned selection post-wrap.
related: https://github.com/raysan5/raylib/pull/833