### PR TITLE
Faster version of ImageClearBackground and ImageDrawRectangleRec

### DIFF
--- a/src/textures.c
+++ b/src/textures.c
@@ -2547,9 +2547,19 @@ void ImageDrawRectangleRec(Image *dst, Rectangle rec, Color color)
     // Security check to avoid program crash
     if ((dst->data == NULL) || (dst->width == 0) || (dst->height == 0)) return;
 
-    Image imRec = GenImageColor((int)rec.width, (int)rec.height, color);
-    ImageDraw(dst, imRec, (Rectangle){ 0, 0, rec.width, rec.height }, rec, WHITE);
-    UnloadImage(imRec);
+    int sy = (int)rec.y;
+    int ey = sy + (int)rec.height;
+
+    int sx = (int)rec.x;
+    int ex = sx + (int)rec.width;
+
+    for (int y = sy; y < ey; y++)
+    {
+        for (int x = sx; x < ex; x++)
+        {
+            ImageDrawPixel(dst, x, y, color);
+        }
+    }
 }
 
 // Draw rectangle lines within an image

--- a/src/textures.c
+++ b/src/textures.c
@@ -2348,7 +2348,8 @@ Rectangle GetImageAlphaBorder(Image image, float threshold)
 // Clear image background with given color
 void ImageClearBackground(Image *dst, Color color)
 {
-    ImageDrawRectangle(dst, 0, 0, dst->width, dst->height, color);
+    for (int i = 0; i < dst->width * dst->height; ++i)
+        ImageDrawPixel(dst, i % dst->width, i / dst->height, color);
 }
 
 // Draw pixel within an image


### PR DESCRIPTION
The use of ImageDrawRectangle to clear an image is very slow. It makes a new image, draws it, and then destroys the image. This is not fast.

This PR changes ImageClearBackground and ImageDrawRectangleRec to fill in the raw image data one pixel at a time (still doing data conversions per pixel), and is an order of magnitude faster.