### PR TITLE
[wip] MeshNormalsSmooth()

### DIFF
--- a/src/models.c
+++ b/src/models.c
@@ -2474,7 +2474,7 @@ void MeshBinormals(Mesh *mesh)
 }
 
 // Smooth (average) vertex normals
-void MeshSmoothNormals(Mesh *mesh)
+void MeshNormalsSmooth(Mesh *mesh)
 {
     #define EPSILON 0.000001 // A small number
 

--- a/src/models.c
+++ b/src/models.c
@@ -2473,6 +2473,74 @@ void MeshBinormals(Mesh *mesh)
     }
 }
 
+// Smooth (average) vertex normals
+void MeshSmoothNormals(Mesh *mesh)
+{
+    #define EPSILON 0.000001 // A small number
+
+    int uvCounter = 0;
+    Vector3 *uniqueVertices = (Vector3 *)RL_CALLOC(mesh->vertexCount, sizeof(Vector3));
+    Vector3 *summedNormals = (Vector3 *)RL_CALLOC(mesh->vertexCount, sizeof(Vector3));
+
+    int uiCounter = 0;
+    int *uniqueIndicies = (int *)RL_CALLOC(mesh->vertexCount, sizeof(int));
+
+    // Sum normals grouped by vertex
+    for (int i = 0; i < mesh->vertexCount; i++)
+    {
+        Vector3 v = { mesh->vertices[(i + 0)*3 + 0], mesh->vertices[(i + 0)*3 + 1], mesh->vertices[(i + 0)*3 + 2] };
+        Vector3 n = { mesh->normals[(i + 0)*3 + 0], mesh->normals[(i + 0)*3 + 1], mesh->normals[(i + 0)*3 + 2] };
+
+        bool matched = false;
+
+        // TODO: Matching vertices is brute force O(N). Do it more efficiently?
+        for (int j = 0; j < uvCounter; j++)
+        {
+            Vector3 uv = uniqueVertices[j];
+
+            bool match = true;
+            match = match && fabs(uv.x - v.x) < EPSILON;
+            match = match && fabs(uv.y - v.y) < EPSILON;
+            match = match && fabs(uv.z - v.z) < EPSILON;
+
+            if (match)
+            {
+                matched = true;
+                summedNormals[j] = Vector3Add(summedNormals[j], n);
+                uniqueIndicies[i] = j;
+                break;
+            }
+        }
+
+        if (!matched)
+        {
+            int j = uvCounter++;
+            uniqueVertices[j] = v;
+            summedNormals[j] = n;
+            uniqueIndicies[i] = j;
+        }
+    }
+
+    // Average and update normals
+    for (int i = 0; i < mesh->vertexCount; i++)
+    {
+        int j = uniqueIndicies[i];
+        Vector3 n = Vector3Normalize(summedNormals[j]);
+        mesh->normals[(i + 0)*3 + 0] = n.x;
+        mesh->normals[(i + 0)*3 + 1] = n.y;
+        mesh->normals[(i + 0)*3 + 2] = n.z;
+    }
+
+    // 2=normals, see rlUpdateMeshAt()
+    rlUpdateMesh(*mesh, 2, mesh->vertexCount);
+
+    RL_FREE(uniqueVertices);
+    RL_FREE(summedNormals);
+    RL_FREE(uniqueIndicies);
+
+    TRACELOG(LOG_INFO, "MESH: Normals smoothed (%d vertices, %d unique)", mesh->vertexCount, uvCounter);
+}
+
 // Draw a model (with texture if set)
 void DrawModel(Model model, Vector3 position, float scale, Color tint)
 {

--- a/src/models.c
+++ b/src/models.c
@@ -2493,7 +2493,7 @@ void MeshSmoothNormals(Mesh *mesh)
 
         bool matched = false;
 
-        // TODO: Matching vertices is brute force O(N). Do it more efficiently?
+        // TODO: Matching vertices is brute force O(N^2). Do it more efficiently?
         for (int j = 0; j < uvCounter; j++)
         {
             Vector3 uv = uniqueVertices[j];

--- a/src/models.c
+++ b/src/models.c
@@ -2483,7 +2483,7 @@ void MeshSmoothNormals(Mesh *mesh)
     Vector3 *summedNormals = (Vector3 *)RL_CALLOC(mesh->vertexCount, sizeof(Vector3));
 
     int uiCounter = 0;
-    int *uniqueIndicies = (int *)RL_CALLOC(mesh->vertexCount, sizeof(int));
+    int *uniqueIndices = (int *)RL_CALLOC(mesh->vertexCount, sizeof(int));
 
     // Sum normals grouped by vertex
     for (int i = 0; i < mesh->vertexCount; i++)
@@ -2507,7 +2507,7 @@ void MeshSmoothNormals(Mesh *mesh)
             {
                 matched = true;
                 summedNormals[j] = Vector3Add(summedNormals[j], n);
-                uniqueIndicies[i] = j;
+                uniqueIndices[i] = j;
                 break;
             }
         }
@@ -2517,14 +2517,14 @@ void MeshSmoothNormals(Mesh *mesh)
             int j = uvCounter++;
             uniqueVertices[j] = v;
             summedNormals[j] = n;
-            uniqueIndicies[i] = j;
+            uniqueIndices[i] = j;
         }
     }
 
     // Average and update normals
     for (int i = 0; i < mesh->vertexCount; i++)
     {
-        int j = uniqueIndicies[i];
+        int j = uniqueIndices[i];
         Vector3 n = Vector3Normalize(summedNormals[j]);
         mesh->normals[(i + 0)*3 + 0] = n.x;
         mesh->normals[(i + 0)*3 + 1] = n.y;
@@ -2536,7 +2536,7 @@ void MeshSmoothNormals(Mesh *mesh)
 
     RL_FREE(uniqueVertices);
     RL_FREE(summedNormals);
-    RL_FREE(uniqueIndicies);
+    RL_FREE(uniqueIndices);
 
     TRACELOG(LOG_INFO, "MESH: Normals smoothed (%d vertices, %d unique)", mesh->vertexCount, uvCounter);
 }

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1325,6 +1325,7 @@ RLAPI Mesh GenMeshCubicmap(Image cubicmap, Vector3 cubeSize);                   
 RLAPI BoundingBox MeshBoundingBox(Mesh mesh);                                                           // Compute mesh bounding box limits
 RLAPI void MeshTangents(Mesh *mesh);                                                                    // Compute mesh tangents
 RLAPI void MeshBinormals(Mesh *mesh);                                                                   // Compute mesh binormals
