### PR TITLE
Possible fix for macOS windows opening with the wrong viewport size

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -4258,10 +4258,12 @@ static void SetupViewport(int width, int height)
     CORE.Window.render.width = width;
     CORE.Window.render.height = height;
 
-    // Set viewport width and height
-    // NOTE: We consider render size and offset in case black bars are required and
-    // render area does not match full display area (this situation is only applicable on fullscreen mode)
-    rlViewport(CORE.Window.renderOffset.x/2, CORE.Window.renderOffset.y/2, CORE.Window.render.width - CORE.Window.renderOffset.x, CORE.Window.render.height - CORE.Window.renderOffset.y);
+	// Set viewport width and height
+	// NOTE: We consider render size (scaled) and offset in case black bars are required and
+	// render area does not match full display area (this situation is only applicable on fullscreen mode)
+	float xScale = 1, yScale = 1;
+	glfwGetWindowContentScale(CORE.Window.handle, &xScale, &yScale);
+	rlViewport(CORE.Window.renderOffset.x/2*xScale, CORE.Window.renderOffset.y/2*yScale, (CORE.Window.render.width - CORE.Window.renderOffset.x)*xScale, (CORE.Window.render.height - CORE.Window.renderOffset.y)*yScale);
 
     rlMatrixMode(RL_PROJECTION);        // Switch to projection matrix
     rlLoadIdentity();                   // Reset current matrix (projection)


### PR DESCRIPTION
This appears to fix the issue with macOS windows opening with the wrong viewport size/scale by ensuring that the open gl viewport is set in the coordinate space of the underlying window which may have a different scale factor. I do not know if this works on any other platforms, but it seems like it should.