### PR TITLE
[Fix]: Avoid dereferencing a null pointer in LoadMaterials function

### DIFF
--- a/src/models.c
+++ b/src/models.c
@@ -948,7 +948,10 @@ Material *LoadMaterials(const char *fileName, int *materialCount)
 #endif
 
     // Set materials shader to default (DIFFUSE, SPECULAR, NORMAL)
-    for (unsigned int i = 0; i < count; i++) materials[i].shader = GetShaderDefault();
+    if (materials != NULL)
+    {
+        for (unsigned int i = 0; i < count; i++) materials[i].shader = GetShaderDefault();
+    }
 
     *materialCount = count;
     return materials;


### PR DESCRIPTION
This PR:
- Fix a dereferencing of a null pointer in the *LoadMaterials* function inside the *models* module.
(the **materials** pointer array is initialized to NULL, then used in a for loop to access it at *i* index).