### PR TITLE
Fix extra memory allocated when updating color buffer in mesh

### DIFF
--- a/src/rlgl.h
+++ b/src/rlgl.h
@@ -2587,7 +2587,7 @@ void rlUpdateMeshAt(Mesh mesh, int buffer, int count, int index)
         case 3:     // Update colors (vertex colors)
         {
             glBindBuffer(GL_ARRAY_BUFFER, mesh.vboId[3]);
-            if (index == 0 && count >= mesh.vertexCount) glBufferData(GL_ARRAY_BUFFER, count*4*sizeof(float), mesh.colors, GL_DYNAMIC_DRAW);
+            if (index == 0 && count >= mesh.vertexCount) glBufferData(GL_ARRAY_BUFFER, count*4*sizeof(unsigned char), mesh.colors, GL_DYNAMIC_DRAW);
             else if (index + count >= mesh.vertexCount) break;
             else glBufferSubData(GL_ARRAY_BUFFER, index*4*sizeof(unsigned char), count*4*sizeof(unsigned char), mesh.colors);
 


### PR DESCRIPTION
Updating the whole color buffer of a mesh would allocate and copy memory for `vertexCount * 4` `float`s instead of `unsigned char`, leading to extra memory allocation as well as data being copied beyond the color buffer.