### PR TITLE
Removed a repeating allocation of memory

### DIFF
--- a/src/models.c
+++ b/src/models.c
@@ -1486,7 +1486,6 @@ Mesh GenMeshPlane(float width, float length, int resX, int resZ)
     mesh.vertices = (float *)RL_MALLOC(plane->ntriangles*3*3*sizeof(float));
     mesh.texcoords = (float *)RL_MALLOC(plane->ntriangles*3*2*sizeof(float));
     mesh.normals = (float *)RL_MALLOC(plane->ntriangles*3*3*sizeof(float));
-    mesh.vboId = (unsigned int *)RL_CALLOC(DEFAULT_MESH_VERTEX_BUFFERS, sizeof(unsigned int));
 
     mesh.vertexCount = plane->ntriangles*3;
     mesh.triangleCount = plane->ntriangles;


### PR DESCRIPTION
Resolves #1495
This line allocated some memory that was already allocated in the beginning of the function and was essentially creating a leak.