### PR TITLE
replace vraylib link

### DIFF
--- a/BINDINGS.md
+++ b/BINDINGS.md
@@ -78,7 +78,7 @@ Here it is a list with the ones I'm aware of:
 | raylib-Ada         | 3.0 | [Ada](https://www.adacore.com/about-ada)  | https://github.com/mimo/raylib-Ada        |
 | jaylib             | 3.0 | [Janet](https://janet-lang.org/)          | https://github.com/janet-lang/jaylib      |
 | raykit             | ? | [Kit](https://www.kitlang.org/)           | https://github.com/Gamerfiend/raykit      |
-| vraylib            | 2.5 | [V](https://vlang.io/)                    | https://github.com/MajorHard/vraylib      |
+| vraylib            | 3.5 | [V](https://vlang.io/)                    | https://github.com/waotzi/vraylib      |
 | ray.mod            | 3.0 | [BlitzMax](https://blitzmax.org/)         | https://github.com/bmx-ng/ray.mod         |
 | ray-ocaml          | 3.0 | [OCaml](https://ocaml.org/)               | https://github.com/tjammer/raylib-ocaml   |
 | raylib-mosaic      | 3.0 | [Mosaic](https://github.com/sal55/langs/tree/master/Mosaic)     | https://github.com/pluckyporcupine/raylib-mosaic   |


### PR DESCRIPTION
the vraylib binding from  MajorHard doesn't seem to be getting any updates, so maybe replace it with the working fork?