### PR TITLE
Fixed offset check in GenImageFontAtlas

### DIFF
--- a/src/text.c
+++ b/src/text.c
@@ -640,7 +640,7 @@ Image GenImageFontAtlas(const CharInfo *chars, Rectangle **charRecs, int charsCo
             {
                 for (int x = 0; x < chars[i].image.width; x++)
                 {
-                    ((unsigned char *)atlas.data)[(offsetY + y)*atlas.width + (offsetX + x)] = ((unsigned char *)chars[i].image.data)[y*chars[i].image.width + x];
+                    ((unsigned char*)atlas.data)[(offsetY + y)*atlas.width + (offsetX + x)] = ((unsigned char*)chars[i].image.data)[y*chars[i].image.width + x];
                 }
             }
 
@@ -653,7 +653,7 @@ Image GenImageFontAtlas(const CharInfo *chars, Rectangle **charRecs, int charsCo
             // Move atlas position X for next character drawing
             offsetX += (chars[i].image.width + 2*padding);
 
-            if (offsetX >= (atlas.width - chars[i].image.width - padding))
+            if (offsetX >= (atlas.width - chars[i].image.width - 2 * padding))
             {
                 offsetX = padding;
 

--- a/src/text.c
+++ b/src/text.c
@@ -640,7 +640,7 @@ Image GenImageFontAtlas(const CharInfo *chars, Rectangle **charRecs, int charsCo
             {
                 for (int x = 0; x < chars[i].image.width; x++)
                 {
-                    ((unsigned char*)atlas.data)[(offsetY + y)*atlas.width + (offsetX + x)] = ((unsigned char*)chars[i].image.data)[y*chars[i].image.width + x];
+                    ((unsigned char *)atlas.data)[(offsetY + y)*atlas.width + (offsetX + x)] = ((unsigned char *)chars[i].image.data)[y*chars[i].image.width + x];
                 }
             }
 
@@ -653,7 +653,7 @@ Image GenImageFontAtlas(const CharInfo *chars, Rectangle **charRecs, int charsCo
             // Move atlas position X for next character drawing
             offsetX += (chars[i].image.width + 2*padding);
 
-            if (offsetX >= (atlas.width - chars[i].image.width - 2 * padding))
+            if (offsetX >= (atlas.width - chars[i].image.width - 2*padding))
             {
                 offsetX = padding;
 


### PR DESCRIPTION
A small fix to a subtle bug in `GenImageFontAtlas` that we previously discussed in this thread: https://github.com/raysan5/raylib/pull/1170