### PR TITLE
Add Vector2Reflect to raymath.h

### DIFF
--- a/src/raymath.h
+++ b/src/raymath.h
@@ -297,6 +297,19 @@ RMDEF Vector2 Vector2Lerp(Vector2 v1, Vector2 v2, float amount)
     return result;
 }
 
+// Calculate reflected vector to normal
+RMDEF Vector2 Vector2Reflect(Vector2 v, Vector2 normal)
+{
+    Vector2 result = { 0 };
+
+    float dotProduct = Vector2DotProduct(v, normal);
+
+    result.x = v.x - (2.0f*normal.x)*dotProduct;
+    result.y = v.y - (2.0f*normal.y)*dotProduct;
+
+    return result;
+}
+
 // Rotate Vector by float in Degrees.
 RMDEF Vector2 Vector2Rotate(Vector2 v, float degs)
 {


### PR DESCRIPTION
Vector3Reflect exists but not Vector2Reflect. The code is pretty much the same.
I'm not sure what RMDEF does, but I added it to match other function definitions (haven't done much C programming, maybe I'm missing something). Can someone explain to me what it does?