### PR TITLE
added import in order for alloca to work on macos

### DIFF
--- a/src/external/stb_vorbis.h
+++ b/src/external/stb_vorbis.h
@@ -570,7 +570,7 @@ enum STBVorbisError
    #if defined(_MSC_VER) || defined(__MINGW32__)
       #include <malloc.h>
    #endif
-   #if defined(__linux__) || defined(__linux) || defined(__EMSCRIPTEN__)
+   #if defined(__linux__) || defined(__linux) || defined(__EMSCRIPTEN__) || defined(__APPLE__)
       #include <alloca.h>
    #endif
 #else // STB_VORBIS_NO_CRT


### PR DESCRIPTION
without this modification, I couldn't get raylib running on macos catalina due to alloca being undefined