### PR TITLE
Preserve floating point values in DrawRectangleLinesEx

### DIFF
--- a/src/shapes.c
+++ b/src/shapes.c
@@ -760,10 +760,26 @@ void DrawRectangleLinesEx(Rectangle rec, int lineThick, Color color)
         else if (rec.width < rec.height) lineThick = (int)rec.width/2;
     }
 
-    DrawRectangle( (int)rec.x, (int)rec.y, (int)rec.width, lineThick, color);
-    DrawRectangle( (int)(rec.x - lineThick + rec.width), (int)(rec.y + lineThick), lineThick, (int)(rec.height - lineThick*2.0f), color);
-    DrawRectangle( (int)rec.x, (int)(rec.y + rec.height - lineThick), (int)rec.width, lineThick, color);
-    DrawRectangle( (int)rec.x, (int)(rec.y + lineThick), lineThick, (int)(rec.height - lineThick*2), color);
+    // When rec = { x, y, 8.0f, 6.0f } and lineThick = 2, the following
+    // four rectangles are drawn ([T]op, [B]ottom, [L]eft, [R]ight):
+    //
+    //   TTTTTTTT
+    //   TTTTTTTT
+    //   LL    RR
+    //   LL    RR
+    //   BBBBBBBB
+    //   BBBBBBBB
+    //
+    float thick = (float)lineThick;
+    Rectangle top    = { rec.x                    , rec.y                     , rec.width, thick                     };
+    Rectangle bottom = { rec.x                    , rec.y - thick + rec.height, rec.width, thick                     };
+    Rectangle left   = { rec.x                    , rec.y + thick             , thick    , rec.height - thick * 2.0f };
+    Rectangle right  = { rec.x - thick + rec.width, rec.y + thick             , thick    , rec.height - thick * 2.0f };
+
+    DrawRectangleRec(top, color);
+    DrawRectangleRec(bottom, color);
+    DrawRectangleRec(left, color);
+    DrawRectangleRec(right, color);
 }
 
 // Draw rectangle with rounded edges
@@ -793,8 +809,8 @@ void DrawRectangleRounded(Rectangle rec, float roundness, int segments, Color co
 
     float stepLength = 90.0f/(float)segments;
 
-    /*  
-    *   Quick sketch to make sense of all of this 
+    /*
+    *   Quick sketch to make sense of all of this
     *   (there are 9 parts to draw, also mark the 12 points we'll use below)
     *
     *      P0____________________P1
@@ -1019,7 +1035,7 @@ void DrawRectangleRoundedLines(Rectangle rec, float roundness, int segments, int
     float stepLength = 90.0f/(float)segments;
     const float outerRadius = radius + (float)lineThick, innerRadius = radius;
 
-    /*  
+    /*
     *   Quick sketch to make sense of all of this (mark the 16 + 4(corner centers P16-19) points we'll use below)
     *       P0 ================== P1
     *      // P8                P9 \\
@@ -1058,7 +1074,7 @@ void DrawRectangleRoundedLines(Rectangle rec, float roundness, int segments, int
         rlSetTexture(rlGetShapesTexture().id);
 
         rlBegin(RL_QUADS);
-        
+
             // Draw all of the 4 corners first: Upper Left Corner, Upper Right Corner, Lower Right Corner, Lower Left Corner
             for (int k = 0; k < 4; ++k) // Hope the compiler is smart enough to unroll this loop
             {


### PR DESCRIPTION
The `Rectangle` version of `DrawRectangle` is `DrawRectangleRec`, and it preserves non-integral floating point values that are passed to it without truncating them.

The `Rectangle` version of `DrawRectangleLines` is `DrawRectangleLinesEx`, and it casts all of the floating point values passed to it  to integers before forwarding them to `DrawRectangleRec` (which is perfectly capable of handling floats, as noted above).

This causes a bug in the public API where it's impossible to outline a rectangle drawn with `DrawRectangleRec` with lines drawn by `DrawRectangleLinesEx` due to the truncation. For example, the outline will jitter around when drawn on top of a smoothly animated rectangle.

The fix is to simply preserve the floating point precision. I've left the intentional truncation in the case when lineWidth > rectangle width or height for consistency with previous behavior in that degenerate case.

P.S. Apologies for the trailing whitespace noise in the diff (my editor is configured to clean it up automatically), but it was few enough that it seemed fine to let it though. Will remove upon request.