### PR TITLE
[Cleanup]: Remove unused condition 

### DIFF
--- a/src/rlgl.h
+++ b/src/rlgl.h
@@ -4788,8 +4788,8 @@ static int GenerateMipmaps(unsigned char *data, int baseWidth, int baseHeight)
     // Count mipmap levels required
     while ((width != 1) && (height != 1))
     {
-        if (width != 1) width /= 2;
-        if (height != 1) height /= 2;
+        width /= 2;
+        height /= 2;
 
         TRACELOGD("TEXTURE: Next mipmap size: %i x %i", width, height);
 


### PR DESCRIPTION
This PR:
- Remove an unused condition in in *GenerateMipmaps* function if macro *GRAPHICS_API_OPENGL_11* is defined.

We don't need to check if the width or height are different to 1 in the while loop because it's actually the condition of the while loop.