### PR TITLE
Fixed unused return value warnings on GCC

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -145,7 +145,7 @@
     #include "camera.h"             // Camera system functionality
 #endif
 
-#define IgnoreResult(x) if (x) {}  // This should fix compiler warnings
+#define IGNORE_RESULT(x) if (x) {}  // This should fix compiler warnings
 
 #if defined(SUPPORT_GIF_RECORDING)
     #define RGIF_MALLOC RL_MALLOC
@@ -2061,7 +2061,7 @@ const char *GetWorkingDirectory(void)
     static char currentDir[MAX_FILEPATH_LENGTH];
     memset(currentDir, 0, MAX_FILEPATH_LENGTH);
 
-    IgnoreResult(GETCWD(currentDir, MAX_FILEPATH_LENGTH - 1));
+    IGNORE_RESULT(GETCWD(currentDir, MAX_FILEPATH_LENGTH - 1));
 
     return currentDir;
 }
@@ -2328,7 +2328,7 @@ void OpenURL(const char *url)
     #elif defined(__APPLE__)
         sprintf(cmd, "open '%s'", url);
     #endif
-        IgnoreResult(system(cmd));
+        IGNORE_RESULT(system(cmd));
         RL_FREE(cmd);
 #endif
 #if defined(PLATFORM_WEB)

--- a/src/core.c
+++ b/src/core.c
@@ -145,6 +145,8 @@
     #include "camera.h"             // Camera system functionality
 #endif
 
+#define ignore_result(x) if (x) {}  // This should fix compiler warnings
+
 #if defined(SUPPORT_GIF_RECORDING)
     #define RGIF_MALLOC RL_MALLOC
     #define RGIF_FREE RL_FREE
@@ -2059,7 +2061,7 @@ const char *GetWorkingDirectory(void)
     static char currentDir[MAX_FILEPATH_LENGTH];
     memset(currentDir, 0, MAX_FILEPATH_LENGTH);
 
-    GETCWD(currentDir, MAX_FILEPATH_LENGTH - 1);
+    ignore_result(GETCWD(currentDir, MAX_FILEPATH_LENGTH - 1));
 
     return currentDir;
 }
@@ -2326,7 +2328,7 @@ void OpenURL(const char *url)
     #elif defined(__APPLE__)
         sprintf(cmd, "open '%s'", url);
     #endif
-        system(cmd);
+        ignore_result(system(cmd));
         RL_FREE(cmd);
 #endif
 #if defined(PLATFORM_WEB)

--- a/src/core.c
+++ b/src/core.c
@@ -145,7 +145,7 @@
     #include "camera.h"             // Camera system functionality
 #endif
 
-#define ignore_result(x) if (x) {}  // This should fix compiler warnings
+#define IgnoreResult(x) if (x) {}  // This should fix compiler warnings
 
 #if defined(SUPPORT_GIF_RECORDING)
     #define RGIF_MALLOC RL_MALLOC
@@ -2061,7 +2061,7 @@ const char *GetWorkingDirectory(void)
     static char currentDir[MAX_FILEPATH_LENGTH];
     memset(currentDir, 0, MAX_FILEPATH_LENGTH);
 
-    ignore_result(GETCWD(currentDir, MAX_FILEPATH_LENGTH - 1));
+    IgnoreResult(GETCWD(currentDir, MAX_FILEPATH_LENGTH - 1));
 
     return currentDir;
 }
@@ -2328,7 +2328,7 @@ void OpenURL(const char *url)
     #elif defined(__APPLE__)
         sprintf(cmd, "open '%s'", url);
     #endif
-        ignore_result(system(cmd));
+        IgnoreResult(system(cmd));
         RL_FREE(cmd);
 #endif
 #if defined(PLATFORM_WEB)


### PR DESCRIPTION
In core.c, GCC (I said G++ in the commit, oops) reports an unused return value warning and this gets rid of those warnings.