### PR TITLE
check for vao extension

### DIFF
--- a/src/rlgl.h
+++ b/src/rlgl.h
@@ -3141,7 +3141,10 @@ unsigned int rlLoadVertexArray(void)
 {
     unsigned int vaoId = 0;
 #if defined(GRAPHICS_API_OPENGL_33) || defined(GRAPHICS_API_OPENGL_ES2)
-    glGenVertexArrays(1, &vaoId);
+    if (RLGL.ExtSupported.vao)
+    {
+        glGenVertexArrays(1, &vaoId);
+    }
 #endif
     return vaoId;
 }


### PR DESCRIPTION
I was updating raylib for vita and i found a little problem. 

Raylib had in older versions a check for vao extension in rlUploadMesh now the code is refactorized in uploadMesh at model.c using calls to rlLoadVertexArray and rlEnableVertexArray.

rlEnableVertexArray has the vao extensin check, but rlLoadVertexArray doesn't so to avoid the crash check for vao extension must be added.

Regards