### PR TITLE
Update easings.h

### DIFF
--- a/src/easings.h
+++ b/src/easings.h
@@ -90,7 +90,7 @@
     #define EASEDEF extern
 #endif
 
-#include <math.h>       // Required for: sinf(), cosf(), sqrt(), pow()
+#include <math.h>       // Required for: sinf(), cosf(), sqrtf(), powf()
 
 #ifndef PI
     #define PI 3.14159265358979323846f //Required as PI is not always defined in math.h
@@ -112,12 +112,12 @@ EASEDEF float EaseSineOut(float t, float b, float c, float d) { return (c*sinf(t
 EASEDEF float EaseSineInOut(float t, float b, float c, float d) { return (-c/2.0f*(cosf(PI*t/d) - 1.0f) + b); }
 
 // Circular Easing functions
-EASEDEF float EaseCircIn(float t, float b, float c, float d) { t /= d; return (-c*(sqrt(1.0f - t*t) - 1.0f) + b); }
-EASEDEF float EaseCircOut(float t, float b, float c, float d) { t = t/d - 1.0f; return (c*sqrt(1.0f - t*t) + b); }
+EASEDEF float EaseCircIn(float t, float b, float c, float d) { t /= d; return (-c*(sqrtf(1.0f - t*t) - 1.0f) + b); }
+EASEDEF float EaseCircOut(float t, float b, float c, float d) { t = t/d - 1.0f; return (c*sqrtf(1.0f - t*t) + b); }
 EASEDEF float EaseCircInOut(float t, float b, float c, float d)
 {
-    if ((t/=d/2.0f) < 1.0f) return (-c/2.0f*(sqrt(1.0f - t*t) - 1.0f) + b);
-    t -= 2.0f; return (c/2.0f*(sqrt(1.0f - t*t) + 1.0f) + b);
+    if ((t/=d/2.0f) < 1.0f) return (-c/2.0f*(sqrtf(1.0f - t*t) - 1.0f) + b);
+    t -= 2.0f; return (c/2.0f*(sqrtf(1.0f - t*t) + 1.0f) + b);
 }
 
 // Cubic Easing functions
@@ -139,15 +139,15 @@ EASEDEF float EaseQuadInOut(float t, float b, float c, float d)
 }
 
 // Exponential Easing functions
-EASEDEF float EaseExpoIn(float t, float b, float c, float d) { return (t == 0.0f) ? b : (c*pow(2.0f, 10.0f*(t/d - 1.0f)) + b); }
-EASEDEF float EaseExpoOut(float t, float b, float c, float d) { return (t == d) ? (b + c) : (c*(-pow(2.0f, -10.0f*t/d) + 1.0f) + b);    }
+EASEDEF float EaseExpoIn(float t, float b, float c, float d) { return (t == 0.0f) ? b : (c*powf(2.0f, 10.0f*(t/d - 1.0f)) + b); }
+EASEDEF float EaseExpoOut(float t, float b, float c, float d) { return (t == d) ? (b + c) : (c*(-powf(2.0f, -10.0f*t/d) + 1.0f) + b);    }
 EASEDEF float EaseExpoInOut(float t, float b, float c, float d)
 {
     if (t == 0.0f) return b;
     if (t == d) return (b + c);
-    if ((t/=d/2.0f) < 1.0f) return (c/2.0f*pow(2.0f, 10.0f*(t - 1.0f)) + b);
+    if ((t/=d/2.0f) < 1.0f) return (c/2.0f*powf(2.0f, 10.0f*(t - 1.0f)) + b);
 
-    return (c/2.0f*(-pow(2.0f, -10.0f*(t - 1.0f)) + 2.0f) + b);
+    return (c/2.0f*(-powf(2.0f, -10.0f*(t - 1.0f)) + 2.0f) + b);
 }
 
 // Back Easing functions
@@ -219,7 +219,7 @@ EASEDEF float EaseElasticIn(float t, float b, float c, float d)
     float p = d*0.3f;
     float a = c;
     float s = p/4.0f;
-    float postFix = a*pow(2.0f, 10.0f*(t-=1.0f));
+    float postFix = a*powf(2.0f, 10.0f*(t-=1.0f));
 
     return (-(postFix*sinf((t*d-s)*(2.0f*PI)/p )) + b);
 }
@@ -233,7 +233,7 @@ EASEDEF float EaseElasticOut(float t, float b, float c, float d)
     float a = c;
     float s = p/4.0f;
 
-    return (a*pow(2.0f,-10.0f*t)*sinf((t*d-s)*(2.0f*PI)/p) + c + b);
+    return (a*powf(2.0f,-10.0f*t)*sinf((t*d-s)*(2.0f*PI)/p) + c + b);
 }
 
 EASEDEF float EaseElasticInOut(float t, float b, float c, float d)
@@ -247,11 +247,11 @@ EASEDEF float EaseElasticInOut(float t, float b, float c, float d)
 
     if (t < 1.0f)
     {
-        float postFix = a*pow(2.0f, 10.0f*(t-=1.0f));
+        float postFix = a*powf(2.0f, 10.0f*(t-=1.0f));
         return -0.5f*(postFix*sinf((t*d-s)*(2.0f*PI)/p)) + b;
     }
 
-    float postFix = a*pow(2.0f, -10.0f*(t-=1.0f));
+    float postFix = a*powf(2.0f, -10.0f*(t-=1.0f));
 
     return (postFix*sinf((t*d-s)*(2.0f*PI)/p)*0.5f + c + b);
 }


### PR DESCRIPTION
Make easings.h use powf and sqrtf instead of pow and sqrt.


Hello,

Almost one year ago I made a pull request that made the easings.h file use the tgmath.h header and specified all values as floats (by appending the character f to the numbers). This made the functions in easings.h faster since it eliminated type conversions.

I found out that later the patch was revised and you reverted tgmath.h to math.h and changed the sin and cos functions to their float equivalents (sinf and cosf), but didn't change sqrt and pow to their float equivalents (sqrtf and powf). Was there a reason for omitting these two or was it a mistake?

I've run the benchmarks I prepared last time against the current easings.h and one that uses sqrtf and powf and the performance indeed increases. The affected functions are the ones in the EaseCirc, EaseExpo and EaseElastic and the results range from around 1.2 to 5.5 speed increase depending on the function and test in my machine (I ran six tests, three short ones and three long ones, with no optimization, O1 and O2 respectively). You can see the test code (and run it) as well as my results here https://github.com/flashback-fx/easings_tools (the benchmark is a bit messy to set up, if someone wants to run it but does not know how please ask).

Finally, I made the easings_testbed but I found out I am not credited in examples/README.md (I am in the actual file tho)
Could I please get credit?

Thanks again to ray and all contributors for this amazing library.