### PR TITLE
Fixes Android builds on Linux environments

### DIFF
--- a/templates/simple_game/Makefile
+++ b/templates/simple_game/Makefile
@@ -101,6 +101,15 @@ ifeq ($(PLATFORM),PLATFORM_DRM)
         PLATFORM_OS=LINUX
     endif
 endif
+ifeq ($(PLATFORM),PLATFORM_ANDROID)
+    UNAMEOS=$(shell uname)
+    ifeq ($(UNAMEOS),Linux)
+        PLATFORM_OS=LINUX
+    endif
+    ifeq ($(UNAMEOS),Darwin)
+        PLATFORM_OS=OSX
+    endif
+endif
 
 # RAYLIB_PATH adjustment for different platforms.
 # If using GNU make, we can get the full path to the top of the tree. Windows? BSD?
@@ -388,6 +397,15 @@ OBJS = $(patsubst %.c, %.o, $(PROJECT_SOURCE_FILES))
 # For Android platform we call a custom Makefile.Android
 ifeq ($(PLATFORM),PLATFORM_ANDROID)
     MAKEFILE_PARAMS = -f Makefile.Android 
+    # For Linux and macOS set make and makefile
+    ifeq ($(PLATFORM_OS),LINUX)
+        MAKE = make
+        MAKEFILE_PARAMS = -f Makefile.Android.linux
+    endif
+    ifeq ($(PLATFORM_OS),OSX)
+        MAKE = make
+        MAKEFILE_PARAMS = -f Makefile.Android.macos
+    endif
     export PROJECT_NAME
     export PROJECT_SOURCE_FILES
 else

--- a/templates/simple_game/Makefile.Android.linux
+++ b/templates/simple_game/Makefile.Android.linux
@@ -28,7 +28,7 @@
 
 # Define required raylib variables
 PLATFORM               ?= PLATFORM_ANDROID
-RAYLIB_PATH            ?= $(HOME)/raylib_sources.ln
+RAYLIB_PATH            ?= ../../
 
 # Define Android architecture (armeabi-v7a, arm64-v8a, x86, x86-64) and API version
 ANDROID_ARCH           ?= ARM64
@@ -48,9 +48,9 @@ endif
 # no need to define JAVA_HOME , JAVA_BIN in linux environment (binaries are in $PATH)
 #JAVA_HOME              ?= C:/JavaJDK/
 #JAVA_BIN		?= $(JAVA_HOME)/bin/
-ANDROID_HOME            = /opt/android-sdk
+ANDROID_HOME            ?= /opt/android-sdk
 #ANDROID_TOOLCHAIN       = C:/android_toolchain_$(ANDROID_ARCH)_API$(ANDROID_API_VERSION)
-ANDROID_TOOLCHAIN = /opt/android-ndk/toolchains/llvm/prebuilt/linux-x86_64/
+ANDROID_TOOLCHAIN ?= /opt/android-ndk/toolchains/llvm/prebuilt/linux-x86_64/
 
 # find the highest version available of build tools
 ANDROID_BUILD_TOOLS = $(shell ls -1d $(ANDROID_HOME)/build-tools/* | tail -n 1)/
@@ -94,11 +94,10 @@ APP_SCREEN_ORIENTATION ?= landscape
 APP_KEYSTORE_PASS ?= raylib
 
 # Library type used for raylib: STATIC (.a) or SHARED (.so/.dll)
-# attention, ne fonctionne pas avec STATIC (manque la libm quelque part)
-RAYLIB_LIBTYPE ?= SHARED
+RAYLIB_LIBTYPE ?= STATIC
 
 # Library path for libraylib.a/libraylib.so
-RAYLIB_LIB_PATH = $(RAYLIB_PATH)/src/android/
+RAYLIB_LIB_PATH = $(RAYLIB_PATH)/src/
 
 # Shared libs must be added to APK if required
 # NOTE: Generated NativeLoader.java automatically load those libraries
@@ -141,7 +140,7 @@ LDFLAGS += -Wl,--build-id -Wl,--no-undefined -Wl,-z,noexecstack -Wl,-z,relro -Wl
 # Force linking of library module to define symbol
 LDFLAGS += -u ANativeActivity_onCreate
 # Library paths containing required libs
-LDFLAGS += -L. -L$(PROJECT_BUILD_PATH)/obj -L$(PROJECT_BUILD_PATH)/lib/$(ANDROID_ARCH_NAME) -L$(ANDROID_TOOLCHAIN)/sysroot/usr/lib/$(ANDROID_TOOLCHAIN_LIBS)
+LDFLAGS += -L. -L$(PROJECT_BUILD_PATH)/obj -L$(PROJECT_BUILD_PATH)/lib/$(ANDROID_ARCH_NAME)
 
 # Define any libraries to link into executable
 # if you want to link libraries (libname.so or libname.a), use the -lname


### PR DESCRIPTION
Description
----------------
This PR corrects some build issues on Linux environments for building Android applications in templates/simple_game.

Fixes/improves:
- Automatically detects if host OS is Windows or Linux in the root Makefile, which avoids manual editing of the file to include 'Makefile.Android.linux' instead of Makefile.Android.

- Leave `ANDROID_HOME` and `ANDROID_TOOLCHAIN` with default values only if they do not already exist, which allows the user to add them as environment variables, and thus, Makefile-independent.

- Fixes `lib$(PROJECT_LIBRARY_NAME).so` builds: the generated library was configured to use the path of the NDK libraries instead of the native Android libraries.