### PR TITLE
[Cleanup]: Modify check condition less than zero for unsigned integers

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -3182,8 +3182,8 @@ static bool InitGraphicsDevice(int width, int height)
     CORE.Window.display.height = mode->height;
 
     // Screen size security check
-    if (CORE.Window.screen.width <= 0) CORE.Window.screen.width = CORE.Window.display.width;
-    if (CORE.Window.screen.height <= 0) CORE.Window.screen.height = CORE.Window.display.height;
+    if (CORE.Window.screen.width == 0) CORE.Window.screen.width = CORE.Window.display.width;
+    if (CORE.Window.screen.height == 0) CORE.Window.screen.height = CORE.Window.display.height;
 #endif  // PLATFORM_DESKTOP
 
 #if defined(PLATFORM_WEB)


### PR DESCRIPTION
This PR:
- Modify the check condition for the screen window height and width in this function for the *PLATFORM_DESKTOP* macro:
```c
static bool InitGraphicsDevice(int width, int height)
```
These values can't be less than zero because they are unsigned int. So we only need to check if they are equal to 0, not less than 0.