### PR TITLE
Skip invalid files when iterating a directory.

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -2421,8 +2421,11 @@ char **GetDirectoryFiles(const char *dirPath, int *fileCount)
 
         while ((entity = readdir(dir)) != NULL)
         {
-            strcpy(dirFilesPath[counter], entity->d_name);
-            counter++;
+            if (entity->d_name != NULL && entity->d_name[0] != '.')
+            {
+                strcpy(dirFilesPath[counter], entity->d_name);
+                counter++;
+            }
         }
 
         closedir(dir);


### PR DESCRIPTION
This PR skips any file that starts with '.'. These are ether a relative link or a hidden file on *nix and should not be iterated.