### PR TITLE
File Read Callbacks

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -2595,7 +2595,7 @@ bool SaveStorageValue(unsigned int position, int value)
 
     unsigned int dataSize = 0;
     unsigned int newDataSize = 0;
-    unsigned char *fileData = LoadFileData(path, &dataSize);
+    unsigned char *fileData = RLLoadFileData(path, &dataSize);
     unsigned char *newFileData = NULL;
 
     if (fileData != NULL)
@@ -2673,7 +2673,7 @@ int LoadStorageValue(unsigned int position)
 #endif
 
     unsigned int dataSize = 0;
-    unsigned char *fileData = LoadFileData(path, &dataSize);
+    unsigned char *fileData = RLLoadFileData(path, &dataSize);
 
     if (fileData != NULL)
     {

--- a/src/models.c
+++ b/src/models.c
@@ -1012,7 +1012,7 @@ ModelAnimation *LoadModelAnimations(const char *fileName, int *animCount)
     #define IQM_VERSION     2                   // only IQM version 2 supported
 
     unsigned int fileSize = 0;
-    unsigned char *fileData = LoadFileData(fileName, &fileSize);
+    unsigned char *fileData = RLLoadFileData(fileName, &fileSize);
     unsigned char *fileDataPtr = fileData;
 
     typedef struct IQMHeader {
@@ -3034,7 +3034,7 @@ static Model LoadOBJ(const char *fileName)
     tinyobj_material_t *materials = NULL;
     unsigned int materialCount = 0;
 
-    char *fileData = LoadFileText(fileName);
+    char *fileData = RLLoadFileText(fileName);
 
     if (fileData != NULL)
     {
@@ -3199,7 +3199,7 @@ static Model LoadIQM(const char *fileName)
     #define MATERIAL_NAME_LENGTH 32         // Material name string length
 
     unsigned int fileSize = 0;
-    unsigned char *fileData = LoadFileData(fileName, &fileSize);
+    unsigned char *fileData = RLLoadFileData(fileName, &fileSize);
     unsigned char *fileDataPtr = fileData;
 
     // IQM file structs
@@ -3738,7 +3738,7 @@ static Model LoadGLTF(const char *fileName)
 
     // glTF file loading
     unsigned int dataSize = 0;
-    unsigned char *fileData = LoadFileData(fileName, &dataSize);
+    unsigned char *fileData = RLLoadFileData(fileName, &dataSize);
 
     if (fileData == NULL) return model;
 

--- a/src/raudio.c
+++ b/src/raudio.c
@@ -385,7 +385,7 @@ static Wave LoadMP3(const unsigned char *fileData, unsigned int fileSize);   // 
 
 #if defined(RAUDIO_STANDALONE)
 static bool IsFileExtension(const char *fileName, const char *ext); // Check file extension
-static unsigned char *LoadFileData(const char *fileName, unsigned int *bytesRead);     // Load file data as byte array (read)
+static unsigned char *RLLoadFileData(const char *fileName, unsigned int *bytesRead);     // Load file data as byte array (read)
 static bool SaveFileData(const char *fileName, void *data, unsigned int bytesToWrite); // Save data to file from byte array (write)
 static bool SaveFileText(const char *fileName, char *text);         // Save text data to file (write), string must be '\0' terminated
 #endif
@@ -690,7 +690,7 @@ Wave LoadWave(const char *fileName)
 
     // Loading file to memory
     unsigned int fileSize = 0;
-    unsigned char *fileData = LoadFileData(fileName, &fileSize);
+    unsigned char *fileData = RLLoadFileData(fileName, &fileSize);
 
     if (fileData != NULL)
     {
@@ -2087,7 +2087,7 @@ static bool IsFileExtension(const char *fileName, const char *ext)
 }
 
 // Load data from file into a buffer
-static unsigned char *LoadFileData(const char *fileName, unsigned int *bytesRead)
+static unsigned char *RLLoadFileData(const char *fileName, unsigned int *bytesRead)
 {
     unsigned char *data = NULL;
     *bytesRead = 0;

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -979,6 +979,14 @@ RLAPI void TakeScreenshot(const char *fileName);                  // Takes a scr
 RLAPI int GetRandomValue(int min, int max);                       // Returns a random value between min and max (both included)
 
 // Files management functions
+
+// Virtual file system override functions
+typedef unsigned char* (*LoadFileBinFunction)(const char* fileName, unsigned int* bytesRead);       // Load file data as byte array (read)
+typedef char* (*LoadFileTextFunction)(const char* fileName);                                        // Load text data from file (read), returns a '\0' terminated string
+
+RLAPI void SetFileSystemFunctions(LoadFileBinFunction loadBin, LoadFileTextFunction loadText);            // override default file access functions
+
+// Native File Management
 RLAPI unsigned char *LoadFileData(const char *fileName, unsigned int *bytesRead);     // Load file data as byte array (read)
 RLAPI void UnloadFileData(unsigned char *data);                   // Unload file data allocated by LoadFileData()
 RLAPI bool SaveFileData(const char *fileName, void *data, unsigned int bytesToWrite); // Save data to file from byte array (write), returns true on success
@@ -1332,6 +1340,7 @@ RLAPI void DrawGizmo(Vector3 position);                                         
 
 // Model loading/unloading functions
 RLAPI Model LoadModel(const char *fileName);                                                            // Load model from files (meshes and materials)
+RLAPI Model LoadModelFromMemory(const char* fileType, const unsigned char* fileData, int dataSize);     // Load model from memory (meshes and materials)
 RLAPI Model LoadModelFromMesh(Mesh mesh);                                                               // Load model from generated mesh (default material)
 RLAPI void UnloadModel(Model model);                                                                    // Unload model (including meshes) from memory (RAM and/or VRAM)
 RLAPI void UnloadModelKeepMeshes(Model model);                                                          // Unload model (but not meshes) from memory (RAM and/or VRAM)

--- a/src/text.c
+++ b/src/text.c
@@ -342,7 +342,7 @@ Font LoadFontEx(const char *fileName, int fontSize, int *fontChars, int charsCou
 
     // Loading file to memory
     unsigned int fileSize = 0;
-    unsigned char *fileData = LoadFileData(fileName, &fileSize);
+    unsigned char *fileData = RLLoadFileData(fileName, &fileSize);
 
     if (fileData != NULL)
     {
@@ -1740,7 +1740,7 @@ static Font LoadBMFont(const char *fileName)
 
     int base = 0;   // Useless data
 
-    char *fileText = LoadFileText(fileName);
+    char *fileText = RLLoadFileText(fileName);
 
     if (fileText == NULL) return font;
 

--- a/src/textures.c
+++ b/src/textures.c
@@ -210,7 +210,7 @@ Image LoadImage(const char *fileName)
 
     // Loading file to memory
     unsigned int fileSize = 0;
-    unsigned char *fileData = LoadFileData(fileName, &fileSize);
+    unsigned char *fileData = RLLoadFileData(fileName, &fileSize);
 
     if (fileData != NULL)
     {
@@ -232,7 +232,7 @@ Image LoadImageRaw(const char *fileName, int width, int height, int format, int 
     Image image = { 0 };
 
     unsigned int dataSize = 0;
-    unsigned char *fileData = LoadFileData(fileName, &dataSize);
+    unsigned char *fileData = RLLoadFileData(fileName, &dataSize);
 
     if (fileData != NULL)
     {
@@ -268,7 +268,7 @@ Image LoadImageAnim(const char *fileName, int *frames)
     if (IsFileExtension(fileName, ".gif"))
     {
         unsigned int dataSize = 0;
-        unsigned char *fileData = LoadFileData(fileName, &dataSize);
+        unsigned char *fileData = RLLoadFileData(fileName, &dataSize);
 
         if (fileData != NULL)
         {

--- a/src/utils.c
+++ b/src/utils.c
@@ -175,6 +175,32 @@ void MemFree(void *ptr)
     RL_FREE(ptr);
 }
 
+LoadFileBinFunction LoadBinCallback = NULL;
+LoadFileTextFunction LoadFileTextCallback = NULL;
+
+// virtual file systems functions
+void SetFileSystemFunctions(LoadFileBinFunction loadBin, LoadFileTextFunction loadText)
+{
+    LoadBinCallback = loadBin;
+    LoadFileTextCallback = loadText;
+}
+
+unsigned char* RLLoadFileData(const char* fileName, unsigned int* bytesRead)
+{
+    if (LoadBinCallback != NULL)
+        return LoadBinCallback(fileName, bytesRead);
+    
+    return LoadFileData(fileName, bytesRead);
+}
+
+char* RLLoadFileText(const char* fileName)
+{
+    if (LoadFileTextCallback != NULL)
+        return LoadFileTextCallback(fileName);
+
+    return LoadFileText(fileName);
+}
+
 // Load data from file into a buffer
 unsigned char *LoadFileData(const char *fileName, unsigned int *bytesRead)
 {

--- a/src/utils.h
+++ b/src/utils.h
@@ -27,6 +27,12 @@
 #ifndef UTILS_H
 #define UTILS_H
 
+// internal loader functions that may or may not call the virtual file system
+unsigned char* RLLoadFileData(const char* fileName, unsigned int* bytesRead);
+void RLUnloadFileData(unsigned char* data);
+char* RLLoadFileText(const char* fileName);
+void RLUnloadFileText(unsigned char* text);
+
 #if defined(PLATFORM_ANDROID)
     #include <stdio.h>                      // Required for: FILE
     #include <android/asset_manager.h>      // Required for: AAssetManager

--- a/src/utils.h
+++ b/src/utils.h
@@ -29,9 +29,7 @@
 
 // internal loader functions that may or may not call the virtual file system
 unsigned char* RLLoadFileData(const char* fileName, unsigned int* bytesRead);
-void RLUnloadFileData(unsigned char* data);
 char* RLLoadFileText(const char* fileName);
-void RLUnloadFileText(unsigned char* text);
 
 #if defined(PLATFORM_ANDROID)
     #include <stdio.h>                      // Required for: FILE


### PR DESCRIPTION
This PR adds in a set of read file callbacks to allow external libraries to provide file reading functionality to raylib. This allows for libraries to provide virtual file systems for raylib that can read from archives or databases with out raylib having to know or care about where the file data comes from while still using all existing file loading capabilities.