### PR TITLE
Fix ImageClearBackground

### DIFF
--- a/src/textures.c
+++ b/src/textures.c
@@ -2347,7 +2347,7 @@ Rectangle GetImageAlphaBorder(Image image, float threshold)
 // Clear image background with given color
 void ImageClearBackground(Image *dst, Color color)
 {
-    for (int i = 0; i < dst->width*dst->height; ++i) ImageDrawPixel(dst, i%dst->width, i/dst->height, color);
+    for (int i = 0; i < dst->width*dst->height; ++i) ImageDrawPixel(dst, i%dst->width, i/dst->width, color);
 }
 
 // Draw pixel within an image


### PR DESCRIPTION
The `ImageClearBackground` implementation in current master skips over some pixels in the image.
The fix is simple - the y-coordinate of each cleared pixel was calculated in the loop as `i/dst->height`, but needs to be `i/dst->width`.

```c
#include "raylib.h"

int main(void)
{
    InitWindow(640, 480, "Example");
    Image image = GenImageColor(320, 160, BLUE);
    ImageClearBackground(&image, RED);
    Texture texture = LoadTextureFromImage(image);
    while (!WindowShouldClose())
    {
        BeginDrawing();
        ClearBackground(RAYWHITE);
        DrawTexture(texture, 0, 0, WHITE);
        EndDrawing();
    }
    UnloadTexture(texture);
    CloseWindow();
}
```

Current master:
![Before](https://user-images.githubusercontent.com/34137153/113782564-153b3b00-973b-11eb-986d-323ff9ed5322.png)

With fix:
![After](https://user-images.githubusercontent.com/34137153/113782563-140a0e00-973b-11eb-87d5-0203cc0cd46d.png)