### PR TITLE
[CORE] Better default sleep/busy loop ratio

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -43,8 +43,8 @@
 #define SUPPORT_WINMM_HIGHRES_TIMER 1
 // Use busy wait loop for timing sync, if not defined, a high-resolution timer is setup and used
 //#define SUPPORT_BUSY_WAIT_LOOP      1
-// Use a half-busy wait loop, in this case frame sleeps for some time and runs a busy-wait-loop at the end
-#define SUPPORT_HALFBUSY_WAIT_LOOP
+// Use a partial-busy wait loop, in this case frame sleeps for most of the time, but then runs a busy loop at the end for accuracy
+#define SUPPORT_PARTIALBUSY_WAIT_LOOP
 // Wait for events passively (sleeping while no events) instead of polling them actively every frame
 //#define SUPPORT_EVENTS_WAITING      1
 // Allow automatic screen capture of current screen pressing F12, defined in KeyCallback()


### PR DESCRIPTION
This PR changes the default "HALF BUSY WAIT" loop to be a "PARTIAL BUSY WAIT" loop. In cases where there is a target FPS set, it will sleep for some fraction of the target frame time before doing a busy loop at the end. By default it will sleep for 95% of the frame time and spin wait for the last 5% for accuracy.

This helps reduce CPU spin load in the default build but still allows for the accuracy of a spin wait.
In cases where there is no target FPS, the code works exactly like it used to, sleeping for 4ms max.
The user can configure the sleep percentage with a #define as needed.