### PR TITLE
Added missing null terminator on Input Box example

### DIFF
--- a/examples/text/text_input_box.c
+++ b/examples/text/text_input_box.c
@@ -22,7 +22,7 @@ int main(void)
 
     InitWindow(screenWidth, screenHeight, "raylib [text] example - input box");
 
-    char name[MAX_INPUT_CHARS + 1] = "\0";      // NOTE: One extra space required for line ending char '\0'
+    char name[MAX_INPUT_CHARS + 1] = "\0";      // NOTE: One extra space required for null terminator char '\0'
     int letterCount = 0;
 
     Rectangle textBox = { screenWidth/2 - 100, 180, 225, 50 };
@@ -56,6 +56,7 @@ int main(void)
                 if ((key >= 32) && (key <= 125) && (letterCount < MAX_INPUT_CHARS))
                 {
                     name[letterCount] = (char)key;
+                    name[letterCount+1] = '\0'; // Add null terminator at the end of the string.
                     letterCount++;
                 }
 


### PR DESCRIPTION
Added missing null terminator when adding characters to the string, otherwise garbage values are read (often zeros which are equal to '\0', but not every time).

This error results in random characters appearing in the text box every once in a while:
```
asdfasdf??? ll??
```
It is corrected with the proposed fix.

This problem was observed by @griveralazo.