### PR TITLE
Poll inputs after frame sleep

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -1847,7 +1847,6 @@ void EndDrawing(void)
 #endif
 
     SwapBuffers();                  // Copy back buffer to front buffer
-    PollInputEvents();              // Poll user events
 
     // Frame time control system
     CORE.Time.current = GetTime();
@@ -1867,6 +1866,8 @@ void EndDrawing(void)
 
         CORE.Time.frame += waitTime;      // Total frame time: update + draw + wait
     }
+
+    PollInputEvents();              // Poll user events
 }
 
 // Initialize 2D mode with custom camera (2D)


### PR DESCRIPTION
This should hopefully slightly reduce input latency when raylib is manually limiting the frame rate of the application. I don't have any concrete numbers, but using the slow mo mode on my camera and running the `core_input_mouse` example it does look like the ball stays slightly closer to my mouse cursor.