### PR TITLE
Changed extension for web from .bc to .a

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -173,7 +173,7 @@ library_path_to_linker_flags(__PKG_CONFIG_LIBS_PRIVATE "${LIBS_PRIVATE}")
 if(STATIC)
   MESSAGE(STATUS "Building raylib static library")
   if(${PLATFORM} MATCHES "Web")
-    set(CMAKE_STATIC_LIBRARY_SUFFIX ".bc")
+    set(CMAKE_STATIC_LIBRARY_SUFFIX ".a")
   endif()
 
   add_library(raylib_static STATIC ${sources})


### PR DESCRIPTION
I did this to support vcpkg expectation. When using the library from vcpkg for web you would install it using vcpkg install raylib:wasm32-emscripten but also vcpkg expects the output lib to be with .a extension instead of .bc

Doesn't make a difference for standalone builds or when raylib is used as a subdirectory dependency.