### PR TITLE
Improved accuracy for DrawRing and DrawCircleSector angles

### DIFF
--- a/examples/shapes/shapes_draw_circle_sector.c
+++ b/examples/shapes/shapes_draw_circle_sector.c
@@ -28,8 +28,8 @@ int main(void)
     Vector2 center = {(GetScreenWidth() - 300)/2, GetScreenHeight()/2 };
 
     float outerRadius = 180.0f;
-    int startAngle = 0;
-    int endAngle = 180;
+    float startAngle = 0.0f;
+    float endAngle = 180.0f;
     int segments = 0;
 
     SetTargetFPS(60);               // Set our game to run at 60 frames-per-second

--- a/examples/shapes/shapes_draw_ring.c
+++ b/examples/shapes/shapes_draw_ring.c
@@ -30,8 +30,8 @@ int main(void)
     float innerRadius = 80.0f;
     float outerRadius = 190.0f;
 
-    int startAngle = 0;
-    int endAngle = 360;
+    float startAngle = 0.0f;
+    float endAngle = 360.0f;
     int segments = 0;
 
     bool drawRing = true;

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1098,15 +1098,15 @@ RLAPI void DrawLineBezier(Vector2 startPos, Vector2 endPos, float thick, Color c
 RLAPI void DrawLineBezierQuad(Vector2 startPos, Vector2 endPos, Vector2 controlPos, float thick, Color color); //Draw line using quadratic bezier curves with a control point
 RLAPI void DrawLineStrip(Vector2 *points, int pointsCount, Color color);                                 // Draw lines sequence
 RLAPI void DrawCircle(int centerX, int centerY, float radius, Color color);                              // Draw a color-filled circle
-RLAPI void DrawCircleSector(Vector2 center, float radius, int startAngle, int endAngle, int segments, Color color);      // Draw a piece of a circle
-RLAPI void DrawCircleSectorLines(Vector2 center, float radius, int startAngle, int endAngle, int segments, Color color); // Draw circle sector outline
+RLAPI void DrawCircleSector(Vector2 center, float radius, float startAngle, float endAngle, int segments, Color color);      // Draw a piece of a circle
+RLAPI void DrawCircleSectorLines(Vector2 center, float radius, float startAngle, float endAngle, int segments, Color color); // Draw circle sector outline
 RLAPI void DrawCircleGradient(int centerX, int centerY, float radius, Color color1, Color color2);       // Draw a gradient-filled circle
 RLAPI void DrawCircleV(Vector2 center, float radius, Color color);                                       // Draw a color-filled circle (Vector version)
 RLAPI void DrawCircleLines(int centerX, int centerY, float radius, Color color);                         // Draw circle outline
 RLAPI void DrawEllipse(int centerX, int centerY, float radiusH, float radiusV, Color color);             // Draw ellipse
 RLAPI void DrawEllipseLines(int centerX, int centerY, float radiusH, float radiusV, Color color);        // Draw ellipse outline
-RLAPI void DrawRing(Vector2 center, float innerRadius, float outerRadius, int startAngle, int endAngle, int segments, Color color); // Draw ring
-RLAPI void DrawRingLines(Vector2 center, float innerRadius, float outerRadius, int startAngle, int endAngle, int segments, Color color);    // Draw ring outline
+RLAPI void DrawRing(Vector2 center, float innerRadius, float outerRadius, float startAngle, float endAngle, int segments, Color color); // Draw ring
+RLAPI void DrawRingLines(Vector2 center, float innerRadius, float outerRadius, float startAngle, float endAngle, int segments, Color color);    // Draw ring outline
 RLAPI void DrawRectangle(int posX, int posY, int width, int height, Color color);                        // Draw a color-filled rectangle
 RLAPI void DrawRectangleV(Vector2 position, Vector2 size, Color color);                                  // Draw a color-filled rectangle (Vector version)
 RLAPI void DrawRectangleRec(Rectangle rec, Color color);                                                 // Draw a color-filled rectangle

--- a/src/shapes.c
+++ b/src/shapes.c
@@ -205,7 +205,7 @@ void DrawCircle(int centerX, int centerY, float radius, Color color)
 }
 
 // Draw a piece of a circle
