### PR TITLE
[cppcheck] Fix minor warnings in models.c and raudio.c

### DIFF
--- a/src/models.c
+++ b/src/models.c
@@ -2840,10 +2840,10 @@ static Model LoadOBJ(const char *fileName)
     unsigned int materialCount = 0;
 
     char *fileData = LoadFileText(fileName);
-    int dataSize = strlen(fileData);
 
     if (fileData != NULL)
     {
+        int dataSize = strlen(fileData);
         char currentDir[1024] = { 0 };
         strcpy(currentDir, GetWorkingDirectory());
         chdir(GetDirectoryPath(fileName));

--- a/src/raudio.c
+++ b/src/raudio.c
@@ -802,10 +802,10 @@ void ExportWaveAsCode(Wave wave, const char *fileName)
 #endif
 
         fprintf(txtFile, "// Wave data information\n");
-        fprintf(txtFile, "#define %s_SAMPLE_COUNT     %d\n", varFileName, wave.sampleCount);
-        fprintf(txtFile, "#define %s_SAMPLE_RATE      %d\n", varFileName, wave.sampleRate);
-        fprintf(txtFile, "#define %s_SAMPLE_SIZE      %d\n", varFileName, wave.sampleSize);
-        fprintf(txtFile, "#define %s_CHANNELS         %d\n\n", varFileName, wave.channels);
+        fprintf(txtFile, "#define %s_SAMPLE_COUNT     %u\n", varFileName, wave.sampleCount);
+        fprintf(txtFile, "#define %s_SAMPLE_RATE      %u\n", varFileName, wave.sampleRate);
+        fprintf(txtFile, "#define %s_SAMPLE_SIZE      %u\n", varFileName, wave.sampleSize);
+        fprintf(txtFile, "#define %s_CHANNELS         %u\n\n", varFileName, wave.channels);
 
         // Write byte data as hexadecimal text
         fprintf(txtFile, "static unsigned char %s_DATA[%i] = { ", varFileName, dataSize);


### PR DESCRIPTION
Errores fixes:

- models.c,2843 Either the condition 'fileData!=NULL' is redundant or there is possible null pointer dereference: fileData.

- raudio.c,805, 806, 807, 808, %d in format string (no. 2) requires 'int' but the argument type is 'unsigned int'.