### PR TITLE
Potential bug in GenImageFontAtlas

### DIFF
--- a/examples/text/text_font_custom_characters.c
+++ b/examples/text/text_font_custom_characters.c
@@ -1,0 +1,24 @@
+#include "raylib.h"
+
+int main(void)
+{
+    const int screenWidth = 800;
+    const int screenHeight = 450;
+
+    InitWindow(screenWidth, screenHeight, "raylib [text] example - font custom characters");
+    SetTargetFPS(60);
+
+    int chars[126 - 33];
+    for (int i = 0; i < 126 - 33; i++) chars[i] = 33 + i;
+
+    Font font = LoadFontEx("resources/KAISG.ttf", 64, chars, 126 - 33);
+
+    while (!WindowShouldClose())
+    {
+        BeginDrawing();
+        ClearBackground(WHITE);
+
+        DrawTexture(font.texture, 0, 0, BLACK);
+        EndDrawing();
+    }
+}

--- a/src/text.c
+++ b/src/text.c
@@ -613,7 +613,7 @@ Image GenImageFontAtlas(const CharInfo *chars, Rectangle **charRecs, int charsCo
     // NOTE 2: SDF font characters already contain an internal padding,
     // so image size would result bigger than default font type
     float requiredArea = 0;
-    for (int i = 0; i < charsCount; i++) requiredArea += ((chars[i].image.width + 2*padding)*(chars[i].image.height + 2*padding));
+    for (int i = 0; i < charsCount; i++) requiredArea += ((chars[i].image.width + padding)*(chars[i].image.height + padding));
     float guessSize = sqrtf(requiredArea)*1.3f;
     int imageSize = (int)powf(2, ceilf(logf((float)guessSize)/logf(2)));  // Calculate next POT
 
@@ -650,7 +650,7 @@ Image GenImageFontAtlas(const CharInfo *chars, Rectangle **charRecs, int charsCo
             recs[i].height = (float)chars[i].image.height;
 
             // Move atlas position X for next character drawing
-            offsetX += (chars[i].image.width + 2*padding);
+            offsetX += (chars[i].image.width + padding);
 
             if (offsetX >= (atlas.width - chars[i].image.width - padding))
             {
@@ -659,7 +659,7 @@ Image GenImageFontAtlas(const CharInfo *chars, Rectangle **charRecs, int charsCo
                 // NOTE: Be careful on offsetY for SDF fonts, by default SDF
                 // use an internal padding of 4 pixels, it means char rectangle
                 // height is bigger than fontSize, it could be up to (fontSize + 8)
-                offsetY += (fontSize + 2*padding);
+                offsetY += (fontSize + padding);
 
                 if (offsetY > (atlas.height - fontSize - padding)) break;
             }
@@ -677,8 +677,8 @@ Image GenImageFontAtlas(const CharInfo *chars, Rectangle **charRecs, int charsCo
         for (int i = 0; i < charsCount; i++)
         {
             rects[i].id = i;
-            rects[i].w = chars[i].image.width + 2*padding;
-            rects[i].h = chars[i].image.height + 2*padding;
+            rects[i].w = chars[i].image.width + padding;
+            rects[i].h = chars[i].image.height + padding;
         }
 
         // Package rectangles into atlas


### PR DESCRIPTION
## Problem Description
If you generate a font with all the default characters except for the whitespace this will cause a character to wrap and not be packed correctly. To test this I added a simple example that loads a font with all the default characters except the whitespace and renders the atlas on screen. This the result:

![](https://cdn.discordapp.com/attachments/176398207310495746/695252355125346344/unknown.png)

Notice the `u` character on the second to last row, right at the end some of its pixels wrap and are placed next to the `b` character.

## Potential fix
While examining the code I found this potential issue that might cause this:
```c
// Move atlas position X for next character drawing
offsetX += (chars[i].image.width + 2*padding);
```

I think the issue here is that we are advancing the `offsetX` by too much, I think it should be `offsetX += (chars[i].image.width + padding);`. 

I removed the instances of `2*padding` that I could find which seemed like bugs and this seems to have fixed the issue. Here is an image showing the result after the changes are applied:


![](https://media.discordapp.net/attachments/176398207310495746/695252470418374756/unknown.png)


## Testing
I also ran all the other text examples to make sure this didn't break anything and they all seem to work fine.