### PR TITLE
Allow SetWindowSize() on web

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -1560,7 +1560,7 @@ void SetWindowMinSize(int width, int height)
 // TODO: Issues on HighDPI scaling
 void SetWindowSize(int width, int height)
 {
-#if defined(PLATFORM_DESKTOP)
+#if defined(PLATFORM_DESKTOP) || defined(PLATFORM_WEB)
     glfwSetWindowSize(CORE.Window.handle, width, height);
 #endif
 #if defined(PLATFORM_WEB)


### PR DESCRIPTION
This is a simple change to allow calling `SetWindowSize()` on web. The recent change https://github.com/raysan5/raylib/commit/9095dd9e82b6be2b4ab477deaea6fe4634d1583c was a good step forward but in my testing I found that on macOS there were some issues with high-dpi due to not multiplying by `devicePixelRatio`. If `SetWindowSize()` is exposed the user can still directly set the desired canvas size multiplied by `devicePixelRatio`. Here is a comparison (first doesn't use `devicePixelRatio`, second does, and last is a comparison of the two screenshots side-by-side at the same zoom level):
<img width="813" alt="Screen Shot 2021-06-22 at 8 22 30 PM" src="https://user-images.githubusercontent.com/49151/123031888-ecb9f900-d399-11eb-9db2-8dcfeed73a11.png">
<img width="817" alt="Screen Shot 2021-06-22 at 8 21 55 PM" src="https://user-images.githubusercontent.com/49151/123031891-ef1c5300-d399-11eb-882b-96bdcc6ca3cd.png">
![image](https://user-images.githubusercontent.com/49151/123032078-3b679300-d39a-11eb-97b9-a007f1e9f810.png)
Regardless of the dpi issues just providing access to `SetWindowSize()` lets the user manage this themselves and also apply other custom size behavior so it seems useful.
This would solve https://github.com/raysan5/raylib/issues/1838.