### PR TITLE
* added macros for compilation.  See issue 1273 in raysan5/raylib

### DIFF
--- a/src/raudio.c
+++ b/src/raudio.c
@@ -127,8 +127,14 @@
 
 // Type required before windows.h inclusion
 typedef struct tagMSG *LPMSG;
-
+ 
+#define CloseWindow CloseWindowDontUse
+#define ShowCursor ShowCursorDontUse
+#define UnhideWindow UnHideWindowDontUse
 #include <windows.h>
+#undef UnhideWindow
+#undef ShowCursor
+#undef CloseWindow
 
 // Type required by some unused function...
 typedef struct tagBITMAPINFOHEADER {


### PR DESCRIPTION
This project as is does not compile on Windows.  There are conflicting symbols that are included indirectly in windows.h on MinGW-32.  These changes let it compile, though it it doesn't result in a working DLL.  Instead, the right-arrow is marked as always pressed.