### PR TITLE
Added Apple Compilation Instructions

### DIFF
--- a/examples/others/rlgl_standalone.c
+++ b/examples/others/rlgl_standalone.c
@@ -15,9 +15,14 @@
 *   allows coding in a pseudo-OpenGL 1.1 style while translating calls to multiple
 *   OpenGL versions backends (1.1, 2.1, 3.3, ES 2.0).
 *
-*   COMPILATION:
+*   WINDOWS COMPILATION:
 *       gcc -o rlgl_standalone.exe rlgl_standalone.c -s -Iexternal\include -I..\..\src  \
 *           -L. -Lexternal\lib -lglfw3 -lopengl32 -lgdi32 -Wall -std=c99 -DGRAPHICS_API_OPENGL_33
+*
+*   APPLE COMPILATION:
+*       gcc -o rlgl_standalone rlgl_standalone.c -I../../src -Iexternal/include -Lexternal/lib \
+*           -lglfw3 -std=c99 -framework CoreVideo -framework OpenGL -framework OpenAL \
+*           -framework IOKit -framework Cocoa -Wno-deprecated-declarations
 *
 *   LICENSE: zlib/libpng
 *


### PR DESCRIPTION
Stumbled on this example and I love this! Adding instructions that work for me on MacOS.. Note that glfw3 will need to be statically built locally and copied to this external/libs directory on mac. I can upload my static version, but it probably makes sense to do this only if there's some general naming convention for adding platform specific folders. Like "external_osx/lib" or "external/lib_osx". Then I'll drop my static libs in there.