### PR TITLE
Extended API to read from Screen at custom position and sizes

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -2555,8 +2555,14 @@ void SetConfigFlags(unsigned int flags)
 // have their own internal file-systems, to dowload image to user file-system some additional mechanism is required
 void TakeScreenshot(const char *fileName)
 {
-    unsigned char *imgData = rlReadScreenPixels(CORE.Window.render.width, CORE.Window.render.height);
-    Image image = { imgData, CORE.Window.render.width, CORE.Window.render.height, 1, PIXELFORMAT_UNCOMPRESSED_R8G8B8A8 };
+    Vector2 zeroPos = {0, 0};
+    TakeScreenshotAtPosAndSize(fileName, zeroPos, CORE.Window.render.width, CORE.Window.render.height);
+}
+
+void TakeScreenshotAtPosAndSize(const char *fileName, Vector2 pos, int width, int height)
+{
+    unsigned char *imgData = rlReadScreenPixelsWithPosition(pos, width, height);
+    Image image = { imgData, width, height, 1, PIXELFORMAT_UNCOMPRESSED_R8G8B8A8 };
 
     char path[512] = { 0 };
 #if defined(PLATFORM_ANDROID)

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1002,6 +1002,8 @@ RLAPI double GetTime(void);                                       // Returns ela
 // Misc. functions
 RLAPI int GetRandomValue(int min, int max);                       // Returns a random value between min and max (both included)
 RLAPI void TakeScreenshot(const char *fileName);                  // Takes a screenshot of current screen (filename extension defines format)
+RLAPI void TakeScreenshotAtPosAndSize(const char *fileName, Vector2 pos, int width, int height);
+
 RLAPI void SetConfigFlags(unsigned int flags);                    // Setup init configuration flags (view FLAGS)
 
 RLAPI void TraceLog(int logLevel, const char *text, ...);         // Show trace log messages (LOG_DEBUG, LOG_INFO, LOG_WARNING, LOG_ERROR)
@@ -1261,6 +1263,7 @@ RLAPI void UpdateTexture(Texture2D texture, const void *pixels);                
 RLAPI void UpdateTextureRec(Texture2D texture, Rectangle rec, const void *pixels);                       // Update GPU texture rectangle with new data
 RLAPI Image GetTextureData(Texture2D texture);                                                           // Get pixel data from GPU texture and return an Image
 RLAPI Image GetScreenData(void);                                                                         // Get pixel data from screen buffer and return an Image (screenshot)
+RLAPI Image GetScreenDataFromPosAndSize(Vector2 pos, int width, int height);
 
 // Texture configuration functions
 RLAPI void GenTextureMipmaps(Texture2D *texture);                                                        // Generate GPU mipmaps for a texture

--- a/src/rlgl.h
+++ b/src/rlgl.h
@@ -588,6 +588,7 @@ RLAPI void rlUnloadTexture(unsigned int id);                              // Unl
 RLAPI void rlGenerateMipmaps(Texture2D *texture);                         // Generate mipmap data for selected texture
 RLAPI void *rlReadTexturePixels(Texture2D texture);                       // Read texture pixel data
 RLAPI unsigned char *rlReadScreenPixels(int width, int height);           // Read screen pixel data (color buffer)
+RLAPI unsigned char *rlReadScreenPixelsWithPosition(Vector2 pos, int width, int height);
 
 // Framebuffer management (fbo)
 RLAPI unsigned int rlLoadFramebuffer(int width, int height);              // Load an empty framebuffer
@@ -2831,13 +2832,19 @@ void *rlReadTexturePixels(Texture2D texture)
 
 
 // Read screen pixel data (color buffer)
-unsigned char *rlReadScreenPixels(int width, int height)
+unsigned char *rlReadScreenPixels(int width, int height) 
+{
+    Vector2 zeroPos = {0, 0};
+    return rlReadScreenPixelsWithPosition(zeroPos, width, height);
+}
+
+unsigned char *rlReadScreenPixelsWithPosition(Vector2 pos, int width, int height)
 {
     unsigned char *screenData = (unsigned char *)RL_CALLOC(width*height*4, sizeof(unsigned char));
 
     // NOTE 1: glReadPixels returns image flipped vertically -> (0,0) is the bottom left corner of the framebuffer
     // NOTE 2: We are getting alpha channel! Be careful, it can be transparent if not cleared properly!
-    glReadPixels(0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE, screenData);
+    glReadPixels(pos.x, pos.y, width, height, GL_RGBA, GL_UNSIGNED_BYTE, screenData);
 
     // Flip image vertically!
     unsigned char *imgData = (unsigned char *)RL_MALLOC(width*height*4*sizeof(unsigned char));

--- a/src/textures.c
+++ b/src/textures.c
@@ -2939,13 +2939,19 @@ Image GetTextureData(Texture2D texture)
 // Get pixel data from GPU frontbuffer and return an Image (screenshot)
 Image GetScreenData(void)
 {
+    Vector2 zeroPos = {0, 0};
+    return GetScreenDataFromPosAndSize(zeroPos, GetScreenWidth(), GetScreenHeight());
+}
+
+Image GetScreenDataFromPosAndSize(Vector2 pos, int width, int height)
+{
     Image image = { 0 };
 
-    image.width = GetScreenWidth();
-    image.height = GetScreenHeight();
+    image.width = width;
+    image.height = height;
     image.mipmaps = 1;
     image.format = PIXELFORMAT_UNCOMPRESSED_R8G8B8A8;
-    image.data = rlReadScreenPixels(image.width, image.height);
+    image.data = rlReadScreenPixelsWithPosition(pos, image.width, image.height);
 
     return image;
 }


### PR DESCRIPTION
I extended the API by two functions

- TakeScreenshotAtPosAndSize <=> TakeScreenshot
- GetScreenDataFromPosAndSize <=> GetScreenData

to allow for a custom position and size of the screenshot or data section taken from the screen / window. The changed API is fully backwards compatible since TakeScreenshot and GetScreenData are simply wrappers around TakeScreenshotAtPosAndSize and GetScreenDataFromPosAndSize.

I didn't implement sanity checks for the position and the dimensions.