### PR TITLE
[examples] Added zoom independent sharp edges to the SDF text example

### DIFF
--- a/examples/text/resources/shaders/glsl330/sdf.fs
+++ b/examples/text/resources/shaders/glsl330/sdf.fs
@@ -12,14 +12,14 @@ uniform vec4 colDiffuse;
 out vec4 finalColor;
 
 // NOTE: Add here your custom variables
-const float smoothing = 1.0/16.0;
 
 void main()
 {
     // Texel color fetching from texture sampler
     // NOTE: Calculate alpha using signed distance field (SDF)
-    float distance = texture(texture0, fragTexCoord).a;
-    float alpha = smoothstep(0.5 - smoothing, 0.5 + smoothing, distance);
+    float distanceFromOutline = texture(texture0, fragTexCoord).a - 0.5;
+    float distanceChangePerFragment = length(vec2(dFdx(distanceFromOutline), dFdy(distanceFromOutline)));
+    float alpha = smoothstep(-distanceChangePerFragment, distanceChangePerFragment, distanceFromOutline);
     
     // Calculate final fragment color
     finalColor = vec4(fragColor.rgb, fragColor.a*alpha);


### PR DESCRIPTION
The signed distance field text rendering example uses a fixed "smoothing" value in the shader. This only works well for one specific zoom level and becomes blurry for others. This PR replaces that with a calculation to always get a sharp text outline regardless of the zoom level. This is based on how much the distance to the outline changes from fragment to fragment (aka local derivatives, dFdx, dFdy).

Unfortunately dFdx and dFdy are optional for GLSL 1.00 and I can't test the GLSL 1.00 shader. Without local derivatives a zoom independent "smoothing" value could be calculated as `FONT_SDF_PIXEL_DIST_SCALE / 255.0f * drawScale` (I think). Where `drawScale` would be 1.0 if the font is drawn 1:1 and 2.0 when the font is drawn twice as large as the distance field. `drawScale` could be calculated e.g. as `currentFontSize / initialFontSize`. But adding all that would make the example quite a bit more complicated and I don't know how relevant the GLSL 1.00 version actually is.