### PR TITLE
fix to LoadShaderFromMemory

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -2414,8 +2414,9 @@ RLAPI Shader LoadShaderFromMemory(const char *vsCode, const char *fsCode)
 
         // Get handles to GLSL uniform locations (vertex shader)
         shader.locs[SHADER_LOC_MATRIX_MVP] = rlGetLocationUniform(shader.id, "mvp");
-        shader.locs[SHADER_LOC_MATRIX_PROJECTION] = rlGetLocationUniform(shader.id, "projection");
         shader.locs[SHADER_LOC_MATRIX_VIEW] = rlGetLocationUniform(shader.id, "view");
+        shader.locs[SHADER_LOC_MATRIX_PROJECTION] = rlGetLocationUniform(shader.id, "projection");
+        shader.locs[SHADER_LOC_MATRIX_NORMAL] = rlGetLocationUniform(shader.id, "matNormal");
 
         // Get handles to GLSL uniform locations (fragment shader)
         shader.locs[SHADER_LOC_COLOR_DIFFUSE] = rlGetLocationUniform(shader.id, "colDiffuse");


### PR DESCRIPTION
Just a simple fix - the LoadShaderFromMemory function almost matches LoadShader, except that the "matNormal" uniform location isn't fetched.

This breaks the lighting in the simple lighting sample (if we switch out the use of LoadShader for LoadShaderFromMemory).

