### PR TITLE
GetCollisionRayMesh makes use of triangle count

### DIFF
--- a/src/models.c
+++ b/src/models.c
@@ -2987,8 +2987,7 @@ RayHitInfo GetCollisionRayMesh(Ray ray, Mesh mesh, Matrix transform)
     // Check if mesh vertex data on CPU for testing
     if (mesh.vertices != NULL)
     {
-        // model->mesh.triangleCount may not be set, vertexCount is more reliable
-        int triangleCount = mesh.vertexCount / 3;
+        int triangleCount = mesh.triangleCount;
 
         // Test against all triangles in mesh
         for (int i = 0; i < triangleCount; i++)


### PR DESCRIPTION
###Reason for the change
The current code is wrong and will cause bugged ray-mesh detections in meshes with shared vertices. 

###Example
If we make use of the GetMeshCube function (where we have 12 triangles but 24 vertices)  there's going to be 4 triangles (2 faces) which are not going to be taken into account for the collision check.

###Comments
I'm not sure on which case the mesh will be intialized without a triangle number but that (in my opinion) should be a problem of the code initializing that mesh and it should not be remedied in the collision check function. 