### PR TITLE
Added method to load TTF font from memory

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -1263,7 +1263,7 @@ void BeginDrawing(void)
 }
 
 // End canvas drawing and swap buffers (double buffering)
-void EndDrawing(void)
+void EndDrawingEx(void(*fn)())
 {
 #if defined(PLATFORM_RPI) && defined(SUPPORT_MOUSE_CURSOR_RPI)
     // On RPI native mode we have no system mouse cursor, so,
@@ -1272,6 +1272,9 @@ void EndDrawing(void)
 #endif
 
     rlglDraw();                     // Draw Buffers (Only OpenGL 3+ and ES2)
+
+    if (fn != NULL)
+        fn();
 
 #if defined(SUPPORT_GIF_RECORDING)
     #define GIF_RECORD_FRAMERATE    10
@@ -1322,6 +1325,12 @@ void EndDrawing(void)
 
         CORE.Time.frame += waitTime;      // Total frame time: update + draw + wait
     }
+}
+
+// End canvas drawing and swap buffers (double buffering)
+void EndDrawing()
+{
+    return EndDrawingEx(NULL);
 }
 
 // Initialize 2D mode with custom camera (2D)

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1207,6 +1207,7 @@ RLAPI int GetPixelDataSize(int width, int height, int format);                  
 RLAPI Font GetFontDefault(void);                                                            // Get the default Font
 RLAPI Font LoadFont(const char *fileName);                                                  // Load font from file into GPU memory (VRAM)
 RLAPI Font LoadFontEx(const char *fileName, int fontSize, int *fontChars, int charsCount);  // Load font from file with extended parameters
+RLAPI Font LoadFontFromMemory(const char* data, int fontSize, int* fontChars, int charsCount);
 RLAPI Font LoadFontFromImage(Image image, Color key, int firstChar);                        // Load font from Image (XNA style)
 RLAPI CharInfo *LoadFontData(const char *fileName, int fontSize, int *fontChars, int charsCount, int type); // Load font data for further use
 RLAPI Image GenImageFontAtlas(const CharInfo *chars, Rectangle **recs, int charsCount, int fontSize, int padding, int packMethod);  // Generate image font atlas using chars info

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -909,7 +909,8 @@ RLAPI void DisableCursor(void);                                   // Disables cu
 // Drawing-related functions
 RLAPI void ClearBackground(Color color);                          // Set background color (framebuffer clear color)
 RLAPI void BeginDrawing(void);                                    // Setup canvas (framebuffer) to start drawing
-RLAPI void EndDrawing(void);                                      // End canvas drawing and swap buffers (double buffering)
+RLAPI void EndDrawingEx(void(*fn)());                               // End canvas drawing and swap buffers (double buffering). This method adds a spot for additional rendering on-top of Raylib render.
+RLAPI void EndDrawing();                                          // End canvas drawing and swap buffers (double buffering)
 RLAPI void BeginMode2D(Camera2D camera);                          // Initialize 2D mode with custom camera (2D)
 RLAPI void EndMode2D(void);                                       // Ends 2D mode with custom camera
 RLAPI void BeginMode3D(Camera3D camera);                          // Initializes 3D mode with custom camera (3D)


### PR DESCRIPTION
I had a few fonts I wanted to embed into my executable, but didn't want to cache to disk before loading them.

Added a method to load TTF fonts directly from memory, thought some might find it useful.

Would also be nice to do so with images, but in the meanwhile I'm just using stb_image as a bridge to decode the raw pixel data.