-void DrawCircleSector(Vector2 center, float radius, int startAngle, int endAngle, int segments, Color color)
+void DrawCircleSector(Vector2 center, float radius, float startAngle, float endAngle, int segments, Color color)
 {
     if (radius <= 0.0f) radius = 0.1f;  // Avoid div by zero
 
@@ -213,7 +213,7 @@ void DrawCircleSector(Vector2 center, float radius, int startAngle, int endAngle
     if (endAngle < startAngle)
     {
         // Swap values
-        int tmp = startAngle;
+        float tmp = startAngle;
         startAngle = endAngle;
         endAngle = tmp;
     }
@@ -227,8 +227,8 @@ void DrawCircleSector(Vector2 center, float radius, int startAngle, int endAngle
         if (segments <= 0) segments = 4;
     }
 
-    float stepLength = (float)(endAngle - startAngle)/(float)segments;
-    float angle = (float)startAngle;
+    float stepLength = (endAngle - startAngle)/(float)segments;
+    float angle = startAngle;
 
 #if defined(SUPPORT_QUADS_DRAW_MODE)
     if (rlCheckBufferLimit(4*segments/2)) rlglDraw();
@@ -294,7 +294,7 @@ void DrawCircleSector(Vector2 center, float radius, int startAngle, int endAngle
 #endif
 }
 
-void DrawCircleSectorLines(Vector2 center, float radius, int startAngle, int endAngle, int segments, Color color)
+void DrawCircleSectorLines(Vector2 center, float radius, float startAngle, float endAngle, int segments, Color color)
 {
     if (radius <= 0.0f) radius = 0.1f;  // Avoid div by zero issue
 
@@ -302,7 +302,7 @@ void DrawCircleSectorLines(Vector2 center, float radius, int startAngle, int end
     if (endAngle < startAngle)
     {
         // Swap values
-        int tmp = startAngle;
+        float tmp = startAngle;
         startAngle = endAngle;
         endAngle = tmp;
     }
@@ -316,13 +316,13 @@ void DrawCircleSectorLines(Vector2 center, float radius, int startAngle, int end
         if (segments <= 0) segments = 4;
     }
 
-    float stepLength = (float)(endAngle - startAngle)/(float)segments;
-    float angle = (float)startAngle;
+    float stepLength = (endAngle - startAngle)/(float)segments;
+    float angle = startAngle;
 
     // Hide the cap lines when the circle is full
     bool showCapLines = true;
     int limit = 2*(segments + 2);
-    if ((endAngle - startAngle)%360 == 0) { limit = 2*segments; showCapLines = false; }
+    if ((int)(endAngle - startAngle)%360 == 0) { limit = 2*segments; showCapLines = false; }
 
     if (rlCheckBufferLimit(limit)) rlglDraw();
 
@@ -427,7 +427,7 @@ void DrawEllipseLines(int centerX, int centerY, float radiusH, float radiusV, Co
     rlEnd();
 }
 
-void DrawRing(Vector2 center, float innerRadius, float outerRadius, int startAngle, int endAngle, int segments, Color color)
+void DrawRing(Vector2 center, float innerRadius, float outerRadius, float startAngle, float endAngle, int segments, Color color)
 {
     if (startAngle == endAngle) return;
 
@@ -445,7 +445,7 @@ void DrawRing(Vector2 center, float innerRadius, float outerRadius, int startAng
     if (endAngle < startAngle)
     {
         // Swap values
-        int tmp = startAngle;
+        float tmp = startAngle;
         startAngle = endAngle;
         endAngle = tmp;
     }
@@ -466,8 +466,8 @@ void DrawRing(Vector2 center, float innerRadius, float outerRadius, int startAng
         return;
     }
 
-    float stepLength = (float)(endAngle - startAngle)/(float)segments;
-    float angle = (float)startAngle;
+    float stepLength = (endAngle - startAngle)/(float)segments;
+    float angle = startAngle;
 
 #if defined(SUPPORT_QUADS_DRAW_MODE)
     if (rlCheckBufferLimit(4*segments)) rlglDraw();
@@ -518,7 +518,7 @@ void DrawRing(Vector2 center, float innerRadius, float outerRadius, int startAng
 #endif
 }
 
-void DrawRingLines(Vector2 center, float innerRadius, float outerRadius, int startAngle, int endAngle, int segments, Color color)
+void DrawRingLines(Vector2 center, float innerRadius, float outerRadius, float startAngle, float endAngle, int segments, Color color)
 {
     if (startAngle == endAngle) return;
 
@@ -536,7 +536,7 @@ void DrawRingLines(Vector2 center, float innerRadius, float outerRadius, int sta
     if (endAngle < startAngle)
     {
         // Swap values
-        int tmp = startAngle;
+        float tmp = startAngle;
         startAngle = endAngle;
         endAngle = tmp;
     }
@@ -556,12 +556,12 @@ void DrawRingLines(Vector2 center, float innerRadius, float outerRadius, int sta
         return;
     }
 
-    float stepLength = (float)(endAngle - startAngle)/(float)segments;
-    float angle = (float)startAngle;
+    float stepLength = (endAngle - startAngle)/(float)segments;
+    float angle = startAngle;
 
     bool showCapLines = true;
     int limit = 4*(segments + 1);
-    if ((endAngle - startAngle)%360 == 0) { limit = 4*segments; showCapLines = false; }
+    if ((int)(endAngle - startAngle)%360 == 0) { limit = 4*segments; showCapLines = false; }
 
     if (rlCheckBufferLimit(limit)) rlglDraw();
 


### PR DESCRIPTION
Here's a nice simple one. The angle params for DrawRing and DrawCircleSector were ints so precise fitting wasn't possible. I've changed them to floats which solves the problem - they get converted to float in the functions anyway. Related examples updated and checked. Good to go.