### PR TITLE
Fix wrong height used when using scissor mode with render texture of different height from window

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -1536,7 +1536,7 @@ void BeginScissorMode(int x, int y, int width, int height)
     rlglDraw(); // Force drawing elements
 
     rlEnableScissorTest();
-    rlScissor(x, GetScreenHeight() - (y + height), width, height);
+    rlScissor(x, CORE.Window.currentFbo.height - (y + height), width, height);
 }
 
 // End scissor mode


### PR DESCRIPTION
Scissor mode implementation uses global window height instead of the current framebuffer height when calculating scissor mode coordinates, leading to inconsistent scissor mode when drawing to smaller framebuffers.