### PR TITLE
[CORE] Add GetCurrentFrameBuffertSize

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -1429,6 +1429,12 @@ int GetScreenHeight(void)
     return CORE.Window.screen.height;
 }
 
+// Get width and height of the current rendering context (screen or texture)
+Vector2 GetCurrentFrameBuffertSize()
+{
+    return (Vector2) { (float)CORE.Window.currentFbo.width, (float)CORE.Window.currentFbo.height };
+}
+
 // Get native window handle
 void *GetWindowHandle(void)
 {

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -918,6 +918,7 @@ RLAPI void SetWindowSize(int width, int height);                  // Set window 
 RLAPI void *GetWindowHandle(void);                                // Get native window handle
 RLAPI int GetScreenWidth(void);                                   // Get current screen width
 RLAPI int GetScreenHeight(void);                                  // Get current screen height
+RLAPI Vector2 GetCurrentFrameBuffertSize();                       // Get width and height of the current rendering context (screen or texture)
 RLAPI int GetMonitorCount(void);                                  // Get number of connected monitors
 RLAPI int GetCurrentMonitor(void);                                // Get current connected monitor
 RLAPI Vector2 GetMonitorPosition(int monitor);                    // Get specified monitor position


### PR DESCRIPTION
This PR adds a function to return the size of the current frame buffer object to the public raylib API.

This is needed to allow external libraries and code to be able to create proper projection matrices when rendering to a texture.
Currently the only thing a library can do is get the screen or monitor size, not the size of the current rendering context. As there are examples that use render textures that are not the same size as the screen, and it is encouraged for people to create external library integrations and camera code, this function is needed.

Integrations of things like Dear ImGui can only set the screen size with functions like
 io->DisplaySize = (ImVec2){(float) GetScreenWidth(), (float) GetScreenHeight()};
If the user wants to render to a texture that is not the same size as the screen, the viewport will be incorrect and there will be no way to resolve the issue.

This also prevents client code from calling rlPerpsective or rlOrtho without knowing if it is rendering to the screen or a texture, making it impossible to create generic external camera code.

The other option would be to have GetScreenWidth and GetScreenHeight return the fbo size instead of the window size, since the "Screen" is the thing that you are currently rendering to.