### PR TITLE
[models] make sure glTF parent bones are not null before trying to compute the offset from the root

### DIFF
--- a/src/models.c
+++ b/src/models.c
@@ -3733,7 +3733,7 @@ static Model LoadGLTF(const char *fileName)
         for (unsigned int j = 0; j < data->nodes_count; j++)
         {
             strcpy(model.bones[j].name, data->nodes[j].name == 0 ? "ANIMJOINT" : data->nodes[j].name);
-            model.bones[j].parent = j != 0 ? data->nodes[j].parent - data->nodes : 0;
+            model.bones[j].parent = (j != 0 && data->nodes[j].parent != NULL) ? data->nodes[j].parent - data->nodes : 0;
         }
         
         for (unsigned int i = 0; i < data->nodes_count; i++)
@@ -3771,7 +3771,10 @@ static Model LoadGLTF(const char *fileName)
         {
             Transform* currentTransform = model.bindPose + i;
             BoneInfo* currentBone = model.bones + i;
-            Transform* parentTransform = model.bindPose + currentBone->parent;
+            int root = currentBone->parent;
+            if (root >= model.boneCount)
+                root = 0;
+            Transform* parentTransform = model.bindPose + root;
             
             if (currentBone->parent >= 0)
             {


### PR DESCRIPTION
The current glFT code assumes that the parent bone is always non null and that it can always compute an offset from it to the root bone. This is not always the case, some bones don't have a parent. If the parent bone node is null, this will compute a very bad offset and cause a segfault later in the code, because the offset is not checked against the bone list bounds.
This change only computes an offset for the parent if the bone is non-null, attaching all null parent bones to the root node.