### PR TITLE
Fix DecompressData() pointer issue

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -3055,7 +3055,7 @@ unsigned char *DecompressData(unsigned char *compData, int compDataLength, int *
 
     *dataLength = length;
 
-    TraceLog(LOG_INFO, "SYSTEM: Decompress data: Comp. size: %i -> Original size: %i", compDataLength, dataLength);
+    TraceLog(LOG_INFO, "SYSTEM: Decompress data: Comp. size: %i -> Original size: %i", compDataLength, *dataLength);
 #endif
 
     return data;


### PR DESCRIPTION
#1854 This issue also exists in the `DecompressData()` function.