### PR TITLE
[text] Added DrawFPSEx() with Color arg (READ DESCRIPTION)

### DIFF
--- a/src/text.c
+++ b/src/text.c
@@ -813,11 +813,18 @@ void UnloadFont(Font font)
     }
 }
 
-// Shows current FPS on top-left corner
+// Draws current FPS
 // NOTE: Uses default font
 void DrawFPS(int posX, int posY)
 {
     DrawText(TextFormat("%2i FPS", GetFPS()), posX, posY, 20, LIME);
+}
+
+// Draws current FPS
+// NOTE: Uses default font
+void DrawFPSEx(int posX, int posY, Color tint)
+{
+    DrawText(TextFormat("%2i FPS", GetFPS()), posX, posY, 20, tint);
 }
 
 // Draw text (using default font)


### PR DESCRIPTION
This Pull Request is aimed at adding a roadmap feature
See the roadmap here: #1523

On the raylib roadmap there was 
`text`: Redesign `DrawFPS()` to support Color parameter like other draw functions. ***BREAKING CHANGE***
But it doesn't have to break existing projects

We could have
```c
// Draws current FPS
// NOTE: Uses default font
void DrawFPSEx(int posX, int posY, Color tint)
{
    DrawText(TextFormat("%2i FPS", GetFPS()), posX, posY, 20, tint);
}
```
(Note, this is what is in the PR)
So existing projects still work.
You can even add the size as a parameter
```c
// Draws current FPS
// NOTE: Uses default font
void DrawFPSEx(int posX, int posY, int fontSize, Color tint)
{
    DrawText(TextFormat("%2i FPS", GetFPS()), posX, posY, fontSize, tint);
}
```
(Note, the code above is not in the actual PR, but if you do want to be able to change the fontSize, tell me in the comments and I will add it)

And if you want font support too
```c
void DrawFPSEx(Font font, int posX, int posY, int fontSize, Color tint)
{
    if (font.texture.id != 0)
    {
       Vector2 pos = { (float)(posX), (float)(posY) };

        int defaultFontSize = 10;
        if (fontSize < defaultFontSize) fontSize = defaultFontSize;
        int spacing = fontSize/defaultFontSize;       

       DrawTextEx(font, TextFormat("%2i FPS", GetFPS()), pos, (float)(fontSize), (float)(spacing), tint);
    }
}
```
(Note, the code above is not in the actual PR, but if you do want to be able to change the font, tell me in the comments and I will add it)