### PR TITLE
Fix 90 degree bug with DrawTexturePro and DrawRectanglePro

### DIFF
--- a/src/shapes.c
+++ b/src/shapes.c
@@ -619,20 +619,20 @@ void DrawRectanglePro(Rectangle rec, Vector2 origin, float rotation, Color color
 {
     rlCheckRenderBatchLimit(4);
 
+    Vector2 topLeft = { 0 };
+    Vector2 topRight = { 0 };
     Vector2 bottomLeft = { 0 };
     Vector2 bottomRight = { 0 };
-    Vector2 topRight = { 0 };
-    Vector2 topLeft = { 0 };
 
     // Only calculate rotation if needed
     if (rotation == 0.0f)
     {
         float x = rec.x - origin.x;
         float y = rec.y - origin.y;
-        bottomLeft = (Vector2){ x, y };
-        bottomRight = (Vector2){ x, y + rec.height };
-        topRight = (Vector2){ x + rec.width, y + rec.height };
-        topLeft = (Vector2){ x + rec.width, y };
+        topLeft = (Vector2){ x, y };
+        topRight = (Vector2){ x + rec.width, y };
+        bottomLeft = (Vector2){ x, y + rec.height };
+        bottomRight = (Vector2){ x + rec.width, y + rec.height };
     }
     else
     {
@@ -643,17 +643,17 @@ void DrawRectanglePro(Rectangle rec, Vector2 origin, float rotation, Color color
         float dx = -origin.x;
         float dy = -origin.y;
 
+        topLeft.x = x + dx*cosRotation - dy*sinRotation;
+        topLeft.y = y + dx*sinRotation + dy*cosRotation;
+
+        topRight.x = x + (dx + rec.width)*cosRotation - dy*sinRotation;
+        topRight.y = y + (dx + rec.width)*sinRotation + dy*cosRotation;
+
         bottomLeft.x = x + dx*cosRotation - (dy + rec.height)*sinRotation;
         bottomLeft.y = y + dx*sinRotation + (dy + rec.height)*cosRotation;
 
         bottomRight.x = x + (dx + rec.width)*cosRotation - (dy + rec.height)*sinRotation;
         bottomRight.y = y + (dx + rec.width)*sinRotation + (dy + rec.height)*cosRotation;
-
-        topRight.x = x + (dx + rec.width)*cosRotation - dy*sinRotation;
-        topRight.y = y + (dx + rec.width)*sinRotation + dy*cosRotation;
-
-        topLeft.x = x + dx*cosRotation - dy*sinRotation;
-        topLeft.y = y + dx*sinRotation + dy*cosRotation;
     }
 
     rlEnableTexture(rlGetShapesTexture().id);
@@ -663,16 +663,16 @@ void DrawRectanglePro(Rectangle rec, Vector2 origin, float rotation, Color color
         rlColor4ub(color.r, color.g, color.b, color.a);
 
         rlTexCoord2f(rlGetShapesTextureRec().x/rlGetShapesTexture().width, rlGetShapesTextureRec().y/rlGetShapesTexture().height);
-        rlVertex2f(bottomLeft.x, bottomLeft.y);
+        rlVertex2f(topLeft.x, topLeft.y);
 
         rlTexCoord2f(rlGetShapesTextureRec().x/rlGetShapesTexture().width, (rlGetShapesTextureRec().y + rlGetShapesTextureRec().height)/rlGetShapesTexture().height);
-        rlVertex2f(bottomRight.x, bottomRight.y);
+        rlVertex2f(bottomLeft.x, bottomLeft.y);
 
         rlTexCoord2f((rlGetShapesTextureRec().x + rlGetShapesTextureRec().width)/rlGetShapesTexture().width, (rlGetShapesTextureRec().y + rlGetShapesTextureRec().height)/rlGetShapesTexture().height);
-        rlVertex2f(topRight.x, topRight.y);
+        rlVertex2f(bottomRight.x, bottomRight.y);
 
         rlTexCoord2f((rlGetShapesTextureRec().x + rlGetShapesTextureRec().width)/rlGetShapesTexture().width, rlGetShapesTextureRec().y/rlGetShapesTexture().height);
-        rlVertex2f(topLeft.x, topLeft.y);
+        rlVertex2f(topRight.x, topRight.y);
 
     rlEnd();
     rlDisableTexture();

--- a/src/textures.c
+++ b/src/textures.c
@@ -3206,20 +3206,20 @@ void DrawTexturePro(Texture2D texture, Rectangle source, Rectangle dest, Vector2
         if (source.width < 0) { flipX = true; source.width *= -1; }
         if (source.height < 0) source.y -= source.height;
 
+        Vector2 topLeft = { 0 };
+        Vector2 topRight = { 0 };
         Vector2 bottomLeft = { 0 };
         Vector2 bottomRight = { 0 };
-        Vector2 topRight = { 0 };
-        Vector2 topLeft = { 0 };
 
         // Only calculate rotation if needed
         if (rotation == 0.0f)
         {
             float x = dest.x - origin.x;
             float y = dest.y - origin.y;
-            bottomLeft = (Vector2){ x, y };
-            bottomRight = (Vector2){ x, y + dest.height };
-            topRight = (Vector2){ x + dest.width, y + dest.height };
-            topLeft = (Vector2){ x + dest.width, y };
+            topLeft = (Vector2){ x, y };
+            topRight = (Vector2){ x + dest.width, y };
+            bottomLeft = (Vector2){ x, y + dest.height };
+            bottomRight = (Vector2){ x + dest.width, y + dest.height };
         }
         else
         {
@@ -3230,17 +3230,17 @@ void DrawTexturePro(Texture2D texture, Rectangle source, Rectangle dest, Vector2
             float dx = -origin.x;
             float dy = -origin.y;
 
-            bottomLeft.x = x + dx*cosRotation - (dy + dest.height)*sinRotation;
-            bottomLeft.y = y + dx*sinRotation + (dy + dest.height)*cosRotation;
-
-            bottomRight.x = x + (dx + dest.width)*cosRotation - (dy + dest.height) *sinRotation;
-            bottomRight.y = y + (dx + dest.width)*sinRotation + (dy + dest.height)*cosRotation;
+            topLeft.x = x + dx*cosRotation - dy*sinRotation;
+            topLeft.y = y + dx*sinRotation + dy*cosRotation;
 
             topRight.x = x + (dx + dest.width)*cosRotation - dy*sinRotation;
             topRight.y = y + (dx + dest.width)*sinRotation + dy*cosRotation;
 
-            topLeft.x = x + dx*cosRotation - dy*sinRotation;
-            topLeft.y = y + dx*sinRotation + dy*cosRotation;
+            bottomLeft.x = x + dx*cosRotation - (dy + dest.height)*sinRotation;
+            bottomLeft.y = y + dx*sinRotation + (dy + dest.height)*cosRotation;
+
+            bottomRight.x = x + (dx + dest.width)*cosRotation - (dy + dest.height)*sinRotation;
+            bottomRight.y = y + (dx + dest.width)*sinRotation + (dy + dest.height)*cosRotation;
         }
 
         rlEnableTexture(texture.id);
@@ -3249,25 +3249,25 @@ void DrawTexturePro(Texture2D texture, Rectangle source, Rectangle dest, Vector2
             rlColor4ub(tint.r, tint.g, tint.b, tint.a);
             rlNormal3f(0.0f, 0.0f, 1.0f);                          // Normal vector pointing towards viewer
 
-            // Bottom-left corner for texture and quad
+            // Top-left corner for texture and quad
             if (flipX) rlTexCoord2f((source.x + source.width)/width, source.y/height);
             else rlTexCoord2f(source.x/width, source.y/height);
+            rlVertex2f(topLeft.x, topLeft.y);
+
+            // Bottom-left corner for texture and quad
+            if (flipX) rlTexCoord2f((source.x + source.width)/width, (source.y + source.height)/height);
+            else rlTexCoord2f(source.x/width, (source.y + source.height)/height);
             rlVertex2f(bottomLeft.x, bottomLeft.y);
 
             // Bottom-right corner for texture and quad
-            if (flipX) rlTexCoord2f((source.x + source.width)/width, (source.y + source.height)/height);
-            else rlTexCoord2f(source.x/width, (source.y + source.height)/height);
+            if (flipX) rlTexCoord2f(source.x/width, (source.y + source.height)/height);
+            else rlTexCoord2f((source.x + source.width)/width, (source.y + source.height)/height);
             rlVertex2f(bottomRight.x, bottomRight.y);
 
             // Top-right corner for texture and quad
-            if (flipX) rlTexCoord2f(source.x/width, (source.y + source.height)/height);
-            else rlTexCoord2f((source.x + source.width)/width, (source.y + source.height)/height);
-            rlVertex2f(topRight.x, topRight.y);
-
-            // Top-left corner for texture and quad
             if (flipX) rlTexCoord2f(source.x/width, source.y/height);
             else rlTexCoord2f((source.x + source.width)/width, source.y/height);
-            rlVertex2f(topLeft.x, topLeft.y);
+            rlVertex2f(topRight.x, topRight.y);
 
         rlEnd();
         rlDisableTexture();


### PR DESCRIPTION
- The vertices did not map to where I expected causing rotation to be
off by 90 degrees. I reorganized the vertices making it easier to
reason about which fixes this.
- The order for drawing is now topLeft, bottomLeft, bottomRight,
topRight.