### PR TITLE
Fix for building examples with latest emsdk (LLVM)

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -81,7 +81,7 @@ if(${PLATFORM} MATCHES "Android")
   list(REMOVE_ITEM example_sources ${CMAKE_CURRENT_SOURCE_DIR}/shaders/shaders_basic_lighting.c)
 
 elseif(${PLATFORM} MATCHES "Web")
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Os -s USE_GLFW=3 -s ASSERTIONS=1 -s WASM=1 -s EMTERPRETIFY=1 -s EMTERPRETIFY_ASYNC=1")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Os -s USE_GLFW=3 -s ASSERTIONS=1 -s WASM=1 -s ASYNCIFY")
   # Since WASM is used, ALLOW_MEMORY_GROWTH has no extra overheads
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -s ALLOW_MEMORY_GROWTH=1 --no-heap-copy")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --shell-file ${CMAKE_SOURCE_DIR}/src/shell.html")


### PR DESCRIPTION
I was trying to compile raylib+examples by emcc 
I followed this [instruction](https://github.com/raysan5/raylib/wiki/Working-for-Web-(HTML5))
```
emsdk install latest
emsdk activate latest
```

However, emcc failed with messages about ```LLVM not supporting EMTERPRETIFY```

This PR fixes this issue on my machine:
Ubuntu 19.10
emcc (Emscripten gcc/clang-like replacement) 1.39.12