### PR TITLE
Fixed an issue where SetAudioBufferPitch could not be dynamically changed

### DIFF
--- a/src/raudio.c
+++ b/src/raudio.c
@@ -632,7 +632,7 @@ void SetAudioBufferVolume(AudioBuffer *buffer, float volume)
 // Set pitch for an audio buffer
 void SetAudioBufferPitch(AudioBuffer *buffer, float pitch)
 {
-    if (buffer != NULL)
+    if (buffer != NULL && buffer->pitch != pitch)
     {
         float pitchMul = pitch/buffer->pitch;
 


### PR DESCRIPTION
I tried making a simple program that changes the pitch of the music dynamically and found out that the pitch was not changing at all. 

```c
#include "raylib.h"

#define TARGET_FPS 60

#define DEFAULT_WIDTH 800
#define DEFAULT_HEIGHT 600

Music music_example;

void LoadResources(void);

void UnloadResources(void);

void UpdateCurrentScreen(void);

int main(void) {
    SetTargetFPS(TARGET_FPS);
        
    InitAudioDevice();
    InitWindow(DEFAULT_WIDTH, DEFAULT_HEIGHT, "some example");
    
    LoadResources();
    
    while (!WindowShouldClose())
        UpdateCurrentScreen();
    
    UnloadResources();

    CloseAudioDevice();
    CloseWindow();
    
    return 0;
}

void LoadResources(void) {
    music_example = LoadMusicStream("res/example.mp3");
    PlayMusicStream(music_example);
}

void UnloadResources(void) {
    StopMusicStream(music_example);
    UnloadMusicStream(music_example);
}

void UpdateCurrentScreen(void) {
    BeginDrawing();
    
    ClearBackground(RAYWHITE);
    
    if (IsKeyDown(KEY_UP))
        SetMusicPitch(music_example, 1.25f);
    else if (IsKeyDown(KEY_DOWN))
        SetMusicPitch(music_example, 0.75f);
    else;
    
    UpdateMusicStream(music_example);
    
    DrawFPS(8, 8);
    
    EndDrawing();
}
```

So I modified the `SetAudioBufferPitch` function to print the value of `pitchMul`, expected value of the changed sample rate and `newOutputSampleRate` and got these results. As you can see, when `buffer->pitch` equals to the second argument of `SetAudioBufferPitch` (`float pitch`), the pitch of the audio won't change compared to what we expected. While this might not be an appropriate solution to this problem, at least adding `buffer->pitch != pitch` to the `if` statement resolved this issue for me. Please let me know if you have any ideas about this problem. Thank you very much!

```c
INFO: TIMER: Target time per frame: 16.667 milliseconds
INFO: AUDIO: Device initialized successfully
INFO:     > Backend:       miniaudio / PulseAudio
INFO:     > Format:        32-bit IEEE Floating Point -> 16-bit Signed Integer
INFO:     > Channels:      2 -> 2
INFO:     > Sample rate:   44100 -> 44100
INFO:     > Periods size:  1320
INFO: AUDIO: Multichannel pool size: 16
INFO: Initializing raylib 3.1-dev
INFO: DISPLAY: Device initialized successfully
INFO:     > Display size: 1680 x 1050
INFO:     > Render size:  800 x 600
INFO:     > Screen size:  800 x 600
INFO:     > Viewport offsets: 0, 0
INFO: GLAD: OpenGL extensions loaded successfully
INFO: GL: OpenGL 3.3 Core profile supported
INFO: GL: OpenGL device information:
INFO:     > Vendor:   Intel Open Source Technology Center
INFO:     > Renderer: Mesa DRI Intel(R) HD Graphics (Coffeelake 3x8 GT2) 
INFO:     > Version:  4.5 (Core Profile) Mesa 18.0.0-rc5
INFO:     > GLSL:     4.50
INFO: GL: Supported extensions count: 191
INFO: GL: DXT compressed textures supported
INFO: GL: ETC2/EAC compressed textures supported
INFO: GL: Anisotropic textures filtering supported (max: 16X)
INFO: TEXTURE: [ID 1] Texture created successfully (1x1 - 1 mipmaps)
INFO: TEXTURE: [ID 1] Default texture loaded successfully
INFO: SHADER: [ID 1] Compiled successfully
INFO: SHADER: [ID 2] Compiled successfully
INFO: SHADER: [ID 3] Program loaded successfully
INFO: SHADER: [ID 3] Default shader loaded successfully
INFO: RLGL: Internal vertex buffers initialized successfully in RAM (CPU)
INFO: RLGL: Render batch vertex buffers loaded successfully
INFO: RLGL: Default state initialized successfully
INFO: TEXTURE: [ID 2] Texture created successfully (128x128 - 1 mipmaps)
INFO: FONT: Default font loaded successfully
INFO: STREAM: Initialized successfully (44100 Hz, 32 bit, Stereo)
INFO: FILEIO: [res/example.mp3] Music file successfully loaded:
INFO:     > Total samples: 34205184
INFO:     > Sample rate:   44100 Hz
INFO:     > Sample size:   32 bits
INFO:     > Channels:      2 (Stereo)

pitchMul: 1.250000
target: 35280
result: 35280
pitchMul: 1.000000
target: 35280
result: 44100
pitchMul: 1.000000
target: 35280
result: 44100

...
```
  