### PR TITLE
mouse: Return float movement for precise scrolling where possible

### DIFF
--- a/projects/Geany/raylib.c.tags
+++ b/projects/Geany/raylib.c.tags
@@ -103,7 +103,7 @@ GetMousePosition|Vector2|(void);|
 SetMousePosition|void|(int x, int y);|
 SetMouseOffset|void|(int offsetX, int offsetY);|
 SetMouseScale|void|(float scaleX, float scaleY);|
-GetMouseWheelMove|int|(void);|
+GetMouseWheelMove|float|(void);|
 GetTouchX|int|(void);|
 GetTouchY|int|(void);|
 GetTouchPosition|Vector2|(int index);|

--- a/projects/Notepad++/c_raylib.xml
+++ b/projects/Notepad++/c_raylib.xml
@@ -436,7 +436,7 @@
             </Overload>
         </KeyWord>
         <KeyWord name="GetMouseWheelMove" func="yes">
-            <Overload retVal="int" descr="Returns mouse wheel movement Y"></Overload>
+            <Overload retVal="float" descr="Returns mouse wheel movement Y"></Overload>
         </KeyWord>
 
         <!-- Input-related functions: touch -->

--- a/projects/Notepad++/raylib_npp_parser/raylib_npp.xml
+++ b/projects/Notepad++/raylib_npp_parser/raylib_npp.xml
@@ -571,7 +571,7 @@
             </Overload>
         </KeyWord>
         <KeyWord name="GetMouseWheelMove" func="yes">
-            <Overload retVal="int" descr="Returns mouse wheel movement Y"></Overload>
+            <Overload retVal="float" descr="Returns mouse wheel movement Y"></Overload>
         </KeyWord>
 
         <!-- Input-related functions: touch -->

--- a/projects/Notepad++/raylib_npp_parser/raylib_to_parse.h
+++ b/projects/Notepad++/raylib_npp_parser/raylib_to_parse.h
@@ -147,7 +147,7 @@ RLAPI Vector2 GetMousePosition(void);                         // Returns mouse p
 RLAPI void SetMousePosition(int x, int y);                    // Set mouse position XY
 RLAPI void SetMouseOffset(int offsetX, int offsetY);          // Set mouse offset
 RLAPI void SetMouseScale(float scaleX, float scaleY);         // Set mouse scaling
-RLAPI int GetMouseWheelMove(void);                            // Returns mouse wheel movement Y
+RLAPI float GetMouseWheelMove(void);                          // Returns mouse wheel movement Y
 
 // Input-related functions: touch
 RLAPI int GetTouchX(void);                                    // Returns touch position X for touch point 0 (relative to screen size)

--- a/projects/VS2017.UWP/raylib.App.UWP/App.cpp
+++ b/projects/VS2017.UWP/raylib.App.UWP/App.cpp
@@ -213,7 +213,7 @@ void App::GameLoop()
         DisableCursor();
     }
 
-    static int pos = 0;
+    static float pos = 0;
     pos -= GetMouseWheelMove();
     //----------------------------------------------------------------------------------
 
@@ -235,7 +235,7 @@ void App::GameLoop()
 		if (IsKeyDown(KEY_BACKSPACE)) DrawRectangle(280, 250, 20, 20, BLACK);
 		if (IsMouseButtonDown(MOUSE_LEFT_BUTTON)) DrawRectangle(280, 250, 20, 20, BLACK);
 
-		DrawRectangle(280, pos + 50, 20, 20, BLACK);
+		DrawRectangle(280, (int)pos + 50, 20, 20, BLACK);
 		DrawRectangle(250, 280 + (gTime++ % 60), 10, 10, PURPLE);
 
 	EndDrawing();

--- a/src/camera.h
+++ b/src/camera.h
@@ -236,7 +236,7 @@ static void DisableCursor() {}      // Lock cursor
 static int IsKeyDown(int key) { return 0; }
 
 static int IsMouseButtonDown(int button) { return 0;}
-static int GetMouseWheelMove() { return 0; }
+static float GetMouseWheelMove() { return 0.f; }
 static Vector2 GetMousePosition() { return (Vector2){ 0.0f, 0.0f }; }
 #endif
 
@@ -285,7 +285,7 @@ void UpdateCamera(Camera *camera)
     // Mouse movement detection
     Vector2 mousePositionDelta = { 0.0f, 0.0f };
     Vector2 mousePosition = GetMousePosition();
-    int mouseWheelMove = GetMouseWheelMove();
+    float mouseWheelMove = GetMouseWheelMove();
 
     // Keys input detection
     // TODO: Input detection is raylib-dependant, it could be moved outside the module

