### PR TITLE
Include SUPPORT_DATA_STORAGE flag for building with CMake

### DIFF
--- a/src/CMakeOptions.txt
+++ b/src/CMakeOptions.txt
@@ -32,6 +32,7 @@ option(SUPPORT_GIF_RECORDING "Allow automatic gif recording of current screen pr
 option(SUPPORT_BUSY_WAIT_LOOP "Use busy wait loop for timing sync instead of a high-resolution timer" OFF)
 option(SUPPORT_EVENTS_WAITING "Wait for events passively (sleeping while no events) instead of polling them actively every frame" OFF)
 option(SUPPORT_HIGH_DPI "Support high DPI displays" OFF)
+option(SUPPORT_DATA_STORAGE "Support for persistent data storage" ON)
 
 # rlgl.h
 option(SUPPORT_VR_SIMULATOR "Support VR simulation functionality (stereo rendering)" ON)

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -21,6 +21,8 @@
 #cmakedefine SUPPORT_HIGH_DPI 1
 // Support CompressData() and DecompressData() functions
 #cmakedefine SUPPORT_COMPRESSION_API 1
+// Support for persistent data storage
+#cmakedefine SUPPORT_DATA_STORAGE 1
 
 // rlgl.h
 // Support VR simulation functionality (stereo rendering)


### PR DESCRIPTION
A few changes to include the SUPPORT_DATA_STORAGE flag option to make the `SaveStorageValue()` and `LoadStorageValue()` functions usable when building raylib with CMake. 