### PR TITLE
Added GLFW_OPENGL_FORWARD_COMPAT for Apple Support

### DIFF
--- a/examples/others/rlgl_standalone.c
+++ b/examples/others/rlgl_standalone.c
@@ -99,6 +99,10 @@ int main(void)
     glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
     glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
     //glfwWindowHint(GLFW_OPENGL_DEBUG_CONTEXT, GL_TRUE);
+#if defined(__APPLE__)
+    glfwWindowHint( GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE );
+#endif
+
    
     GLFWwindow *window = glfwCreateWindow(screenWidth, screenHeight, "rlgl standalone", NULL, NULL);
     


### PR DESCRIPTION
Without GLFW_OPENGL_FORWARD_COMPAT, running this as a standalone will yield the error:
```
NSGL: The targeted version of macOS only supports forward-compatible core profile contexts for OpenGL 3.2 and above
```