--- a/src/core.c
+++ b/src/core.c
@@ -428,8 +428,8 @@ typedef struct CoreData {
 
             char currentButtonState[3];     // Registers current mouse button state
             char previousButtonState[3];    // Registers previous mouse button state
-            int currentWheelMove;           // Registers current mouse wheel variation
-            int previousWheelMove;          // Registers previous mouse wheel variation
+            float currentWheelMove;         // Registers current mouse wheel variation
+            float previousWheelMove;        // Registers previous mouse wheel variation
 #if defined(PLATFORM_RPI) || defined(PLATFORM_DRM)
             char currentButtonStateEvdev[3];    // Holds the new mouse state for the next polling event to grab (Can't be written directly due to multithreading, app could miss the update)
 #endif
@@ -2722,12 +2722,12 @@ void SetMouseScale(float scaleX, float scaleY)
 }
 
 // Returns mouse wheel movement Y
-int GetMouseWheelMove(void)
+float GetMouseWheelMove(void)
 {
 #if defined(PLATFORM_ANDROID)
-    return 0;
+    return 0.f;
 #elif defined(PLATFORM_WEB)
-    return CORE.Input.Mouse.previousWheelMove/100;
+    return CORE.Input.Mouse.previousWheelMove/100.f;
 #else
     return CORE.Input.Mouse.previousWheelMove;
 #endif
@@ -3896,7 +3896,7 @@ static void PollInputEvents(void)
 
     // Register previous mouse states
     CORE.Input.Mouse.previousWheelMove = CORE.Input.Mouse.currentWheelMove;
-    CORE.Input.Mouse.currentWheelMove = 0;
+    CORE.Input.Mouse.currentWheelMove = 0.f;
     for (int i = 0; i < 3; i++)
     {
         CORE.Input.Mouse.previousButtonState[i] = CORE.Input.Mouse.currentButtonState[i];
@@ -3918,7 +3918,7 @@ static void PollInputEvents(void)
 
     // Register previous mouse states
     CORE.Input.Mouse.previousWheelMove = CORE.Input.Mouse.currentWheelMove;
-    CORE.Input.Mouse.currentWheelMove = 0;
+    CORE.Input.Mouse.currentWheelMove = 0.f;
 
     for (int i = 0; i < 3; i++) CORE.Input.Mouse.previousButtonState[i] = CORE.Input.Mouse.currentButtonState[i];
 #endif  // PLATFORM_UWP
@@ -3934,7 +3934,7 @@ static void PollInputEvents(void)
 
     // Register previous mouse wheel state
     CORE.Input.Mouse.previousWheelMove = CORE.Input.Mouse.currentWheelMove;
-    CORE.Input.Mouse.currentWheelMove = 0;
+    CORE.Input.Mouse.currentWheelMove = 0.f;
 #endif
 
     // Register previous touch states
@@ -4151,7 +4151,7 @@ static void ErrorCallback(int error, const char *description)
 // GLFW3 Srolling Callback, runs on mouse wheel
 static void ScrollCallback(GLFWwindow *window, double xoffset, double yoffset)
 {
-    CORE.Input.Mouse.currentWheelMove = (int)yoffset;
+    CORE.Input.Mouse.currentWheelMove = (float)yoffset;
 }
 
 // GLFW3 Keyboard Callback, runs on key pressed
@@ -5520,7 +5520,7 @@ void UWPSetMouseSetPosFunc(UWPMouseSetPosFunc func) { uwpMouseSetPosFunc = func;
 
 void *UWPGetCoreWindowPtr() { return uwpCoreWindow; }
 void UWPSetCoreWindowPtr(void* ptr) { uwpCoreWindow = ptr; }
-void UWPMouseWheelEvent(int deltaY) { CORE.Input.Mouse.currentWheelMove = (int)deltaY; }
+void UWPMouseWheelEvent(int deltaY) { CORE.Input.Mouse.currentWheelMove = (float)deltaY; }
 
 void UWPKeyDownEvent(int key, bool down, bool controlKey)
 {

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1015,7 +1015,7 @@ RLAPI Vector2 GetMousePosition(void);                         // Returns mouse p
 RLAPI void SetMousePosition(int x, int y);                    // Set mouse position XY
 RLAPI void SetMouseOffset(int offsetX, int offsetY);          // Set mouse offset
 RLAPI void SetMouseScale(float scaleX, float scaleY);         // Set mouse scaling
-RLAPI int GetMouseWheelMove(void);                            // Returns mouse wheel movement Y
+RLAPI float GetMouseWheelMove(void);                          // Returns mouse wheel movement Y
 
 // Input-related functions: touch
 RLAPI int GetTouchX(void);                                    // Returns touch position X for touch point 0 (relative to screen size)


### PR DESCRIPTION
Making mouse wheel return a float means the threshold between not scrolling and scrolling is more sensitive and allows for finer grained response.

Right now, especially on desktop through GLFW, we truncate the scroll movement from double to int and so we lose quite a bit of data. Implementing for example a window that can be scrolled by the mouse is very choppy because we lose that precision.