### PR TITLE
Protect against double free() on Meshes?

### DIFF
--- a/examples/models/models_first_person_maze.c
+++ b/examples/models/models_first_person_maze.c
@@ -117,6 +117,7 @@ int main(void)
 
     UnloadTexture(cubicmap);    // Unload cubicmap texture
     UnloadTexture(texture);     // Unload map texture
+    UnloadMesh(mesh);           // Unload mesh
     UnloadModel(model);         // Unload map model
 
     CloseWindow();              // Close window and OpenGL context


### PR DESCRIPTION
Currently, the `UnloadModel()` function will also unload the associated meshes. There is a `UnloadModelKeepMeshes()` function to allow unloading the model without unloading the meshes, but it seems somewhat counter intuitive.

[models_first_person_maze.c](https://github.com/raysan5/raylib/blob/master/examples/models/models_first_person_maze.c) is a good example of what we can run into. In it, we see.....

``` c
// Generate a Cubicmap mesh
Mesh mesh = GenMeshCubicmap(imMap, (Vector3){ 1.0f, 1.0f, 1.0f });
Model model = LoadModelFromMesh(mesh);
```

In normal C logic, one would assume that when you generate an object, you should Unload it. So, at the end of the file, you would assume you would put...

``` c
// De-Initialization
UnloadModel(model);
UnloadMesh(mesh);
```

But this is not the case, because `UnloadModel()` will unload both the Model and the Mesh, so calling `UnloadMesh(mesh)` results in a double free error. There is a `UnloadModelKeepMeshes()` function, but I believe there should be a bit of protection against double free-ing.

**DO NOT MERGE THIS**. This is just a demonstration of how to reproduce the issue through the [models_first_person_maze.c](https://github.com/raysan5/raylib/blob/master/examples/models/models_first_person_maze.c) example. When run, this is what you get when closing the application.

``` log
INFO: FILEIO: [resources/cubicmap.png] File loaded successfully
INFO: IMAGE: [resources/cubicmap.png] Data loaded successfully (32x16)
INFO: TEXTURE: [ID 3] Texture created successfully (32x16 - 1 mipmaps)
INFO: VAO: [ID 2] Mesh uploaded successfully to VRAM (GPU)
INFO: FILEIO: [resources/cubicmap_atlas.png] File loaded successfully
INFO: IMAGE: [resources/cubicmap_atlas.png] Data loaded successfully (256x256)
INFO: TEXTURE: [ID 4] Texture created successfully (256x256 - 1 mipmaps)
INFO: TIMER: Target time per frame: 16.667 milliseconds
INFO: TEXTURE: [ID 3] Unloaded texture data from VRAM (GPU)
INFO: TEXTURE: [ID 4] Unloaded texture data from VRAM (GPU)
INFO: VAO: [ID 2] Unloaded vertex data from VRAM (GPU)
double free or corruption (!prev)
[1]    59167 abort (core dumped)  ./models_first_person_maze
```

Is adding some error correction in the Unload logic a good step forwards to protect against the double-free issue? I assume this also applies to Materials?

If not, feel free to close this issue :wink: 