### PR TITLE
Removing +1 on comparing extesnions because this way it checked the f…

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -2325,7 +2325,7 @@ bool IsFileExtension(const char *fileName, const char *ext)
 
         for (int i = 0; i < extCount; i++)
         {
-            if (TextIsEqual(fileExtLower, TextToLower(checkExts[i] + 1)))
+            if (TextIsEqual(fileExtLower, TextToLower(checkExts[i])))
             {
                 result = true;
                 break;


### PR DESCRIPTION
…ile extension without the . against the file extension with the . resulting in always false.

@raysan5 This is due to recent commit "bcc4418f" which modifies the function for getting the file extension to return the extesnion with the "." For me this resulted in models not being loaded and loading only cubes