### PR TITLE
Use local includes for GLFW 

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -189,13 +189,13 @@
 #if defined(PLATFORM_DESKTOP)
     #define GLFW_INCLUDE_NONE       // Disable the standard OpenGL header inclusion on GLFW3
                                     // NOTE: Already provided by rlgl implementation (on glad.h)
-    #include <GLFW/glfw3.h>         // GLFW3 library: Windows, OpenGL context and Input management
+    #include "GLFW/glfw3.h"         // GLFW3 library: Windows, OpenGL context and Input management
                                     // NOTE: GLFW3 already includes gl.h (OpenGL) headers
 
     // Support retrieving native window handlers
     #if defined(_WIN32)
         #define GLFW_EXPOSE_NATIVE_WIN32
-        #include <GLFW/glfw3native.h>       // WARNING: It requires customization to avoid windows.h inclusion!
+        #include "GLFW/glfw3native.h"       // WARNING: It requires customization to avoid windows.h inclusion!
 
         #if !defined(SUPPORT_BUSY_WAIT_LOOP)
             // NOTE: Those functions require linking with winmm library
@@ -209,12 +209,12 @@
         //#define GLFW_EXPOSE_NATIVE_X11      // WARNING: Exposing Xlib.h > X.h results in dup symbols for Font type
         //#define GLFW_EXPOSE_NATIVE_WAYLAND
         //#define GLFW_EXPOSE_NATIVE_MIR
-        #include <GLFW/glfw3native.h>       // Required for: glfwGetX11Window()
+        #include "GLFW/glfw3native.h"       // Required for: glfwGetX11Window()
     #elif defined(__APPLE__)
         #include <unistd.h>                 // Required for: usleep()
 
         //#define GLFW_EXPOSE_NATIVE_COCOA    // WARNING: Fails due to type redefinition
-        #include <GLFW/glfw3native.h>       // Required for: glfwGetCocoaWindow()
+        #include "GLFW/glfw3native.h"       // Required for: glfwGetCocoaWindow()
     #endif
 #endif
 
@@ -263,7 +263,7 @@
 
 #if defined(PLATFORM_WEB)
     #define GLFW_INCLUDE_ES2            // GLFW3: Enable OpenGL ES 2.0 (translated to WebGL)
-    #include <GLFW/glfw3.h>             // GLFW3 library: Windows, OpenGL context and Input management
+    #include "GLFW/glfw3.h"             // GLFW3 library: Windows, OpenGL context and Input management
     #include <sys/time.h>               // Required for: timespec, nanosleep(), select() - POSIX
 
     #include <emscripten/emscripten.h>  // Emscripten library - LLVM to JavaScript compiler


### PR DESCRIPTION
GLFW was included using #include <GLFW. This tells the compiler to check the system library paths for the header. Raylib includes it's own GLFW so it should be using #include "GLFW.
This PR makes this change, and helps some platforms produce fewer errors/warnings.