### PR TITLE
Added support for additional mouse buttons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,8 +55,6 @@ packages/
 
 # Ignore all examples files
 examples/*
-# Unignore all examples dirs
-!examples/*/
 # Unignore all examples files with extension
 !examples/*.c
 !examples/*.png

--- a/examples/audio/audio_raw_stream.c
+++ b/examples/audio/audio_raw_stream.c
@@ -71,7 +71,7 @@ int main(void)
         // Sample mouse input.
         mousePosition = GetMousePosition();
 
-        if (IsMouseButtonDown(MOUSE_LEFT_BUTTON))
+        if (IsMouseButtonDown(MOUSE_BUTTON_LEFT))
         {
             float fp = (float)(mousePosition.y);
             frequency = 40.0f + (float)(fp);

--- a/examples/core/core_3d_picking.c
+++ b/examples/core/core_3d_picking.c
@@ -47,7 +47,7 @@ int main(void)
         //----------------------------------------------------------------------------------
         UpdateCamera(&camera);          // Update camera
 
-        if (IsMouseButtonPressed(MOUSE_LEFT_BUTTON))
+        if (IsMouseButtonPressed(MOUSE_BUTTON_LEFT))
         {
             if (!collision)
             {

--- a/examples/core/core_input_mouse.c
+++ b/examples/core/core_input_mouse.c
@@ -36,6 +36,10 @@ int main(void)
         if (IsMouseButtonPressed(MOUSE_LEFT_BUTTON)) ballColor = MAROON;
         else if (IsMouseButtonPressed(MOUSE_MIDDLE_BUTTON)) ballColor = LIME;
         else if (IsMouseButtonPressed(MOUSE_RIGHT_BUTTON)) ballColor = DARKBLUE;
+        else if (IsMouseButtonPressed(MOUSE_SIDE_BUTTON)) ballColor = PURPLE;
+        else if (IsMouseButtonPressed(MOUSE_EXTRA_BUTTON)) ballColor = YELLOW;
+        else if (IsMouseButtonPressed(MOUSE_FORWARD_BUTTON)) ballColor = ORANGE;
+        else if (IsMouseButtonPressed(MOUSE_BACK_BUTTON)) ballColor = BEIGE;
         //----------------------------------------------------------------------------------
 
         // Draw

--- a/examples/core/core_input_mouse.c
+++ b/examples/core/core_input_mouse.c
@@ -33,13 +33,13 @@ int main(void)
         //----------------------------------------------------------------------------------
         ballPosition = GetMousePosition();
 
-        if (IsMouseButtonPressed(MOUSE_LEFT_BUTTON)) ballColor = MAROON;
-        else if (IsMouseButtonPressed(MOUSE_MIDDLE_BUTTON)) ballColor = LIME;
-        else if (IsMouseButtonPressed(MOUSE_RIGHT_BUTTON)) ballColor = DARKBLUE;
-        else if (IsMouseButtonPressed(MOUSE_SIDE_BUTTON)) ballColor = PURPLE;
-        else if (IsMouseButtonPressed(MOUSE_EXTRA_BUTTON)) ballColor = YELLOW;
-        else if (IsMouseButtonPressed(MOUSE_FORWARD_BUTTON)) ballColor = ORANGE;
-        else if (IsMouseButtonPressed(MOUSE_BACK_BUTTON)) ballColor = BEIGE;
+        if (IsMouseButtonPressed(MOUSE_BUTTON_LEFT)) ballColor = MAROON;
+        else if (IsMouseButtonPressed(MOUSE_BUTTON_MIDDLE)) ballColor = LIME;
+        else if (IsMouseButtonPressed(MOUSE_BUTTON_RIGHT)) ballColor = DARKBLUE;
+        else if (IsMouseButtonPressed(MOUSE_BUTTON_SIDE)) ballColor = PURPLE;
+        else if (IsMouseButtonPressed(MOUSE_BUTTON_EXTRA)) ballColor = YELLOW;
+        else if (IsMouseButtonPressed(MOUSE_BUTTON_FORWARD)) ballColor = ORANGE;
+        else if (IsMouseButtonPressed(MOUSE_BUTTON_BACK)) ballColor = BEIGE;
         //----------------------------------------------------------------------------------
 
         // Draw

--- a/examples/core/core_input_multitouch.c
+++ b/examples/core/core_input_multitouch.c
@@ -42,13 +42,13 @@ int main(void)
 
         ballColor = BEIGE;
 
-        if (IsMouseButtonDown(MOUSE_LEFT_BUTTON)) ballColor = MAROON;
-        if (IsMouseButtonDown(MOUSE_MIDDLE_BUTTON)) ballColor = LIME;
-        if (IsMouseButtonDown(MOUSE_RIGHT_BUTTON)) ballColor = DARKBLUE;
+        if (IsMouseButtonDown(MOUSE_BUTTON_LEFT)) ballColor = MAROON;
+        if (IsMouseButtonDown(MOUSE_BUTTON_MIDDLE)) ballColor = LIME;
+        if (IsMouseButtonDown(MOUSE_BUTTON_RIGHT)) ballColor = DARKBLUE;
 
-        if (IsMouseButtonPressed(MOUSE_LEFT_BUTTON)) touchCounter = 10;
-        if (IsMouseButtonPressed(MOUSE_MIDDLE_BUTTON)) touchCounter = 10;
-        if (IsMouseButtonPressed(MOUSE_RIGHT_BUTTON)) touchCounter = 10;
+        if (IsMouseButtonPressed(MOUSE_BUTTON_LEFT)) touchCounter = 10;
+        if (IsMouseButtonPressed(MOUSE_BUTTON_MIDDLE)) touchCounter = 10;
+        if (IsMouseButtonPressed(MOUSE_BUTTON_RIGHT)) touchCounter = 10;
 
         if (touchCounter > 0) touchCounter--;
         //----------------------------------------------------------------------------------

--- a/examples/models/models_loading.c
+++ b/examples/models/models_loading.c
@@ -95,7 +95,7 @@ int main(void)
         }
 
         // Select model on mouse click
-        if (IsMouseButtonPressed(MOUSE_LEFT_BUTTON))
+        if (IsMouseButtonPressed(MOUSE_BUTTON_LEFT))
         {
             // Check collision between ray and box
             if (CheckCollisionRayBox(GetMouseRay(GetMousePosition(), camera), bounds)) selected = !selected;

--- a/examples/models/models_mesh_generation.c
+++ b/examples/models/models_mesh_generation.c
@@ -113,7 +113,7 @@ int main(void)
         //----------------------------------------------------------------------------------
         UpdateCamera(&camera);      // Update internal camera and our camera
 
-        if (IsMouseButtonPressed(MOUSE_LEFT_BUTTON))
+        if (IsMouseButtonPressed(MOUSE_BUTTON_LEFT))
         {
             currentModel = (currentModel + 1)%NUM_MODELS; // Cycle between the textures
         }

--- a/examples/physics/physics_demo.c
+++ b/examples/physics/physics_demo.c
@@ -63,8 +63,8 @@ int main(void)
         }
 
         // Physics body creation inputs
-        if (IsMouseButtonPressed(MOUSE_LEFT_BUTTON)) CreatePhysicsBodyPolygon(GetMousePosition(), GetRandomValue(20, 80), GetRandomValue(3, 8), 10);
-        else if (IsMouseButtonPressed(MOUSE_RIGHT_BUTTON)) CreatePhysicsBodyCircle(GetMousePosition(), GetRandomValue(10, 45), 10);
+        if (IsMouseButtonPressed(MOUSE_BUTTON_LEFT)) CreatePhysicsBodyPolygon(GetMousePosition(), GetRandomValue(20, 80), GetRandomValue(3, 8), 10);
+        else if (IsMouseButtonPressed(MOUSE_BUTTON_RIGHT)) CreatePhysicsBodyCircle(GetMousePosition(), GetRandomValue(10, 45), 10);
 
         // Destroy falling physics bodies
         int bodiesCount = GetPhysicsBodiesCount();

--- a/examples/physics/physics_shatter.c
+++ b/examples/physics/physics_shatter.c
@@ -53,7 +53,7 @@ int main(void)
             CreatePhysicsBodyPolygon((Vector2){ screenWidth/2.0f, screenHeight/2.0f }, GetRandomValue(80, 200), GetRandomValue(3, 8), 10);
         }
 
-        if (IsMouseButtonPressed(MOUSE_LEFT_BUTTON))    // Physics shatter input
+        if (IsMouseButtonPressed(MOUSE_BUTTON_LEFT))    // Physics shatter input
         {
             int count = GetPhysicsBodiesCount();
             for (int i = count - 1; i >= 0; i--)

--- a/examples/shaders/shaders_hot_reloading.c
+++ b/examples/shaders/shaders_hot_reloading.c
@@ -67,7 +67,7 @@ int main(void)
         SetShaderValue(shader, mouseLoc, mousePos, SHADER_UNIFORM_VEC2);
 
         // Hot shader reloading
-        if (shaderAutoReloading || (IsMouseButtonPressed(MOUSE_LEFT_BUTTON)))
+        if (shaderAutoReloading || (IsMouseButtonPressed(MOUSE_BUTTON_LEFT)))
         {
             long currentFragShaderModTime = GetFileModTime(TextFormat(fragShaderFileName, GLSL_VERSION));
 

--- a/examples/shaders/shaders_julia_set.c
+++ b/examples/shaders/shaders_julia_set.c
@@ -115,10 +115,10 @@ int main(void)
 
             // TODO: The idea is to zoom and move around with mouse
             // Probably offset movement should be proportional to zoom level
-            if (IsMouseButtonDown(MOUSE_LEFT_BUTTON) || IsMouseButtonDown(MOUSE_RIGHT_BUTTON))
+            if (IsMouseButtonDown(MOUSE_BUTTON_LEFT) || IsMouseButtonDown(MOUSE_BUTTON_RIGHT))
             {
-                if (IsMouseButtonDown(MOUSE_LEFT_BUTTON)) zoom += zoom*0.003f;
-                if (IsMouseButtonDown(MOUSE_RIGHT_BUTTON)) zoom -= zoom*0.003f;
+                if (IsMouseButtonDown(MOUSE_BUTTON_LEFT)) zoom += zoom*0.003f;
+                if (IsMouseButtonDown(MOUSE_BUTTON_RIGHT)) zoom -= zoom*0.003f;
 
                 Vector2 mousePos = GetMousePosition();
 

--- a/examples/shapes/shapes_lines_bezier.c
+++ b/examples/shapes/shapes_lines_bezier.c
@@ -32,8 +32,8 @@ int main(void)
     {
         // Update
         //----------------------------------------------------------------------------------
-        if (IsMouseButtonDown(MOUSE_LEFT_BUTTON)) start = GetMousePosition();
-        else if (IsMouseButtonDown(MOUSE_RIGHT_BUTTON)) end = GetMousePosition();
+        if (IsMouseButtonDown(MOUSE_BUTTON_LEFT)) start = GetMousePosition();
+        else if (IsMouseButtonDown(MOUSE_BUTTON_RIGHT)) end = GetMousePosition();
         //----------------------------------------------------------------------------------
 
         // Draw

--- a/examples/shapes/shapes_rectangle_scaling.c
+++ b/examples/shapes/shapes_rectangle_scaling.c
@@ -45,7 +45,7 @@ int main(void)
             CheckCollisionPointRec(mousePosition, (Rectangle){ rec.x + rec.width - MOUSE_SCALE_MARK_SIZE, rec.y + rec.height - MOUSE_SCALE_MARK_SIZE, MOUSE_SCALE_MARK_SIZE, MOUSE_SCALE_MARK_SIZE }))
         {
             mouseScaleReady = true;
-            if (IsMouseButtonPressed(MOUSE_LEFT_BUTTON)) mouseScaleMode = true;
+            if (IsMouseButtonPressed(MOUSE_BUTTON_LEFT)) mouseScaleMode = true;
         }
         else mouseScaleReady = false;
 
@@ -59,7 +59,7 @@ int main(void)
             if (rec.width < MOUSE_SCALE_MARK_SIZE) rec.width = MOUSE_SCALE_MARK_SIZE;
             if (rec.height < MOUSE_SCALE_MARK_SIZE) rec.height = MOUSE_SCALE_MARK_SIZE;
 
-            if (IsMouseButtonReleased(MOUSE_LEFT_BUTTON)) mouseScaleMode = false;
+            if (IsMouseButtonReleased(MOUSE_BUTTON_LEFT)) mouseScaleMode = false;
         }
         //----------------------------------------------------------------------------------
 

--- a/examples/text/text_draw_3d.c
+++ b/examples/text/text_draw_3d.c
@@ -186,7 +186,7 @@ int main(void)
         }
 
         // Handle clicking the cube
-        if (IsMouseButtonPressed(MOUSE_LEFT_BUTTON))
+        if (IsMouseButtonPressed(MOUSE_BUTTON_LEFT))
         {
             Ray ray = GetMouseRay(GetMousePosition(), camera);
 

--- a/examples/text/text_rectangle_bounds.c
+++ b/examples/text/text_rectangle_bounds.c
@@ -61,7 +61,7 @@ tempor incididunt ut labore et dolore magna aliqua. Nec ullamcorper sit amet ris
         // Container resizing logic
         if (resizing)
         {
-            if (IsMouseButtonReleased(MOUSE_LEFT_BUTTON)) resizing = false;
+            if (IsMouseButtonReleased(MOUSE_BUTTON_LEFT)) resizing = false;
 
             float width = container.width + (mouse.x - lastMouse.x);
             container.width = (width > minWidth)? ((width < maxWidth)? width : maxWidth) : minWidth;
@@ -72,7 +72,7 @@ tempor incididunt ut labore et dolore magna aliqua. Nec ullamcorper sit amet ris
         else
         {
             // Check if we're resizing
-            if (IsMouseButtonDown(MOUSE_LEFT_BUTTON) && CheckCollisionPointRec(mouse, resizer)) resizing = true;
+            if (IsMouseButtonDown(MOUSE_BUTTON_LEFT) && CheckCollisionPointRec(mouse, resizer)) resizing = true;
         }
 
         // Move resizer rectangle properly

--- a/examples/text/text_unicode.c
+++ b/examples/text/text_unicode.c
@@ -180,7 +180,7 @@ int main(int argc, char **argv)
         if (IsKeyPressed(KEY_SPACE)) RandomizeEmoji();
 
         // Set the selected emoji and copy its text to clipboard
-        if (IsMouseButtonPressed(MOUSE_LEFT_BUTTON) && (hovered != -1) && (hovered != selected))
+        if (IsMouseButtonPressed(MOUSE_BUTTON_LEFT) && (hovered != -1) && (hovered != selected))
         {
             selected = hovered;
             selectedPos = hoveredPos;

--- a/examples/textures/textures_bunnymark.c
+++ b/examples/textures/textures_bunnymark.c
@@ -49,7 +49,7 @@ int main(void)
     {
         // Update
         //----------------------------------------------------------------------------------
-        if (IsMouseButtonDown(MOUSE_LEFT_BUTTON))
+        if (IsMouseButtonDown(MOUSE_BUTTON_LEFT))
         {
             // Create more bunnies
             for (int i = 0; i < 100; i++)

--- a/examples/textures/textures_draw_tiled.c
+++ b/examples/textures/textures_draw_tiled.c
@@ -75,7 +75,7 @@ int main(int argc, char **argv)
         screenHeight = GetScreenHeight();
 
         // Handle mouse
-        if (IsMouseButtonPressed(MOUSE_LEFT_BUTTON))
+        if (IsMouseButtonPressed(MOUSE_BUTTON_LEFT))
         {
             const Vector2 mouse = GetMousePosition();
 

--- a/examples/textures/textures_image_generation.c
+++ b/examples/textures/textures_image_generation.c
@@ -59,7 +59,7 @@ int main(void)
     {
         // Update
         //----------------------------------------------------------------------------------
-        if (IsMouseButtonPressed(MOUSE_LEFT_BUTTON) || IsKeyPressed(KEY_RIGHT))
+        if (IsMouseButtonPressed(MOUSE_BUTTON_LEFT) || IsKeyPressed(KEY_RIGHT))
         {
             currentTexture = (currentTexture + 1)%NUM_TEXTURES; // Cycle between the textures
         }

--- a/examples/textures/textures_image_processing.c
+++ b/examples/textures/textures_image_processing.c
@@ -80,7 +80,7 @@ int main(void)
             {
                 mouseHoverRec = i;
 
-                if (IsMouseButtonReleased(MOUSE_LEFT_BUTTON))
+                if (IsMouseButtonReleased(MOUSE_BUTTON_LEFT))
                 {
                     currentProcess = i;
                     textureReload = true;

--- a/examples/textures/textures_mouse_painting.c
+++ b/examples/textures/textures_mouse_painting.c
@@ -88,7 +88,7 @@ int main(void)
             else colorMouseHover = -1;
         }
 
-        if ((colorMouseHover >= 0) && IsMouseButtonPressed(MOUSE_LEFT_BUTTON))
+        if ((colorMouseHover >= 0) && IsMouseButtonPressed(MOUSE_BUTTON_LEFT))
         {
             colorSelected = colorMouseHover;
             colorSelectedPrev = colorSelected;
@@ -107,7 +107,7 @@ int main(void)
             EndTextureMode();
         }
 
-        if (IsMouseButtonDown(MOUSE_LEFT_BUTTON) || (GetGestureDetected() == GESTURE_DRAG))
+        if (IsMouseButtonDown(MOUSE_BUTTON_LEFT) || (GetGestureDetected() == GESTURE_DRAG))
         {
             // Paint circle into render texture
             // NOTE: To avoid discontinuous circles, we could store
@@ -117,7 +117,7 @@ int main(void)
             EndTextureMode();
         }
 
-        if (IsMouseButtonDown(MOUSE_RIGHT_BUTTON))
+        if (IsMouseButtonDown(MOUSE_BUTTON_RIGHT))
         {
             if (!mouseWasPressed)
             {
@@ -132,7 +132,7 @@ int main(void)
             if (mousePos.y > 50) DrawCircle((int)mousePos.x, (int)mousePos.y, brushSize, colors[0]);
             EndTextureMode();
         }
-        else if (IsMouseButtonReleased(MOUSE_RIGHT_BUTTON) && mouseWasPressed)
+        else if (IsMouseButtonReleased(MOUSE_BUTTON_RIGHT) && mouseWasPressed)
         {
             colorSelected = colorSelectedPrev;
             mouseWasPressed = false;
@@ -144,7 +144,7 @@ int main(void)
 
         // Image saving logic
         // NOTE: Saving painted texture to a default named image
-        if ((btnSaveMouseHover && IsMouseButtonReleased(MOUSE_LEFT_BUTTON)) || IsKeyPressed(KEY_S))
+        if ((btnSaveMouseHover && IsMouseButtonReleased(MOUSE_BUTTON_LEFT)) || IsKeyPressed(KEY_S))
         {
             Image image = GetTextureData(target.texture);
             ImageFlipVertical(&image);
@@ -177,7 +177,7 @@ int main(void)
         // Draw drawing circle for reference
         if (mousePos.y > 50)
         {
-            if (IsMouseButtonDown(MOUSE_RIGHT_BUTTON)) DrawCircleLines((int)mousePos.x, (int)mousePos.y, brushSize, GRAY);
+            if (IsMouseButtonDown(MOUSE_BUTTON_RIGHT)) DrawCircleLines((int)mousePos.x, (int)mousePos.y, brushSize, GRAY);
             else DrawCircle(GetMouseX(), GetMouseY(), brushSize, colors[colorSelected]);
         }
 

--- a/examples/textures/textures_sprite_button.c
+++ b/examples/textures/textures_sprite_button.c
@@ -53,10 +53,10 @@ int main(void)
         // Check button state
         if (CheckCollisionPointRec(mousePoint, btnBounds))
         {
-            if (IsMouseButtonDown(MOUSE_LEFT_BUTTON)) btnState = 2;
+            if (IsMouseButtonDown(MOUSE_BUTTON_LEFT)) btnState = 2;
             else btnState = 1;
 
-            if (IsMouseButtonReleased(MOUSE_LEFT_BUTTON)) btnAction = true;
+            if (IsMouseButtonReleased(MOUSE_BUTTON_LEFT)) btnAction = true;
         }
         else btnState = 0;
 

--- a/examples/textures/textures_sprite_explosion.c
+++ b/examples/textures/textures_sprite_explosion.c
@@ -53,7 +53,7 @@ int main(void)
         //----------------------------------------------------------------------------------
 
         // Check for mouse button pressed and activate explosion (if not active)
-        if (IsMouseButtonPressed(MOUSE_LEFT_BUTTON) && !active)
+        if (IsMouseButtonPressed(MOUSE_BUTTON_LEFT) && !active)
         {
             position = GetMousePosition();
             active = true;

--- a/projects/VS2017.UWP/raylib.App.UWP/App.cpp
+++ b/projects/VS2017.UWP/raylib.App.UWP/App.cpp
@@ -231,7 +231,7 @@ void App::GameLoop()
 
 		if (IsKeyDown(KEY_LEFT_ALT)) DrawRectangle(250, 250, 20, 20, BLACK);
 		if (IsKeyDown(KEY_BACKSPACE)) DrawRectangle(280, 250, 20, 20, BLACK);
-		if (IsMouseButtonDown(MOUSE_LEFT_BUTTON)) DrawRectangle(280, 250, 20, 20, BLACK);
+		if (IsMouseButtonDown(MOUSE_BUTTON_LEFT)) DrawRectangle(280, 250, 20, 20, BLACK);
 
 		DrawRectangle(280, (int)pos + 50, 20, 20, BLACK);
 		DrawRectangle(250, 280 + (gTime++ % 60), 10, 10, PURPLE);
@@ -398,9 +398,9 @@ void App::OnPointerPressed(Windows::UI::Core::CoreWindow^ sender, Windows::UI::C
 
     if (device->PointerDeviceType == Windows::Devices::Input::PointerDeviceType::Mouse)
     {
-        if (props->IsLeftButtonPressed) UWPMouseButtonEvent(MOUSE_LEFT_BUTTON, true);
-        if (props->IsMiddleButtonPressed) UWPMouseButtonEvent(MOUSE_MIDDLE_BUTTON, true);
-        if (props->IsRightButtonPressed) UWPMouseButtonEvent(MOUSE_RIGHT_BUTTON, true);
+        if (props->IsLeftButtonPressed) UWPMouseButtonEvent(MOUSE_BUTTON_LEFT, true);
+        if (props->IsMiddleButtonPressed) UWPMouseButtonEvent(MOUSE_BUTTON_MIDDLE, true);
+        if (props->IsRightButtonPressed) UWPMouseButtonEvent(MOUSE_BUTTON_RIGHT, true);
     }
     else if (device->PointerDeviceType == PointerDeviceType::Touch)
     {
@@ -418,9 +418,9 @@ void App::OnPointerReleased(Windows::UI::Core::CoreWindow^ sender, Windows::UI::
 
     if (device->PointerDeviceType == PointerDeviceType::Mouse)
     {
-        if (!props->IsLeftButtonPressed) UWPMouseButtonEvent(MOUSE_LEFT_BUTTON, false);
-        if (!props->IsMiddleButtonPressed) UWPMouseButtonEvent(MOUSE_MIDDLE_BUTTON, false);
-        if (!props->IsRightButtonPressed) UWPMouseButtonEvent(MOUSE_RIGHT_BUTTON, false);
+        if (!props->IsLeftButtonPressed) UWPMouseButtonEvent(MOUSE_BUTTON_LEFT, false);
+        if (!props->IsMiddleButtonPressed) UWPMouseButtonEvent(MOUSE_BUTTON_MIDDLE, false);
+        if (!props->IsRightButtonPressed) UWPMouseButtonEvent(MOUSE_BUTTON_RIGHT, false);
     }
     else if (device->PointerDeviceType == PointerDeviceType::Touch)
     {

--- a/src/camera.h
+++ b/src/camera.h
@@ -222,7 +222,7 @@ static CameraData CAMERA = {        // Global CAMERA state context
     .moveControl = { 'W', 'S', 'D', 'A', 'E', 'Q' },
     .smoothZoomControl = 341,       // raylib: KEY_LEFT_CONTROL
     .altControl = 342,              // raylib: KEY_LEFT_ALT
-    .panControl = 2                 // raylib: MOUSE_MIDDLE_BUTTON
+    .panControl = 2                 // raylib: MOUSE_BUTTON_MIDDLE
 };
 
 //----------------------------------------------------------------------------------

--- a/src/core.c
+++ b/src/core.c
@@ -438,12 +438,12 @@ typedef struct CoreData {
             bool cursorHidden;              // Track if cursor is hidden
             bool cursorOnScreen;            // Tracks if cursor is inside client area
 
-            char currentButtonState[3];     // Registers current mouse button state
-            char previousButtonState[3];    // Registers previous mouse button state
+            char currentButtonState[MOUSE_BUTTON_MAX];     // Registers current mouse button state
+            char previousButtonState[MOUSE_BUTTON_MAX];    // Registers previous mouse button state
             float currentWheelMove;         // Registers current mouse wheel variation
             float previousWheelMove;        // Registers previous mouse wheel variation
 #if defined(PLATFORM_RPI) || defined(PLATFORM_DRM)
-            char currentButtonStateEvdev[3];    // Holds the new mouse state for the next polling event to grab (Can't be written directly due to multithreading, app could miss the update)
+            char currentButtonStateEvdev[MOUSE_BUTTON_MAX];    // Holds the new mouse state for the next polling event to grab (Can't be written directly due to multithreading, app could miss the update)
 #endif
         } Mouse;
         struct {
@@ -6104,6 +6104,10 @@ static void *EventThread(void *arg)
 
                 if (event.code == BTN_RIGHT) CORE.Input.Mouse.currentButtonStateEvdev[MOUSE_RIGHT_BUTTON] = event.value;
                 if (event.code == BTN_MIDDLE) CORE.Input.Mouse.currentButtonStateEvdev[MOUSE_MIDDLE_BUTTON] = event.value;
+                if (event.code == BTN_SIDE) CORE.Input.Mouse.currentButtonStateEvdev[MOUSE_SIDE_BUTTON] = event.value;
+                if (event.code == BTN_EXTRA) CORE.Input.Mouse.currentButtonStateEvdev[MOUSE_EXTRA_BUTTON] = event.value;
+                if (event.code == BTN_FORWARD) CORE.Input.Mouse.currentButtonStateEvdev[MOUSE_FORWARD_BUTTON] = event.value;
+                if (event.code == BTN_BACK) CORE.Input.Mouse.currentButtonStateEvdev[MOUSE_BACK_BUTTON] = event.value;
             }
 
             // Screen confinement

--- a/src/core.c
+++ b/src/core.c
@@ -5345,11 +5345,11 @@ static int32_t AndroidInputCallback(struct android_app *app, AInputEvent *event)
 
     if (flags == AMOTION_EVENT_ACTION_DOWN || flags == AMOTION_EVENT_ACTION_MOVE)
     {
-        CORE.Input.Touch.currentTouchState[MOUSE_LEFT_BUTTON] = 1;
+        CORE.Input.Touch.currentTouchState[MOUSE_BUTTON_LEFT] = 1;
     }
     else if (flags == AMOTION_EVENT_ACTION_UP)
     {
-        CORE.Input.Touch.currentTouchState[MOUSE_LEFT_BUTTON] = 0;
+        CORE.Input.Touch.currentTouchState[MOUSE_BUTTON_LEFT] = 0;
     }
 
 #if defined(SUPPORT_GESTURES_SYSTEM)
@@ -6062,11 +6062,11 @@ static void *EventThread(void *arg)
                 // Touchscreen tap
                 if (event.code == ABS_PRESSURE)
                 {
-                    int previousMouseLeftButtonState = CORE.Input.Mouse.currentButtonStateEvdev[MOUSE_LEFT_BUTTON];
+                    int previousMouseLeftButtonState = CORE.Input.Mouse.currentButtonStateEvdev[MOUSE_BUTTON_LEFT];
 
                     if (!event.value && previousMouseLeftButtonState)
                     {
-                        CORE.Input.Mouse.currentButtonStateEvdev[MOUSE_LEFT_BUTTON] = 0;
+                        CORE.Input.Mouse.currentButtonStateEvdev[MOUSE_BUTTON_LEFT] = 0;
 
                         #if defined(SUPPORT_GESTURES_SYSTEM)
                             touchAction = TOUCH_UP;
@@ -6076,7 +6076,7 @@ static void *EventThread(void *arg)
 
                     if (event.value && !previousMouseLeftButtonState)
                     {
-                        CORE.Input.Mouse.currentButtonStateEvdev[MOUSE_LEFT_BUTTON] = 1;
+                        CORE.Input.Mouse.currentButtonStateEvdev[MOUSE_BUTTON_LEFT] = 1;
 
                         #if defined(SUPPORT_GESTURES_SYSTEM)
                             touchAction = TOUCH_DOWN;
@@ -6093,7 +6093,7 @@ static void *EventThread(void *arg)
                 // Mouse button parsing
                 if ((event.code == BTN_TOUCH) || (event.code == BTN_LEFT))
                 {
-                    CORE.Input.Mouse.currentButtonStateEvdev[MOUSE_LEFT_BUTTON] = event.value;
+                    CORE.Input.Mouse.currentButtonStateEvdev[MOUSE_BUTTON_LEFT] = event.value;
 
                     #if defined(SUPPORT_GESTURES_SYSTEM)
                         if (event.value > 0) touchAction = TOUCH_DOWN;
@@ -6102,12 +6102,12 @@ static void *EventThread(void *arg)
                     #endif
                 }
 
-                if (event.code == BTN_RIGHT) CORE.Input.Mouse.currentButtonStateEvdev[MOUSE_RIGHT_BUTTON] = event.value;
-                if (event.code == BTN_MIDDLE) CORE.Input.Mouse.currentButtonStateEvdev[MOUSE_MIDDLE_BUTTON] = event.value;
-                if (event.code == BTN_SIDE) CORE.Input.Mouse.currentButtonStateEvdev[MOUSE_SIDE_BUTTON] = event.value;
-                if (event.code == BTN_EXTRA) CORE.Input.Mouse.currentButtonStateEvdev[MOUSE_EXTRA_BUTTON] = event.value;
-                if (event.code == BTN_FORWARD) CORE.Input.Mouse.currentButtonStateEvdev[MOUSE_FORWARD_BUTTON] = event.value;
-                if (event.code == BTN_BACK) CORE.Input.Mouse.currentButtonStateEvdev[MOUSE_BACK_BUTTON] = event.value;
+                if (event.code == BTN_RIGHT) CORE.Input.Mouse.currentButtonStateEvdev[MOUSE_BUTTON_RIGHT] = event.value;
+                if (event.code == BTN_MIDDLE) CORE.Input.Mouse.currentButtonStateEvdev[MOUSE_BUTTON_MIDDLE] = event.value;
+                if (event.code == BTN_SIDE) CORE.Input.Mouse.currentButtonStateEvdev[MOUSE_BUTTON_SIDE] = event.value;
+                if (event.code == BTN_EXTRA) CORE.Input.Mouse.currentButtonStateEvdev[MOUSE_BUTTON_EXTRA] = event.value;
+                if (event.code == BTN_FORWARD) CORE.Input.Mouse.currentButtonStateEvdev[MOUSE_BUTTON_FORWARD] = event.value;
+                if (event.code == BTN_BACK) CORE.Input.Mouse.currentButtonStateEvdev[MOUSE_BUTTON_BACK] = event.value;
             }
 
             // Screen confinement

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -637,15 +637,20 @@ typedef enum {
     KEY_VOLUME_DOWN     = 25
 } KeyboardKey;
 
+// Add backwards compatibility support for deprecated names
+#define MOUSE_LEFT_BUTTON   MOUSE_BUTTON_LEFT
+#define MOUSE_RIGHT_BUTTON  MOUSE_BUTTON_RIGHT
+#define MOUSE_MIDDLE_BUTTON MOUSE_BUTTON_MIDDLE
+
 // Mouse buttons
 typedef enum {
-    MOUSE_LEFT_BUTTON    = 0,
-    MOUSE_RIGHT_BUTTON   = 1,
-    MOUSE_MIDDLE_BUTTON  = 2,
-    MOUSE_SIDE_BUTTON    = 3,
-    MOUSE_EXTRA_BUTTON   = 4,
-    MOUSE_FORWARD_BUTTON = 5,
-    MOUSE_BACK_BUTTON    = 6,
+    MOUSE_BUTTON_LEFT    = 0,
+    MOUSE_BUTTON_RIGHT   = 1,
+    MOUSE_BUTTON_MIDDLE  = 2,
+    MOUSE_BUTTON_SIDE    = 3,
+    MOUSE_BUTTON_EXTRA   = 4,
+    MOUSE_BUTTON_FORWARD = 5,
+    MOUSE_BUTTON_BACK    = 6,
     MOUSE_BUTTON_MAX     = 7
 } MouseButton;
 

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -639,9 +639,14 @@ typedef enum {
 
 // Mouse buttons
 typedef enum {
-    MOUSE_LEFT_BUTTON   = 0,
-    MOUSE_RIGHT_BUTTON  = 1,
-    MOUSE_MIDDLE_BUTTON = 2
+    MOUSE_LEFT_BUTTON    = 0,
+    MOUSE_RIGHT_BUTTON   = 1,
+    MOUSE_MIDDLE_BUTTON  = 2,
+    MOUSE_SIDE_BUTTON    = 3,
+    MOUSE_EXTRA_BUTTON   = 4,
+    MOUSE_FORWARD_BUTTON = 5,
+    MOUSE_BACK_BUTTON    = 6,
+    MOUSE_BUTTON_MAX     = 7
 } MouseButton;
 
 // Mouse cursor


### PR DESCRIPTION
Changes Tested on Windows 10 using the `core_input_mouse example`.

On my mouse:
MOUSE_SIDE_BUTTON is Mouse 4
MOUSE_EXTRA_BUTTON is Mouse 5
I could not test the MOUSE_FORWARD_BUTTON and MOUSE_BACK_BUTTON keys as my mouse doesn't have them, but I added support for it anyways. 

Build tools: 
mingw32-make --version
GNU Make 4.2.1
gcc --version
gcc (x86_64-posix-seh-rev0, Built by MinGW-W64 project) 8.1.0