### PR TITLE
core: added GetWindowHandle[GL/Native] to also expose opengl handle

### DIFF
--- a/projects/Geany/raylib.c.tags
+++ b/projects/Geany/raylib.c.tags
@@ -15,7 +15,8 @@ SetWindowPosition|void|(int x, int y);|
 SetWindowMonitor|void|(int monitor);|
 SetWindowMinSize|void|(int width, int height);|
 SetWindowSize|void|(int width, int height);|
-GetWindowHandle|void *|(void);|
+GetWindowHandleGL|void *|(void);|
+GetWindowHandleNative|void *|(void);|
 GetScreenWidth|int|(void);|
 GetScreenHeight|int|(void);|
 GetMonitorCount|int|(void);|

--- a/projects/Notepad++/raylib_npp_parser/raylib_npp.xml
+++ b/projects/Notepad++/raylib_npp_parser/raylib_npp.xml
@@ -97,7 +97,10 @@
                 <Param name="int height" />
             </Overload>
         </KeyWord>
-        <KeyWord name="GetWindowHandle" func="yes">
+        <KeyWord name="GetWindowHandleGL" func="yes">
+            <Overload retVal="void" descr="Get opengl window handle"></Overload>
+        </KeyWord>
+        <KeyWord name="GetWindowHandleNative" func="yes">
             <Overload retVal="void" descr="Get native window handle"></Overload>
         </KeyWord>
         <KeyWord name="GetScreenWidth" func="yes">

--- a/projects/Notepad++/raylib_npp_parser/raylib_to_parse.h
+++ b/projects/Notepad++/raylib_npp_parser/raylib_to_parse.h
@@ -26,7 +26,8 @@ RLAPI void SetWindowPosition(int x, int y);                       // Set window 
 RLAPI void SetWindowMonitor(int monitor);                         // Set monitor for the current window (fullscreen mode)
 RLAPI void SetWindowMinSize(int width, int height);               // Set window minimum dimensions (for FLAG_WINDOW_RESIZABLE)
 RLAPI void SetWindowSize(int width, int height);                  // Set window dimensions
-RLAPI void *GetWindowHandle(void);                                // Get native window handle
+RLAPI void *GetWindowHandleGL(void);                              // Get opengl window handle
+RLAPI void *GetWindowHandleNative(void);                          // Get native window handle
 RLAPI int GetScreenWidth(void);                                   // Get current screen width
 RLAPI int GetScreenHeight(void);                                  // Get current screen height
 RLAPI int GetMonitorCount(void);                                  // Get number of connected monitors

--- a/src/core.c
+++ b/src/core.c
@@ -348,10 +348,10 @@ typedef struct { unsigned int width; unsigned int height; } Size;
 typedef struct CoreData {
     struct {
 #if defined(PLATFORM_DESKTOP) || defined(PLATFORM_WEB)
-        GLFWwindow *handle;                 // Native window handle (graphic device)
+        GLFWwindow *handle;                 // opengl window handle (graphic device)
 #endif
 #if defined(PLATFORM_RPI)
-        EGL_DISPMANX_WINDOW_T handle;       // Native window handle (graphic device)
+        EGL_DISPMANX_WINDOW_T handle;       // opengl window handle (graphic device)
 #endif
 #if defined(PLATFORM_ANDROID) || defined(PLATFORM_RPI) || defined(PLATFORM_DRM) || defined(PLATFORM_UWP)
 #if defined(PLATFORM_DRM)
@@ -1467,8 +1467,14 @@ int GetScreenHeight(void)
     return CORE.Window.currentFbo.height;
 }
 
+// Get opengl window handle
+void *GetWindowHandleGL(void)
+{
+    return CORE.Window.handle;
+}
+
 // Get native window handle
-void *GetWindowHandle(void)
+void *GetWindowHandleNative(void)
 {
 #if defined(PLATFORM_DESKTOP) && defined(_WIN32)
     // NOTE: Returned handle is: void *HWND (windows.h)

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -936,7 +936,8 @@ RLAPI void SetWindowPosition(int x, int y);                       // Set window 
 RLAPI void SetWindowMonitor(int monitor);                         // Set monitor for the current window (fullscreen mode)
 RLAPI void SetWindowMinSize(int width, int height);               // Set window minimum dimensions (for FLAG_WINDOW_RESIZABLE)
 RLAPI void SetWindowSize(int width, int height);                  // Set window dimensions
-RLAPI void *GetWindowHandle(void);                                // Get native window handle
+RLAPI void *GetWindowHandleGL(void);                              // Get native window handle
+RLAPI void *GetWindowHandleNative(void);                          // Get native window handle
 RLAPI int GetScreenWidth(void);                                   // Get current screen width
 RLAPI int GetScreenHeight(void);                                  // Get current screen height
 RLAPI int GetMonitorCount(void);                                  // Get number of connected monitors


### PR DESCRIPTION
I exposed the opengl window handle by doing the following:

Removed the standart GetWindowHandle function and replaced it with 2 other functions:
- GetWindowHandleGL: gets the opengl handle
- GetWindowHandleNative: gets the native handle

an alternative would be to just change the current GetWindowHandle to return the opengl handle instead of the native one, since getting the native one from the opengl handle should be quite simple.
This would have the problem of silently changling what the function does and potentially break a lot of programs that used it for the native handle without any obvious errors

I also modified all the other files containing the name of the function, maybe that shouldnt be done because they get automatically updated?