### PR TITLE
[Shaders] Fix compiler error in GSSL 3 version of color_mix_shader

### DIFF
--- a/examples/shaders/resources/shaders/glsl330/color_mix.fs
+++ b/examples/shaders/resources/shaders/glsl330/color_mix.fs
@@ -19,7 +19,7 @@ void main()
     vec4 texelColor1 = texture(texture1, fragTexCoord);
 
     float x = fract(fragTexCoord.s);
-    float out = smoothstep(0.4, 0.6, x);
+    float outVal = smoothstep(0.4, 0.6, x);
     
-    finalColor = mix(texelColor0, texelColor1, out);
+    finalColor = mix(texelColor0, texelColor1, outVal);
 }


### PR DESCRIPTION
out is a keyword in shaders and can't be used as a variable name.
This PR changes it to outVal so it compiles.