### PR TITLE
[Fix]: Missing <stdbool.h> 

### DIFF
--- a/src/raymath.h
+++ b/src/raymath.h
@@ -47,6 +47,8 @@
 
 #ifndef RAYMATH_STANDALONE
     #include "raylib.h"           // Required for structs: Vector3, Matrix
+#else
+    #include <stdbool.h>
 #endif
 
 #if defined(RAYMATH_IMPLEMENTATION) && defined(RAYMATH_HEADER_ONLY)


### PR DESCRIPTION
This PR adds the missing <stdbool.h> include if we are using *raymath.h* as a standalone.