### PR TITLE
Fix color of ambient light

### DIFF
--- a/examples/shaders/resources/shaders/glsl330/lighting.fs
+++ b/examples/shaders/resources/shaders/glsl330/lighting.fs
@@ -75,7 +75,7 @@ void main()
     }
 
     finalColor = (texelColor*((colDiffuse + vec4(specular, 1.0))*vec4(lightDot, 1.0)));
-    finalColor += texelColor*(ambient/10.0);
+    finalColor += texelColor*(ambient/10.0)*colDiffuse;
     
     // Gamma correction
     finalColor = pow(finalColor, vec4(1.0/2.2));


### PR DESCRIPTION
The shader as it is right now renders it like this:
![image](https://user-images.githubusercontent.com/54390138/88886627-bc9cc100-d1ef-11ea-8cf8-16d11bbe8f48.png)

But with the change, it looks like this:
![image](https://user-images.githubusercontent.com/54390138/88886642-c3c3cf00-d1ef-11ea-9cca-f27475188aaa.png)

The problem is that the shader currently is not multiplying the ambient color by the texture diffuse color, so it's just using a white texture multiplied by the `ambient` vector as the diffuse layer. We can simply resolve this by just multiplying by the diffuse color.