### PR TITLE
GetPixelColor: Fix incorrect color transform to 255 space

### DIFF
--- a/src/textures.c
+++ b/src/textures.c
@@ -3543,26 +3543,26 @@ Color GetPixelColor(void *srcPtr, int format)
         case UNCOMPRESSED_GRAY_ALPHA: col = (Color){ ((unsigned char *)srcPtr)[0], ((unsigned char *)srcPtr)[0], ((unsigned char *)srcPtr)[0], ((unsigned char *)srcPtr)[1] }; break;
         case UNCOMPRESSED_R5G6B5:
         {
-            col.r = (unsigned char)(((((unsigned short *)srcPtr)[0] >> 11)*31)/255);
-            col.g = (unsigned char)((((((unsigned short *)srcPtr)[0] >> 5) & 0b0000000000111111)*63)/255);
-            col.b = (unsigned char)(((((unsigned short *)srcPtr)[0] & 0b0000000000011111)*31)/255);
+            col.r = (unsigned char)((((unsigned short *)srcPtr)[0] >> 11)*255/31);
+            col.g = (unsigned char)(((((unsigned short *)srcPtr)[0] >> 5) & 0b0000000000111111)*255/63);
+            col.b = (unsigned char)((((unsigned short *)srcPtr)[0] & 0b0000000000011111)*255/31);
             col.a = 255;
             
         } break;
         case UNCOMPRESSED_R5G5B5A1:
         {
-            col.r = (unsigned char)(((((unsigned short *)srcPtr)[0] >> 11)*31)/255);
-            col.g = (unsigned char)((((((unsigned short *)srcPtr)[0] >> 6) & 0b0000000000011111)*31)/255);
-            col.b = (unsigned char)(((((unsigned short *)srcPtr)[0] & 0b0000000000011111)*31)/255);
+            col.r = (unsigned char)((((unsigned short *)srcPtr)[0] >> 11)*255/31);
+            col.g = (unsigned char)(((((unsigned short *)srcPtr)[0] >> 6) & 0b0000000000011111)*255/31);
+            col.b = (unsigned char)((((unsigned short *)srcPtr)[0] & 0b0000000000011111)*255/31);
             col.a = (((unsigned short *)srcPtr)[0] & 0b0000000000000001)? 255 : 0;
 
         } break;
         case UNCOMPRESSED_R4G4B4A4:
         {
-            col.r = (unsigned char)(((((unsigned short *)srcPtr)[0] >> 12)*15)/255);
-            col.g = (unsigned char)((((((unsigned short *)srcPtr)[0] >> 8) & 0b0000000000001111)*15)/255);
-            col.b = (unsigned char)((((((unsigned short *)srcPtr)[0] >> 4) & 0b0000000000001111)*15)/255);
-            col.a = (unsigned char)(((((unsigned short *)srcPtr)[0] & 0b0000000000001111)*15)/255);
+            col.r = (unsigned char)((((unsigned short *)srcPtr)[0] >> 12)*255/15);
+            col.g = (unsigned char)(((((unsigned short *)srcPtr)[0] >> 8) & 0b0000000000001111)*255/15);
+            col.b = (unsigned char)(((((unsigned short *)srcPtr)[0] >> 4) & 0b0000000000001111)*255/15);
+            col.a = (unsigned char)((((unsigned short *)srcPtr)[0] & 0b0000000000001111)*255/15);
             
         } break;
         case UNCOMPRESSED_R8G8B8A8: col = (Color){ ((unsigned char *)srcPtr)[0], ((unsigned char *)srcPtr)[1], ((unsigned char *)srcPtr)[2], ((unsigned char *)srcPtr)[3] }; break;


### PR DESCRIPTION
Reproducing case

```cpp
#include <assert.h>
int main(int argc, char **argv)
{
    Color color = {};
    color.r     = 255;
    color.b     = 255;

    uint16_t pixel = {};
    SetPixelColor(&pixel, color, UNCOMPRESSED_R5G6B5);
    Color color_after = GetPixelColor(&pixel, UNCOMPRESSED_R5G6B5);

    assert(color.r == color_after.r);
    assert(color.g == color_after.g);
    assert(color.b == color_after.b);
    return 0;
}
```

Previously, for RGB565 the color component is stored with a range of [0, 31] in the uncompressed format. Before this patch, suppose a pixel that's completely red in RGB565 := (R31, G0, B0), GetPixelColor will convert to 255 space and do

```
R = (31 * 31)  / 255
R = 961 / 255
R = 3.7
```

Where as we expect a completely red pixel in RGB565 to return 255 for red. Patch fixes the conversion

```
R = 31 / 31 * 255
R = 1 * 255
R = 255
```

Patch actually does `(31 * 255 / 31)` (i.e. multiply by larger coefficient first) to minimize precision loss in the 16 bit space.

