### PR TITLE
Small parser bugfix

### DIFF
--- a/parser/raylib_parser.c
+++ b/parser/raylib_parser.c
@@ -173,7 +173,7 @@ int main()
                     validStruct = true;
                     break;
                 }
-                else if (buffer[i + j] == ';') 
+                else if (buffer[i + c] == ';')
                 {
                     // Not valid struct: 
                     // i.e typedef struct rAudioBuffer rAudioBuffer; -> Typedef and forward declaration


### PR DESCRIPTION
Fixed a bug that was causing struct 27: AudioStream to be malformed. Before the fix it looked like this:
```
Struct 27:  (6 fields)
  Fields 1: ypedef struct rAudioBuffer rAudioBuffer 
  Fields 2:   
  Fields 3: rAudioBuffer * buffer // Pointer to internal data used by the audio system
  Fields 4: unsigned int sampleRate // Frequency (samples per second)
  Fields 5: unsigned int sampleSize // Bit depth (bits per sample): 8, 16, 32 (24 not supported)
  Fields 6: unsigned int channels // Number of channels (1-mono, 2-stereo)
```

After the fix it is properly parsed:
```
Struct 27: AudioStream (4 fields)
  Fields 1: rAudioBuffer * buffer // Pointer to internal data used by the audio system
  Fields 2: unsigned int sampleRate // Frequency (samples per second)
  Fields 3: unsigned int sampleSize // Bit depth (bits per sample): 8, 16, 32 (24 not supported)
  Fields 4: unsigned int channels // Number of channels (1-mono, 2-stereo)
```