### PR TITLE
Fix wrong values shown for monitor width and height in pixels when fu…

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -1032,7 +1032,7 @@ void ToggleFullscreen(void)
             glfwSetWindowMonitor(CORE.Window.handle, glfwGetPrimaryMonitor(), 0, 0, CORE.Window.screen.width, CORE.Window.screen.height, GLFW_DONT_CARE);
             return;
         }
-
+    
         const GLFWvidmode *mode = glfwGetVideoMode(monitor);
         glfwSetWindowMonitor(CORE.Window.handle, glfwGetPrimaryMonitor(), 0, 0, CORE.Window.screen.width, CORE.Window.screen.height, mode->refreshRate);
 
@@ -1480,8 +1480,13 @@ int GetMonitorWidth(int monitor)
 
     if ((monitor >= 0) && (monitor < monitorCount))
     {
-        const GLFWvidmode *mode = glfwGetVideoMode(monitors[monitor]);
-        return mode->width;
+        int count = 0;
+        const GLFWvidmode *modes = glfwGetVideoModes(monitors[monitor], &count);
+    
+        if(count > 0)
+        {
+            return modes[count - 1].width;
+        } else TRACELOG(LOG_WARNING, "GLFW: Failed to find video mode for selected monitor");
     }
     else TRACELOG(LOG_WARNING, "GLFW: Failed to find selected monitor");
 #endif
@@ -1497,8 +1502,13 @@ int GetMonitorHeight(int monitor)
 
     if ((monitor >= 0) && (monitor < monitorCount))
     {
-        const GLFWvidmode *mode = glfwGetVideoMode(monitors[monitor]);
-        return mode->height;
+        int count = 0;
+        const GLFWvidmode *modes = glfwGetVideoModes(monitors[monitor], &count);
+        
+        if(count > 0)
+        {
+            return modes[count - 1].height;
+        } else TRACELOG(LOG_WARNING, "GLFW: Failed to find video mode for selected monitor");
     }
     else TRACELOG(LOG_WARNING, "GLFW: Failed to find selected monitor");
 #endif


### PR DESCRIPTION
…llscreen is toggled.

This solves issue #1322 which in my opinion was prematurely closed. As the monitor resolution is expected to be the maximum that the monitor supports. My change is that as per GLFW documentation you can get all current video modes sorted by max resolution. When you toggle fullscreen the first video mode returned would be the current screen resolution setup but that doesn't help if you want to know the maximum supported.