### PR TITLE
Updated raylib CMake project version to 3.7.0

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Setup the project and settings
 project(raylib C)
-set(PROJECT_VERSION 3.5.0)
-set(API_VERSION 351)
+set(PROJECT_VERSION 3.7.0)
+set(API_VERSION 370)
 
 include(GNUInstallDirs)
 include(JoinPaths)


### PR DESCRIPTION
Updated to fix versioning and linking issues.
Old version would cause examples to not be linked on fresh raylib install or linked with an old library version on updated raylib install.