### PR TITLE
Update compilation warning flags

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -182,12 +182,14 @@ endif
 #  -O1                  defines optimization level
 #  -g                   include debug information on compilation
 #  -s                   strip unnecessary data from build
-#  -Wall                turns on most, but not all, compiler warnings
 #  -std=c99             defines C language mode (standard C from 1999 revision)
 #  -std=gnu99           defines C language mode (GNU C from 1999 revision)
 #  -Wno-missing-braces  ignore invalid warning (GCC bug 53119)
 #  -D_DEFAULT_SOURCE    use with -std=c99 on Linux and PLATFORM_WEB, required for timespec
-CFLAGS += -Wall -std=c99 -D_DEFAULT_SOURCE -Wno-missing-braces
+CFLAGS += -D_DEFAULT_SOURCE -Wno-missing-braces -Werror=pointer-arith -fno-strict-aliasing
+
+# Define compiler warning flags:
+CFLAGS += -Wbool-compare -Wbool-operation -Wbuiltin-declaration-mismatch -Wcast-align -Wchar-subscripts -Wchkp -Wdeprecated -Wformat-overflow -Wfree-nonheap-object -Wimplicit -Wint-in-bool-context -Wint-to-pointer-cast -Wmissing-parameter-type  -Woverlength-strings -Wpointer-sign -Wpointer-to-int-cast -Wunused-label -Wunused-local-typedefs -Wunused-result 
 
 ifeq ($(BUILD_MODE),DEBUG)
     CFLAGS += -g

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -186,7 +186,7 @@ endif
 #  -std=gnu99           defines C language mode (GNU C from 1999 revision)
 #  -Wno-missing-braces  ignore invalid warning (GCC bug 53119)
 #  -D_DEFAULT_SOURCE    use with -std=c99 on Linux and PLATFORM_WEB, required for timespec
-CFLAGS += -D_DEFAULT_SOURCE -Wno-missing-braces -Werror=pointer-arith -fno-strict-aliasing
+CFLAGS += -std=c99 -D_DEFAULT_SOURCE -Wno-missing-braces
 
 # Define compiler warning flags:
 CFLAGS += -Wbool-compare -Wbool-operation -Wbuiltin-declaration-mismatch -Wcast-align -Wchar-subscripts -Wchkp -Wdeprecated -Wformat-overflow -Wfree-nonheap-object -Wimplicit -Wint-in-bool-context -Wint-to-pointer-cast -Wmissing-parameter-type  -Woverlength-strings -Wpointer-sign -Wpointer-to-int-cast -Wunused-label -Wunused-local-typedefs -Wunused-result 

--- a/src/Makefile
+++ b/src/Makefile
@@ -265,14 +265,16 @@ endif
 #  -O1                      defines optimization level
 #  -g                       include debug information on compilation
 #  -s                       strip unnecessary data from build
-#  -Wall                    turns on most, but not all, compiler warnings
 #  -std=c99                 defines C language mode (standard C from 1999 revision)
 #  -std=gnu99               defines C language mode (GNU C from 1999 revision)
 #  -Wno-missing-braces      ignore invalid warning (GCC bug 53119)
 #  -D_DEFAULT_SOURCE        use with -std=c99 on Linux and PLATFORM_WEB, required for timespec
 #  -Werror=pointer-arith    catch unportable code that does direct arithmetic on void pointers
 #  -fno-strict-aliasing     jar_xm.h does shady stuff (breaks strict aliasing)
-CFLAGS += -Wall -D_DEFAULT_SOURCE -Wno-missing-braces -Werror=pointer-arith -fno-strict-aliasing
+CFLAGS += -D_DEFAULT_SOURCE -Wno-missing-braces -Werror=pointer-arith -fno-strict-aliasing
+
+# Define compiler warning flags:
+CFLAGS += -Wbool-compare -Wbool-operation -Wbuiltin-declaration-mismatch -Wcast-align -Wchar-subscripts -Wchkp -Wdeprecated -Wformat-overflow -Wfree-nonheap-object -Wimplicit -Wint-in-bool-context -Wint-to-pointer-cast -Wmissing-parameter-type  -Woverlength-strings -Wpointer-sign -Wpointer-to-int-cast -Wunused-label -Wunused-local-typedefs -Wunused-result 
 
 ifeq ($(PLATFORM), PLATFORM_WEB)
     CFLAGS += -std=gnu99


### PR DESCRIPTION
Hi all. My first PR here!!

I have been reviewing many compilation flags for warnings  and testing them (the complete list is 
`gcc --help=warning`). So far I tested the next ones:

```
-Wbad-function-cast -Wbool-compare  -Wbool-operation -Wbuiltin-declaration-mismatch -Wcast-align -Wcast-qual -Wchar-subscripts -Wcharacter-truncation -Wchkp -Wconversion-extra  -Wdeprecated -Wformat-overflow -Wfree-nonheap-object -Wimplicit -Wint-in-bool-context -Wint-to-pointer-cast -Winteger-division -Wmissing-parameter-type -Wmissing-prototypes -Woverlength-strings -Wpointer-sign -Wpointer-to-int-cast -Wunused
-Wunused-but-set-parameter -Wunused-but-set-variable -Wunused-const-variable -Wunused-const-variable -Wunused-dummy-argument -Wunused-function -Wunused-label -Wunused-local-typedefs -Wunused-macros -Wunused-parameter -Wunused-result -Wunused-value -Wunused-variable
```

And being honest....I didn't see any of them adding useful info for improving the code. Indeed I ended up with the oposite proposal: 

With the `-Wall` flag many warnings shown always (`-Wunused-function` and similars). They report that functions are not being used in textures.c and in many files in external folder. As these files are  complete libraries and not all of their functions are being used, this warnings are OK and they can  be ignored always. 

So my proposal here is:
* If the warnings have to be ignored...then the warnings are not useful. That's why I removed them.
* To continue the work in static analysis of raylib in order to detect dead code and any other potential risk.

any comment is welcome!!
