### PR TITLE
Fix build with external glfw on win32

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -189,7 +189,7 @@
 
     // Support retrieving native window handlers
     #if defined(_WIN32)
-        #define GLFW_EXPOSE_NATIVE_WIN32
+        //#define GLFW_EXPOSE_NATIVE_WIN32
         #include <GLFW/glfw3native.h>       // WARNING: It requires customization to avoid windows.h inclusion!
 
         #if !defined(SUPPORT_BUSY_WAIT_LOOP)


### PR DESCRIPTION
This seems to fix the the build with an external glftw (with mingw):
```
~/projects/aur-scripts/mingw-w64-raylib/src/build_i686-w64-mingw32 ~/projects/aur-scripts/mingw-w64-raylib/src
-- The C compiler identification is GNU 10.1.0
-- The CXX compiler identification is GNU 10.1.0
-- Check for working C compiler: /usr/bin/i686-w64-mingw32-gcc
-- Check for working C compiler: /usr/bin/i686-w64-mingw32-gcc - works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/i686-w64-mingw32-g++
-- Check for working CXX compiler: /usr/bin/i686-w64-mingw32-g++ - works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Performing Test COMPILER_HAS_THOSE_TOGGLES
-- Performing Test COMPILER_HAS_THOSE_TOGGLES - Success
-- Testing if -Werror=pointer-arith can be used -- compiles
-- Testing if -Werror=implicit-function-declaration can be used -- compiles
-- Testing if -fno-strict-aliasing can be used -- compiles
-- Testing if file system supports symlinks
-- Testing if file system supports symlinks -- supported
-- Using external GLFW
-- Audio Backend: miniaudio
-- Building raylib shared library
-- Generated build type: Release
-- Compiling with the flags:
--   PLATFORM=PLATFORM_DESKTOP
--   GRAPHICS=GRAPHICS_API_OPENGL_33
-- Configuring done
-- Generating done
CMake Warning:
  Manually-specified variables were not used by the project:

    CMAKE_CROSSCOMPILING_EMULATOR


-- Build files have been written to: /home/xantares/projects/aur-scripts/mingw-w64-raylib/src/build_i686-w64-mingw32
[1/8] Building C object src/CMakeFiles/raylib.dir/core.c.obj
FAILED: src/CMakeFiles/raylib.dir/core.c.obj 
/usr/bin/i686-w64-mingw32-gcc -DGRAPHICS_API_OPENGL_33 -DPLATFORM_DESKTOP -DRAYLIB_CMAKE=1 -D_CRT_SECURE_NO_WARNINGS -Draylib_EXPORTS -I. -I/home/xantares/projects/aur-scripts/mingw-w64-raylib/src/raylib-3.0.0/src/. -fno-strict-aliasing -Werror=implicit-function-declaration -Werror=pointer-arith  -w -O3 -DNDEBUG   -std=gnu99 -MD -MT src/CMakeFiles/raylib.dir/core.c.obj -MF src/CMakeFiles/raylib.dir/core.c.obj.d -o src/CMakeFiles/raylib.dir/core.c.obj   -c /home/xantares/projects/aur-scripts/mingw-w64-raylib/src/raylib-3.0.0/src/core.c
In file included from /usr/i686-w64-mingw32/include/winbase.h:31,
                 from /usr/i686-w64-mingw32/include/windows.h:70,
                 from /usr/i686-w64-mingw32/include/GLFW/glfw3native.h:92,
                 from /home/xantares/projects/aur-scripts/mingw-w64-raylib/src/raylib-3.0.0/src/core.c:197:
/usr/i686-w64-mingw32/include/profileapi.h:16:29: error: conflicting types for ‘QueryPerformanceCounter’
   16 |   WINBASEAPI WINBOOL WINAPI QueryPerformanceCounter (LARGE_INTEGER *lpPerformanceCount);
      |                             ^~~~~~~~~~~~~~~~~~~~~~~
In file included from /home/xantares/projects/aur-scripts/mingw-w64-raylib/src/raylib-3.0.0/src/core.c:140:
/home/xantares/projects/aur-scripts/mingw-w64-raylib/src/raylib-3.0.0/src/gestures.h:145:19: note: previous declaration of ‘QueryPerformanceCounter’ was here
  145 |     int __stdcall QueryPerformanceCounter(unsigned long long int *lpPerformanceCount);
      |                   ^~~~~~~~~~~~~~~~~~~~~~~
In file included from /usr/i686-w64-mingw32/include/winbase.h:31,
                 from /usr/i686-w64-mingw32/include/windows.h:70,
                 from /usr/i686-w64-mingw32/include/GLFW/glfw3native.h:92,
                 from /home/xantares/projects/aur-scripts/mingw-w64-raylib/src/raylib-3.0.0/src/core.c:197:
/usr/i686-w64-mingw32/include/profileapi.h:17:29: error: conflicting types for ‘QueryPerformanceFrequency’
   17 |   WINBASEAPI WINBOOL WINAPI QueryPerformanceFrequency (LARGE_INTEGER *lpFrequency);
      |                             ^~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /home/xantares/projects/aur-scripts/mingw-w64-raylib/src/raylib-3.0.0/src/core.c:140:
/home/xantares/projects/aur-scripts/mingw-w64-raylib/src/raylib-3.0.0/src/gestures.h:146:19: note: previous declaration of ‘QueryPerformanceFrequency’ was here
  146 |     int __stdcall QueryPerformanceFrequency(unsigned long long int *lpFrequency);
      |                   ^~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /usr/i686-w64-mingw32/include/windows.h:71,
                 from /usr/i686-w64-mingw32/include/GLFW/glfw3native.h:92,
                 from /home/xantares/projects/aur-scripts/mingw-w64-raylib/src/raylib-3.0.0/src/core.c:197:
/usr/i686-w64-mingw32/include/wingdi.h:3049:28: error: ‘Rectangle’ redeclared as different kind of symbol
 3049 |   WINGDIAPI WINBOOL WINAPI Rectangle(HDC hdc,int left,int top,int right,int bottom);
      |                            ^~~~~~~~~
In file included from /home/xantares/projects/aur-scripts/mingw-w64-raylib/src/raylib-3.0.0/src/core.c:116:
/home/xantares/projects/aur-scripts/mingw-w64-raylib/src/raylib-3.0.0/src/raylib.h:219:3: note: previous declaration of ‘Rectangle’ was here
  219 | } Rectangle;
      |   ^~~~~~~~~
In file included from /home/xantares/projects/aur-scripts/mingw-w64-raylib/src/raylib-3.0.0/src/core.c:116:
/home/xantares/projects/aur-scripts/mingw-w64-raylib/src/raylib-3.0.0/src/raylib.h:160:21: error: conflicting types for ‘UnhideWindow’
  160 | #define ShowWindow  UnhideWindow
      |                     ^~~~~~~~~~~~
In file included from /home/xantares/projects/aur-scripts/mingw-w64-raylib/src/raylib-3.0.0/src/core.c:116:
/home/xantares/projects/aur-scripts/mingw-w64-raylib/src/raylib-3.0.0/src/raylib.h:881:12: note: previous declaration of ‘UnhideWindow’ was here
  881 | RLAPI void UnhideWindow(void);                                    // Show the window
      |            ^~~~~~~~~~~~
In file included from /usr/i686-w64-mingw32/include/windows.h:72,
                 from /usr/i686-w64-mingw32/include/GLFW/glfw3native.h:92,
                 from /home/xantares/projects/aur-scripts/mingw-w64-raylib/src/raylib-3.0.0/src/core.c:197:
/usr/i686-w64-mingw32/include/winuser.h:2213:29: error: conflicting types for ‘CloseWindow’
 2213 |   WINUSERAPI WINBOOL WINAPI CloseWindow (HWND hWnd);
      |                             ^~~~~~~~~~~
In file included from /home/xantares/projects/aur-scripts/mingw-w64-raylib/src/raylib-3.0.0/src/core.c:116:
/home/xantares/projects/aur-scripts/mingw-w64-raylib/src/raylib-3.0.0/src/raylib.h:874:12: note: previous declaration of ‘CloseWindow’ was here
  874 | RLAPI void CloseWindow(void);                                     // Close window and unload OpenGL context
      |            ^~~~~~~~~~~
In file included from /usr/i686-w64-mingw32/include/windows.h:72,
                 from /usr/i686-w64-mingw32/include/GLFW/glfw3native.h:92,
                 from /home/xantares/projects/aur-scripts/mingw-w64-raylib/src/raylib-3.0.0/src/core.c:197:
/usr/i686-w64-mingw32/include/winuser.h:3612:25: error: conflicting types for ‘ShowCursor’
 3612 |   WINUSERAPI int WINAPI ShowCursor(WINBOOL bShow);
      |                         ^~~~~~~~~~
In file included from /home/xantares/projects/aur-scripts/mingw-w64-raylib/src/raylib-3.0.0/src/core.c:116:
/home/xantares/projects/aur-scripts/mingw-w64-raylib/src/raylib-3.0.0/src/raylib.h:903:12: note: previous declaration of ‘ShowCursor’ was here
  903 | RLAPI void ShowCursor(void);                                      // Shows cursor
      |            ^~~~~~~~~~
/home/xantares/projects/aur-scripts/mingw-w64-raylib/src/raylib-3.0.0/src/core.c:482:13: error: conflicting types for ‘SwapBuffers’
  482 | static void SwapBuffers(void);                          // Copy back buffer to front buffers
      |             ^~~~~~~~~~~
In file included from /usr/i686-w64-mingw32/include/windows.h:71,
                 from /usr/i686-w64-mingw32/include/GLFW/glfw3native.h:92,
                 from /home/xantares/projects/aur-scripts/mingw-w64-raylib/src/raylib-3.0.0/src/core.c:197:
/usr/i686-w64-mingw32/include/wingdi.h:4186:28: note: previous declaration of ‘SwapBuffers’ was here
 4186 |   WINGDIAPI WINBOOL WINAPI SwapBuffers(HDC);
      |                            ^~~~~~~~~~~
/home/xantares/projects/aur-scripts/mingw-w64-raylib/src/raylib-3.0.0/src/core.c: In function ‘InitWindow’:
/home/xantares/projects/aur-scripts/mingw-w64-raylib/src/raylib-3.0.0/src/core.c:691:14: error: expected ‘;’ before ‘rec’
  691 |     Rectangle rec = GetFontDefault().recs[95];
      |              ^~~~
      |              ;
/home/xantares/projects/aur-scripts/mingw-w64-raylib/src/raylib-3.0.0/src/core.c:693:59: error: expected ‘)’ before ‘{’ token
  693 |     SetShapesTexture(GetFontDefault().texture, (Rectangle){ rec.x + 1, rec.y + 1, rec.width - 2, rec.height - 2 });
      |                                                           ^
      |                                                           )
/home/xantares/projects/aur-scripts/mingw-w64-raylib/src/raylib-3.0.0/src/core.c:693:48: error: incompatible type for argument 2 of ‘SetShapesTexture’
  693 |     SetShapesTexture(GetFontDefault().texture, (Rectangle){ rec.x + 1, rec.y + 1, rec.width - 2, rec.height - 2 });
      |                                                ^~~~~~~~~~~
      |                                                |
      |                                                WINBOOL (__attribute__((stdcall)) *)(struct HDC__ *, int,  int,  int,  int) {aka int (__attribute__((stdcall)) *)(struct HDC__ *, int,  int,  int,  int)}
In file included from /home/xantares/projects/aur-scripts/mingw-w64-raylib/src/raylib-3.0.0/src/core.c:136:
/home/xantares/projects/aur-scripts/mingw-w64-raylib/src/raylib-3.0.0/src/rlgl.h:2971:52: note: expected ‘Rectangle’ but argument is of type ‘WINBOOL (__attribute__((stdcall)) *)(struct HDC__ *, int,  int,  int,  int)’ {aka ‘int (__attribute__((stdcall)) *)(struct HDC__ *, int,  int,  int,  int)’}
 2971 | void SetShapesTexture(Texture2D texture, Rectangle source)
      |                                          ~~~~~~~~~~^~~~~~
In file included from /home/xantares/projects/aur-scripts/mingw-w64-raylib/src/raylib-3.0.0/src/core.c:116:
/home/xantares/projects/aur-scripts/mingw-w64-raylib/src/raylib-3.0.0/src/core.c: In function ‘EndDrawing’:
/home/xantares/projects/aur-scripts/mingw-w64-raylib/src/raylib-3.0.0/src/raylib.h:136:35: error: incompatible type for argument 5 of ‘DrawTextA’
  136 | #define MAROON     CLITERAL(Color){ 190, 33, 55, 255 }     // Maroon
      |                                   ^~~~~~~~~~~~~~~~~~~~
      |                                   |
      |                                   Color
/home/xantares/projects/aur-scripts/mingw-w64-raylib/src/raylib-3.0.0/src/core.c:1297:75: note: in expansion of macro ‘MAROON’
 1297 |             DrawText("RECORDING", 50, CORE.Window.screen.height - 25, 10, MAROON);
      |                                                                           ^~~~~~
In file included from /usr/i686-w64-mingw32/include/windows.h:72,
                 from /usr/i686-w64-mingw32/include/GLFW/glfw3native.h:92,
                 from /home/xantares/projects/aur-scripts/mingw-w64-raylib/src/raylib-3.0.0/src/core.c:197:
/usr/i686-w64-mingw32/include/winuser.h:3335:88: note: expected ‘UINT’ {aka ‘unsigned int’} but argument is of type ‘Color’
 3335 |   WINUSERAPI int WINAPI DrawTextA(HDC hdc,LPCSTR lpchText,int cchText,LPRECT lprc,UINT format);
      |                                                                                   ~~~~~^~~~~~
[5/8] Building C object src/CMakeFiles/raylib.dir/models.c.obj
```