### PR TITLE
Added support for high DPI monitors (windows 10 / multi monitor configuration)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # Ignore generated files
 # ...
 
+.vscode
+
 # Ignore VIM's backup generated files
 *.swp
 *.swo

--- a/examples/models/models_material_pbr.c
+++ b/examples/models/models_material_pbr.c
@@ -24,6 +24,8 @@
 #define IRRADIANCE_SIZE       32        // Irradiance texture size
 #define PREFILTERED_SIZE     256        // Prefiltered HDR environment texture size
 #define BRDF_SIZE            512        // BRDF LUT texture size
+#define LIGHT_DISTANCE 1000.0f
+#define LIGHT_HEIGHT 1.0f
 
 // PBR material loading
 static Material LoadMaterialPBR(Color albedo, float metalness, float roughness);

--- a/projects/Notepad++/raylib_npp_parser/raylib_to_parse.h
+++ b/projects/Notepad++/raylib_npp_parser/raylib_to_parse.h
@@ -16,6 +16,9 @@ RLAPI bool IsWindowResized(void);                                 // Check if wi
 RLAPI bool IsWindowState(unsigned int flag);                      // Check if one specific window flag is enabled
 RLAPI void SetWindowState(unsigned int flags);                    // Set window configuration state using flags
 RLAPI void ClearWindowState(unsigned int flags);                  // Clear window configuration state flags
+RLAPI void SetWindowScale(float scaleFactor);                     // Set window scale factor
+RLAPI void SaveWindowScale(void);                                 // Save window scale to defaults
+RLAPI void RestoreWindowScale(void);                              // Load window scale from defaults
 RLAPI void ToggleFullscreen(void);                                // Toggle window state: fullscreen/windowed (only PLATFORM_DESKTOP)
 RLAPI void MaximizeWindow(void);                                  // Set window state: maximized, if resizable (only PLATFORM_DESKTOP)
 RLAPI void MinimizeWindow(void);                                  // Set window state: minimized, if resizable (only PLATFORM_DESKTOP)

--- a/src/core.c
+++ b/src/core.c
@@ -1044,27 +1044,8 @@ void ToggleFullscreen(void)
         {
             TRACELOG(LOG_WARNING, "GLFW: Failed to get monitor");
             monitor = glfwGetPrimaryMonitor();
-
-            Vector2 windowPos = GetWindowPosition();
-
-            int monitorCount = 0;
-            GLFWmonitor **monitors = glfwGetMonitors(&monitorCount);
-
-            // Check window monitor
-            for (int i = 0; i < monitorCount; i++)
-            {
-                int xpos, ypos, width, height;
-                glfwGetMonitorWorkarea(monitors[i], &xpos, &ypos, &width, &height);
-
-                if ((windowPos.x >= xpos) && (windowPos.x < xpos + width) &&
-                    (windowPos.y >= ypos) && (windowPos.y < ypos + height))
-                {
-                    monitor = monitors[i];
-                    break;
-                }
-            }
         }
-
+        
         const GLFWvidmode *mode = glfwGetVideoMode(monitor);
         SetWindowScale(1.0f);
         glfwSetWindowMonitor(CORE.Window.handle, monitor, 0, 0, CORE.Window.screen.width, CORE.Window.screen.height, mode->refreshRate);
@@ -1073,9 +1054,10 @@ void ToggleFullscreen(void)
         // NOTE: V-Sync can be enabled by graphic driver configuration
         if (CORE.Window.flags & FLAG_VSYNC_HINT) glfwSwapInterval(1);
     }
