### PR TITLE
Fixing pointer arithmetic to avoid error [-Werror=pointer-arith]

### DIFF
--- a/src/rlgl.h
+++ b/src/rlgl.h
@@ -3118,7 +3118,7 @@ void rlDrawVertexArray(int offset, int count)
 
 void rlDrawVertexArrayElements(int offset, int count, void *buffer)
 {
-    glDrawElements(GL_TRIANGLES, count, GL_UNSIGNED_SHORT, buffer + offset);
+    glDrawElements(GL_TRIANGLES, count, GL_UNSIGNED_SHORT, (unsigned short*)buffer + offset);
 }
 
 void rlDrawVertexArrayInstanced(int offset, int count, int instances)
@@ -3131,7 +3131,7 @@ void rlDrawVertexArrayInstanced(int offset, int count, int instances)
 void rlDrawVertexArrayElementsInstanced(int offset, int count, void *buffer, int instances)
 {
 #if defined(GRAPHICS_API_OPENGL_33) || defined(GRAPHICS_API_OPENGL_ES2)
-    glDrawElementsInstanced(GL_TRIANGLES, count, GL_UNSIGNED_SHORT, buffer + offset, instances);
+    glDrawElementsInstanced(GL_TRIANGLES, count, GL_UNSIGNED_SHORT, (unsigned short*)buffer + offset, instances);
 #endif
 }
 


### PR DESCRIPTION
When building with cmake I get:

```
raylib/src/core.c:136:
raylib/src/rlgl.h: In function ‘rlDrawVertexArrayElements’:
raylib/src/rlgl.h:3121:67: error: pointer of type ‘void *’ used in arithmetic [-Werror=pointer-arith]
 3121 |     glDrawElements(GL_TRIANGLES, count, GL_UNSIGNED_SHORT, buffer + offset);
      |                                                                   ^
raylib/src/rlgl.h: In function ‘rlDrawVertexArrayElementsInstanced’:
raylib/src/rlgl.h:3134:76: error: pointer of type ‘void *’ used in arithmetic [-Werror=pointer-arith]
 3134 |     glDrawElementsInstanced(GL_TRIANGLES, count, GL_UNSIGNED_SHORT, buffer + offset, instances);
```

So I'm fixing up pointer arithmetics in those functions. Note that they were previously used always with offset 0.

```
raylib/src$ grep -R rlDrawVertexArrayElements .
./models.c:        if (mesh.indices != NULL) rlDrawVertexArrayElements(0, mesh.triangleCount*3, mesh.indices);
./models.c:            if (mesh.indices != NULL) rlDrawVertexArrayElementsInstanced(0, mesh.triangleCount*3, 0, instances);
./models.c:            if (mesh.indices != NULL) rlDrawVertexArrayElements(0, mesh.triangleCount*3, 0);
raylib/src$ grep -R rlDrawVertexArrayElementsInstanced .
./models.c:            if (mesh.indices != NULL) rlDrawVertexArrayElementsInstanced(0, mesh.triangleCount*3, 0, instances);
```



