### PR TITLE
scale perspective top calc for near culling plane

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -1443,7 +1443,7 @@ void BeginMode3D(Camera3D camera)
     if (camera.type == CAMERA_PERSPECTIVE)
     {
         // Setup perspective projection
-        double top = 0.01*tan(camera.fovy*0.5*DEG2RAD);
+        double top = RL_CULL_DISTANCE_NEAR*tan(camera.fovy*0.5*DEG2RAD);
         double right = top*aspect;
 
         rlFrustum(-right, right, -top, top, RL_CULL_DISTANCE_NEAR, RL_CULL_DISTANCE_FAR);


### PR DESCRIPTION
I was adjusting `RL_CULL_DISTANCE_NEAR` and found the remaining hard coded `0.01` scaling value used for perspective top/right frustum calculations needed adjustment too. I suggest this change gives more intuitive results from `BeginMode3D` when people first try changing `RL_CULL_DISTANCE_NEAR` and expect only the near plane to move.