### PR TITLE
Add methods to transform the VR output

### DIFF
--- a/examples/core/core_vr_simulator.c
+++ b/examples/core/core_vr_simulator.c
@@ -72,6 +72,8 @@ int main(void)
 
     SetCameraMode(camera, CAMERA_FIRST_PERSON);         // Set first person camera mode
 
+    SetVrOutputTransform(VR_OUTPUT_ROTATE_NONE);        // Do not rotate the VR output
+
     SetTargetFPS(90);                   // Set our game to run at 90 frames-per-second
     //--------------------------------------------------------------------------------------
 

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -872,6 +872,15 @@ typedef enum {
     NPT_3PATCH_HORIZONTAL   // Npatch defined by 3x1 tiles
 } NPatchType;
 
+// VR Output Transformations
+typedef enum {
+    VR_OUTPUT_ROTATE_90     = 0x00000001,   // Set to rotate the output stereo view by 90 degrees (clockwise)
+    VR_OUTPUT_ROTATE_180    = 0x00000002,   // Set to rotate the output stereo view by 180 degrees (clockwise)
+    VR_OUTPUT_ROTATE_270    = 0x00000003,   // Set to rotate the output stereo view by 270 degrees (clockwise)
+    VR_OUTPUT_FLIP_H        = 0x00000004,   // Set to horizontally flip the stereo view before applying all rotations
+    VR_OUTPUT_FLIP_V        = 0x00000008    // Set to vertically flip the stereo view before applying all rotations
+} VrOutputTransform;
+
 // Callbacks to be implemented by users
 typedef void (*TraceLogCallback)(int logType, const char *text, va_list args);
 typedef void *(*MemAllocCallback)(int size);
@@ -1446,6 +1455,7 @@ RLAPI void InitVrSimulator(void);                       // Init VR simulator for
 RLAPI void CloseVrSimulator(void);                      // Close VR simulator for current device
 RLAPI void UpdateVrTracking(Camera *camera);            // Update VR tracking (position and orientation) and camera
 RLAPI void SetVrConfiguration(VrDeviceInfo info, Shader distortion);      // Set stereo rendering configuration parameters