-    else {
+    else
+    {
         RestoreWindowScale();
-        glfwSetWindowMonitor(CORE.Window.handle, NULL, CORE.Window.position.x, CORE.Window.position.y, (int)((float)CORE.Window.screen.width * CORE.Window.screenScaleX), (int)((float)CORE.Window.screen.height * CORE.Window.screenScaleY), GLFW_DONT_CARE);
+        glfwSetWindowMonitor(CORE.Window.handle, NULL, CORE.Window.position.x, CORE.Window.position.y, (int)(((float)CORE.Window.screen.width) * CORE.Window.screenScaleX), (int)(((float)CORE.Window.screen.height) * CORE.Window.screenScaleY), GLFW_DONT_CARE);
     }
 
 #endif
@@ -1124,9 +1106,11 @@ void ToggleFullscreen(void)
 void SetWindowScale(float scaleFactor)
 {
 #if defined(PLATFORM_DESKTOP)
+#if !defined(__APPLE__)
     CORE.Window.screenScaleX = scaleFactor;
     CORE.Window.screenScaleY = scaleFactor;
     CORE.Window.screenScale = (scaleFactor == 1.0f) ? MatrixIdentity(): MatrixScale(scaleFactor, scaleFactor, 1.0f);
+#endif
 #endif
 }
 
@@ -1134,22 +1118,26 @@ void SetWindowScale(float scaleFactor)
 void SaveWindowScale()
 {
 #if defined(PLATFORM_DESKTOP)
+#if !defined(__APPLE__)
     CORE.Window.defaultScreenScaleX = CORE.Window.screenScaleX;
     CORE.Window.defaultScreenScaleY = CORE.Window.screenScaleY;
     CORE.Window.defaultScreen = CORE.Window.screen;
     CORE.Window.defaultRender = CORE.Window.render;
     CORE.Window.defaultScreenScale = CORE.Window.screenScale;
 #endif
+#endif
 }
 
 // Load window scale from defaults
 void RestoreWindowScale() {
 #if defined(PLATFORM_DESKTOP)
+#if !defined(__APPLE__)
     CORE.Window.screenScaleX = CORE.Window.defaultScreenScaleX;
     CORE.Window.screenScaleY = CORE.Window.defaultScreenScaleY;
     CORE.Window.screen = CORE.Window.defaultScreen;
     CORE.Window.render = CORE.Window.defaultRender;
     CORE.Window.screenScale = CORE.Window.defaultScreenScale;
+#endif
 #endif
 }
 
@@ -4117,7 +4105,9 @@ static void SetupWindowContentScale(int width, int height)
             float* screenScaleY = &(CORE.Window.screenScaleY);
             glfwGetWindowContentScale(CORE.Window.handle, screenScaleX, screenScaleY);
             CORE.Window.screenScale = MatrixScale(CORE.Window.screenScaleX, CORE.Window.screenScaleY, 1.0f);
-        } else {
+        }
+        else
+        {
             SetWindowScale(1.0f);
         }
     }
@@ -4125,23 +4115,33 @@ static void SetupWindowContentScale(int width, int height)
     {
         SetWindowScale(1.0f);
     }
