### PR TITLE
Make SaveFile* callbacks return a boolean

### DIFF
--- a/src/raylib.h
+++ b/src/raylib.h
@@ -880,9 +880,9 @@ typedef enum {
 // WARNING: This callbacks are intended for advance users
 typedef void (*TraceLogCallback)(int logLevel, const char *text, va_list args);  // Logging: Redirect trace log messages
 typedef unsigned char* (*LoadFileDataCallback)(const char* fileName, unsigned int* bytesRead);      // FileIO: Load binary data
-typedef void (*SaveFileDataCallback)(const char *fileName, void *data, unsigned int bytesToWrite);  // FileIO: Save binary data
+typedef bool (*SaveFileDataCallback)(const char *fileName, void *data, unsigned int bytesToWrite);  // FileIO: Save binary data
 typedef char *(*LoadFileTextCallback)(const char* fileName);                // FileIO: Load text data
-typedef void (*SaveFileTextCallback)(const char *fileName, char *text);     // FileIO: Save text data
+typedef bool (*SaveFileTextCallback)(const char *fileName, char *text);     // FileIO: Save text data
 
 
 #if defined(__cplusplus)

--- a/src/utils.c
+++ b/src/utils.c
@@ -245,8 +245,7 @@ bool SaveFileData(const char *fileName, void *data, unsigned int bytesToWrite)
     {
         if (saveFileData)
         {
-            saveFileData(fileName, data, bytesToWrite);
-            return success;
+            return saveFileData(fileName, data, bytesToWrite);
         }
 #if defined(SUPPORT_STANDARD_FILEIO)
         FILE *file = fopen(fileName, "wb");
@@ -340,8 +339,7 @@ bool SaveFileText(const char *fileName, char *text)
     {
         if (saveFileText)
         {
-            saveFileText(fileName, text);
-            return success;
+            return saveFileText(fileName, text);
         }
 #if defined(SUPPORT_STANDARD_FILEIO)
         FILE *file = fopen(fileName, "wt");


### PR DESCRIPTION
The `SaveFileText` and `SaveFileData` callbacks returned `void`, which loses out on whether or not the save was successful. If a save failed, the callback would still return `true`. This change makes it so that those callbacks report the output directly so that you correctly know when a save failed.