### PR TITLE
Fix issue when trying to build raylib statically

### DIFF
--- a/cmake/GlfwImport.cmake
+++ b/cmake/GlfwImport.cmake
@@ -23,7 +23,7 @@ if(NOT glfw3_FOUND AND NOT USE_EXTERNAL_GLFW STREQUAL "ON" AND "${PLATFORM}" MAT
 
     add_subdirectory(external/glfw)
 
-    set(BUILD_SHARED_LIBS WAS_SHARED CACHE BOOL " " FORCE)
+    set(BUILD_SHARED_LIBS ${WAS_SHARED} CACHE BOOL " " FORCE)
     unset(WAS_SHARED)
     
     list(APPEND raylib_sources $<TARGET_OBJECTS:glfw_objlib>)


### PR DESCRIPTION
This PR fixes an issue where raylib would build as a shared library regardless of the value in `BUILD_SHARED_LIBS`. This was due to a simple syntax mistake in `cmake/GlfwImport.cmake`.