### PR TITLE
Fix VSCode

### DIFF
--- a/projects/VSCode/.vscode/launch.json
+++ b/projects/VSCode/.vscode/launch.json
@@ -8,7 +8,7 @@
             "name": "Debug",
             "type": "cppdbg",
             "request": "launch",
-            "program": "${workspaceFolder}/main",
+            "program": "${workspaceFolder}/game",
             "args": [],
             "stopAtEntry": false,
             "cwd": "${workspaceFolder}",

--- a/projects/VSCode/Makefile
+++ b/projects/VSCode/Makefile
@@ -180,6 +180,9 @@ ifeq ($(PLATFORM),PLATFORM_DESKTOP)
     ifeq ($(PLATFORM_OS),LINUX)
         MAKE = make
     endif
+    ifeq ($(PLATFORM_OS),OSX)
+        MAKE = make
+    endif
 endif
 
 # Define compiler flags:


### PR DESCRIPTION
- Fixes the built executable not launching when debugging from VSCode because of misconfiguration
- Fixes the build error on macOS due to calling the wrong make version