### PR TITLE
Fix off by one bug with GetGamepadAxisCount on PLATFORM_DESKTOP

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -4735,7 +4735,7 @@ static void PollInputEvents(void)
             CORE.Input.Gamepad.currentState[i][GAMEPAD_BUTTON_LEFT_TRIGGER_2] = (char)(CORE.Input.Gamepad.axisState[i][GAMEPAD_AXIS_LEFT_TRIGGER] > 0.1);
             CORE.Input.Gamepad.currentState[i][GAMEPAD_BUTTON_RIGHT_TRIGGER_2] = (char)(CORE.Input.Gamepad.axisState[i][GAMEPAD_AXIS_RIGHT_TRIGGER] > 0.1);
 
-            CORE.Input.Gamepad.axisCount = GLFW_GAMEPAD_AXIS_LAST;
+            CORE.Input.Gamepad.axisCount = GLFW_GAMEPAD_AXIS_LAST + 1;
         }
     }
 


### PR DESCRIPTION
Found testing `core_input_gamepad`. The last axis was not drawn.
I found that `GLFW_GAMEPAD_AXIS_LAST` is defined to the last axis which is 5
not the total number of axes which is 6.

See GLFW docs for reference:
https://www.glfw.org/docs/latest/group__gamepad__axes.html 