### PR TITLE
Hotfix for smooth pixel-perfect camera example [core_2d_camera_smooth_pixelperfect.c]

### DIFF
--- a/examples/core/core_2d_camera_smooth_pixelperfect.c
+++ b/examples/core/core_2d_camera_smooth_pixelperfect.c
@@ -25,7 +25,7 @@ int main(void)
     const int virualScreenWidth = 160;
     const int virtualScreenHeight = 90;
 
-    const float virtualRatio = (float)screenWidth/(float)virualScreenWidth;
+    const float virtualRatio = (float)screenWidth / (float)virualScreenWidth;
 
     InitWindow(screenWidth, screenHeight, "raylib [core] example - smooth pixel-perfect camera");
 
@@ -43,7 +43,7 @@ int main(void)
 
     //The renderTexture's height is flipped (in the source Rectangle), due to OpenGL reasons.
     Rectangle renderTextureSource = { 0.0f, 0.0f, (float)renderTexture.texture.width, (float)-renderTexture.texture.height };
-    Rectangle renderTextureDest = { -virtualRatio, -virtualRatio, screenWidth + (virtualRatio*2), screenHeight + (virtualRatio*2) };
+    Rectangle renderTextureDest = { -virtualRatio, -virtualRatio, screenWidth + (virtualRatio * 2), screenHeight + (virtualRatio * 2) };
 
     Vector2 origin = { 0.0f, 0.0f };
 
@@ -61,30 +61,24 @@ int main(void)
     {
         // Update
         //----------------------------------------------------------------------------------
-        rotation += degreesPerSecond*GetFrameTime(); // Rotate the rectangles.
+        rotation += degreesPerSecond * GetFrameTime(); // Rotate the rectangles.
 
         // Make the camera move to demonstrate the effect.
-        cameraX = (sinf(GetTime())*50.0f) - 10.0f;
-        cameraY = cosf(GetTime())*30.0f;
+        cameraX = (sinf(GetTime()) * 50.0f) - 10.0f;
+        cameraY = cosf(GetTime()) * 30.0f;
 
         // Set the camera's target to the values computed above.
         screenSpaceCamera.target = (Vector2){ cameraX, cameraY };
 
-        // Round worldCamera's X, keep the decimals on screenSpaceCamera.
-        if (screenSpaceCamera.target.x >= 1 || screenSpaceCamera.target.x <= -1)
-        {
-            worldSpaceCamera.target.x = (int)screenSpaceCamera.target.x;
-            screenSpaceCamera.target.x -= worldSpaceCamera.target.x;
-            screenSpaceCamera.target.x *= virtualRatio;
-        }
+        //Round worldSpace coordinates, keep decimals into screenSpace coordinates.
+        worldSpaceCamera.target.x = (int)screenSpaceCamera.target.x;
+        screenSpaceCamera.target.x -= worldSpaceCamera.target.x;
+        screenSpaceCamera.target.x *= virtualRatio;
 
-        // Round worldCamera's Y, keep the decimals on screenSpaceCamera.
-        if (screenSpaceCamera.target.y >= 1 || screenSpaceCamera.target.y <= -1)
-        {
-            worldSpaceCamera.target.y = (int)screenSpaceCamera.target.y;
-            screenSpaceCamera.target.y -= worldSpaceCamera.target.y;
-            screenSpaceCamera.target.y *= virtualRatio;
-        }
+        worldSpaceCamera.target.y = (int)screenSpaceCamera.target.y;
+        screenSpaceCamera.target.y -= worldSpaceCamera.target.y;
+        screenSpaceCamera.target.y *= virtualRatio;
+
         //----------------------------------------------------------------------------------
 
         // Draw

--- a/examples/core/core_2d_camera_smooth_pixelperfect.c
+++ b/examples/core/core_2d_camera_smooth_pixelperfect.c
@@ -25,7 +25,7 @@ int main(void)
     const int virualScreenWidth = 160;
     const int virtualScreenHeight = 90;
 
-    const float virtualRatio = (float)screenWidth / (float)virualScreenWidth;
+    const float virtualRatio = (float)screenWidth/(float)virualScreenWidth;
 
     InitWindow(screenWidth, screenHeight, "raylib [core] example - smooth pixel-perfect camera");
 
@@ -43,7 +43,7 @@ int main(void)
 
     //The renderTexture's height is flipped (in the source Rectangle), due to OpenGL reasons.
     Rectangle renderTextureSource = { 0.0f, 0.0f, (float)renderTexture.texture.width, (float)-renderTexture.texture.height };
-    Rectangle renderTextureDest = { -virtualRatio, -virtualRatio, screenWidth + (virtualRatio * 2), screenHeight + (virtualRatio * 2) };
+    Rectangle renderTextureDest = { -virtualRatio, -virtualRatio, screenWidth + (virtualRatio*2), screenHeight + (virtualRatio*2) };
 
     Vector2 origin = { 0.0f, 0.0f };
 
@@ -61,11 +61,11 @@ int main(void)
     {
         // Update
         //----------------------------------------------------------------------------------
-        rotation += degreesPerSecond * GetFrameTime(); // Rotate the rectangles.
+        rotation += degreesPerSecond*GetFrameTime(); // Rotate the rectangles.
 
         // Make the camera move to demonstrate the effect.
-        cameraX = (sinf(GetTime()) * 50.0f) - 10.0f;
-        cameraY = cosf(GetTime()) * 30.0f;
+        cameraX = (sinf(GetTime())*50.0f) - 10.0f;
+        cameraY = cosf(GetTime())*30.0f;
 
         // Set the camera's target to the values computed above.
         screenSpaceCamera.target = (Vector2){ cameraX, cameraY };


### PR DESCRIPTION
Fixed an if-statement which caused lag while moving the camera. Should be perfect now. 