### PR TITLE
Fixed over-allocation of buffer

### DIFF
--- a/src/models.c
+++ b/src/models.c
@@ -4728,7 +4728,7 @@ static ModelAnimation *LoadGLTFModelAnimations(const char *fileName, int *animCo
             // Initiate with zero bone translations
             for (int frame = 0; frame < output->frameCount; frame++)
             {
-                output->framePoses[frame] = RL_MALLOC(output->frameCount*data->nodes_count*sizeof(Transform));
+                output->framePoses[frame] = RL_MALLOC(data->nodes_count*sizeof(Transform));
 
                 for (unsigned int i = 0; i < data->nodes_count; i++)
                 {


### PR DESCRIPTION
output->framePoses[frame] is over-allocated.
framePoses is a 2D array:
- first dimension: frames (allocated l. 4717)
- second dimension: nodes (allocated l. 4731)

Second dimension should be allocated of nodes_count transformations only.