### PR TITLE
Added bool IsCursorOnScreen(void).

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -1318,6 +1318,12 @@ void DisableCursor(void)
     CORE.Input.Mouse.cursorHidden = true;
 }
 
+// Check if cursor is on the current screen.
+bool IsCursorOnScreen(void)
+{
+    return CORE.Input.Mouse.cursorOnScreen;
+}
+
 // Set background color (framebuffer clear color)
 void ClearBackground(Color color)
 {

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -903,6 +903,7 @@ RLAPI void HideCursor(void);                                      // Hides curso
 RLAPI bool IsCursorHidden(void);                                  // Check if cursor is not visible
 RLAPI void EnableCursor(void);                                    // Enables cursor (unlock cursor)
 RLAPI void DisableCursor(void);                                   // Disables cursor (lock cursor)
+RLAPI bool IsCursorOnScreen(void);                                // Check if cursor is on the current screen.
 
 // Drawing-related functions
 RLAPI void ClearBackground(Color color);                          // Set background color (framebuffer clear color)


### PR DESCRIPTION
The camera in my game can move when the cursor is at the edges of the screen. However it will still move when it is outside the screen. I could try to find a workaround but I saw cursorOnScreen is stored in core.c. It is called IsCursorOnScreen instead of IsMouseOnScreen to match other cursor functions like IsCursorHidden.

Example usage:
```c
if (IsCursorOnScreen())
{
    TraceLog(LOG_INFO, "Cursor on screen!");
}
else
{
    TraceLog(LOG_INFO, "Cursor off screen!");
}
```

To check if the mouse entered or exited the window you have to store the previous state of IsCursorOnScreen. This seems to be how similar functions in core work.

```c
// Load
bool cursorOnScreen = false;
bool lastCursorOnScreen = false;

// Update
cursorOnScreen = IsCursorOnScreen();
if (cursorOnScreen && !lastCursorOnScreen)
{
    TraceLog(LOG_INFO, "Cursor enter screen");
}
else if (!cursorOnScreen && lastCursorOnScreen)
{
    TraceLog(LOG_INFO, "Cursor exit screen");
}
lastCursorOnScreen = cursorOnScreen;
```