### PR TITLE
TSnake41/raylib-lua updated to 3.5

### DIFF
--- a/BINDINGS.md
+++ b/BINDINGS.md
@@ -24,7 +24,7 @@ Here it is a list with the ones I'm aware of:
 | raylib-lua         | 1.7 | [Lua](http://www.lua.org/)            | https://github.com/raysan5/raylib-lua       |
 | raylib-lua-ffi     | 2.0 | [Lua](http://www.lua.org/)            | https://github.com/raysan5/raylib/issues/693    |
 | raylib-lua-sol     | 2.5 | [Lua](http://www.lua.org/)          | https://github.com/RobLoach/raylib-lua-sol     |
-| raylib-lua         | 3.0 | [Lua](http://www.lua.org/)            | https://github.com/TSnake41/raylib-lua       |
+| raylib-lua         | 3.5 | [Lua](http://www.lua.org/)            | https://github.com/TSnake41/raylib-lua       |
 | raylib-luamore     | 3.0 | [Lua](http://www.lua.org/)            | https://github.com/HDPLocust/raylib-luamore    |
 | raylua             | 3.5 | [Lua](http://www.lua.org/)            | https://github.com/Rabios/raylua          |
 | LuaJIT-Raylib      | 2.6 | [Lua](http://www.lua.org/)            | https://github.com/Bambofy/LuaJIT-Raylib    |


### PR DESCRIPTION
[raylua v3.5a](https://github.com/TSnake41/raylib-lua/releases/tag/v3.5a) has been released