### PR TITLE
Bumped minimum GLFW version in cmake

### DIFF
--- a/cmake/GlfwImport.cmake
+++ b/cmake/GlfwImport.cmake
@@ -1,8 +1,8 @@
 
 if(USE_EXTERNAL_GLFW STREQUAL "ON")
-    find_package(glfw3 3.2.1 REQUIRED)
+    find_package(glfw3 3.3.3 REQUIRED)
 elseif(USE_EXTERNAL_GLFW STREQUAL "IF_POSSIBLE")
-    find_package(glfw3 3.2.1 QUIET)
+    find_package(glfw3 3.3.3 QUIET)
 endif()
 if (glfw3_FOUND)
     set(LIBS_PRIVATE ${LIBS_PRIVATE} glfw)


### PR DESCRIPTION
GLFW versions under 3.3.3 do not support MacOS 11, so I've bumped it in the CMake file

See issue #1787 