### PR TITLE
[raudio] Fix load and unload issues with Music

### DIFF
--- a/src/external/jar_xm.h
+++ b/src/external/jar_xm.h
@@ -696,7 +696,9 @@ int jar_xm_create_context_safe(jar_xm_context_t** ctxp, const char* moddata, siz
 }
 
 void jar_xm_free_context(jar_xm_context_t* ctx) {
-    JARXM_FREE(ctx->allocated_memory);
+    if (ctx != NULL) {
+        JARXM_FREE(ctx->allocated_memory);
+    }
 }
 
 void jar_xm_set_max_loop_count(jar_xm_context_t* ctx, uint8_t loopcnt) {

--- a/src/raudio.c
+++ b/src/raudio.c
@@ -275,7 +275,8 @@ typedef struct tagBITMAPINFOHEADER {
 // NOTE: Depends on data structure provided by the library
 // in charge of reading the different file types
 typedef enum {
-    MUSIC_AUDIO_WAV = 0,
+    MUSIC_AUDIO_NONE = 0,
+    MUSIC_AUDIO_WAV,
     MUSIC_AUDIO_OGG,
     MUSIC_AUDIO_FLAC,
     MUSIC_AUDIO_MP3,
@@ -465,7 +466,7 @@ void InitAudioDevice(void)
         ma_context_uninit(&AUDIO.System.context);
         return;
     }
-    
+
     // Init dummy audio buffers pool for multichannel sound playing
     for (int i = 0; i < MAX_AUDIO_BUFFER_POOL_CHANNELS; i++)
     {
@@ -502,7 +503,7 @@ void CloseAudioDevice(void)
                 RL_FREE(AUDIO.MultiChannel.pool[i]);
             }
         }
-        
+
         ma_mutex_uninit(&AUDIO.System.lock);
         ma_device_uninit(&AUDIO.System.device);
         ma_context_uninit(&AUDIO.System.context);
@@ -1112,9 +1113,9 @@ float *LoadWaveSamples(Wave wave)
 
     for (unsigned int i = 0; i < wave.sampleCount; i++)
     {
-            if (wave.sampleSize == 8) samples[i] = (float)(((unsigned char *)wave.data)[i] - 127)/256.0f;
-            else if (wave.sampleSize == 16) samples[i] = (float)(((short *)wave.data)[i])/32767.0f;
-            else if (wave.sampleSize == 32) samples[i] = ((float *)wave.data)[i];
+        if (wave.sampleSize == 8) samples[i] = (float)(((unsigned char *)wave.data)[i] - 127)/256.0f;
+        else if (wave.sampleSize == 16) samples[i] = (float)(((short *)wave.data)[i])/32767.0f;
+        else if (wave.sampleSize == 32) samples[i] = ((float *)wave.data)[i];
     }
 
     return samples;


### PR DESCRIPTION
Made changes to raudio to fix issues with `LoadMusicStream` and `UnloadMusicStream`.

Issues fixed:
- If a format is not valid or fails to load it is no longer assumed to be wav. This makes sure the correct unload call is made and makes the format clear to the user.

- Fixed crashing with invalid wav files when unloading. It was trying to use a callback where it shouldn't because it was not initialized to a zero value.

- Fixed crash in jar_xm when unloading a NULL ctxData.