+RLAPI void MeshSmoothNormals(Mesh *mesh);                                                               // Smooth (average) vertex normals
 
 // Model drawing functions
 RLAPI void DrawModel(Model model, Vector3 position, float scale, Color tint);                           // Draw a model (with texture if set)

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1325,7 +1325,7 @@ RLAPI Mesh GenMeshCubicmap(Image cubicmap, Vector3 cubeSize);                   
 RLAPI BoundingBox MeshBoundingBox(Mesh mesh);                                                           // Compute mesh bounding box limits
 RLAPI void MeshTangents(Mesh *mesh);                                                                    // Compute mesh tangents
 RLAPI void MeshBinormals(Mesh *mesh);                                                                   // Compute mesh binormals
-RLAPI void MeshSmoothNormals(Mesh *mesh);                                                               // Smooth (average) vertex normals
+RLAPI void MeshNormalsSmooth(Mesh *mesh);                                                               // Smooth (average) vertex normals
 
 // Model drawing functions
 RLAPI void DrawModel(Model model, Vector3 position, float scale, Color tint);                           // Draw a model (with texture if set)


### PR DESCRIPTION
Probably still [wip] and [rfc] but this is working for me and perhaps is generally useful.

`MeshSmoothNormals` sums and averages vertex normals. I use it for visually smoothing terrain generated by `GenMeshHeightmap`.