### PR TITLE
Rename relevant occurences of MeshBoundingBox to GetMeshBoundingBox

### DIFF
--- a/projects/Geany/raylib.c.tags
+++ b/projects/Geany/raylib.c.tags
@@ -298,7 +298,7 @@ GenMeshTorus|Mesh|(float radius, float size, int radSeg, int sides);|
 GenMeshKnot|Mesh|(float radius, float size, int radSeg, int sides);|
 GenMeshHeightmap|Mesh|(Image heightmap, Vector3 size);|
 GenMeshCubicmap|Mesh|(Image cubicmap, Vector3 cubeSize);|
-MeshBoundingBox|BoundingBox|(Mesh mesh);|
+GetMeshBoundingBox|BoundingBox|(Mesh mesh);|
 MeshTangents|void|(Mesh *mesh);|
 MeshBinormals|void|(Mesh *mesh);|
 DrawModel|void|(Model model, Vector3 position, float scale, Color tint);|

--- a/projects/Notepad++/c_raylib.xml
+++ b/projects/Notepad++/c_raylib.xml
@@ -1549,7 +1549,7 @@
         </KeyWord>
 
         <!-- Mesh manipulation functions -->
-        <KeyWord name="MeshBoundingBox" func="yes">
+        <KeyWord name="GetMeshBoundingBox" func="yes">
             <Overload retVal="BoundingBox" descr="Compute mesh bounding box limits">
                 <Param name="Mesh mesh" />
             </Overload>

--- a/projects/Notepad++/raylib_npp_parser/raylib_npp.xml
+++ b/projects/Notepad++/raylib_npp_parser/raylib_npp.xml
@@ -2495,7 +2495,7 @@
         </KeyWord>
 
         <!-- Mesh manipulation functions -->
-        <KeyWord name="MeshBoundingBox" func="yes">
+        <KeyWord name="GetMeshBoundingBox" func="yes">
             <Overload retVal="BoundingBox" descr="Compute mesh bounding box limits">
                 <Param name="Mesh mesh" />
             </Overload>

--- a/projects/Notepad++/raylib_npp_parser/raylib_to_parse.h
+++ b/projects/Notepad++/raylib_npp_parser/raylib_to_parse.h
@@ -515,7 +515,7 @@ RLAPI Mesh GenMeshHeightmap(Image heightmap, Vector3 size);                     
 RLAPI Mesh GenMeshCubicmap(Image cubicmap, Vector3 cubeSize);                               // Generate cubes-based map mesh from image data
 
 // Mesh manipulation functions
-RLAPI BoundingBox MeshBoundingBox(Mesh mesh);                                               // Compute mesh bounding box limits
+RLAPI BoundingBox GetMeshBoundingBox(Mesh mesh);                                               // Compute mesh bounding box limits
 RLAPI void MeshTangents(Mesh *mesh);                                                        // Compute mesh tangents
 RLAPI void MeshBinormals(Mesh *mesh);                                                       // Compute mesh binormals
 


### PR DESCRIPTION
## Changes

The MeshBoundingBox function does not exist, so I've renamed some of the occurences of the function to GetMeshBoundingBox.
