### PR TITLE
[Math Feature]: Add two functions for Vector2 to know if two lines intersect and two segments intersect

### DIFF
--- a/src/raymath.h
+++ b/src/raymath.h
@@ -337,7 +337,7 @@ RMDEF Vector2 Vector2MoveTowards(Vector2 v, Vector2 target, float maxDistance)
 }
 
 // Get the intersection point of two lines A and B defined by A(p1, p2) and B(p3, p4), return true if it exists, else false
-RMDEF _Bool Vector2LineIntersect(Vector2 p1, Vector2 p2, Vector2 p3, Vector2 p4, Vector2* pointIntersection)
+RMDEF bool Vector2LineIntersect(Vector2 p1, Vector2 p2, Vector2 p3, Vector2 p4, Vector2* pointIntersection)
 {
     const float div = (p4.y - p3.y)*(p2.x - p1.x) - (p4.x -p3.x)*(p2.y - p1.y);
 
@@ -354,7 +354,7 @@ RMDEF _Bool Vector2LineIntersect(Vector2 p1, Vector2 p2, Vector2 p3, Vector2 p4,
 }
 
 // Get the intersection point of two segments A and B defined by A(p1, p2) and B(P3, p4), return true if it exists, else false
-RMDEF _Bool Vector2SegmentIntersect(Vector2 p1, Vector2 p2, Vector2 p3, Vector2 p4, Vector2* pointIntersection)
+RMDEF bool Vector2SegmentIntersect(Vector2 p1, Vector2 p2, Vector2 p3, Vector2 p4, Vector2* pointIntersection)
 {
     const float div = (p4.y - p3.y)*(p2.x - p1.x) - (p4.x -p3.x)*(p2.y - p1.y);
 

--- a/src/raymath.h
+++ b/src/raymath.h
@@ -337,7 +337,7 @@ RMDEF Vector2 Vector2MoveTowards(Vector2 v, Vector2 target, float maxDistance)
 }
 
 // Get the intersection point of two lines A and B defined by A(p1, p2) and B(p3, p4), return true if it exists, else false
-RMDEF _Bool Vector2 Vector2LineIntersect(Vector2 p1, Vector2 p2, Vector2 p3, Vector2 p4, Vector2* pointIntersection)
+RMDEF _Bool Vector2LineIntersect(Vector2 p1, Vector2 p2, Vector2 p3, Vector2 p4, Vector2* pointIntersection)
 {
     const float div = (p4.y - p3.y)*(p2.x - p1.x) - (p4.x -p3.x)*(p2.y - p1.y);
 

--- a/src/raymath.h
+++ b/src/raymath.h
@@ -342,13 +342,13 @@ RMDEF Vector2 Vector2LineIntersect(Vector2 p1, Vector2 p2, Vector2 p3, Vector2 p
     Vector2 result = { 0 };
     const float div = (p4.y - p3.y)*(p2.x - p1.x) - (p4.x -p3.x)*(p2.y - p1.y);
 
-	if (div == 0.f) return result;
+    if (div == 0.f) return result;
 
-	const float coeff = ((p4.x - p3.x)*(p1.y - p3.y) - (p4.y - p3.y)*(p1.x - p3.x)) / div;
+    const float coeff = ((p4.x - p3.x)*(p1.y - p3.y) - (p4.y - p3.y)*(p1.x - p3.x)) / div;
 
-	result.x = p1.x + (p2.x - p1.x) * coeff;
+    result.x = p1.x + (p2.x - p1.x) * coeff;
     result.y = p1.y + (p2.y - p1.y) * coeff; 
-	return result;
+    return result;
 }
 
 //----------------------------------------------------------------------------------

--- a/src/raymath.h
+++ b/src/raymath.h
@@ -336,19 +336,43 @@ RMDEF Vector2 Vector2MoveTowards(Vector2 v, Vector2 target, float maxDistance)
     return result;
 }
 
-// Get the intersection point of two lines A and B defined by A(p1, p2) and B(p3, p4)
-RMDEF Vector2 Vector2LineIntersect(Vector2 p1, Vector2 p2, Vector2 p3, Vector2 p4)
+// Get the intersection point of two lines A and B defined by A(p1, p2) and B(p3, p4), return true if it exists, else false
+RMDEF _Bool Vector2 Vector2LineIntersect(Vector2 p1, Vector2 p2, Vector2 p3, Vector2 p4, Vector2* pointIntersection)
 {
-    Vector2 result = { 0 };
     const float div = (p4.y - p3.y)*(p2.x - p1.x) - (p4.x -p3.x)*(p2.y - p1.y);
 
-    if (div == 0.f) return result;
+    if (div == 0.f) return false;
 
     const float coeff = ((p4.x - p3.x)*(p1.y - p3.y) - (p4.y - p3.y)*(p1.x - p3.x)) / div;
 
-    result.x = p1.x + (p2.x - p1.x) * coeff;
-    result.y = p1.y + (p2.y - p1.y) * coeff; 
-    return result;
+    if (pointIntersection)
+    {
+        pointIntersection.x = p1.x + (p2.x - p1.x) * coeff;
+        pointIntersection.y = p1.y + (p2.y - p1.y) * coeff;
+    }
+    return true;
+}
+
+// Get the intersection point of two segments A and B defined by A(p1, p2) and B(P3, p4), return true if it exists, else false
+RMDEF _Bool Vector2SegmentIntersect(Vector2 p1, Vector2 p2, Vector2 p3, Vector2 p4, Vector2* pointIntersection)
+{
+    const float div = (p4.y - p3.y)*(p2.x - p1.x) - (p4.x -p3.x)*(p2.y - p1.y);
+
+    if (div == 0.f) return false;
+
+    const float xi = ((p3.x - p3.x)*(p1.x * p2.y - p1.y * p2.x) - (p1.x - p2.x)*(p3.x * p4.y - p3.y * p4.x)) / div;
+    const float yi = ((p3.y - p4.y)*(p1.x * p2.y - p1.y * p2.x) - (p1.y - p2.y)*(p3.x * p4.y - p3.y * p4.x)) / div;
+
+    if (xi < fminf(x1, x2) || xi > fmaxf(x1, x2)) return false;
+    if (xi < fminf(x3, x4) || xi > fmaxf(x3, x4)) return false;
+	if (yi < fminf(y1, y2) || yi > fmaxf(y1, y2)) return false;
+	if (yi < fminf(y3, y4) || yi > fmaxf(y3, y4)) return false;
+    if (pointIntersection)
+    {
+        pointIntersection->x = xi;
+        pointIntersection->y = yi;
+    }
+    return true;
 }
 
 //----------------------------------------------------------------------------------

--- a/src/raymath.h
+++ b/src/raymath.h
@@ -365,8 +365,8 @@ RMDEF _Bool Vector2SegmentIntersect(Vector2 p1, Vector2 p2, Vector2 p3, Vector2 
 
     if (xi < fminf(x1, x2) || xi > fmaxf(x1, x2)) return false;
     if (xi < fminf(x3, x4) || xi > fmaxf(x3, x4)) return false;
-	if (yi < fminf(y1, y2) || yi > fmaxf(y1, y2)) return false;
-	if (yi < fminf(y3, y4) || yi > fmaxf(y3, y4)) return false;
+    if (yi < fminf(y1, y2) || yi > fmaxf(y1, y2)) return false;
+    if (yi < fminf(y3, y4) || yi > fmaxf(y3, y4)) return false;
     if (pointIntersection)
     {
         pointIntersection->x = xi;

--- a/src/raymath.h
+++ b/src/raymath.h
@@ -336,6 +336,21 @@ RMDEF Vector2 Vector2MoveTowards(Vector2 v, Vector2 target, float maxDistance)
     return result;
 }
 
+// Get the intersection point of two lines A and B defined by A(p1, p2) and B(p3, p4)
+RMDEF Vector2 Vector2LineIntersect(Vector2 p1, Vector2 p2, Vector2 p3, Vector2 p4)
+{
+    Vector2 result = { 0 };
+    const float div = (p4.y - p3.y)*(p2.x - p1.x) - (p4.x -p3.x)*(p2.y - p1.y);
+
+	if (div == 0.f) return result;
+
+	const float coeff = ((p4.x - p3.x)*(p1.y - p3.y) - (p4.y - p3.y)*(p1.x - p3.x)) / div;
+
+	result.x = p1.x + (p2.x - p1.x) * coeff;
+    result.y = p1.y + (p2.y - p1.y) * coeff; 
+	return result;
+}
+
 //----------------------------------------------------------------------------------
 // Module Functions Definition - Vector3 math
 //----------------------------------------------------------------------------------

--- a/src/raymath.h
+++ b/src/raymath.h
@@ -347,8 +347,8 @@ RMDEF _Bool Vector2LineIntersect(Vector2 p1, Vector2 p2, Vector2 p3, Vector2 p4,
 
     if (pointIntersection)
     {
-        pointIntersection.x = p1.x + (p2.x - p1.x) * coeff;
-        pointIntersection.y = p1.y + (p2.y - p1.y) * coeff;
+        pointIntersection->x = p1.x + (p2.x - p1.x) * coeff;
+        pointIntersection->y = p1.y + (p2.y - p1.y) * coeff;
     }
     return true;
 }

--- a/src/raymath.h
+++ b/src/raymath.h
@@ -363,10 +363,10 @@ RMDEF _Bool Vector2SegmentIntersect(Vector2 p1, Vector2 p2, Vector2 p3, Vector2 
     const float xi = ((p3.x - p3.x)*(p1.x * p2.y - p1.y * p2.x) - (p1.x - p2.x)*(p3.x * p4.y - p3.y * p4.x)) / div;
     const float yi = ((p3.y - p4.y)*(p1.x * p2.y - p1.y * p2.x) - (p1.y - p2.y)*(p3.x * p4.y - p3.y * p4.x)) / div;
 
-    if (xi < fminf(x1, x2) || xi > fmaxf(x1, x2)) return false;
-    if (xi < fminf(x3, x4) || xi > fmaxf(x3, x4)) return false;
-    if (yi < fminf(y1, y2) || yi > fmaxf(y1, y2)) return false;
-    if (yi < fminf(y3, y4) || yi > fmaxf(y3, y4)) return false;
+    if (xi < fminf(p1.x, p2.x) || xi > fmaxf(p1.x, p2.x)) return false;
+    if (xi < fminf(p3.x, p4.x) || xi > fmaxf(p3.x, p4.x)) return false;
+    if (yi < fminf(p1.y, p2.y) || yi > fmaxf(p1.y, p2.y)) return false;
+    if (yi < fminf(p3.y, p4.y) || yi > fmaxf(p3.y, p4.y)) return false;
     if (pointIntersection)
     {
         pointIntersection->x = xi;


### PR DESCRIPTION
This PR adds two function in the [raymath.h](https://github.com/raysan5/raylib/blob/master/src/raymath.h) header:

```c
    bool Vector2LineIntersect(Vector2 p1, Vector2 p2, Vector2 p3, Vector2 p4, Vector2* pointIntersection)
```
```c
    bool Vector2SegmentIntersect(Vector2 p1, Vector2 p2, Vector2 p3, Vector2 p4, Vector2* pointIntersection)
```

If the second one is true, the first one is always true.

### Vector2LineIntersect:
The first one check if two lines A and B defined by their points, so that A is defined by (p1, p2) and B is defined by (p3, p4) intersect. If it's true, it put the intersection point in the *Vector2\* pointIntersection* parameter, if it's not NULL.

Which corresponds to this image for example:
<kbd>
<img src="https://user-images.githubusercontent.com/20202017/102786646-25075d00-43a0-11eb-9e62-fa091e1e21a8.png" width=600>
</kbd>
</br>


### Vector2SegmentIntersect:
The second one check if two segments A and B defined by their points, so that A is defined by (p1, p2) and B is defined by (p3, p4) intersect. If it's true, it put the intersection point in the *Vector2\* pointIntersection* parameter, if it's not NULL.

Which corresponds to this image for example:
<kbd>
<img src="https://user-images.githubusercontent.com/20202017/102786815-626bea80-43a0-11eb-8f61-6c058fa89bef.png" width=600>
</kbd>
</br>


I choosed to get back a boolean from these two functions, and get the intersection point as a pointer, because we can't just return an empty Vector2 if the segments, or the lines don't intersect. That would mean that we can't ever have an intersection point which has the coordinates { 0, 0 }.