### PR TITLE
fix GetCurrentMonitor to correctly lookup the monitor index

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -1456,7 +1456,16 @@ int GetMonitorCount(void)
 int GetCurrentMonitor(void)
 {
 #if defined(PLATFORM_DESKTOP)
-    return glfwGetWindowMonitor(CORE.Window.handle);
+    int monitorCount;
+    GLFWmonitor** monitors = glfwGetMonitors(&monitorCount);
+
+    GLFWmonitor* monitor = glfwGetWindowMonitor(CORE.Window.handle);
+    for (int i = 0; i < monitorCount; i++)
+    {
+        if (monitors[i] == monitor)
+            return i;
+    }
+    return 0;
 #else
     return 0;
 #endif


### PR DESCRIPTION
GetCurrentMonitor calls a function that returns the current monitor handle, not the index. This PR looks up that monitor in the monitor list to get the index so it can be used by other functions.