### PR TITLE
Fix fullscreen resolution

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -1056,7 +1056,7 @@ void ToggleFullscreen(void)
         CORE.Window.flags |= FLAG_FULLSCREEN_MODE;
         
         const GLFWvidmode *mode = glfwGetVideoMode(monitor);
-        glfwSetWindowMonitor(CORE.Window.handle, monitor, 0, 0, mode->width, mode->height, 0);
+        glfwSetWindowMonitor(CORE.Window.handle, monitor, 0, 0, mode->width, mode->height, mode->refreshRate);
     }
     else
     {

--- a/src/core.c
+++ b/src/core.c
@@ -1055,8 +1055,7 @@ void ToggleFullscreen(void)
         CORE.Window.fullscreen = true;          // Toggle fullscreen flag
         CORE.Window.flags |= FLAG_FULLSCREEN_MODE;
         
-        const GLFWvidmode *mode = glfwGetVideoMode(monitor);
-        glfwSetWindowMonitor(CORE.Window.handle, monitor, 0, 0, mode->width, mode->height, mode->refreshRate);
+        glfwSetWindowMonitor(CORE.Window.handle, monitor, 0, 0, CORE.Window.screen.width, CORE.Window.screen.height, GLFW_DONT_CARE);
     }
     else
     {

--- a/src/core.c
+++ b/src/core.c
@@ -1048,9 +1048,7 @@ void ToggleFullscreen(void)
             CORE.Window.fullscreen = false;          // Toggle fullscreen flag
             CORE.Window.flags &= ~FLAG_FULLSCREEN_MODE;
             
-            int modesCount = 0;
-            const GLFWvidmode *modes = glfwGetVideoModes(glfwGetPrimaryMonitor(), &modesCount);
-            glfwSetWindowMonitor(CORE.Window.handle, glfwGetPrimaryMonitor(), 0, 0, modes[modesCount - 1].width, modes[modesCount - 1].height, GLFW_DONT_CARE);
+            glfwSetWindowMonitor(CORE.Window.handle, NULL, 0, 0, CORE.Window.screen.width, CORE.Window.screen.height, GLFW_DONT_CARE);
             return;
         }
     

--- a/src/core.c
+++ b/src/core.c
@@ -1044,30 +1044,33 @@ void ToggleFullscreen(void)
         if (!monitor)
         {
             TRACELOG(LOG_WARNING, "GLFW: Failed to get monitor");
-            glfwSetWindowSizeCallback(CORE.Window.handle, NULL);
-            glfwSetWindowMonitor(CORE.Window.handle, glfwGetPrimaryMonitor(), 0, 0, CORE.Window.screen.width, CORE.Window.screen.height, GLFW_DONT_CARE);
-            glfwSetWindowSizeCallback(CORE.Window.handle, WindowSizeCallback);
+    
+            CORE.Window.fullscreen = false;          // Toggle fullscreen flag
+            CORE.Window.flags &= ~FLAG_FULLSCREEN_MODE;
+            
+            int modesCount = 0;
+            const GLFWvidmode *modes = glfwGetVideoModes(glfwGetPrimaryMonitor(), &modesCount);
+            glfwSetWindowMonitor(CORE.Window.handle, glfwGetPrimaryMonitor(), 0, 0, modes[modesCount - 1].width, modes[modesCount - 1].height, GLFW_DONT_CARE);
             return;
         }
     
+        CORE.Window.fullscreen = true;          // Toggle fullscreen flag
+        CORE.Window.flags |= FLAG_FULLSCREEN_MODE;
+        
         const GLFWvidmode *mode = glfwGetVideoMode(monitor);
-        glfwSetWindowSizeCallback(CORE.Window.handle, NULL);
-        glfwSetWindowMonitor(CORE.Window.handle, monitor, 0, 0, CORE.Window.screen.width, CORE.Window.screen.height, GLFW_DONT_CARE);
-        glfwSetWindowSizeCallback(CORE.Window.handle, WindowSizeCallback);
+        glfwSetWindowMonitor(CORE.Window.handle, monitor, 0, 0, mode->width, mode->height, 0);
     }
     else
     {
-        glfwSetWindowSizeCallback(CORE.Window.handle, NULL);
+        CORE.Window.fullscreen = false;          // Toggle fullscreen flag
+        CORE.Window.flags &= ~FLAG_FULLSCREEN_MODE;
+        
         glfwSetWindowMonitor(CORE.Window.handle, NULL, CORE.Window.position.x, CORE.Window.position.y, CORE.Window.screen.width, CORE.Window.screen.height, GLFW_DONT_CARE);
-        glfwSetWindowSizeCallback(CORE.Window.handle, WindowSizeCallback);
     }
 
 	// Try to enable GPU V-Sync, so frames are limited to screen refresh rate (60Hz -> 60 FPS)
     // NOTE: V-Sync can be enabled by graphic driver configuration
     if (CORE.Window.flags & FLAG_VSYNC_HINT) glfwSwapInterval(1);
-
-    CORE.Window.fullscreen = !CORE.Window.fullscreen;          // Toggle fullscreen flag
-    CORE.Window.flags ^= FLAG_FULLSCREEN_MODE;
 
 #endif
 #if defined(PLATFORM_WEB)
