### PR TITLE
Fix activeTextureId to have MAX_BATCH_ACTIVE_TEXTURES elements instead of the hardcoded 4

### DIFF
--- a/src/rlgl.h
+++ b/src/rlgl.h
@@ -825,7 +825,7 @@ typedef struct rlglData {
         Texture2D shapesTexture;            // Texture used on shapes drawing (usually a white pixel)
         Rectangle shapesTextureRec;         // Texture source rectangle used on shapes drawing
         unsigned int defaultTextureId;      // Default texture used on shapes/poly drawing (required by shader)
-        unsigned int activeTextureId[4];    // Active texture ids to be enabled on batch drawing (0 active by default)
+        unsigned int activeTextureId[MAX_BATCH_ACTIVE_TEXTURES];    // Active texture ids to be enabled on batch drawing (0 active by default)
         unsigned int defaultVShaderId;      // Default vertex shader id (used by default shader program)
         unsigned int defaultFShaderId;      // Default fragment shader Id (used by default shader program)
         Shader defaultShader;               // Basic shader, support vertex color and diffuse texture


### PR DESCRIPTION
Thanks for this nice project!

`RLGL.State.activeTextureId` is used in for-loop like that:
```C
for (int i = 0; i < MAX_BATCH_ACTIVE_TEXTURES; i++)
{
    if (RLGL.State.activeTextureId[i] > 0)
    {
        glActiveTexture(GL_TEXTURE0 + 1 + i);
        glBindTexture(GL_TEXTURE_2D, RLGL.State.activeTextureId[i]);
    }
}
```

So the size of `RLGL.State.activeTextureId` should be MAX_BATCH_ACTIVE_TEXTURES.

I'm using raylib to run a Neural Network on the Raspberry Pi GPU using GLSL shaders. So I needed to increase MAX_BATCH_ACTIVE_TEXTURES.
