### PR TITLE
[AUDIO] Use device native sample rates

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -195,7 +195,6 @@
 //------------------------------------------------------------------------------------
 #define AUDIO_DEVICE_FORMAT    ma_format_f32    // Device output format (miniaudio: float-32bit)
 #define AUDIO_DEVICE_CHANNELS              2    // Device output channels: stereo
-#define AUDIO_DEVICE_SAMPLE_RATE       44100    // Device output sample rate
 
 #define DEFAULT_AUDIO_BUFFER_SIZE       4096    // Default audio buffer size for streaming
 #define MAX_AUDIO_BUFFER_POOL_CHANNELS    16    // Maximum number of audio pool channels

--- a/src/config.h
+++ b/src/config.h
@@ -197,7 +197,6 @@
 #define AUDIO_DEVICE_CHANNELS              2    // Device output channels: stereo
 #define AUDIO_DEVICE_SAMPLE_RATE           0    // Device sample rate (device default)
 
-#define DEFAULT_AUDIO_BUFFER_SIZE       4096    // Default audio buffer size for streaming
 #define MAX_AUDIO_BUFFER_POOL_CHANNELS    16    // Maximum number of audio pool channels
 
 //------------------------------------------------------------------------------------

--- a/src/config.h
+++ b/src/config.h
@@ -195,6 +195,7 @@
 //------------------------------------------------------------------------------------
 #define AUDIO_DEVICE_FORMAT    ma_format_f32    // Device output format (miniaudio: float-32bit)
 #define AUDIO_DEVICE_CHANNELS              2    // Device output channels: stereo
+#define AUDIO_DEVICE_SAMPLE_RATE           0    // Device sample rate (device default)
 
 #define DEFAULT_AUDIO_BUFFER_SIZE       4096    // Default audio buffer size for streaming
 #define MAX_AUDIO_BUFFER_POOL_CHANNELS    16    // Maximum number of audio pool channels


### PR DESCRIPTION
Currently the audio device is forced to init at 44.1k and is only configuratable by a compile time config flag. This will not work well as not all devices support the same sample rates.

This PR forces MinAudio to init with a sample rate of 0 and then reads the effective sample rate from the device after it has been started.  Then this sample rate is used as the target for all sounds to minimize resampling during playback.

This PR changes no APIs, removes a config define and enhances playback quality.
