### PR TITLE
Unset CORE.Window.ready on CloseWindow

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -919,6 +919,7 @@ void CloseWindow(void)
     if (CORE.Input.Gamepad.threadId) pthread_join(CORE.Input.Gamepad.threadId, NULL);
 #endif
 
+    CORE.Window.ready = false;
     TRACELOG(LOG_INFO, "Window closed successfully");
 }
 


### PR DESCRIPTION
Window shouldn't be considered ready when CloseWindow has been called.