### PR TITLE
Fix parsing multiple struct fields defined in one line (Matrix struct)

### DIFF
--- a/parser/raylib_parser.c
+++ b/parser/raylib_parser.c
@@ -589,7 +589,7 @@ void GetDataTypeAndName(const char *typeName, int typeNameLen, char *type, char 
 {
     for (int k = typeNameLen; k > 0; k--)
     {
-        if (typeName[k] == ' ')
+        if (typeName[k] == ' ' && typeName[k - 1] != ',')
         {
             // Function name starts at this point (and ret type finishes at this point)
             MemoryCopy(type, typeName, k);


### PR DESCRIPTION
Fixed a bug that was causing the Matrix fields to be of type `float m0, m4, m8,`. Now the type is parsed correctly and the field name is `m0, m4, m8, m12`.