### PR TITLE
[core] Add functions to set near and far culling planes.

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -95,8 +95,8 @@
 #define MAX_SHADER_LOCATIONS            32      // Maximum number of shader locations supported
 #define MAX_MATERIAL_MAPS               12      // Maximum number of shader maps supported
 
-#define RL_CULL_DISTANCE_NEAR         0.01      // Default projection matrix near cull distance
-#define RL_CULL_DISTANCE_FAR        1000.0      // Default projection matrix far cull distance
+#define RL_DEFAULT_CULL_DISTANCE_NEAR         0.01      // Default projection matrix near cull distance
+#define RL_DEFAULT_CULL_DISTANCE_FAR        1000.0      // Default projection matrix far cull distance
 
 // Default shader vertex attribute names to set location points
 #define DEFAULT_SHADER_ATTRIB_NAME_POSITION    "vertexPosition"    // Binded by default to shader location: 0

--- a/src/core.c
+++ b/src/core.c
@@ -484,6 +484,9 @@ static CoreData CORE = { 0 };               // Global CORE state context
 static char **dirFilesPath = NULL;          // Store directory files paths as strings
 static int dirFilesCount = 0;               // Count directory files strings
 
+static double cullDistanceNear = RL_DEFAULT_CULL_DISTANCE_NEAR;     // Default projection matrix near cull distance
+static double cullDistanceFar = RL_DEFAULT_CULL_DISTANCE_FAR;       // Default projection matrix far cull distance
+
 #if defined(SUPPORT_SCREEN_CAPTURE)
 static int screenshotCounter = 0;           // Screenshots counter
 #endif
@@ -1891,10 +1894,10 @@ void BeginMode3D(Camera3D camera)
     if (camera.type == CAMERA_PERSPECTIVE)
     {
         // Setup perspective projection
-        double top = RL_CULL_DISTANCE_NEAR*tan(camera.fovy*0.5*DEG2RAD);
+        double top = cullDistanceNear*tan(camera.fovy*0.5*DEG2RAD);
         double right = top*aspect;
 
-        rlFrustum(-right, right, -top, top, RL_CULL_DISTANCE_NEAR, RL_CULL_DISTANCE_FAR);
+        rlFrustum(-right, right, -top, top, cullDistanceNear, cullDistanceFar);
     }
     else if (camera.type == CAMERA_ORTHOGRAPHIC)
     {
@@ -1902,7 +1905,7 @@ void BeginMode3D(Camera3D camera)
         double top = camera.fovy/2.0;
         double right = top*aspect;
 
-        rlOrtho(-right, right, -top,top, RL_CULL_DISTANCE_NEAR, RL_CULL_DISTANCE_FAR);
+        rlOrtho(-right, right, -top,top, cullDistanceNear, cullDistanceFar);
     }
 
     // NOTE: zNear and zFar values are important when computing depth buffer values