-    if (width == 0) {
+    if (width == 0)
+    {
         width = (int)(((float)CORE.Window.defaultScreen.width)/CORE.Window.screenScaleX);
-    } else {
+    }
+    else
+    {
         if (!CORE.Window.fullscreen) 
         {
-            CORE.Window.screen.width = (int)((float)width/CORE.Window.screenScaleX);
-        } else {
+            CORE.Window.screen.width = (int)(((float)width)/CORE.Window.screenScaleX);
+        }
+        else
+        {
             CORE.Window.screen.width = width;
         }
     }
-    if (height == 0) {
+    if (height == 0)
+    {
         height = (int)(((float)CORE.Window.defaultScreen.height)/CORE.Window.screenScaleY);
-    } else {
+    }
+    else
+    {
         if (!CORE.Window.fullscreen) 
         {
-            CORE.Window.screen.height = (int)((float)height/CORE.Window.screenScaleY);
-        } else {
+            CORE.Window.screen.height = (int)(((float)height)/CORE.Window.screenScaleY);
+        }
+        else
+        {
             CORE.Window.screen.height = height;
         }
     }
@@ -4149,21 +4149,13 @@ static void SetupWindowContentScale(int width, int height)
 #else
 #endif
 #endif
-    CORE.Window.render.width = width;
-    CORE.Window.render.height = height;
 }
 
 // Set viewport for a provided width and height
 static void SetupViewport(int width, int height)
 {
-#if defined(PLATFORM_DESKTOP)
-#if !defined(__APPLE__)
-    SetupWindowContentScale(width, height);
-#else
     CORE.Window.render.width = width;
     CORE.Window.render.height = height;
-#endif
-#endif
 
     // Set viewport width and height
     // NOTE: We consider render size and offset in case black bars are required and
@@ -4252,7 +4244,6 @@ static void SetupFramebuffer(int width, int height)
     }
     else
     {
-        // SetupWindowContentScale(width, height); or SetupViewport(width, height); 
         CORE.Window.render.width = CORE.Window.screen.width;
         CORE.Window.render.height = CORE.Window.screen.height;
         CORE.Window.renderOffset.x = 0;
@@ -4676,13 +4667,15 @@ static void ErrorCallback(int error, const char *description)
 static void WindowContentScaleCallback(GLFWwindow *window, float xscale, float yscale)
 {
 #if defined(PLATFORM_DESKTOP)
-#if defined(_WIN32)
+#if !defined(__APPLE__)
     if (!CORE.Window.fullscreen)
     {
         CORE.Window.screenScaleX = xscale;
         CORE.Window.screenScaleY = yscale;
+        CORE.Window.screenScale = MatrixScale(CORE.Window.screenScaleX, CORE.Window.screenScaleY, 1.0f);
+        CORE.Window.render.width = (int)((float)CORE.Window.defaultScreen.width * CORE.Window.screenScaleX);
+        CORE.Window.render.height = (int)((float)CORE.Window.defaultScreen.height * CORE.Window.screenScaleY);
         SetMouseScale(1.0f/CORE.Window.screenScaleX, 1.0f/CORE.Window.screenScaleY);
-        SetupWindowContentScale(0, 0);
     }
 #endif
 #endif
@@ -4692,6 +4685,7 @@ static void WindowContentScaleCallback(GLFWwindow *window, float xscale, float y
 // NOTE: Window resizing not allowed by default
 static void WindowSizeCallback(GLFWwindow *window, int width, int height)
 {
+    SetupWindowContentScale(width, height);
     SetupViewport(width, height);
 
 #if defined(PLATFORM_DESKTOP)

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -902,6 +902,9 @@ RLAPI bool IsWindowResized(void);                                 // Check if wi
 RLAPI bool IsWindowState(unsigned int flag);                      // Check if one specific window flag is enabled
 RLAPI void SetWindowState(unsigned int flags);                    // Set window configuration state using flags
 RLAPI void ClearWindowState(unsigned int flags);                  // Clear window configuration state flags
+RLAPI void SetWindowScale(float scaleFactor);                     // Set window scale factor
+RLAPI void SaveWindowScale(void);                                 // Save window scale to defaults
+RLAPI void RestoreWindowScale(void);                              // Load window scale from defaults
 RLAPI void ToggleFullscreen(void);                                // Toggle window state: fullscreen/windowed (only PLATFORM_DESKTOP)
 RLAPI void MaximizeWindow(void);                                  // Set window state: maximized, if resizable (only PLATFORM_DESKTOP)
 RLAPI void MinimizeWindow(void);                                  // Set window state: minimized, if resizable (only PLATFORM_DESKTOP)


### PR DESCRIPTION
Added support for hi DPI monitors:

Used core_windows_flags app as the only one with internal high DPI flag enabled by default (Windows 10 latest)

Scenario: 

1) add support for moving app window from one hi DPI monitor to another one with different DPI (tested on windows only). need to result in no glitchess, no artefact, correct rescale of app window. i.e. primary monitor (windows 10 latest update) with scale factor 200% will show 800x450 as 1600x900, then, by moving to another monitor, with scale factor 150%, will result in application rescale to 1200x675, with no code change or support from application - Done

2) add support for rescale and app on current window, if scale factor changed by Windows 10, i.e. primary monitor (windows 10 latest update) with scale factor 200% will show 800x450 as 1600x900, then, by changing scale factor on primary monitor, to scale factor 150%, will result in application rescale to 1200x675, with no code change or support fron application - Done

3) add support of correct resizable windowed app resizes with different flags set, i.e. resizing window by dragging size grip will result in correct rescale of high DPI app, then applying scenario 1) or 2) will not change behavior or correctness of scenario 1) or 2) - Done.
