### PR TITLE
[core] minor fixes to Toggle Fullscreen

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -1033,7 +1033,13 @@ void ToggleFullscreen(void)
         // Store previous window position (in case we exit fullscreen)
         glfwGetWindowPos(CORE.Window.handle, &CORE.Window.position.x, &CORE.Window.position.y);
 
-        GLFWmonitor *monitor = glfwGetWindowMonitor(CORE.Window.handle);
+        int monitorCount = 0;
+		GLFWmonitor** monitors = glfwGetMonitors(&monitorCount);
+
+        int monitorIndex = GetCurrentMonitor();
+        // use GetCurrentMonitor so we correctly get the display the window is on
+        GLFWmonitor* monitor = monitorIndex < monitorCount ?  monitors[monitorIndex] : NULL;
+
         if (!monitor)
         {
             TRACELOG(LOG_WARNING, "GLFW: Failed to get monitor");
@@ -1047,10 +1053,6 @@ void ToggleFullscreen(void)
         glfwSetWindowSizeCallback(CORE.Window.handle, NULL);
         glfwSetWindowMonitor(CORE.Window.handle, monitor, 0, 0, CORE.Window.screen.width, CORE.Window.screen.height, GLFW_DONT_CARE);
         glfwSetWindowSizeCallback(CORE.Window.handle, WindowSizeCallback);
-
-        // Try to enable GPU V-Sync, so frames are limited to screen refresh rate (60Hz -> 60 FPS)
-        // NOTE: V-Sync can be enabled by graphic driver configuration
-        if (CORE.Window.flags & FLAG_VSYNC_HINT) glfwSwapInterval(1);
     }
     else
     {
@@ -1058,6 +1060,10 @@ void ToggleFullscreen(void)
         glfwSetWindowMonitor(CORE.Window.handle, NULL, CORE.Window.position.x, CORE.Window.position.y, CORE.Window.screen.width, CORE.Window.screen.height, GLFW_DONT_CARE);
         glfwSetWindowSizeCallback(CORE.Window.handle, WindowSizeCallback);
     }
+
+	// Try to enable GPU V-Sync, so frames are limited to screen refresh rate (60Hz -> 60 FPS)
+    // NOTE: V-Sync can be enabled by graphic driver configuration
+    if (CORE.Window.flags & FLAG_VSYNC_HINT) glfwSwapInterval(1);
 
     CORE.Window.fullscreen = !CORE.Window.fullscreen;          // Toggle fullscreen flag
     CORE.Window.flags ^= FLAG_FULLSCREEN_MODE;


### PR DESCRIPTION
This PR makes some small fixes to ToggleFullscreen to make it work in a more understandable manner.

- Always try to restore vsync
- Use the internal  GetCurrentMonitor instead of glfw so it picks up the current monitor corner.

Note that this does not change how ToggleFullscreen handles resolution. It will still attempts to change the display resolution to match the window size.

Users that want to toggle fullscren to the monitor size should use code similar to this.

![image](https://user-images.githubusercontent.com/322174/110246427-68438780-7f1c-11eb-89dc-3d07938934d6.png)
 