+RLAPI void SetVrOutputTransform(unsigned int transform);// Set the VR simulator output transform flags
 RLAPI bool IsVrSimulatorReady(void);                    // Detect if VR simulator is ready
 RLAPI void ToggleVrMode(void);                          // Enable/Disable VR experience
 RLAPI void BeginVrDrawing(void);                        // Begin VR simulator stereo rendering

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -874,6 +874,7 @@ typedef enum {
 
 // VR Output Transformations
 typedef enum {
+    VR_OUTPUT_ROTATE_NONE   = 0x00000000,   // Set to apply no rotation transform
     VR_OUTPUT_ROTATE_90     = 0x00000001,   // Set to rotate the output stereo view by 90 degrees (clockwise)
     VR_OUTPUT_ROTATE_180    = 0x00000002,   // Set to rotate the output stereo view by 180 degrees (clockwise)
     VR_OUTPUT_ROTATE_270    = 0x00000003,   // Set to rotate the output stereo view by 270 degrees (clockwise)

--- a/src/rlgl.h
+++ b/src/rlgl.h
@@ -4005,41 +4005,44 @@ void EndVrDrawing(void)
 
         rlEnableTexture(RLGL.Vr.stereoTexId);
 
+        // Extract transform flags
         bool shouldFlipH = RLGL.Vr.outputTransformFlags & VR_OUTPUT_FLIP_H;
         bool shouldFlipV = RLGL.Vr.outputTransformFlags & VR_OUTPUT_FLIP_V;
 
-        int point = RLGL.Vr.outputTransformFlags & 0b11; // Extract lower bits from transform flags
-
+        // Declare four UV coordinates with vertical and horizontal flips according to the flags
         float uvPoints[][2] = {
-            { (float)(shouldFlipH ^ 0), (float)(shouldFlipV ^ 1) },
-            { (float)(shouldFlipH ^ 0), (float)(shouldFlipV ^ 0) },
-            { (float)(shouldFlipH ^ 1), (float)(shouldFlipV ^ 0) },
-            { (float)(shouldFlipH ^ 1), (float)(shouldFlipV ^ 1) }
+            { (float)(shouldFlipH ^ 0), (float)(shouldFlipV ^ 1) }, // Bottom-left corner for texture 
+            { (float)(shouldFlipH ^ 0), (float)(shouldFlipV ^ 0) }, // Bottom-right corner for texture
+            { (float)(shouldFlipH ^ 1), (float)(shouldFlipV ^ 0) }, // Top-right corner for texture
+            { (float)(shouldFlipH ^ 1), (float)(shouldFlipV ^ 1) }  // Top-left corner for texture
         };
+
+        int pointOffset = RLGL.Vr.outputTransformFlags & 0b11;      // Extract lower bits from transform flags
+        int point = 0;
 
         rlPushMatrix();
             rlBegin(RL_QUADS);
                 rlColor4ub(255, 255, 255, 255);
                 rlNormal3f(0.0f, 0.0f, 1.0f);
 
-                // Bottom-left corner for texture and quad
+                // Bottom-left corner for quad
+                point = (pointOffset + 0) % 4;
                 rlTexCoord2f(uvPoints[point][0], uvPoints[point][1]);
-                point = (point + 1) % 4;
                 rlVertex2f(0.0f, 0.0f);
 
-                // Bottom-right corner for texture and quad
+                // Bottom-right corner for quad
+                point = (pointOffset + 1) % 4;
                 rlTexCoord2f(uvPoints[point][0], uvPoints[point][1]);
-                point = (point + 1) % 4;
                 rlVertex2f(0.0f, (float)RLGL.State.framebufferHeight);
 
-                // Top-right corner for texture and quad
+                // Top-right corner for quad
+                point = (pointOffset + 2) % 4;
                 rlTexCoord2f(uvPoints[point][0], uvPoints[point][1]);
-                point = (point + 1) % 4;
                 rlVertex2f((float)RLGL.State.framebufferWidth, (float)RLGL.State.framebufferHeight);
 
-                // Top-left corner for texture and quad
+                // Top-left corner for quad
+                point = (pointOffset + 3) % 4;
                 rlTexCoord2f(uvPoints[point][0], uvPoints[point][1]);
-                point = (point + 1) % 4;
                 rlVertex2f((float)RLGL.State.framebufferWidth, 0.0f);
             rlEnd();
         rlPopMatrix();


### PR DESCRIPTION
# This PR:
- Adds a function to the VR simulator called `SetVrOutputTransform()` that allows users to rotate and reflect the VR simulator output
- Adds logic in `EndVrDrawing()` that will transform the VR output according to the transform flags
- Adds `VrOutputTransform` enum
- Updates the `core_vr_simulator` example to include `SetVrOutputTransform()`

# For example:
`VR_OUTPUT_ROTATE_NONE`
![VR_OUTPUT_ROTATE_NONE](https://user-images.githubusercontent.com/40672030/107537794-e5334980-6b88-11eb-9eea-d9cf076ae96d.png)

`VR_OUTPUT_ROTATE_180`
![Screenshot from 2021-02-10 10-20-38](https://user-images.githubusercontent.com/40672030/107538549-b669a300-6b89-11eb-9c46-4d876047967f.png)

`VR_OUTPUT_FLIP_V | VR_OUTPUT_ROTATE_180`
![VR_OUTPUT_FLIP_V | VR_OUTPUT_ROTATE_180](https://user-images.githubusercontent.com/40672030/107538975-237d3880-6b8a-11eb-8245-2be09c7219ff.png)

# Why?
To my knowledge, raylib is the only library that has a VR simulator that can be used to directly drive a real VR headset. However, not all VR headset displays are mounted vertically. By adding this functionality, it would be easy for users using phones or embedded systems (such as the Pi 4) to rotate and/or flip the display without a window server. Since the transformations just change vertex coordinates, it has a negligible performance impact.