### PR TITLE
static libraries linking on windows, without needed config

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -273,6 +273,25 @@
 #endif
 
 //----------------------------------------------------------------------------------
+// Windows libraries linking
+//----------------------------------------------------------------------------------
+#if defined(_WIN32) || defined(PLATFORM_UWP)
+    #pragma comment(lib, "opengl32.lib")
+    #pragma comment(lib, "kernel32.lib")
+    #pragma comment(lib, "user32.lib")
+    #pragma comment(lib, "gdi32.lib")
+    #pragma comment(lib, "winmm.lib")
+    #pragma comment(lib, "winspool.lib")
+    #pragma comment(lib, "comdlg32.lib")
+    #pragma comment(lib, "advapi32.lib")
+    #pragma comment(lib, "shell32.lib")
+    #pragma comment(lib, "ole32.lib")
+    #pragma comment(lib, "oleaut32.lib")
+    #pragma comment(lib, "odbc32.lib")
+    #pragma comment(lib, "odbccp32.lib")
+#endif
+
+//----------------------------------------------------------------------------------
 // Defines and Macros
 //----------------------------------------------------------------------------------
 #if defined(PLATFORM_RPI) || defined(PLATFORM_DRM)


### PR DESCRIPTION
I found it annoying when starting new visual studio and clang on windows project, and need to add too many inputs for linker.