### PR TITLE
Cleanup typecast warnings in visual studio 2019

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -2511,8 +2511,8 @@ bool SaveStorageValue(unsigned int position, int value)
     strcpy(path, STORAGE_DATA_FILE);
 #endif
 
-    unsigned int dataSize = 0;
-    unsigned int newDataSize = 0;
+    size_t dataSize = 0;
+    size_t newDataSize = 0;
     unsigned char *fileData = LoadFileData(path, &dataSize);
     unsigned char *newFileData = NULL;
 
@@ -2526,7 +2526,7 @@ bool SaveStorageValue(unsigned int position, int value)
 
             if (newFileData != NULL)
             {
-                // RL_REALLOC succeded
+                // RL_REALLOC succeeded
                 int *dataPtr = (int *)newFileData;
                 dataPtr[position] = value;
             }
@@ -2590,7 +2590,7 @@ int LoadStorageValue(unsigned int position)
     strcpy(path, STORAGE_DATA_FILE);
 #endif
 
-    unsigned int dataSize = 0;
+    size_t dataSize = 0;
     unsigned char *fileData = LoadFileData(path, &dataSize);
 
     if (fileData != NULL)

--- a/src/external/jar_xm.h
+++ b/src/external/jar_xm.h
@@ -141,7 +141,7 @@ void jar_xm_generate_samples_16bit(jar_xm_context_t* ctx, short* output, size_t 
     if(output){
         int x;
         for(x=0;x<2*numsamples;x++)
-            output[x] = musicBuffer[x] * SHRT_MAX;
+            output[x] = (short)(musicBuffer[x] * SHRT_MAX);
     }
 
     JARXM_FREE(musicBuffer);
@@ -160,7 +160,7 @@ void jar_xm_generate_samples_8bit(jar_xm_context_t* ctx, char* output, size_t nu
     if(output){
         int x;
         for(x=0;x<2*numsamples;x++)
-            output[x] = musicBuffer[x] * CHAR_MAX;
+            output[x] = (char)(musicBuffer[x] * CHAR_MAX);
     }
 
     JARXM_FREE(musicBuffer);
@@ -1460,7 +1460,7 @@ static float jar_xm_envelope_lerp(jar_xm_envelope_point_t* a, jar_xm_envelope_po
 static void jar_xm_post_pattern_change(jar_xm_context_t* ctx) {
     /* Loop if necessary */
     if(ctx->current_table_index >= ctx->module.length) {
-        ctx->current_table_index = ctx->module.restart_position;
+        ctx->current_table_index = (uint8_t)ctx->module.restart_position;
     }
 }
 
@@ -1473,9 +1473,9 @@ static float jar_xm_linear_frequency(float period) {
 }
 
 static float jar_xm_amiga_period(float note) {
-    unsigned int intnote = note;
+    unsigned int intnote = (unsigned int)note;
     uint8_t a = intnote % 12;
-    int8_t octave = note / 12.f - 2;
+    int8_t octave = (int8_t)(note / 12.f - 2);
     uint16_t p1 = amiga_frequencies[a], p2 = amiga_frequencies[a + 1];
 
     if(octave > 0) {
@@ -1746,7 +1746,7 @@ static void jar_xm_handle_note_and_instrument(jar_xm_context_t* ctx, jar_xm_chan
                 ch->sample_position = -1;
                 break;
             }
-            ch->sample_position = final_offset;
+            ch->sample_position = (float)final_offset;
         }
         break;
 
@@ -1781,14 +1781,14 @@ static void jar_xm_handle_note_and_instrument(jar_xm_context_t* ctx, jar_xm_chan
             if(s->effect_param & 0x0F) {
                 ch->fine_portamento_up_param = s->effect_param & 0x0F;
             }
-            jar_xm_pitch_slide(ctx, ch, -ch->fine_portamento_up_param);
+            jar_xm_pitch_slide(ctx, ch, (float)(-ch->fine_portamento_up_param));
             break;
 
         case 2: /* E2y: Fine portamento down */
             if(s->effect_param & 0x0F) {
                 ch->fine_portamento_down_param = s->effect_param & 0x0F;
             }
-            jar_xm_pitch_slide(ctx, ch, ch->fine_portamento_down_param);
+            jar_xm_pitch_slide(ctx, ch, (float)ch->fine_portamento_down_param);
             break;
 
         case 4: /* E4y: Set vibrato control */
@@ -2234,12 +2234,12 @@ static void jar_xm_tick(jar_xm_context_t* ctx) {
 
         case 1: /* 1xx: Portamento up */
             if(ctx->current_tick == 0) break;
-            jar_xm_pitch_slide(ctx, ch, -ch->portamento_up_param);
+            jar_xm_pitch_slide(ctx, ch, (float)(-ch->portamento_up_param));
             break;
 
         case 2: /* 2xx: Portamento down */
             if(ctx->current_tick == 0) break;
-            jar_xm_pitch_slide(ctx, ch, ch->portamento_down_param);
+            jar_xm_pitch_slide(ctx, ch, (float)ch->portamento_down_param);
             break;
 
         case 3: /* 3xx: Tone portamento */
@@ -2369,7 +2369,7 @@ static void jar_xm_tick(jar_xm_context_t* ctx) {
         float panning, volume;
 
         panning = ch->panning +
-            (ch->panning_envelope_panning - .5f) * (.5f - fabs(ch->panning - .5f)) * 2.0f;
+            (ch->panning_envelope_panning - .5f) * (.5f - (float)fabs(ch->panning - .5f)) * 2.0f;
 
         if(ch->tremor_on) {
                 volume = .0f;
@@ -2566,7 +2566,7 @@ uint64_t jar_xm_get_remaining_samples(jar_xm_context_t* ctx)
 
     while(jar_xm_get_loop_count(ctx) == currentLoopCount)
     {
-        total += ctx->remaining_samples_in_tick;
+        total += (uint64_t)ctx->remaining_samples_in_tick;
         ctx->remaining_samples_in_tick = 0;
         jar_xm_tick(ctx);
     }

--- a/src/external/par_shapes.h
+++ b/src/external/par_shapes.h
@@ -173,7 +173,7 @@ par_shapes_mesh* par_shapes_weld(par_shapes_mesh const*, float epsilon,
 void par_shapes_compute_normals(par_shapes_mesh* m);
 
 #ifndef PAR_PI
-#define PAR_PI (3.14159265359)
+#define PAR_PI (3.14159265359f)
 #define PAR_MIN(a, b) (a > b ? b : a)
 #define PAR_MAX(a, b) (a > b ? a : b)
 #define PAR_CLAMP(v, lo, hi) PAR_MAX(lo, PAR_MIN(hi, v))
@@ -270,7 +270,7 @@ static void par_shapes__scale3(float* result, float a)
 
 static void par_shapes__normalize3(float* v)
 {
-    float lsqr = sqrt(v[0]*v[0] + v[1]*v[1] + v[2]*v[2]);
+    float lsqr = (float)sqrt(v[0]*v[0] + v[1]*v[1] + v[2]*v[2]);
     if (lsqr > 0) {
         par_shapes__scale3(v, 1.0f / lsqr);
     }
@@ -302,7 +302,7 @@ static void par_shapes__compute_welded_normals(par_shapes_mesh* m)
 {
     m->normals = PAR_MALLOC(float, m->npoints * 3);
     PAR_SHAPES_T* weldmap = PAR_MALLOC(PAR_SHAPES_T, m->npoints);
-    par_shapes_mesh* welded = par_shapes_weld(m, 0.01, weldmap);
+    par_shapes_mesh* welded = par_shapes_weld(m, 0.01f, weldmap);
     par_shapes_compute_normals(welded);
     float* pdst = m->normals;
     for (int i = 0; i < m->npoints; i++, pdst += 3) {
@@ -332,7 +332,7 @@ par_shapes_mesh* par_shapes_create_parametric_sphere(int slices, int stacks)
     }
     par_shapes_mesh* m = par_shapes_create_parametric(par_shapes__sphere,
         slices, stacks, 0);
-    par_shapes_remove_degenerate(m, 0.0001);
+    par_shapes_remove_degenerate(m, 0.0001f);
     return m;
 }
 
@@ -343,7 +343,7 @@ par_shapes_mesh* par_shapes_create_hemisphere(int slices, int stacks)
     }
     par_shapes_mesh* m = par_shapes_create_parametric(par_shapes__hemisphere,
         slices, stacks, 0);
-    par_shapes_remove_degenerate(m, 0.0001);
+    par_shapes_remove_degenerate(m, 0.0001f);
     return m;
 }
 
@@ -600,24 +600,24 @@ static void par_shapes__trefoil(float const* uv, float* xyz, void* userdata)
     const float d = minor * 0.1f;
     const float u = (1 - uv[0]) * 4 * PAR_PI;
     const float v = uv[1] * 2 * PAR_PI;
-    const float r = a + b * cos(1.5f * u);
-    const float x = r * cos(u);
-    const float y = r * sin(u);
-    const float z = c * sin(1.5f * u);
+    const float r = a + b * (float)cos(1.5f * u);
+    const float x = r * (float)cos(u);
+    const float y = r * (float)sin(u);
+    const float z = c * (float)sin(1.5f * u);
     float q[3];
-    q[0] =
-        -1.5f * b * sin(1.5f * u) * cos(u) - (a + b * cos(1.5f * u)) * sin(u);
+    q[0] = 
+        (float)(-1.5f * b * sin(1.5f * u) * cos(u) - (a + b * cos(1.5f * u)) * sin(u));
     q[1] =
-        -1.5f * b * sin(1.5f * u) * sin(u) + (a + b * cos(1.5f * u)) * cos(u);
-    q[2] = 1.5f * c * cos(1.5f * u);
+        (float)(-1.5f * b * sin(1.5f * u) * sin(u) + (a + b * cos(1.5f * u)) * cos(u));
+    q[2] = (float)(1.5f * c * cos(1.5f * u));
     par_shapes__normalize3(q);
     float qvn[3] = {q[1], -q[0], 0};
     par_shapes__normalize3(qvn);
     float ww[3];
     par_shapes__cross3(ww, q, qvn);
-    xyz[0] = x + d * (qvn[0] * cos(v) + ww[0] * sin(v));
-    xyz[1] = y + d * (qvn[1] * cos(v) + ww[1] * sin(v));
-    xyz[2] = z + d * ww[2] * sin(v);
+    xyz[0] = x + d * (float)(qvn[0] * cos(v) + ww[0] * sin(v));
+    xyz[1] = y + d * (float)(qvn[1] * cos(v) + ww[1] * sin(v));
+    xyz[2] = z + d * ww[2] * (float)sin(v);
 }
 
 void par_shapes_merge(par_shapes_mesh* dst, par_shapes_mesh const* src)
@@ -667,8 +667,8 @@ par_shapes_mesh* par_shapes_create_disk(float radius, int slices,
     *points++ = 0;
     for (int i = 0; i < slices; i++) {
         float theta = i * PAR_PI * 2 / slices;
-        *points++ = radius * cos(theta);
-        *points++ = radius * sin(theta);
+        *points++ = radius * (float)cos(theta);
+        *points++ = radius * (float)sin(theta);
         *points++ = 0;
     }
     float nnormal[3] = {normal[0], normal[1], normal[2]};
@@ -692,7 +692,7 @@ par_shapes_mesh* par_shapes_create_disk(float radius, int slices,
     float axis[3];
     par_shapes__cross3(axis, nnormal, k);
     par_shapes__normalize3(axis);
-    par_shapes_rotate(mesh, acos(nnormal[2]), axis);
+    par_shapes_rotate(mesh, (float)acos(nnormal[2]), axis);
     par_shapes_translate(mesh, center[0], center[1], center[2]);
     return mesh;
 }
@@ -803,18 +803,18 @@ void par_shapes_invert(par_shapes_mesh* m, int face, int nfaces)
 par_shapes_mesh* par_shapes_create_icosahedron()
 {
     static float verts[] = {
-        0.000,  0.000,  1.000,
-        0.894,  0.000,  0.447,
-        0.276,  0.851,  0.447,
-        -0.724,  0.526,  0.447,
-        -0.724, -0.526,  0.447,
-        0.276, -0.851,  0.447,
-        0.724,  0.526, -0.447,
-        -0.276,  0.851, -0.447,
-        -0.894,  0.000, -0.447,
-        -0.276, -0.851, -0.447,
-        0.724, -0.526, -0.447,
-        0.000,  0.000, -1.000
+        0.000f,  0.000f,  1.000f,
+        0.894f,  0.000f,  0.447f,
+        0.276f,  0.851f,  0.447f,
+        -0.724f,  0.526f,  0.447f,
+        -0.724f, -0.526f,  0.447f,
+        0.276f, -0.851f,  0.447f,
+        0.724f,  0.526f, -0.447f,
+        -0.276f,  0.851f, -0.447f,
+        -0.894f,  0.000f, -0.447f,
+        -0.276f, -0.851f, -0.447f,
+        0.724f, -0.526f, -0.447f,
+        0.000f,  0.000f, -1.000f
     };
     static PAR_SHAPES_T faces[] = {
         0,1,2,
@@ -851,26 +851,26 @@ par_shapes_mesh* par_shapes_create_icosahedron()
 par_shapes_mesh* par_shapes_create_dodecahedron()
 {
     static float verts[20 * 3] = {
-        0.607, 0.000, 0.795,
-        0.188, 0.577, 0.795,
-        -0.491, 0.357, 0.795,
-        -0.491, -0.357, 0.795,
-        0.188, -0.577, 0.795,
-        0.982, 0.000, 0.188,
-        0.304, 0.934, 0.188,
-        -0.795, 0.577, 0.188,
-        -0.795, -0.577, 0.188,
-        0.304, -0.934, 0.188,
-        0.795, 0.577, -0.188,
-        -0.304, 0.934, -0.188,
-        -0.982, 0.000, -0.188,
-        -0.304, -0.934, -0.188,
-        0.795, -0.577, -0.188,
-        0.491, 0.357, -0.795,
-        -0.188, 0.577, -0.795,
-        -0.607, 0.000, -0.795,
-        -0.188, -0.577, -0.795,
-        0.491, -0.357, -0.795,
+        0.607f, 0.000f, 0.795f,
+        0.188f, 0.577f, 0.795f,
+        -0.491f, 0.357f, 0.795f,
+        -0.491f, -0.357f, 0.795f,
+        0.188f, -0.577f, 0.795f,
+        0.982f, 0.000f, 0.188f,
+        0.304f, 0.934f, 0.188f,
+        -0.795f, 0.577f, 0.188f,
+        -0.795f, -0.577f, 0.188f,
+        0.304f, -0.934f, 0.188f,
+        0.795f, 0.577f, -0.188f,
+        -0.304f, 0.934f, -0.188f,
+        -0.982f, 0.000f, -0.188f,
+        -0.304f, -0.934f, -0.188f,
+        0.795f, -0.577f, -0.188f,
+        0.491f, 0.357f, -0.795f,
+        -0.188f, 0.577f, -0.795f,
+        -0.607f, 0.000f, -0.795f,
+        -0.188f, -0.577f, -0.795f,
+        0.491f, -0.357f, -0.795f,
     };
     static PAR_SHAPES_T pentagons[12 * 5] = {
         0,1,2,3,4,
@@ -913,12 +913,12 @@ par_shapes_mesh* par_shapes_create_dodecahedron()
 par_shapes_mesh* par_shapes_create_octahedron()
 {
     static float verts[6 * 3] = {
-        0.000, 0.000, 1.000,
-        1.000, 0.000, 0.000,
-        0.000, 1.000, 0.000,
-        -1.000, 0.000, 0.000,
-        0.000, -1.000, 0.000,
-        0.000, 0.000, -1.000
+        0.000f, 0.000f, 1.000f,
+        1.000f, 0.000f, 0.000f,
+        0.000f, 1.000f, 0.000f,
+        -1.000f, 0.000f, 0.000f,
+        0.000f, -1.000f, 0.000f,
+        0.000f, 0.000f, -1.000
     };
     static PAR_SHAPES_T triangles[8 * 3] = {
         0,1,2,
@@ -951,10 +951,10 @@ par_shapes_mesh* par_shapes_create_octahedron()
 par_shapes_mesh* par_shapes_create_tetrahedron()
 {
     static float verts[4 * 3] = {
-        0.000, 1.333, 0,
-        0.943, 0, 0,
-        -0.471, 0, 0.816,
-        -0.471, 0, -0.816,
+        0.000f, 1.333f, 0,
+        0.943f, 0, 0,
+        -0.471f, 0, 0.816f,
+        -0.471f, 0, -0.816f,
     };
     static PAR_SHAPES_T triangles[4 * 3] = {
         2,1,0,
@@ -1281,13 +1281,13 @@ par_shapes_mesh* par_shapes_create_lsystem(char const* text, int slices,
             par_shapes__copy3(frame->position, position);
             continue;
         } else {
-            value = atof(cmd->arg);
+            value = (float)atof(cmd->arg);
             if (!strcmp(cmd->cmd, "rx")) {
-                par_shapes_rotate(turtle, value * PAR_PI / 180.0, xaxis);
+                par_shapes_rotate(turtle, value * PAR_PI / 180.0f, xaxis);
             } else if (!strcmp(cmd->cmd, "ry")) {
-                par_shapes_rotate(turtle, value * PAR_PI / 180.0, yaxis);
+                par_shapes_rotate(turtle, value * PAR_PI / 180.0f, yaxis);
             } else if (!strcmp(cmd->cmd, "rz")) {
-                par_shapes_rotate(turtle, value * PAR_PI / 180.0, zaxis);
+                par_shapes_rotate(turtle, value * PAR_PI / 180.0f, zaxis);
             } else if (!strcmp(cmd->cmd, "tx")) {
                 float vec[3] = {value, 0, 0};
                 float t[3] = {
@@ -1444,7 +1444,7 @@ par_shapes_mesh* par_shapes_create_subdivided_sphere(int nsubd)
         mesh->triangles[i] = i;
     }
     par_shapes_mesh* tmp = mesh;
-    mesh = par_shapes_weld(mesh, 0.01, 0);
+    mesh = par_shapes_weld(mesh, 0.01f, 0);
     par_shapes_free_mesh(tmp);
     par_shapes_compute_normals(mesh);
     return mesh;
@@ -1461,11 +1461,11 @@ par_shapes_mesh* par_shapes_create_rock(int seed, int subd)
         double n = a * par__simplex_noise2(ctx, f * pt[0], f * pt[2]);
         a *= 0.5; f *= 2;
         n += a * par__simplex_noise2(ctx, f * pt[0], f * pt[2]);
-        pt[0] *= 1 + 2 * n;
-        pt[1] *= 1 + n;
-        pt[2] *= 1 + 2 * n;
+        pt[0] *= 1 + 2 * (float)n;
+        pt[1] *= 1 + (float)n;
+        pt[2] *= 1 + 2 * (float)n;
         if (pt[1] < 0) {
-            pt[1] = -pow(-pt[1], 0.5) / 2;
+            pt[1] = (float)(-pow(-pt[1], 0.5) / 2);
         }
     }
     par__simplex_noise_free(ctx);
@@ -1714,7 +1714,7 @@ par_shapes_mesh* par_shapes_weld(par_shapes_mesh const* mesh, float epsilon,
     par_shapes_mesh* clone = par_shapes_clone(mesh, 0);
     float aabb[6];
     int gridsize = 20;
-    float maxcell = gridsize - 1;
+    float maxcell = (float)(gridsize - 1);
     par_shapes_compute_aabb(clone, aabb);
     float scale[3] = {
         aabb[3] == aabb[0] ? 1.0f : maxcell / (aabb[3] - aabb[0]),
@@ -1745,7 +1745,7 @@ par_shapes_mesh* par_shapes_weld(par_shapes_mesh const* mesh, float epsilon,
         PAR_FREE(newmap);
     }
     PAR_FREE(sortmap);
-    par_shapes_scale(clone, 1.0 / scale[0], 1.0 / scale[1], 1.0 / scale[2]);
+    par_shapes_scale(clone, 1.0f / scale[0], 1.0f / scale[1], 1.0f / scale[2]);
     par_shapes_translate(clone, aabb[0], aabb[1], aabb[2]);
     return clone;
 }

--- a/src/models.c
+++ b/src/models.c
@@ -830,7 +830,7 @@ bool ExportMesh(Mesh mesh, const char *fileName)
     if (IsFileExtension(fileName, ".obj"))
     {
         // Estimated data size, it should be enough...
-        int dataSize = mesh.vertexCount/3*strlen("v 0000.00f 0000.00f 0000.00f") +
+        size_t dataSize = mesh.vertexCount/3*strlen("v 0000.00f 0000.00f 0000.00f") +
                        mesh.vertexCount/2*strlen("vt 0.000f 0.00f") +
                        mesh.vertexCount/3*strlen("vn 0.000f 0.00f 0.00f") +
                        mesh.triangleCount/3*strlen("f 00000/00000/00000 00000/00000/00000 00000/00000/00000");
@@ -973,7 +973,7 @@ ModelAnimation *LoadModelAnimations(const char *fileName, int *animCount)
     #define IQM_MAGIC       "INTERQUAKEMODEL"   // IQM file magic number
     #define IQM_VERSION     2                   // only IQM version 2 supported
 
-    unsigned int fileSize = 0;
+    size_t fileSize = 0;
     unsigned char *fileData = LoadFileData(fileName, &fileSize);
     unsigned char *fileDataPtr = fileData;
 
@@ -2997,9 +2997,9 @@ static Model LoadOBJ(const char *fileName)
         // count the faces for each material
         int *matFaces = RL_CALLOC(meshCount, sizeof(int));
 
-        for (int mi = 0; mi < meshCount; mi++)
+        for (unsigned int mi = 0; mi < meshCount; mi++)
         {
-            for (int fi = 0; fi < meshes[mi].length; fi++)
+            for (unsigned int fi = 0; fi < meshes[mi].length; fi++)
             {
                 int idx = attrib.material_ids[meshes[mi].face_offset + fi];
                 if (idx == -1) idx = 0; // for no material face (which could be the whole model)
@@ -3124,7 +3124,7 @@ static Model LoadIQM(const char *fileName)
     #define MESH_NAME_LENGTH    32          // Mesh name string length
     #define MATERIAL_NAME_LENGTH 32         // Material name string length
 
-    unsigned int fileSize = 0;
+    size_t fileSize = 0;
     unsigned char *fileData = LoadFileData(fileName, &fileSize);
     unsigned char *fileDataPtr = fileData;
 
@@ -3663,7 +3663,7 @@ static Model LoadGLTF(const char *fileName)
     Model model = { 0 };
 
     // glTF file loading
-    unsigned int dataSize = 0;
+    size_t dataSize = 0;
     unsigned char *fileData = LoadFileData(fileName, &dataSize);
 
     if (fileData == NULL) return model;

--- a/src/raudio.c
+++ b/src/raudio.c
@@ -370,23 +370,23 @@ static void InitAudioBufferPool(void);                  // Initialise the multic
 static void CloseAudioBufferPool(void);                 // Close the audio buffers pool
 
 #if defined(SUPPORT_FILEFORMAT_WAV)
-static Wave LoadWAV(const unsigned char *fileData, unsigned int fileSize);   // Load WAV file
+static Wave LoadWAV(const unsigned char *fileData, size_t fileSize);   // Load WAV file
 static int SaveWAV(Wave wave, const char *fileName);    // Save wave data as WAV file
 #endif
 #if defined(SUPPORT_FILEFORMAT_OGG)
-static Wave LoadOGG(const unsigned char *fileData, unsigned int fileSize);   // Load OGG file
+static Wave LoadOGG(const unsigned char *fileData, size_t fileSize);   // Load OGG file
 #endif
 #if defined(SUPPORT_FILEFORMAT_FLAC)
-static Wave LoadFLAC(const unsigned char *fileData, unsigned int fileSize);  // Load FLAC file
+static Wave LoadFLAC(const unsigned char *fileData, size_t fileSize);  // Load FLAC file
 #endif
 #if defined(SUPPORT_FILEFORMAT_MP3)
-static Wave LoadMP3(const unsigned char *fileData, unsigned int fileSize);   // Load MP3 file
+static Wave LoadMP3(const unsigned char *fileData, size_t fileSize);   // Load MP3 file
 #endif
 
 #if defined(RAUDIO_STANDALONE)
 static bool IsFileExtension(const char *fileName, const char *ext); // Check file extension
-static unsigned char *LoadFileData(const char *fileName, unsigned int *bytesRead);     // Load file data as byte array (read)
-static bool SaveFileData(const char *fileName, void *data, unsigned int bytesToWrite); // Save data to file from byte array (write)
+static unsigned char *LoadFileData(const char *fileName, size_t *bytesRead);     // Load file data as byte array (read)
+static bool SaveFileData(const char *fileName, void *data, size_t bytesToWrite); // Save data to file from byte array (write)
 static bool SaveFileText(const char *fileName, char *text);         // Save text data to file (write), string must be '\0' terminated
 #endif
 
@@ -691,7 +691,7 @@ Wave LoadWave(const char *fileName)
     Wave wave = { 0 };
 
     // Loading file to memory
-    unsigned int fileSize = 0;
+    size_t fileSize = 0;
     unsigned char *fileData = LoadFileData(fileName, &fileSize);
 
     if (fileData != NULL)
@@ -706,7 +706,7 @@ Wave LoadWave(const char *fileName)
 }
 
 // Load wave from memory buffer, fileType refers to extension: i.e. "wav"
-Wave LoadWaveFromMemory(const char *fileType, const unsigned char *fileData, int dataSize)
+Wave LoadWaveFromMemory(const char *fileType, const unsigned char *fileData, size_t dataSize)
 {
     Wave wave = { 0 };
 
@@ -1920,7 +1920,7 @@ static void CloseAudioBufferPool(void)
 #if defined(SUPPORT_FILEFORMAT_WAV)
 // Load WAV file data into Wave structure
 // NOTE: Using dr_wav library
-static Wave LoadWAV(const unsigned char *fileData, unsigned int fileSize)
+static Wave LoadWAV(const unsigned char *fileData, size_t fileSize)
 {
     Wave wave = { 0 };
     drwav wav = { 0 };
@@ -1929,7 +1929,7 @@ static Wave LoadWAV(const unsigned char *fileData, unsigned int fileSize)
 
     if (success)
     {
-        wave.sampleCount = wav.totalPCMFrameCount*wav.channels;
+        wave.sampleCount = (unsigned int)wav.totalPCMFrameCount*wav.channels;
         wave.sampleRate = wav.sampleRate;
         wave.sampleSize = 16;   // NOTE: We are forcing conversion to 16bit
         wave.channels = wav.channels;
@@ -1958,9 +1958,9 @@ static int SaveWAV(Wave wave, const char *fileName)
     format.bitsPerSample = wave.sampleSize;
 
     unsigned char *fileData = NULL;
-    unsigned int fileDataSize = 0;
+    size_t fileDataSize = 0;
     success = drwav_init_memory_write(&wav, &fileData, &fileDataSize, &format, NULL);
-    if (success) success = drwav_write_pcm_frames(&wav, wave.sampleCount/wave.channels, wave.data);
+    if (success) success = (int)drwav_write_pcm_frames(&wav, wave.sampleCount/wave.channels, wave.data);
     drwav_result result = drwav_uninit(&wav);
     
     if (result == DRWAV_SUCCESS) success = SaveFileData(fileName, fileData, fileDataSize);
@@ -1974,11 +1974,11 @@ static int SaveWAV(Wave wave, const char *fileName)
 #if defined(SUPPORT_FILEFORMAT_OGG)
 // Load OGG file data into Wave structure
 // NOTE: Using stb_vorbis library
-static Wave LoadOGG(const unsigned char *fileData, unsigned int fileSize)
+static Wave LoadOGG(const unsigned char *fileData, size_t fileSize)
 {
     Wave wave = { 0 };
 
-    stb_vorbis *oggData = stb_vorbis_open_memory((unsigned char *)fileData, fileSize, NULL, NULL);
+    stb_vorbis *oggData = stb_vorbis_open_memory((unsigned char *)fileData, (int)fileSize, NULL, NULL);
 
     if (oggData != NULL)
     {
@@ -2009,7 +2009,7 @@ static Wave LoadOGG(const unsigned char *fileData, unsigned int fileSize)
 #if defined(SUPPORT_FILEFORMAT_FLAC)
 // Load FLAC file data into Wave structure
 // NOTE: Using dr_flac library
-static Wave LoadFLAC(const unsigned char *fileData, unsigned int fileSize)
+static Wave LoadFLAC(const unsigned char *fileData, size_t fileSize)
 {
     Wave wave = { 0 };
 
@@ -2033,7 +2033,7 @@ static Wave LoadFLAC(const unsigned char *fileData, unsigned int fileSize)
 #if defined(SUPPORT_FILEFORMAT_MP3)
 // Load MP3 file data into Wave structure
 // NOTE: Using dr_mp3 library
-static Wave LoadMP3(const unsigned char *fileData, unsigned int fileSize)
+static Wave LoadMP3(const unsigned char *fileData, size_t fileSize)
 {
     Wave wave = { 0 };
     drmp3_config config = { 0 };
@@ -2078,7 +2078,7 @@ static bool IsFileExtension(const char *fileName, const char *ext)
 }
 
 // Load data from file into a buffer
-static unsigned char *LoadFileData(const char *fileName, unsigned int *bytesRead)
+static unsigned char *LoadFileData(const char *fileName, size_t *bytesRead)
 {
     unsigned char *data = NULL;
     *bytesRead = 0;
@@ -2118,7 +2118,7 @@ static unsigned char *LoadFileData(const char *fileName, unsigned int *bytesRead
 }
 
 // Save data to file from buffer
-static bool SaveFileData(const char *fileName, void *data, unsigned int bytesToWrite)
+static bool SaveFileData(const char *fileName, void *data, size_t bytesToWrite)
 {
     if (fileName != NULL)
     {

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -972,8 +972,8 @@ RLAPI void TakeScreenshot(const char *fileName);                  // Takes a scr
 RLAPI int GetRandomValue(int min, int max);                       // Returns a random value between min and max (both included)
 
 // Files management functions
-RLAPI unsigned char *LoadFileData(const char *fileName, unsigned int *bytesRead);     // Load file data as byte array (read)
-RLAPI bool SaveFileData(const char *fileName, void *data, unsigned int bytesToWrite); // Save data to file from byte array (write), returns true on success
+RLAPI unsigned char *LoadFileData(const char *fileName, size_t *bytesRead);     // Load file data as byte array (read)
+RLAPI bool SaveFileData(const char *fileName, void *data, size_t bytesToWrite); // Save data to file from byte array (write), returns true on success
 RLAPI char *LoadFileText(const char *fileName);                   // Load text data from file (read), returns a '\0' terminated string
 RLAPI bool SaveFileText(const char *fileName, char *text);        // Save text data to file (write), string must be '\0' terminated, returns true on success
 RLAPI bool FileExists(const char *fileName);                      // Check if file exists
@@ -1128,7 +1128,7 @@ RLAPI bool CheckCollisionPointTriangle(Vector2 point, Vector2 p1, Vector2 p2, Ve
 RLAPI Image LoadImage(const char *fileName);                                                             // Load image from file into CPU memory (RAM)
 RLAPI Image LoadImageRaw(const char *fileName, int width, int height, int format, int headerSize);       // Load image from RAW file data
 RLAPI Image LoadImageAnim(const char *fileName, int *frames);                                            // Load image sequence from file (frames appended to image.data)
-RLAPI Image LoadImageFromMemory(const char *fileType, const unsigned char *fileData, int dataSize);      // Load image from memory buffer, fileType refers to extension: i.e. "png"
+RLAPI Image LoadImageFromMemory(const char *fileType, const unsigned char *fileData, size_t dataSize);      // Load image from memory buffer, fileType refers to extension: i.e. "png"
 RLAPI void UnloadImage(Image image);                                                                     // Unload image from CPU memory (RAM)
 RLAPI bool ExportImage(Image image, const char *fileName);                                               // Export image data to file, returns true on success
 RLAPI bool ExportImageAsCode(Image image, const char *fileName);                                         // Export image as code file defining an array of bytes, returns true on success
@@ -1244,8 +1244,8 @@ RLAPI Font GetFontDefault(void);                                                
 RLAPI Font LoadFont(const char *fileName);                                                  // Load font from file into GPU memory (VRAM)
 RLAPI Font LoadFontEx(const char *fileName, int fontSize, int *fontChars, int charsCount);  // Load font from file with extended parameters
 RLAPI Font LoadFontFromImage(Image image, Color key, int firstChar);                        // Load font from Image (XNA style)
-RLAPI Font LoadFontFromMemory(const char *fileType, const unsigned char *fileData, int dataSize, int fontSize, int *fontChars, int charsCount); // Load font from memory buffer, fileType refers to extension: i.e. "ttf"
-RLAPI CharInfo *LoadFontData(const unsigned char *fileData, int dataSize, int fontSize, int *fontChars, int charsCount, int type);      // Load font data for further use
+RLAPI Font LoadFontFromMemory(const char *fileType, const unsigned char *fileData, size_t dataSize, int fontSize, int *fontChars, int charsCount); // Load font from memory buffer, fileType refers to extension: i.e. "ttf"
+RLAPI CharInfo *LoadFontData(const unsigned char *fileData, size_t dataSize, int fontSize, int *fontChars, int charsCount, int type);      // Load font data for further use
 RLAPI Image GenImageFontAtlas(const CharInfo *chars, Rectangle **recs, int charsCount, int fontSize, int padding, int packMethod);      // Generate image font atlas using chars info
 RLAPI void UnloadFont(Font font);                                                           // Unload Font from GPU memory (VRAM)
 
@@ -1441,7 +1441,7 @@ RLAPI void SetMasterVolume(float volume);                             // Set mas
 
 // Wave/Sound loading/unloading functions
 RLAPI Wave LoadWave(const char *fileName);                            // Load wave data from file
-RLAPI Wave LoadWaveFromMemory(const char *fileType, const unsigned char *fileData, int dataSize); // Load wave from memory buffer, fileType refers to extension: i.e. "wav"
+RLAPI Wave LoadWaveFromMemory(const char *fileType, const unsigned char *fileData, size_t dataSize); // Load wave from memory buffer, fileType refers to extension: i.e. "wav"
 RLAPI Sound LoadSound(const char *fileName);                          // Load sound from file
 RLAPI Sound LoadSoundFromWave(Wave wave);                             // Load sound from wave data
 RLAPI void UpdateSound(Sound sound, const void *data, int samplesCount);// Update sound buffer with new data

--- a/src/text.c
+++ b/src/text.c
@@ -340,7 +340,7 @@ Font LoadFontEx(const char *fileName, int fontSize, int *fontChars, int charsCou
     Font font = { 0 };
 
     // Loading file to memory
-    unsigned int fileSize = 0;
+    size_t fileSize = 0;
     unsigned char *fileData = LoadFileData(fileName, &fileSize);
 
     if (fileData != NULL)
@@ -478,7 +478,7 @@ Font LoadFontFromImage(Image image, Color key, int firstChar)
 }
 
 // Load font from memory buffer, fileType refers to extension: i.e. "ttf"
-Font LoadFontFromMemory(const char *fileType, const unsigned char *fileData, int dataSize, int fontSize, int *fontChars, int charsCount)
+Font LoadFontFromMemory(const char *fileType, const unsigned char *fileData, size_t dataSize, int fontSize, int *fontChars, int charsCount)
 {
     Font font = { 0 };
 
@@ -520,7 +520,7 @@ Font LoadFontFromMemory(const char *fileType, const unsigned char *fileData, int
 
 // Load font data for further use
 // NOTE: Requires TTF font memory data and can generate SDF data
-CharInfo *LoadFontData(const unsigned char *fileData, int dataSize, int fontSize, int *fontChars, int charsCount, int type)
+CharInfo *LoadFontData(const unsigned char *fileData, size_t dataSize, int fontSize, int *fontChars, int charsCount, int type)
 {
     // NOTE: Using some SDF generation default values,
     // trades off precision with ability to handle *smaller* sizes

--- a/src/textures.c
+++ b/src/textures.c
@@ -171,20 +171,20 @@
 // Module specific Functions Declaration
 //----------------------------------------------------------------------------------
 #if defined(SUPPORT_FILEFORMAT_DDS)
-static Image LoadDDS(const unsigned char *fileData, unsigned int fileSize);   // Load DDS file data
+static Image LoadDDS(const unsigned char *fileData, size_t fileSize);   // Load DDS file data
 #endif
 #if defined(SUPPORT_FILEFORMAT_PKM)
-static Image LoadPKM(const unsigned char *fileData, unsigned int fileSize);   // Load PKM file data
+static Image LoadPKM(const unsigned char *fileData, size_t fileSize);   // Load PKM file data
 #endif
 #if defined(SUPPORT_FILEFORMAT_KTX)
-static Image LoadKTX(const unsigned char *fileData, unsigned int fileSize);   // Load KTX file data
+static Image LoadKTX(const unsigned char *fileData, size_t fileSize);   // Load KTX file data
 static int SaveKTX(Image image, const char *fileName);  // Save image data as KTX file
 #endif
 #if defined(SUPPORT_FILEFORMAT_PVR)
-static Image LoadPVR(const unsigned char *fileData, unsigned int fileSize);   // Load PVR file data
+static Image LoadPVR(const unsigned char *fileData, size_t fileSize);   // Load PVR file data
 #endif
 #if defined(SUPPORT_FILEFORMAT_ASTC)
-static Image LoadASTC(const unsigned char *fileData, unsigned int fileSize);  // Load ASTC file data
+static Image LoadASTC(const unsigned char *fileData, size_t fileSize);  // Load ASTC file data
 #endif
 
 //----------------------------------------------------------------------------------
@@ -208,7 +208,7 @@ Image LoadImage(const char *fileName)
 #endif
 
     // Loading file to memory
-    unsigned int fileSize = 0;
+    size_t fileSize = 0;
     unsigned char *fileData = LoadFileData(fileName, &fileSize);
 
     if (fileData != NULL)
@@ -230,7 +230,7 @@ Image LoadImageRaw(const char *fileName, int width, int height, int format, int 
 {
     Image image = { 0 };
 
-    unsigned int dataSize = 0;
+    size_t dataSize = 0;
     unsigned char *fileData = LoadFileData(fileName, &dataSize);
 
     if (fileData != NULL)
@@ -266,14 +266,14 @@ Image LoadImageAnim(const char *fileName, int *frames)
 #if defined(SUPPORT_FILEFORMAT_GIF)
     if (IsFileExtension(fileName, ".gif"))
     {
-        unsigned int dataSize = 0;
+        size_t dataSize = 0;
         unsigned char *fileData = LoadFileData(fileName, &dataSize);
 
         if (fileData != NULL)
         {
             int comp = 0;
             int **delays = NULL;
-            image.data = stbi_load_gif_from_memory(fileData, dataSize, delays, &image.width, &image.height, &framesCount, &comp, 4);
+            image.data = stbi_load_gif_from_memory(fileData, (int)dataSize, delays, &image.width, &image.height, &framesCount, &comp, 4);
 
             image.mipmaps = 1;
             image.format = UNCOMPRESSED_R8G8B8A8;
@@ -294,7 +294,7 @@ Image LoadImageAnim(const char *fileName, int *frames)
 }
 
 // Load image from memory buffer, fileType refers to extension: i.e. "png"
-Image LoadImageFromMemory(const char *fileType, const unsigned char *fileData, int dataSize)
+Image LoadImageFromMemory(const char *fileType, const unsigned char *fileData, size_t dataSize)
 {
     Image image = { 0 };
 
@@ -333,7 +333,7 @@ Image LoadImageFromMemory(const char *fileType, const unsigned char *fileData, i
         if (fileData != NULL)
         {
             int comp = 0;
-            image.data = stbi_load_from_memory(fileData, dataSize, &image.width, &image.height, &comp, 0);
+            image.data = stbi_load_from_memory(fileData, (int)dataSize, &image.width, &image.height, &comp, 0);
 
             image.mipmaps = 1;
 
@@ -351,7 +351,7 @@ Image LoadImageFromMemory(const char *fileType, const unsigned char *fileData, i
         if (fileData != NULL)
         {
             int comp = 0;
-            image.data = stbi_loadf_from_memory(fileData, dataSize, &image.width, &image.height, &comp, 0);
+            image.data = stbi_loadf_from_memory(fileData, (int)dataSize, &image.width, &image.height, &comp, 0);
 
             image.mipmaps = 1;
 
@@ -811,9 +811,9 @@ Image ImageFromImage(Image image, Rectangle rec)
 
     // TODO: Check rec is valid?
 
-    result.width = rec.width;
-    result.height = rec.height;
-    result.data = RL_CALLOC(rec.width*rec.height*bytesPerPixel, 1);
+    result.width = (int)rec.width;
+    result.height = (int)rec.height;
+    result.data = RL_CALLOC((size_t)(rec.width*rec.height*bytesPerPixel), 1);
     result.format = image.format;
     result.mipmaps = 1;
 
@@ -849,7 +849,7 @@ void ImageCrop(Image *image, Rectangle crop)
     {
         int bytesPerPixel = GetPixelDataSize(1, 1, image->format);
 
-        unsigned char *croppedData = (unsigned char *)RL_MALLOC(crop.width*crop.height*bytesPerPixel);
+        unsigned char *croppedData = (unsigned char *)RL_MALLOC((size_t)(crop.width*crop.height*bytesPerPixel));
 
         // OPTION 1: Move cropped data line-by-line
         for (int y = (int)crop.y, offsetSize = 0; y < (int)(crop.y + crop.height); y++)
@@ -1437,27 +1437,27 @@ void ImageResizeCanvas(Image *image, int newWidth, int newHeight, int offsetX, i
     if (image->format >= COMPRESSED_DXT1_RGB) TRACELOG(LOG_WARNING, "Image manipulation not supported for compressed formats");
     else if ((newWidth != image->width) || (newHeight != image->height))
     {
-        Rectangle srcRec = { 0, 0, image->width, image->height };
-        Vector2 dstPos = { offsetX, offsetY };
+        Rectangle srcRec = { 0, 0, (float)image->width, (float)image->height };
+        Vector2 dstPos = { (float)offsetX, (float)offsetY };
 
         if (offsetX < 0)
         {
-            srcRec.x = -offsetX;
-            srcRec.width += offsetX;
+            srcRec.x = (float)-offsetX;
+            srcRec.width += (float)offsetX;
             dstPos.x = 0;
         }
-        else if ((offsetX + image->width) > newWidth) srcRec.width = newWidth - offsetX;
+        else if ((offsetX + image->width) > newWidth) srcRec.width = (float)(newWidth - offsetX);
 
         if (offsetY < 0)
         {
-            srcRec.y = -offsetY;
-            srcRec.height += offsetY;
+            srcRec.y = (float)-offsetY;
+            srcRec.height += (float)offsetY;
             dstPos.y = 0;
         }
-        else if ((offsetY + image->height) > newHeight) srcRec.height = newHeight - offsetY;
+        else if ((offsetY + image->height) > newHeight) srcRec.height = (float)(newHeight - offsetY);
 
-        if (newWidth < srcRec.width) srcRec.width = newWidth;
-        if (newHeight < srcRec.height) srcRec.height = newHeight;
+        if (newWidth < srcRec.width) srcRec.width = (float)newWidth;
+        if (newHeight < srcRec.height) srcRec.height = (float)newHeight;
 
         int bytesPerPixel = GetPixelDataSize(1, 1, image->format);
         unsigned char *resizedData = (unsigned char *)RL_CALLOC(newWidth*newHeight*bytesPerPixel, 1);
@@ -2569,7 +2569,7 @@ void ImageDraw(Image *dst, Image src, Rectangle srcRec, Rectangle dstRec, Color 
         {
             srcMod = ImageFromImage(src, srcRec);   // Create image from another image
             ImageResize(&srcMod, (int)dstRec.width, (int)dstRec.height);   // Resize to destination rectangle
-            srcRec = (Rectangle){ 0, 0, srcMod.width, srcMod.height };
+            srcRec = (Rectangle){ 0, 0, (float)srcMod.width, (float)srcMod.height };
 
             srcPtr = &srcMod;
             useSrcMod = true;
@@ -2592,8 +2592,8 @@ void ImageDraw(Image *dst, Image src, Rectangle srcRec, Rectangle dstRec, Color 
         }
         else if ((dstRec.y + srcRec.height) > dst->height) srcRec.height = dst->height - dstRec.y;
 
-        if (dst->width < srcRec.width) srcRec.width = dst->width;
-        if (dst->height < srcRec.height) srcRec.height = dst->height;
+        if (dst->width < srcRec.width) srcRec.width = (float)dst->width;
+        if (dst->height < srcRec.height) srcRec.height = (float)dst->height;
 
         // This blitting method is quite fast! The process followed is:
         // for every pixel -> [get_src_format/get_dst_format -> blend -> format_to_dst]
@@ -2627,7 +2627,7 @@ void ImageDraw(Image *dst, Image src, Rectangle srcRec, Rectangle dstRec, Color 
             unsigned char *pDst = pDstBase;
 
             // Fast path: Avoid moving pixel by pixel if no blend required and same format
-            if (!blendRequired && (srcPtr->format == dst->format)) memcpy(pDst, pSrc, srcRec.width*bytesPerPixelSrc);
+            if (!blendRequired && (srcPtr->format == dst->format)) memcpy(pDst, pSrc, (size_t)(srcRec.width*bytesPerPixelSrc));
             else
             {
                 for (int x = 0; x < (int)srcRec.width; x++)
@@ -3079,7 +3079,7 @@ void DrawTextureTiled(Texture2D texture, Rectangle sourceRec, Rectangle destRec,
 {
     if (texture.id <= 0 || scale <= 0.0f) return;  // Wanna see a infinite loop?!...just delete this line!
 
-    int tileWidth = sourceRec.width*scale, tileHeight = sourceRec.height*scale;
+    int tileWidth = (int)(sourceRec.width*scale), tileHeight = (int)(sourceRec.height*scale);
     if (destRec.width < tileWidth && destRec.height < tileHeight)
     {
         // Can fit only one tile
@@ -3092,7 +3092,7 @@ void DrawTextureTiled(Texture2D texture, Rectangle sourceRec, Rectangle destRec,
         int dy = 0;
         for (;dy+tileHeight < destRec.height; dy += tileHeight)
         {
-            DrawTexturePro(texture, (Rectangle){sourceRec.x, sourceRec.y, ((float)destRec.width/tileWidth)*sourceRec.width, sourceRec.height}, (Rectangle){destRec.x, destRec.y + dy, destRec.width, tileHeight}, origin, rotation, tint);
+            DrawTexturePro(texture, (Rectangle){sourceRec.x, sourceRec.y, ((float)destRec.width/tileWidth)*sourceRec.width, sourceRec.height}, (Rectangle){destRec.x, destRec.y + dy, destRec.width, (float)tileHeight}, origin, rotation, tint);
         }
 
         // Fit last tile
@@ -3108,7 +3108,7 @@ void DrawTextureTiled(Texture2D texture, Rectangle sourceRec, Rectangle destRec,
         int dx = 0;
         for (;dx+tileWidth < destRec.width; dx += tileWidth)
         {
-            DrawTexturePro(texture, (Rectangle){sourceRec.x, sourceRec.y, sourceRec.width, ((float)destRec.height/tileHeight)*sourceRec.height}, (Rectangle){destRec.x + dx, destRec.y, tileWidth, destRec.height}, origin, rotation, tint);
+            DrawTexturePro(texture, (Rectangle){sourceRec.x, sourceRec.y, sourceRec.width, (float)(destRec.height/tileHeight)*sourceRec.height}, (Rectangle){destRec.x + dx, destRec.y, (float)tileWidth, destRec.height}, origin, rotation, tint);
         }
 
         // Fit last tile
@@ -3127,13 +3127,13 @@ void DrawTextureTiled(Texture2D texture, Rectangle sourceRec, Rectangle destRec,
             int dy = 0;
             for (;dy+tileHeight < destRec.height; dy += tileHeight)
             {
-                DrawTexturePro(texture, sourceRec, (Rectangle){destRec.x + dx, destRec.y + dy, tileWidth, tileHeight}, origin, rotation, tint);
+                DrawTexturePro(texture, sourceRec, (Rectangle){destRec.x + dx, destRec.y + dy, (float)tileWidth, (float)tileHeight}, origin, rotation, tint);
             }
 
             if (dy < destRec.height)
             {
                 DrawTexturePro(texture, (Rectangle){sourceRec.x, sourceRec.y, sourceRec.width, ((float)(destRec.height - dy)/tileHeight)*sourceRec.height},
-                    (Rectangle){destRec.x + dx, destRec.y + dy, tileWidth, destRec.height - dy}, origin, rotation, tint);
+                    (Rectangle){destRec.x + dx, destRec.y + dy, (float)tileWidth, (float)(destRec.height - dy)}, origin, rotation, tint);
             }
         }
 
@@ -3144,7 +3144,7 @@ void DrawTextureTiled(Texture2D texture, Rectangle sourceRec, Rectangle destRec,
             for (;dy+tileHeight < destRec.height; dy += tileHeight)
             {
                 DrawTexturePro(texture, (Rectangle){sourceRec.x, sourceRec.y, ((float)(destRec.width - dx)/tileWidth)*sourceRec.width, sourceRec.height},
-                        (Rectangle){destRec.x + dx, destRec.y + dy, destRec.width - dx, tileHeight}, origin, rotation, tint);
+                        (Rectangle){destRec.x + dx, destRec.y + dy, destRec.width - dx, (float)tileHeight}, origin, rotation, tint);
             }
 
             // Draw final tile in the bottom right corner
@@ -3787,7 +3787,7 @@ int GetPixelDataSize(int width, int height, int format)
 //----------------------------------------------------------------------------------
 #if defined(SUPPORT_FILEFORMAT_DDS)
 // Loading DDS image data (compressed or uncompressed)
-static Image LoadDDS(const unsigned char *fileData, unsigned int fileSize)
+static Image LoadDDS(const unsigned char *fileData, size_t fileSize)
 {
     unsigned char *fileDataPtr = (unsigned char *)fileData;
 
@@ -3869,7 +3869,7 @@ static Image LoadDDS(const unsigned char *fileData, unsigned int fileSize)
             {
                 if (ddsHeader->ddspf.flags == 0x40)         // no alpha channel
                 {
-                    int dataSize = image.width*image.height*sizeof(unsigned short);
+                    size_t dataSize = image.width*image.height*sizeof(unsigned short);
                     image.data = (unsigned short *)RL_MALLOC(dataSize);
 
                     memcpy(image.data, fileDataPtr, dataSize);
@@ -3880,7 +3880,7 @@ static Image LoadDDS(const unsigned char *fileData, unsigned int fileSize)
                 {
                     if (ddsHeader->ddspf.aBitMask == 0x8000)    // 1bit alpha
                     {
-                        int dataSize = image.width*image.height*sizeof(unsigned short);
+                        size_t dataSize = image.width*image.height*sizeof(unsigned short);
                         image.data = (unsigned short *)RL_MALLOC(dataSize);
 
                         memcpy(image.data, fileDataPtr, dataSize);
@@ -3899,7 +3899,7 @@ static Image LoadDDS(const unsigned char *fileData, unsigned int fileSize)
                     }
                     else if (ddsHeader->ddspf.aBitMask == 0xf000)   // 4bit alpha
                     {
-                        int dataSize = image.width*image.height*sizeof(unsigned short);
+                        size_t dataSize = image.width*image.height*sizeof(unsigned short);
                         image.data = (unsigned short *)RL_MALLOC(dataSize);
 
                         memcpy(image.data, fileDataPtr, dataSize);
@@ -3920,7 +3920,7 @@ static Image LoadDDS(const unsigned char *fileData, unsigned int fileSize)
             }
             else if (ddsHeader->ddspf.flags == 0x40 && ddsHeader->ddspf.rgbBitCount == 24)   // DDS_RGB, no compressed
             {
-                int dataSize = image.width*image.height*3*sizeof(unsigned char);
+                size_t dataSize = image.width*image.height*3*sizeof(unsigned char);
                 image.data = (unsigned short *)RL_MALLOC(dataSize);
 
                 memcpy(image.data, fileDataPtr, dataSize);
@@ -3929,7 +3929,7 @@ static Image LoadDDS(const unsigned char *fileData, unsigned int fileSize)
             }
             else if (ddsHeader->ddspf.flags == 0x41 && ddsHeader->ddspf.rgbBitCount == 32) // DDS_RGBA, no compressed
             {
-                int dataSize = image.width*image.height*4*sizeof(unsigned char);
+                size_t dataSize = image.width*image.height*4*sizeof(unsigned char);
                 image.data = (unsigned short *)RL_MALLOC(dataSize);
 
                 memcpy(image.data, fileDataPtr, dataSize);
@@ -3950,7 +3950,7 @@ static Image LoadDDS(const unsigned char *fileData, unsigned int fileSize)
             }
             else if (((ddsHeader->ddspf.flags == 0x04) || (ddsHeader->ddspf.flags == 0x05)) && (ddsHeader->ddspf.fourCC > 0)) // Compressed
             {
-                int dataSize = 0;
+                size_t dataSize = 0;
 
                 // Calculate data size, including all mipmaps
                 if (ddsHeader->mipmapCount > 1) dataSize = ddsHeader->pitchOrLinearSize*2;
@@ -3983,7 +3983,7 @@ static Image LoadDDS(const unsigned char *fileData, unsigned int fileSize)
 // Loading PKM image data (ETC1/ETC2 compression)
 // NOTE: KTX is the standard Khronos Group compression format (ETC1/ETC2, mipmaps)
 // PKM is a much simpler file format used mainly to contain a single ETC1/ETC2 compressed image (no mipmaps)
-static Image LoadPKM(const unsigned char *fileData, unsigned int fileSize)
+static Image LoadPKM(const unsigned char *fileData, size_t fileSize)
 {
     unsigned char *fileDataPtr = (unsigned char *)fileData;
 
@@ -4045,7 +4045,7 @@ static Image LoadPKM(const unsigned char *fileData, unsigned int fileSize)
             int bpp = 4;
             if (pkmHeader->format == 3) bpp = 8;
 
-            int dataSize = image.width*image.height*bpp/8;  // Total data size in bytes
+            size_t dataSize = image.width*image.height*bpp/8;  // Total data size in bytes
 
             image.data = (unsigned char *)RL_MALLOC(dataSize*sizeof(unsigned char));
 
@@ -4063,7 +4063,7 @@ static Image LoadPKM(const unsigned char *fileData, unsigned int fileSize)
 
 #if defined(SUPPORT_FILEFORMAT_KTX)
 // Load KTX compressed image data (ETC1/ETC2 compression)
-static Image LoadKTX(const unsigned char *fileData, unsigned int fileSize)
+static Image LoadKTX(const unsigned char *fileData, size_t fileSize)
 {
     unsigned char *fileDataPtr = (unsigned char *)fileData;
 
@@ -4127,7 +4127,7 @@ static Image LoadKTX(const unsigned char *fileData, unsigned int fileSize)
 
             fileDataPtr += ktxHeader->keyValueDataSize; // Skip value data size
 
-            int dataSize = ((int *)fileDataPtr)[0];
+            size_t dataSize = ((int *)fileDataPtr)[0];
             fileDataPtr += sizeof(int);
 
             image.data = (unsigned char *)RL_MALLOC(dataSize*sizeof(unsigned char));
@@ -4170,7 +4170,7 @@ static int SaveKTX(Image image, const char *fileName)
     } KTXHeader;
 
     // Calculate file dataSize required
-    int dataSize = sizeof(KTXHeader);
+    size_t dataSize = sizeof(KTXHeader);
 
     for (int i = 0, width = image.width, height = image.height; i < image.mipmaps; i++)
     {
@@ -4218,12 +4218,12 @@ static int SaveKTX(Image image, const char *fileName)
 
         int width = image.width;
         int height = image.height;
-        int dataOffset = 0;
+        size_t dataOffset = 0;
 
         // Save all mipmaps data
         for (int i = 0; i < image.mipmaps; i++)
         {
-            unsigned int dataSize = GetPixelDataSize(width, height, image.format);
+            size_t dataSize = (size_t)GetPixelDataSize(width, height, image.format);
 
             memcpy(fileDataPtr, &dataSize, sizeof(unsigned int));
             memcpy(fileDataPtr + 4, (unsigned char *)image.data + dataOffset, dataSize);
@@ -4247,7 +4247,7 @@ static int SaveKTX(Image image, const char *fileName)
 #if defined(SUPPORT_FILEFORMAT_PVR)
 // Loading PVR image data (uncompressed or PVRT compression)
 // NOTE: PVR v2 not supported, use PVR v3 instead
-static Image LoadPVR(const unsigned char *fileData, unsigned int fileSize)
+static Image LoadPVR(const unsigned char *fileData, size_t fileSize)
 {
     unsigned char *fileDataPtr = (unsigned char *)fileData;
 
@@ -4367,7 +4367,7 @@ static Image LoadPVR(const unsigned char *fileData, unsigned int fileSize)
                     default: break;
                 }
 
-                int dataSize = image.width*image.height*bpp/8;  // Total data size in bytes
+                size_t dataSize = image.width*image.height*bpp/8;  // Total data size in bytes
                 image.data = (unsigned char *)RL_MALLOC(dataSize*sizeof(unsigned char));
 
                 memcpy(image.data, fileDataPtr, dataSize);
@@ -4382,7 +4382,7 @@ static Image LoadPVR(const unsigned char *fileData, unsigned int fileSize)
 
 #if defined(SUPPORT_FILEFORMAT_ASTC)
 // Load ASTC compressed image data (ASTC compression)
-static Image LoadASTC(const unsigned char *fileData, unsigned int fileSize)
+static Image LoadASTC(const unsigned char *fileData, size_t fileSize)
 {
     unsigned char *fileDataPtr = (unsigned char *)fileData;
 
@@ -4436,7 +4436,7 @@ static Image LoadASTC(const unsigned char *fileData, unsigned int fileSize)
             // NOTE: Currently we only support 2 blocks configurations: 4x4 and 8x8
             if ((bpp == 8) || (bpp == 2))
             {
-                int dataSize = image.width*image.height*bpp/8;  // Data size in bytes
+                size_t dataSize = image.width*image.height*bpp/8;  // Data size in bytes
 
                 image.data = (unsigned char *)RL_MALLOC(dataSize*sizeof(unsigned char));
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -164,7 +164,7 @@ void TraceLog(int logType, const char *text, ...)
 }
 
 // Load data from file into a buffer
-unsigned char *LoadFileData(const char *fileName, unsigned int *bytesRead)
+unsigned char *LoadFileData(const char *fileName, size_t *bytesRead)
 {
     unsigned char *data = NULL;
     *bytesRead = 0;
@@ -186,7 +186,7 @@ unsigned char *LoadFileData(const char *fileName, unsigned int *bytesRead)
                 data = (unsigned char *)RL_MALLOC(size*sizeof(unsigned char));
 
                 // NOTE: fread() returns number of read elements instead of bytes, so we read [1 byte, size elements]
-                unsigned int count = (unsigned int)fread(data, sizeof(unsigned char), size, file);
+                size_t count = fread(data, sizeof(unsigned char), size, file);
                 *bytesRead = count;
 
                 if (count != size) TRACELOG(LOG_WARNING, "FILEIO: [%s] File partially loaded", fileName);
@@ -204,7 +204,7 @@ unsigned char *LoadFileData(const char *fileName, unsigned int *bytesRead)
 }
 
 // Save data to file from buffer
-bool SaveFileData(const char *fileName, void *data, unsigned int bytesToWrite)
+bool SaveFileData(const char *fileName, void *data, size_t bytesToWrite)
 {
     bool success = false;
     
@@ -214,7 +214,7 @@ bool SaveFileData(const char *fileName, void *data, unsigned int bytesToWrite)
 
         if (file != NULL)
         {
-            unsigned int count = (unsigned int)fwrite(data, sizeof(unsigned char), bytesToWrite, file);
+            size_t count = fwrite(data, sizeof(unsigned char), bytesToWrite, file);
 
             if (count == 0) TRACELOG(LOG_WARNING, "FILEIO: [%s] Failed to write file", fileName);
             else if (count != bytesToWrite) TRACELOG(LOG_WARNING, "FILEIO: [%s] File partially written", fileName);


### PR DESCRIPTION
There are a number of type cast warnings when building the library in visual studio. This PR adds casts to those places to prevent the warnings and make the intent of the code more clear.