@@ -2015,7 +2018,7 @@ Ray GetMouseRay(Vector2 mouse, Camera camera)
     if (camera.type == CAMERA_PERSPECTIVE)
     {
         // Calculate projection matrix from perspective
-        matProj = MatrixPerspective(camera.fovy*DEG2RAD, ((double)GetScreenWidth()/(double)GetScreenHeight()), RL_CULL_DISTANCE_NEAR, RL_CULL_DISTANCE_FAR);
+        matProj = MatrixPerspective(camera.fovy*DEG2RAD, ((double)GetScreenWidth()/(double)GetScreenHeight()), cullDistanceNear, cullDistanceFar);
     }
     else if (camera.type == CAMERA_ORTHOGRAPHIC)
     {
@@ -2099,7 +2102,7 @@ Vector2 GetWorldToScreenEx(Vector3 position, Camera camera, int width, int heigh
     if (camera.type == CAMERA_PERSPECTIVE)
     {
         // Calculate projection matrix from perspective
-        matProj = MatrixPerspective(camera.fovy * DEG2RAD, ((double)width/(double)height), RL_CULL_DISTANCE_NEAR, RL_CULL_DISTANCE_FAR);
+        matProj = MatrixPerspective(camera.fovy * DEG2RAD, ((double)width/(double)height), cullDistanceNear, cullDistanceFar);
     }
     else if (camera.type == CAMERA_ORTHOGRAPHIC)
     {
@@ -2108,7 +2111,7 @@ Vector2 GetWorldToScreenEx(Vector3 position, Camera camera, int width, int heigh
         double right = top*aspect;
 
         // Calculate projection matrix from orthographic
-        matProj = MatrixOrtho(-right, right, -top, top, RL_CULL_DISTANCE_NEAR, RL_CULL_DISTANCE_FAR);
+        matProj = MatrixOrtho(-right, right, -top, top, cullDistanceNear, cullDistanceFar);
     }
 
     // Calculate view matrix from camera look at (and transpose it)
@@ -2148,6 +2151,12 @@ Vector2 GetScreenToWorld2D(Vector2 position, Camera2D camera)
     Vector3 transform = Vector3Transform((Vector3){ position.x, position.y, 0 }, invMatCamera);
 
     return (Vector2){ transform.x, transform.y };
+}
+
+void SetCullingPlanes(double near, double far)
+{
+    cullDistanceFar = far;
+    cullDistanceNear = near;
 }
 
 // Set target FPS (maximum)

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -965,6 +965,9 @@ RLAPI int GetFPS(void);                                           // Returns cur
 RLAPI float GetFrameTime(void);                                   // Returns time in seconds for last frame drawn
 RLAPI double GetTime(void);                                       // Returns elapsed time in seconds since InitWindow()
 
+// culling plane functions
+RLAPI void SetCullingPlanes(double near, double far);
+
 // Misc. functions
 RLAPI void SetConfigFlags(unsigned int flags);                    // Setup init configuration flags (view FLAGS)
 
@@ -1080,6 +1083,7 @@ RLAPI void SetCameraPanControl(int keyPan);                       // Set camera 
 RLAPI void SetCameraAltControl(int keyAlt);                       // Set camera alt key to combine with mouse movement (free camera)
 RLAPI void SetCameraSmoothZoomControl(int keySmoothZoom);         // Set camera smooth zoom key to combine with mouse (free camera)
 RLAPI void SetCameraMoveControls(int keyFront, int keyBack, int keyRight, int keyLeft, int keyUp, int keyDown); // Set camera move controls (1st person and 3rd person cameras)
+
 
 //------------------------------------------------------------------------------------
 // Basic Shapes Drawing Functions (Module: shapes)

--- a/src/rlgl.h
+++ b/src/rlgl.h
@@ -167,11 +167,11 @@
 #endif
 
 // Projection matrix culling
-#ifndef RL_CULL_DISTANCE_NEAR
-    #define RL_CULL_DISTANCE_NEAR         0.01      // Default near cull distance
+#ifndef RL_DEFAULT_CULL_DISTANCE_NEAR
+    #define RL_DEFAULT_CULL_DISTANCE_NEAR         0.01      // Default near cull distance
 #endif
-#ifndef RL_CULL_DISTANCE_FAR
-    #define RL_CULL_DISTANCE_FAR        1000.0      // Default far cull distance
+#ifndef RL_DEFAULT_CULL_DISTANCE_FAR
+    #define RL_DEFAULT_CULL_DISTANCE_FAR        1000.0      // Default far cull distance
 #endif
 
 // Texture parameters (equivalent to OpenGL defines)
@@ -3483,7 +3483,7 @@ TextureCubemap GenTextureCubemap(Shader shader, Texture2D panorama, int size, in
     // NOTE: Shader is used to convert HDR equirectangular environment map to cubemap equivalent (6 faces)
 
     // Define projection matrix and send it to shader
-    Matrix fboProjection = MatrixPerspective(90.0*DEG2RAD, 1.0, RL_CULL_DISTANCE_NEAR, RL_CULL_DISTANCE_FAR);
+    Matrix fboProjection = MatrixPerspective(90.0*DEG2RAD, 1.0, RL_DEFAULT_CULL_DISTANCE_NEAR, RL_DEFAULT_CULL_DISTANCE_FAR);
     SetShaderValueMatrix(shader, shader.locs[LOC_MATRIX_PROJECTION], fboProjection);
 
     // Define view matrix for every side of the cubemap
@@ -3568,7 +3568,7 @@ TextureCubemap GenTextureIrradiance(Shader shader, TextureCubemap cubemap, int s
     // NOTE: Shader is used to solve diffuse integral by convolution to create an irradiance cubemap
 
     // Define projection matrix and send it to shader
-    Matrix fboProjection = MatrixPerspective(90.0*DEG2RAD, 1.0, RL_CULL_DISTANCE_NEAR, RL_CULL_DISTANCE_FAR);
+    Matrix fboProjection = MatrixPerspective(90.0*DEG2RAD, 1.0, RL_DEFAULT_CULL_DISTANCE_NEAR, RL_DEFAULT_CULL_DISTANCE_FAR);
     SetShaderValueMatrix(shader, shader.locs[LOC_MATRIX_PROJECTION], fboProjection);
 
     // Define view matrix for every side of the cubemap
@@ -3645,7 +3645,7 @@ TextureCubemap GenTexturePrefilter(Shader shader, TextureCubemap cubemap, int si
     // NOTE: Shader is used to prefilter HDR and store data into mipmap levels
 
     // Define projection matrix and send it to shader
-    Matrix fboProjection = MatrixPerspective(90.0*DEG2RAD, 1.0, RL_CULL_DISTANCE_NEAR, RL_CULL_DISTANCE_FAR);
+    Matrix fboProjection = MatrixPerspective(90.0*DEG2RAD, 1.0, RL_DEFAULT_CULL_DISTANCE_NEAR, RL_DEFAULT_CULL_DISTANCE_FAR);
     SetShaderValueMatrix(shader, shader.locs[LOC_MATRIX_PROJECTION], fboProjection);
 
     // Define view matrix for every side of the cubemap
@@ -3887,7 +3887,7 @@ void SetVrConfiguration(VrDeviceInfo hmd, Shader distortion)
 
     // Compute camera projection matrices
     float projOffset = 4.0f*lensShift;      // Scaled to projection space coordinates [-1..1]
-    Matrix proj = MatrixPerspective(fovy, aspect, RL_CULL_DISTANCE_NEAR, RL_CULL_DISTANCE_FAR);
+    Matrix proj = MatrixPerspective(fovy, aspect, RL_DEFAULT_CULL_DISTANCE_NEAR, RL_DEFAULT_CULL_DISTANCE_FAR);
     RLGL.Vr.config.eyesProjection[0] = MatrixMultiply(proj, MatrixTranslate(projOffset, 0.0f, 0.0f));
     RLGL.Vr.config.eyesProjection[1] = MatrixMultiply(proj, MatrixTranslate(-projOffset, 0.0f, 0.0f));
 


### PR DESCRIPTION
Currently the near and far clipping planes are hardcoded in raylib and can only be changed by rebuilding raylib. This PR adds settable near and far plane values to raylib and uses them when creating projection matrices.

By default the same config planes are used, so no code changes are required for existing code to work like it used to.