### PR TITLE
Add function to get the position of a monitor (and fix some comments)

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -1437,7 +1437,26 @@ int GetMonitorCount(void)
 #endif
 }
 
-// Get primary monitor width
+// Get selected monitor width
+Vector2 GetMonitorPosition(int monitor)
+{
+#if defined(PLATFORM_DESKTOP)
+	int monitorCount;
+	GLFWmonitor** monitors = glfwGetMonitors(&monitorCount);
+
+	if ((monitor >= 0) && (monitor < monitorCount))
+	{
+        int x, y;
+        glfwGetMonitorPos(monitors[monitor], &x, &y);
+		const GLFWvidmode* mode = glfwGetVideoMode(monitors[monitor]);
+		return (Vector2){ (float)x, (float)y };
+	}
+	else TRACELOG(LOG_WARNING, "GLFW: Failed to find selected monitor");
+#endif
+    return (Vector2){ 0, 0 };
+}
+
+// Get selected monitor width
 int GetMonitorWidth(int monitor)
 {
 #if defined(PLATFORM_DESKTOP)
@@ -1454,7 +1473,7 @@ int GetMonitorWidth(int monitor)
     return 0;
 }
 
-// Get primary monitor width
+// Get selected monitor width
 int GetMonitorHeight(int monitor)
 {
 #if defined(PLATFORM_DESKTOP)
@@ -1471,7 +1490,7 @@ int GetMonitorHeight(int monitor)
     return 0;
 }
 
-// Get primary montior physical width in millimetres
+// Get selected monitor physical width in millimetres
 int GetMonitorPhysicalWidth(int monitor)
 {
 #if defined(PLATFORM_DESKTOP)

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -913,11 +913,12 @@ RLAPI void *GetWindowHandle(void);                                // Get native 
 RLAPI int GetScreenWidth(void);                                   // Get current screen width
 RLAPI int GetScreenHeight(void);                                  // Get current screen height
 RLAPI int GetMonitorCount(void);                                  // Get number of connected monitors
-RLAPI int GetMonitorWidth(int monitor);                           // Get primary monitor width
-RLAPI int GetMonitorHeight(int monitor);                          // Get primary monitor height
-RLAPI int GetMonitorPhysicalWidth(int monitor);                   // Get primary monitor physical width in millimetres
-RLAPI int GetMonitorPhysicalHeight(int monitor);                  // Get primary monitor physical height in millimetres
-RLAPI int GetMonitorRefreshRate(int monitor);                     // Get primary monitor refresh rate
+RLAPI Vector2 GetMonitorPosition(int monitor);                    // Get specified monitor position
+RLAPI int GetMonitorWidth(int monitor);                           // Get specified monitor width
+RLAPI int GetMonitorHeight(int monitor);                          // Get specified monitor height
+RLAPI int GetMonitorPhysicalWidth(int monitor);                   // Get specified monitor physical width in millimetres
+RLAPI int GetMonitorPhysicalHeight(int monitor);                  // Get specified monitor physical height in millimetres
+RLAPI int GetMonitorRefreshRate(int monitor);                     // Get specified monitor refresh rate
 RLAPI Vector2 GetWindowPosition(void);                            // Get window position XY on monitor
 RLAPI Vector2 GetWindowScaleDPI(void);                            // Get window scale DPI factor
 RLAPI const char *GetMonitorName(int monitor);                    // Get the human-readable, UTF-8 encoded name of the primary monitor


### PR DESCRIPTION
This PR adds a function to the API that returns information about multiple displays on desktop platforms that tells you where a monitor is relative to the primary monitor, so you can move a window onto it. This PR also changes some comments that refer to the primary monitor but are attached to functions that deal with selected monitors.