### PR TITLE
Add check to flip quaternion

### DIFF
--- a/src/raymath.h
+++ b/src/raymath.h
@@ -1271,6 +1271,11 @@ RMDEF Quaternion QuaternionSlerp(Quaternion q1, Quaternion q2, float amount)
 
     float cosHalfTheta =  q1.x*q2.x + q1.y*q2.y + q1.z*q2.z + q1.w*q2.w;
 
+    if (cosHalfTheta < 0) {
+        q2.x = -q2.x; q2.y = -q2.y; q2.z = -q2.z; q2.w = -q2.w;
+        cosHalfTheta = -cosHalfTheta;
+    }    
+
     if (fabs(cosHalfTheta) >= 1.0f) result = q1;
     else if (cosHalfTheta > 0.95f) result = QuaternionNlerp(q1, q2, amount);
     else


### PR DESCRIPTION
This commit add a check to `QuaternionSlerp()` which inverts one of the quaternions if they are inverted to each other (same rotation, just all components are negative)

The check is outlined here in the other issues section on this page.
https://www.euclideanspace.com/maths/algebra/realNormedAlgebra/quaternions/slerp

Three.js has this exact same check in their slerp function, so I'm guessing this is the standard way to do this in graphics focused stuff.