### PR TITLE
Fix keyboard state change detection on RPI

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -414,7 +414,7 @@ typedef struct CoreData {
 #if defined(PLATFORM_RPI) || defined(PLATFORM_DRM)
             int defaultMode;                // Default keyboard mode
             struct termios defaultSettings; // Default keyboard settings
-			int fd;            				// File descriptor for the evdev keyboard
+            int fd;                         // File descriptor for the evdev keyboard
 #endif
         } Keyboard;
         struct {


### PR DESCRIPTION
## Overview
On Raspberry Pi DRM builds, keyboard state changes are rarely detected (if at all) by `IsKeyPressed(`) / `IsKeyReleased()`.

## Problem
When a key is pressed or released, the input worker thread in `EventThread()` reads the event, maps the scan code to a keycode, then registers the keycode in `CORE.Input.Keyboard.currentKeyState[]`, setting it to 1 for pressed and 0 for released.

When the user’s application calls `EndDrawing()`, that in turn calls `PollInputEvents()`. One of the first things that `PollInputEvents()` does is copy `CORE.Input.Keyboard.currentKeyState[]` to `CORE.Input.Keyboard.previousKeyState[]`.

The input functions `IsKeyPressed()` and `IsKeyReleased()` are supposed to detect key state changes from frame to frame. They do this by comparing `currentKeyState[key]` with `previousKeyState[key]`.

What seems to be happening is that there is a data race in which `PollInputEvents()` can run and update `previousKeyState` with `currentKeyState` before `IsKeyPressed()` / `IsKeyReleased()` has had a chance to see the state change, resulting in nothing being detected and key events being missed. This happens more often than not.

### Code to demonstrate issue (compile for PLATFORM_DRM)
Run the following in a local (non-windowed) tty on a Raspberry Pi. What should happen is that both pressing [space] and pressing [enter] will advance the message. What actually happens is that pressing [space] very rarely advances the message.

```c
#include "raylib.h"

#if defined(PLATFORM_WEB) || defined(EMSCRIPTEN)
#include <emscripten/emscripten.h>
#endif

#define UPDATE_FPS 60
#define SCREEN_WIDTH 1280
#define SCREEN_HEIGHT 960

static const char* instruction = "Press [space] or [enter] to advance the message";
static const char* messages[] = {"raylib", "is", "great"};
static int index = 0;
static int numMessages = sizeof(messages) / sizeof(messages[0]);
static bool wasEnterDown = false;

static void Draw(void)
{
    ClearBackground(BLACK);
    BeginDrawing();

    int width = MeasureText(messages[index], 64);
    DrawText(messages[index], (GetScreenWidth() - width) / 2, GetScreenHeight() / 2, 64, GREEN);

    width = MeasureText(instruction, 32);
    DrawText(instruction, (GetScreenWidth() - width) / 2, GetScreenHeight() / 4, 32, RAYWHITE);

    DrawFPS(4, 4);
    EndDrawing();
}

static void UpdateDrawFrame(void)
{
    // Check for [space] changing state to pressed with IsKeyPressed().
    if (IsKeyPressed(KEY_SPACE))
    {
        index = (index + 1) % numMessages;
    }

    // Check for [enter] changing state to pressed by maintaining our own state.
    bool isEnterDown = IsKeyDown(KEY_ENTER);
    if (isEnterDown && !wasEnterDown)
    {
        index = (index + 1) % numMessages;
    }
    wasEnterDown = isEnterDown;

    Draw();
}

int main(void)
{
    InitWindow(SCREEN_WIDTH, SCREEN_HEIGHT, "Empty");
    SetTargetFPS(UPDATE_FPS);

#if defined(PLATFORM_WEB) || defined(EMSCRIPTEN)
    emscripten_set_main_loop(UpdateDrawFrame, 0, 1);
#else
    while (!WindowShouldClose())
    {
        UpdateDrawFrame();
    }
#endif
    CloseWindow();

    return 0;
}
```

## Solution
Make the keyboard state _changes_ persist from frame to frame. This is done by adding another array `CORE.Input.Keyboard.changedKeyState[]`, which is updated in `PollInputEvents()` by XORing the previous state with the current state. Checking `IsKeyPressed(`) / `IsKeyReleased()` then become a matter of checking that `changedKeyState` is non-zero, then looking at `previousKeyState` to see whether it was pressed or released.