### PR TITLE
new windows functions allows borderless mode

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -350,6 +350,7 @@ typedef struct CoreData {
         const char *title;                  // Window text title const pointer
         bool ready;                         // Flag to check if window has been initialized successfully
         bool minimized;                     // Flag to check if window has been minimized
+        bool maximized;                     // Flag to check if window has been maximized
         bool focused;                       // Flag to check if window has been focused
         bool resized;                       // Flag to check if window has been resized
         bool fullscreen;                    // Flag to check if fullscreen mode required
@@ -501,6 +502,7 @@ static void WindowSizeCallback(GLFWwindow *window, int width, int height);      
 static void WindowIconifyCallback(GLFWwindow *window, int iconified);                      // GLFW3 WindowIconify Callback, runs when window is minimized/restored
 static void WindowFocusCallback(GLFWwindow *window, int focused);                          // GLFW3 WindowFocus Callback, runs when window get/lose focus
 static void WindowDropCallback(GLFWwindow *window, int count, const char **paths);         // GLFW3 Window Drop Callback, runs when drop files into window
+static void WindowMaximizeCallback(GLFWwindow *window, int maximized);                     // GLFW3 Window Maximize Callback, runs when window is maximized
 #endif
 
 #if defined(PLATFORM_ANDROID)
@@ -874,6 +876,16 @@ bool IsWindowMinimized(void)
 #endif
 }
 
+// Check if window has been maximized (only PLATFORM_DESKTOP)
+bool IsWindowMaximized(void)
+{
+#if defined(PLATFORM_DESKTOP)
+    return CORE.Window.maximized;
+#else
+    return false;
+#endif
+}
+
 // Check if window has the focus
 bool IsWindowFocused(void)
 {
@@ -1072,6 +1084,44 @@ void HideWindow(void)
 {
 #if defined(PLATFORM_DESKTOP)
     glfwHideWindow(CORE.Window.handle);
+#endif
+}
+
+// Decorate the window (only PLATFORM_DESKTOP)
+void DecorateWindow(void)
+{
+#if defined(PLATFORM_DESKTOP)
+    glfwSetWindowAttrib(CORE.Window.handle, GLFW_DECORATED, GLFW_TRUE);
+#endif
+}
+
+// // Undecorate the window (only PLATFORM_DESKTOP)
+void UndecorateWindow(void)
+{
+#if defined(PLATFORM_DESKTOP)
+    glfwSetWindowAttrib(CORE.Window.handle, GLFW_DECORATED, GLFW_FALSE);
+#endif
+}
+
+// Maximize the window, if resizable (only PLATFORM_DESKTOP)
+void MaximizeWindow(void)
+{
+#if defined(PLATFORM_DESKTOP)
+    if (glfwGetWindowAttrib(CORE.Window.handle, GLFW_RESIZABLE) == GLFW_TRUE)
+    {
+        glfwMaximizeWindow(CORE.Window.handle);
+    }
+#endif
+}
+
+// Restore the window, if resizable (only PLATFORM_DESKTOP)
+void RestoreWindow(void)
+{
+#if defined(PLATFORM_DESKTOP)
+    if (glfwGetWindowAttrib(CORE.Window.handle, GLFW_RESIZABLE) == GLFW_TRUE)
+    {
+        glfwRestoreWindow(CORE.Window.handle);
+    }
 #endif
 }
 
@@ -2880,6 +2930,7 @@ static bool InitGraphicsDevice(int width, int height)
     glfwSetWindowIconifyCallback(CORE.Window.handle, WindowIconifyCallback);
     glfwSetWindowFocusCallback(CORE.Window.handle, WindowFocusCallback);
     glfwSetDropCallback(CORE.Window.handle, WindowDropCallback);
+    glfwSetWindowMaximizeCallback(CORE.Window.handle, WindowMaximizeCallback);
 
     glfwMakeContextCurrent(CORE.Window.handle);
 
@@ -3936,6 +3987,12 @@ static void WindowDropCallback(GLFWwindow *window, int count, const char **paths
     }
 
     CORE.Window.dropFilesCount = count;
+}
+
+static void WindowMaximizeCallback(GLFWwindow *window, int maximized)
+{
+    if (maximized) CORE.Window.maximized = true;  // The window was maximized
+    else CORE.Window.maximized = false;           // The window was restored
 }
 #endif
 

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -871,6 +871,7 @@ RLAPI bool WindowShouldClose(void);                               // Check if KE
 RLAPI void CloseWindow(void);                                     // Close window and unload OpenGL context
 RLAPI bool IsWindowReady(void);                                   // Check if window has been initialized successfully
 RLAPI bool IsWindowMinimized(void);                               // Check if window has been minimized
+RLAPI bool IsWindowMaximized(void);                               // Check if window has been maximized (only PLATFORM_DESKTOP)
 RLAPI bool IsWindowFocused(void);                                 // Check if window has been focused
 RLAPI bool IsWindowResized(void);                                 // Check if window has been resized
 RLAPI bool IsWindowHidden(void);                                  // Check if window is currently hidden
@@ -878,6 +879,10 @@ RLAPI bool IsWindowFullscreen(void);                              // Check if wi
 RLAPI void ToggleFullscreen(void);                                // Toggle fullscreen mode (only PLATFORM_DESKTOP)
 RLAPI void UnhideWindow(void);                                    // Show the window
 RLAPI void HideWindow(void);                                      // Hide the window
+RLAPI void DecorateWindow(void);                                  // Decorate the window (only PLATFORM_DESKTOP)
+RLAPI void UndecorateWindow(void);                                // Undecorate the window (only PLATFORM_DESKTOP)
+RLAPI void MaximizeWindow(void);                                  // Maximize the window, if resizable (only PLATFORM_DESKTOP)
+RLAPI void RestoreWindow(void);                                   // Restore the window, if resizable (only PLATFORM_DESKTOP)
 RLAPI void SetWindowIcon(Image image);                            // Set icon for window (only PLATFORM_DESKTOP)
 RLAPI void SetWindowTitle(const char *title);                     // Set title for window (only PLATFORM_DESKTOP)
 RLAPI void SetWindowPosition(int x, int y);                       // Set window position on screen (only PLATFORM_DESKTOP)


### PR DESCRIPTION
Hi, I've added the following windows related functions.

**New functions, desktop only** 
```c
// Decorate the window (only PLATFORM_DESKTOP)
void DecorateWindow(void);
 // Undecorate the window (only PLATFORM_DESKTOP)
void UndecorateWindow(void);

 // Maximize the window, if resizable (only PLATFORM_DESKTOP)
void MaximizeWindow(void);
// Restore the window, if resizable (only PLATFORM_DESKTOP)
void RestoreWindow(void);
 // Check if window has been maximized (only PLATFORM_DESKTOP) 
bool IsWindowMaximized(void);
```

**Usage**
For example with the new functions, for set full-screen windowed borderless mode you could do:

```c
SetConfigFlags(FLAG_WINDOW_RESIZABLE);
InitWindow(screenWidth, screenHeight, "some game");    
    
MaximizeWindow();
UndecorateWindow();
```

To restore to the normal windowed

```c
RestoreWindow();
DecorateWindow();
```
**Additional Context**

The rationality behind is to allow games to have full screen windowed borderless modes. 

Many players nowadays like to be playing their games meanwhile doing other things, such watching youtube, chatting on discord and so on.

Those gamers really prefer borderless modes that are faster for switching between applications, and even better with multiple monitors since the mouse is free to move between screens without alt-tabbing.
