### PR TITLE
Add headers to install cmake

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -173,7 +173,7 @@ library_path_to_linker_flags(__PKG_CONFIG_LIBS_PRIVATE "${LIBS_PRIVATE}")
 if(STATIC)
   MESSAGE(STATUS "Building raylib static library")
   if(${PLATFORM} MATCHES "Web")
-    set(CMAKE_STATIC_LIBRARY_SUFFIX ".bc")
+    set(CMAKE_STATIC_LIBRARY_SUFFIX ".a")
   endif()
 
   add_library(raylib_static STATIC ${sources})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -207,7 +207,7 @@ if(STATIC)
       ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
       PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
   )
-set_target_properties(raylib_static PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_BINARY_DIR}")
+  set_target_properties(raylib_static PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_BINARY_DIR}")
 
   add_test("pkg-config--static" ${PROJECT_SOURCE_DIR}/../cmake/test-pkgconfig.sh --static)
 endif(STATIC)
@@ -291,6 +291,13 @@ file(COPY "rlgl.h" DESTINATION ".")
 file(COPY "physac.h" DESTINATION ".")
 file(COPY "raymath.h" DESTINATION ".")
 file(COPY "raudio.h" DESTINATION ".")
+
+# Also install them
+install(FILES "raylib.h" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+install(FILES "rlgl.h" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+install(FILES "physac.h" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+install(FILES "raymath.h" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+install(FILES "raudio.h" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 
 # Print the flags for the user
 if (DEFINED CMAKE_BUILD_TYPE)


### PR DESCRIPTION
@raysan5 Another small improvement. I really want to get this to work for vcpkg and currently vcpkg only has one of these critical headers.