### PR TITLE
clamp ray hit y position to ground plane height

### DIFF
--- a/src/models.c
+++ b/src/models.c
@@ -2862,6 +2862,7 @@ RayHitInfo GetCollisionRayGround(Ray ray, float groundHeight)
             result.distance = distance;
             result.normal = (Vector3){ 0.0, 1.0, 0.0 };
             result.position = Vector3Add(ray.position, Vector3Scale(ray.direction, distance));
+            result.position.y = groundHeight;
         }
     }
 


### PR DESCRIPTION
When intersecting from a `Ray` to a `Y` ground plane, error can accumulate in resulting `RayHitInfo.position.y`, and it may be negative (beneath the supplied positive Y-normal plane).

Example: It's possible to call `GetCollisionRayGround(<mouse ray>, 0.0f)` and intermittently get results that flip flop between `(Vector3){..., 0.0, ...}` and `(Vector3){..., -0.000001, ...}`.

I suggest this should be cleanly clamped to `groundHeight` since we know the hit position must occur on the supplied plane, or not at all.