### PR TITLE
Fix 1393

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -192,7 +192,7 @@ if(STATIC)
   set(PKG_CONFIG_LIBS_PRIVATE ${__PKG_CONFIG_LIBS_PRIVATE} ${GLFW_PKG_LIBS})
   string (REPLACE ";" " " PKG_CONFIG_LIBS_PRIVATE "${PKG_CONFIG_LIBS_PRIVATE}")
   if (${PLATFORM} MATCHES "Desktop")
-    target_link_libraries(raylib_static glfw ${GLFW_LIBRARIES} ${LIBS_PRIVATE})
+    target_link_libraries(raylib_static PRIVATE glfw ${GLFW_LIBRARIES} ${LIBS_PRIVATE})
   endif()
 
   if (WITH_PIC)


### PR DESCRIPTION
This fixed the cmake issue in #1393.

The problem here is that target_link_libraries for raylib_static is called once with keyword "PUBLIC" (line 189) and once without keyword (line 195). Cmake does not allow mixing these signatures. To fix, either have both calls without keyword or both with.