### PR TITLE
[Text] Have FPS colors change based on good/bad FPS values

### DIFF
--- a/src/text.c
+++ b/src/text.c
@@ -817,7 +817,13 @@ void UnloadFont(Font font)
 // NOTE: Uses default font
 void DrawFPS(int posX, int posY)
 {
-    DrawText(TextFormat("%2i FPS", GetFPS()), posX, posY, 20, LIME);
+    Color color = LIME; // good fps
+    int fps = GetFPS();
+
+    if (fps < 30 && fps >= 15) color = ORANGE;  // warning FPS
+    else if (fps < 15) color = RED;    // bad FPS
+
+    DrawText(TextFormat("%2i FPS", GetFPS()), posX, posY, 20, color);
 }
 
 // Draw text (using default font)


### PR DESCRIPTION
This PR makes the default FPS display change colors based on the actual FPS values.
FPS >= 30 = Green (good FPS)
FPS < 30 and FPS >= 15  = Orange (not great FPS)
FPS < 15 = Red (Bad FPS)