@@ -4619,16 +4622,18 @@ static void ErrorCallback(int error, const char *description)
 static void WindowSizeCallback(GLFWwindow *window, int width, int height)
 {
     SetupViewport(width, height);    // Reset viewport and projection matrix for new size
-
+    CORE.Window.currentFbo.width = width;
+    CORE.Window.currentFbo.height = height;
+    CORE.Window.resizedLastFrame = true;
+    
+    if(IsWindowFullscreen())
+        return;
+    
     // Set current screen size
     CORE.Window.screen.width = width;
     CORE.Window.screen.height = height;
-    CORE.Window.currentFbo.width = width;
-    CORE.Window.currentFbo.height = height;
-
     // NOTE: Postprocessing texture is not scaled to new size
 
-    CORE.Window.resizedLastFrame = true;
 }
 
 // GLFW3 WindowIconify Callback, runs when window is minimized/restored

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -873,15 +873,18 @@ typedef enum {
     NPATCH_THREE_PATCH_HORIZONTAL   // Npatch defined by 3x1 tiles
 } NPatchType;
 
-// Callbacks to be implemented by users
-typedef void (*TraceLogCallback)(int logType, const char *text, va_list args);
-typedef void *(*MemAllocCallback)(int size);
-typedef void *(*MemReallocCallback)(void *ptr, int size);
-typedef void (*MemFreeCallback)(void *ptr);
-typedef unsigned char* (*LoadFileDataCallback)(const char* fileName, unsigned int* bytesRead);
-typedef void (*SaveFileDataCallback)(const char *fileName, void *data, unsigned int bytesToWrite);
-typedef char *(*LoadFileTextCallback)(const char* fileName);
-typedef void (*SaveFileTextCallback)(const char *fileName, char *text);
+// Callbacks to hook some internal functions
+// WARNING: This callbacks are intended for advance users
+typedef void (*TraceLogCallback)(int logType, const char *text, va_list args);  // Logging: Redirect trace log messages
+
+typedef void *(*MemAllocCallback)(int size);                // Memory: Custom allocator
+typedef void *(*MemReallocCallback)(void *ptr, int size);   // Memory: Custom re-allocator
+typedef void (*MemFreeCallback)(void *ptr);                 // Memory: Custom free
+
+typedef unsigned char* (*LoadFileDataCallback)(const char* fileName, unsigned int* bytesRead);      // FileIO: Load binary data
+typedef void (*SaveFileDataCallback)(const char *fileName, void *data, unsigned int bytesToWrite);  // FileIO: Save binary data
+typedef char *(*LoadFileTextCallback)(const char* fileName);                // FileIO: Load text data
+typedef void (*SaveFileTextCallback)(const char *fileName, char *text);     // FileIO: Save text data
 
 
 #if defined(__cplusplus)
@@ -985,15 +988,16 @@ RLAPI void *MemAlloc(int size);                                   // Internal me
 RLAPI void *MemRealloc(void *ptr, int size);                      // Internal memory reallocator
 RLAPI void MemFree(void *ptr);                                    // Internal memory free
 
-// Set custom system callbacks
+// Set custom callbacks
+// WARNING: Callbacks setup is intended for advance users
 RLAPI void SetTraceLogCallback(TraceLogCallback callback);        // Set custom trace log
 RLAPI void SetMemAllocCallback(MemAllocCallback callback);        // Set custom memory allocator
 RLAPI void SetMemReallocCallback(MemReallocCallback callback);    // Set custom memory reallocator
 RLAPI void SetMemFreeCallback(MemFreeCallback callback);          // Set custom memory free
-RLAPI void SetLoadFileDataCallback(LoadFileDataCallback callback);  // Set custom file data loader
-RLAPI void SetSaveFileDataCallback(SaveFileDataCallback callback);  // Set custom file data saver
-RLAPI void SetLoadFileTextCallback(LoadFileTextCallback callback);  // Set custom file text loader
-RLAPI void SetSaveFileTextCallback(SaveFileTextCallback callback);  // Set custom file text saver
+RLAPI void SetLoadFileDataCallback(LoadFileDataCallback callback);  // Set custom file binary data loader
+RLAPI void SetSaveFileDataCallback(SaveFileDataCallback callback);  // Set custom file binary data saver
+RLAPI void SetLoadFileTextCallback(LoadFileTextCallback callback);  // Set custom file text data loader
+RLAPI void SetSaveFileTextCallback(SaveFileTextCallback callback);  // Set custom file text data saver
 
 // Files management functions
 RLAPI unsigned char *LoadFileData(const char *fileName, unsigned int *bytesRead);     // Load file data as byte array (read)


### PR DESCRIPTION
Fixes #1294
Uses not yet submitted pull request of @JeffM2501 - #1636 

Modified how fullscreen gets toggled.

- Removed the unsetting and setting of the resize callback function. Instead of that I moved the fullscreen flag setting into a more correct place before setting the fullscreen so that this flag can be used in the callback.
- In the resize callback now window size is only set when it is not fullscreen resulting in preserving the window size.
- When going fullscreen the larges resolution is used so that there are no problems of the type when you minimize the window you cannot use anything else in your desktop because the resolution might be too low. If a low res effect is desired one should use render texture (this is the approach all game engines use).

@raysan5 This should yield the required results.
