### PR TITLE
Enable DRM platform cross compilation support

### DIFF
--- a/cmake/LibraryConfigurations.cmake
+++ b/cmake/LibraryConfigurations.cmake
@@ -73,7 +73,9 @@ elseif (${PLATFORM} MATCHES "DRM")
     find_library(DRM drm)
     find_library(GBM gbm)
     
-    include_directories(/usr/include/libdrm)
+    if (NOT CMAKE_CROSSCOMPILING)
+        include_directories(/usr/include/libdrm)
+    endif ()
     set(LIBS_PRIVATE ${GLESV2} ${EGL} ${DRM} ${GBM} pthread m dl)
 
 endif ()

--- a/src/models.c
+++ b/src/models.c
@@ -3168,7 +3168,11 @@ static Model LoadOBJ(const char *fileName)
         unsigned int dataSize = (unsigned int)strlen(fileData);
         char currentDir[1024] = { 0 };
         strcpy(currentDir, GetWorkingDirectory());
-        chdir(GetDirectoryPath(fileName));
+        const char *workingDir = GetDirectoryPath(fileName);
+        if (CHDIR(workingDir) != 0)
+        {
+            TRACELOG(LOG_WARNING, "MODEL: [%s] Failed to change working directory", workingDir);
+        }
 
         unsigned int flags = TINYOBJ_FLAG_TRIANGULATE;
         int ret = tinyobj_parse_obj(&attrib, &meshes, &meshCount, &materials, &materialCount, fileData, dataSize, flags);
@@ -3306,7 +3310,10 @@ static Model LoadOBJ(const char *fileName)
         RL_FREE(vnCount);
         RL_FREE(faceCount);
 
-        chdir(currentDir);
+        if (CHDIR(currentDir) != 0)
+        {
+            TRACELOG(LOG_WARNING, "MODEL: [%s] Failed to change working directory", currentDir);
+        }
     }
 
     return model;


### PR DESCRIPTION
A couple minor changes I needed to enable cross compiling     
raylib DRM platform in a Yocto/BitBake environment.           
                                                              
First issue I encountered was dealing with unused result from `chdir()` in `LoadOBJ()`.
>  warning: ignoring return value of 'chdir', declared with attribute warn_unused_result [-Wunused-result]
                                                              
I just tossed in a `LOG_WARNING` if something went wrong.     
Also noticed that it was using `chdir()` directly, which seemed to conflict
with the `#define CHDIR _chdir` setup happening here:
https://github.com/raysan5/raylib/blob/d17c519f88ff33084772263f4585a96051c45cfa/src/models.c#L53-L59         
So I also converted it to use `CHDIR()` instead.              
                                                              
The next issue was related to CMake.                          
The DRM platform was using                                    
> include_directories(/usr/include/libdrm)                    
                                                              
This can be problematic when cross compiling because it doesn't consider `CMAKE_SYSROOT`.
> cc1: warning: include location "/usr/include/libdrm" is unsafe for cross-compilation [-Wpoison-system-directories]                                                  
                                                              
Now it does so conditionally based on `CMAKE_CROSSCOMPILING`.