### PR TITLE
Fix initialize GLFW's Joystick before window is created on Desktop platforms (#1554)

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -3321,6 +3321,20 @@ static bool InitGraphicsDevice(int width, int height)
 #endif
     }
 
+#if defined(PLATFORM_DESKTOP)
+    // NOTE: GLFW 3.4+ defers initialization of the Joystick subsystem on the
+    // first call to any Joystick related functions. Forcing this
+    // initialization here avoids doing it on `PollInputEvents` called by
+    // `EndDrawing` after first frame has been just drawn. The initialization
+    // will still happen and possible delays still occur, but before the window
+    // is shown, which is a nicer experience.
+    // Ref: https://github.com/raysan5/raylib/issues/1554
+    if (MAX_GAMEPADS > 0)
+    {
+        glfwSetJoystickCallback(NULL);
+    }
+#endif  // PLATFORM_DESKTOP
+
     if (CORE.Window.fullscreen)
     {
         // remember center for switchinging from fullscreen to window


### PR DESCRIPTION
This PR forces Joystick initialization before the window is created and shown on Desktop platforms, to avoid long first frames as in #1554.