### PR TITLE
Circle sector minimum segments

### DIFF
--- a/examples/shapes/shapes_draw_circle_sector.c
+++ b/examples/shapes/shapes_draw_circle_sector.c
@@ -31,6 +31,7 @@ int main(void)
     float startAngle = 0.0f;
     float endAngle = 180.0f;
     int segments = 0;
+    int minSegments = 4;
 
     SetTargetFPS(60);               // Set our game to run at 60 frames-per-second
     //--------------------------------------------------------------------------------------
@@ -64,7 +65,8 @@ int main(void)
             segments = GuiSliderBar((Rectangle){ 600, 170, 120, 20}, "Segments", NULL, segments, 0, 100);
             //------------------------------------------------------------------------------
             
-            DrawText(TextFormat("MODE: %s", (segments >= 4)? "MANUAL" : "AUTO"), 600, 200, 10, (segments >= 4)? MAROON : DARKGRAY);
+            minSegments = (int)ceilf((endAngle - startAngle) / 90);
+            DrawText(TextFormat("MODE: %s", (segments >= minSegments)? "MANUAL" : "AUTO"), 600, 200, 10, (segments >= minSegments)? MAROON : DARKGRAY);
             
             DrawFPS(10, 10);
             

--- a/examples/shapes/shapes_draw_ring.c
+++ b/examples/shapes/shapes_draw_ring.c
@@ -33,6 +33,7 @@ int main(void)
     float startAngle = 0.0f;
     float endAngle = 360.0f;
     int segments = 0;
+    int minSegments = 4;
 
     bool drawRing = true;
     bool drawRingLines = false;
@@ -77,7 +78,8 @@ int main(void)
             drawCircleLines = GuiCheckBox((Rectangle){ 600, 380, 20, 20 }, "Draw CircleLines", drawCircleLines);
             //------------------------------------------------------------------------------
 
-            DrawText(TextFormat("MODE: %s", (segments >= 4)? "MANUAL" : "AUTO"), 600, 270, 10, (segments >= 4)? MAROON : DARKGRAY);
+            int minSegments = (int)ceilf((endAngle - startAngle) / 90);
+            DrawText(TextFormat("MODE: %s", (segments >= minSegments)? "MANUAL" : "AUTO"), 600, 270, 10, (segments >= minSegments)? MAROON : DARKGRAY);
 
             DrawFPS(10, 10);
 

--- a/src/shapes.c
+++ b/src/shapes.c
@@ -224,13 +224,15 @@ void DrawCircleSector(Vector2 center, float radius, float startAngle, float endA
         endAngle = tmp;
     }
 
-    if (segments < 4)
+    int minSegments = (int)ceilf((endAngle - startAngle)/90);
+
+    if (segments < minSegments)
     {
         // Calculate the maximum angle between segments based on the error rate (usually 0.5f)
         float th = acosf(2*powf(1 - SMOOTH_CIRCLE_ERROR_RATE/radius, 2) - 1);
         segments = (int)((endAngle - startAngle)*ceilf(2*PI/th)/360);
 
-        if (segments <= 0) segments = 4;
+        if (segments <= 0) segments = minSegments;
     }
 
     float stepLength = (endAngle - startAngle)/(float)segments;
@@ -313,13 +315,15 @@ void DrawCircleSectorLines(Vector2 center, float radius, float startAngle, float
         endAngle = tmp;
     }
 
-    if (segments < 4)
+    int minSegments = (int)ceilf((endAngle - startAngle)/90);
+
+    if (segments < minSegments)
     {
         // Calculate the maximum angle between segments based on the error rate (usually 0.5f)
         float th = acosf(2*powf(1 - SMOOTH_CIRCLE_ERROR_RATE/radius, 2) - 1);
         segments = (int)((endAngle - startAngle)*ceilf(2*PI/th)/360);
 
-        if (segments <= 0) segments = 4;
+        if (segments <= 0) segments = minSegments;
     }
 
     float stepLength = (endAngle - startAngle)/(float)segments;
@@ -456,13 +460,15 @@ void DrawRing(Vector2 center, float innerRadius, float outerRadius, float startA
         endAngle = tmp;
     }
 
-    if (segments < 4)
+    int minSegments = (int)ceilf((endAngle - startAngle)/90);
+
+    if (segments < minSegments)
     {
         // Calculate the maximum angle between segments based on the error rate (usually 0.5f)
         float th = acosf(2*powf(1 - SMOOTH_CIRCLE_ERROR_RATE/outerRadius, 2) - 1);
         segments = (int)((endAngle - startAngle)*ceilf(2*PI/th)/360);
 
-        if (segments <= 0) segments = 4;
+        if (segments <= 0) segments = minSegments;
     }
 
     // Not a ring
@@ -547,13 +553,15 @@ void DrawRingLines(Vector2 center, float innerRadius, float outerRadius, float s
         endAngle = tmp;
     }
 
-    if (segments < 4)
+    int minSegments = (int)ceilf((endAngle - startAngle)/90);
+
+    if (segments < minSegments)
     {
         // Calculate the maximum angle between segments based on the error rate (usually 0.5f)
         float th = acosf(2*powf(1 - SMOOTH_CIRCLE_ERROR_RATE/outerRadius, 2) - 1);
         segments = (int)((endAngle - startAngle)*ceilf(2*PI/th)/360);
 
-        if (segments <= 0) segments = 4;
+        if (segments <= 0) segments = minSegments;
     }
 
     if (innerRadius <= 0.0f)


### PR DESCRIPTION
There's a hard-coded restriction on the minimum number of segments in DrawRing, DrawCircleSector etc. It's a problem when you need to draw small sectors, e.g. 10 or 20 degrees. These only require 1, 2 or 3 segments (depending on radius) but they're forced to use 4 which is significantly more resource-hungry than necessary.

This change sets the minimum number of segments based on the degree range. I have also updated related examples.

I present this solution but actually prefer having no logic other than the check for zero to trigger the auto calculation. What do you prefer? I'm happy to rework it.