### PR TITLE
Fixed CMake project template for MacOS

### DIFF
--- a/projects/CMake/CMakeLists.txt
+++ b/projects/CMake/CMakeLists.txt
@@ -34,4 +34,11 @@ add_executable(${PROJECT_NAME} core_basic_window.c)
 #set(raylib_VERBOSE 1)
 target_link_libraries(${PROJECT_NAME} raylib)
 
+# Checks if OSX and links appropriate frameworks (Only required on MacOS)
+if (APPLE)
+    target_link_libraries(${PROJECT_NAME} "-framework IOKit")
+    target_link_libraries(${PROJECT_NAME} "-framework Cocoa")
+    target_link_libraries(${PROJECT_NAME} "-framework OpenGL")
+endif()
+
 # That's it! You should have an example executable that you can run. Have fun!


### PR DESCRIPTION
The CMake project template didn't link to the required libraries for macOS, causing the build to fail. I added calls to include the IOKit, Cocoa, and OpenGL libraries in the CMake template for those who are building on macOS.