### PR TITLE
Added checks to fix compat with switch homebrew

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -45,6 +45,10 @@ endif()
 
 add_definitions("-DRAYLIB_CMAKE=1")
 
+if(${PLATFORM} MATCHES "Switch")
+  set(USE_AUDIO FALSE)
+endif()
+
 if(USE_AUDIO)
   MESSAGE(STATUS "Audio Backend: miniaudio")
   set(sources ${raylib_sources})
@@ -57,8 +61,13 @@ endif()
 
 ### Config options ###
 # Translate the config options to what raylib wants
-if(${PLATFORM} MATCHES "Desktop")
-  set(PLATFORM_CPP "PLATFORM_DESKTOP")
+if(${PLATFORM} MATCHES "Desktop" OR ${PLATFORM} MATCHES "Switch")
+  if (${PLATFORM} MATCHES "Desktop")
+    set(PLATFORM_CPP "PLATFORM_DESKTOP")
+  else()
+    set(PLATFORM_CPP "PLATFORM_SWITCH")
+    add_compile_definitions(PLATFORM_DESKTOP PLATFORM_SWITCH)
+  endif()
 
   if(APPLE)
     # Need to force OpenGL 3.3 on OS X
@@ -119,7 +128,7 @@ elseif(${PLATFORM} MATCHES "Raspberry Pi")
 
 endif()
 
-if (${OPENGL_VERSION})
+if (OPENGL_VERSION)
   set(${SUGGESTED_GRAPHICS} "${GRAPHICS}")
   if (${OPENGL_VERSION} MATCHES "3.3")
     set(GRAPHICS "GRAPHICS_API_OPENGL_33")
@@ -162,6 +171,10 @@ if(STATIC)
   if (${PLATFORM} MATCHES "Desktop")
     target_link_libraries(raylib_static glfw ${GLFW_LIBRARIES} ${LIBS_PRIVATE})
   endif()
+  if (${PLATFORM} MATCHES "Switch")
+    target_link_libraries(raylib_static glfw3 EGL drm_nouveau glapi GLESv1_CM GLESv2 nxd deko3dd deko3d nx m pthread)
+  endif()
+
 
   if (WITH_PIC)
     set_property(TARGET raylib_static PROPERTY POSITION_INDEPENDENT_CODE ON)

--- a/src/CMakeOptions.txt
+++ b/src/CMakeOptions.txt
@@ -2,7 +2,7 @@
 include(CMakeDependentOption)
 include(EnumOption)
 
-enum_option(PLATFORM "Desktop;Web;Android;Raspberry Pi" "Platform to build for.")
+enum_option(PLATFORM "Desktop;Web;Android;Raspberry Pi;Switch" "Platform to build for.")
 
 enum_option(OPENGL_VERSION "OFF;3.3;2.1;1.1;ES 2.0" "Force a specific OpenGL Version?")
 

--- a/src/core.c
+++ b/src/core.c
@@ -34,6 +34,9 @@
 *       Universal Windows Platform support, using OpenGL ES 2.0 through ANGLE on multiple Windows platforms,
 *       including Windows 10 App, Windows Phone and Xbox One platforms.
 *
+*   #define PLATFORM_SWITCH
+*       Windowing and input system configured for the Ninendo Switch Platform
+*
 *   #define SUPPORT_DEFAULT_FONT (default)
 *       Default font is loaded on window initialization to be available for the user to render simple text.
 *       NOTE: If enabled, uses external module functions to load default raylib font (module: text)
@@ -2744,6 +2747,7 @@ static bool InitGraphicsDevice(int width, int height)
 
     // NOTE: Getting video modes is not implemented in emscripten GLFW3 version
 #if defined(PLATFORM_DESKTOP)
+#if !defined(PLATFORM_SWITCH)
     // Find monitor resolution
     GLFWmonitor *monitor = glfwGetPrimaryMonitor();
     if (!monitor)
@@ -2755,6 +2759,10 @@ static bool InitGraphicsDevice(int width, int height)
 
     CORE.Window.display.width = mode->width;
     CORE.Window.display.height = mode->height;
+#else
+    CORE.Window.display.width = width;
+    CORE.Window.display.height = height;
+#endif
 
     // Screen size security check
     if (CORE.Window.screen.width <= 0) CORE.Window.screen.width = CORE.Window.display.width;
@@ -2845,6 +2853,7 @@ static bool InitGraphicsDevice(int width, int height)
 
         // Obtain recommended CORE.Window.display.width/CORE.Window.display.height from a valid videomode for the monitor
         int count = 0;
+#if !defined(PLATFORM_SWITCH)
         const GLFWvidmode *modes = glfwGetVideoModes(glfwGetPrimaryMonitor(), &count);
 
         // Get closest video mode to desired CORE.Window.screen.width/CORE.Window.screen.height
@@ -2860,6 +2869,7 @@ static bool InitGraphicsDevice(int width, int height)
                 }
             }
         }
+#endif
 
 #if defined(PLATFORM_DESKTOP)
         // If we are windowed fullscreen, ensures that window does not minimize when focus is lost


### PR DESCRIPTION
Make file will need some changes
```
if PLATFORM=Switch(May need to change to Switch_HB)
    Check if ENV:DEVKITPRO exists
    // This is due to switch not liking miniaudio
    Disable raudio.c

    // Switch homebrew compiling does not like dynamic linking
    compile as static

    // The switch uses most of the code from the desktop platform core
    // And has precompiler flags setup to block the code that breaks
    // on switch
    define both PLATFORM_SWITCH and PLATFORM_DESKTOP

    // Make sure -lGL is not being assigned anywhere as devkitpro does
    // not supply a direct OpenGL library
    Use external GLFW3 from devkitpro
    Add linking flags:
     -lnx -lm -lpthread -lEGL -lglfw3 -ldrm_nouveau -lglapi
     -lGLESv1_CM -lGLESv2 -lnxd -ldeko3dd -ldeko3d
endif
```