### PR TITLE
[Examples] Add a custom mesh to mesh generation example

### DIFF
--- a/examples/models/models_mesh_generation.c
+++ b/examples/models/models_mesh_generation.c
@@ -11,7 +11,58 @@
 
 #include "raylib.h"
 
-#define NUM_MODELS  8      // Parametric 3d shapes to generate
+#define NUM_MODELS  9      // Parametric 3d shapes to generate
+
+void AllocateMeshData(Mesh* mesh, int triangleCount)
+{
+    mesh->vertexCount = triangleCount * 3;
+    mesh->triangleCount = triangleCount;
+
+    mesh->vertices = (float*)MemAlloc(mesh->vertexCount * 3 * sizeof(float));
+    mesh->texcoords = (float*)MemAlloc(mesh->vertexCount * 2 * sizeof(float));
+    mesh->normals = (float*)MemAlloc(mesh->vertexCount * 3 * sizeof(float));
+}
+
+// generate a simple triangle mesh from code
+Mesh MakeMesh()
+{
+    Mesh mesh = { 0 };
+    AllocateMeshData(&mesh, 1);
+
+    // vertex at the origin
+    mesh.vertices[0] = 0;
+    mesh.vertices[1] = 0;
+    mesh.vertices[2] = 0;
+    mesh.normals[0] = 0;
+    mesh.normals[1] = 1;
+    mesh.normals[2] = 0;
+    mesh.texcoords[0] = 0;
+    mesh.texcoords[1] = 0;
+
+    // vertex at 1,0,2
+    mesh.vertices[3] = 1;
+    mesh.vertices[4] = 0;
+    mesh.vertices[5] = 2;
+    mesh.normals[3] = 0;
+    mesh.normals[4] = 1;
+    mesh.normals[5] = 0;
+    mesh.texcoords[2] = 0.5f;
+    mesh.texcoords[3] = 1.0f;
+
+    // vertex at 2,0,0
+    mesh.vertices[6] = 2;
+    mesh.vertices[7] = 0;
+    mesh.vertices[8] = 0;
+    mesh.normals[6] = 0;
+    mesh.normals[7] = 1;
+    mesh.normals[8] = 0;
+    mesh.texcoords[4] = 1;
+    mesh.texcoords[5] =0;
+
+    UploadMesh(&mesh, false);
+
+    return mesh;
+}
 
 int main(void)
 {
@@ -37,6 +88,7 @@ int main(void)
     models[5] = LoadModelFromMesh(GenMeshTorus(0.25f, 4.0f, 16, 32));
     models[6] = LoadModelFromMesh(GenMeshKnot(1.0f, 2.0f, 16, 128));
     models[7] = LoadModelFromMesh(GenMeshPoly(5, 2.0f));
+    models[8] = LoadModelFromMesh(MakeMesh());
 
     // Set checked texture as default diffuse component for all models material
     for (int i = 0; i < NUM_MODELS; i++) models[i].materials[0].maps[MATERIAL_MAP_DIFFUSE].texture = texture;
@@ -86,9 +138,8 @@ int main(void)
 
             BeginMode3D(camera);
 
-                DrawModel(models[currentModel], position, 1.0f, WHITE);
-
-                DrawGrid(10, 1.0);
+               DrawModel(models[currentModel], position, 1.0f, WHITE);
+               DrawGrid(10, 1.0);
 
             EndMode3D();
 
@@ -106,6 +157,7 @@ int main(void)
                 case 5: DrawText("TORUS", 680, 10, 20, DARKBLUE); break;
                 case 6: DrawText("KNOT", 680, 10, 20, DARKBLUE); break;
                 case 7: DrawText("POLY", 680, 10, 20, DARKBLUE); break;
+                case 8: DrawText("Parametric(custom)", 580, 10, 20, DARKBLUE); break;
                 default: break;
             }
 


### PR DESCRIPTION
This PR adds a custom mesh to the mesh generation example to show users how to define allocate, define, and upload a mesh from pure code.