### PR TITLE
DrawArc() and Vector3Slerp

### DIFF
--- a/src/models.c
+++ b/src/models.c
@@ -631,19 +631,20 @@ void DrawCylinderWires(Vector3 position, float radiusTop, float radiusBottom, fl
 
 //Draw an arc between two points
 //If iradius=0. the arc is a semi-circle with a center at the midpoint of the line between the two points.  Increase iradius for a flatter arc with a center off the midpoint.  Theta rotates the arc around the line between the two points.
-void DrawArc(Vector3 v1, Vector3 v2, float iradius, float theta, int steps, Color color) {
+void DrawArc(Vector3 v1, Vector3 v2, float iradius, float theta, int steps, Color color) 
+{
     float increment=1.0/(float)steps;
     Vector3 p;
 
     rlCheckRenderBatchLimit(2*(steps+1));
     rlBegin(RL_LINES);
         rlColor4ub(color.r, color.g, color.b, color.a);
-        for (float t=0.0;t<1.0;t+=increment) {
+        for (float t=0.0;t<1.0;t+=increment) 
+        {
             p=Vector3Slerp(v1,v2,t,iradius,theta);
             rlVertex3f(p.x,p.y,p.z);
             p=Vector3Slerp(v1,v2,t+increment,iradius,theta);
             rlVertex3f(p.x,p.y,p.z);
-
         }
     rlEnd();
 return;

--- a/src/models.c
+++ b/src/models.c
@@ -629,6 +629,26 @@ void DrawCylinderWires(Vector3 position, float radiusTop, float radiusBottom, fl
     rlPopMatrix();
 }
 
+//Draw an arc between two points
+//If iradius=0. the arc is a semi-circle with a center at the midpoint of the line between the two points.  Increase iradius for a flatter arc with a center off the midpoint.  Theta rotates the arc around the line between the two points.
+void DrawArc(Vector3 v1, Vector3 v2, float iradius, float theta, int steps, Color color) {
+    float increment=1.0/(float)steps;
+    Vector3 p;
+
+    rlCheckRenderBatchLimit(2*(steps+1));
+    rlBegin(RL_LINES);
+        rlColor4ub(color.r, color.g, color.b, color.a);
+        for (float t=0.0;t<1.0;t+=increment) {
+            p=Vector3Slerp(v1,v2,t,iradius,theta);
+            rlVertex3f(p.x,p.y,p.z);
+            p=Vector3Slerp(v1,v2,t+increment,iradius,theta);
+            rlVertex3f(p.x,p.y,p.z);
+
+        }
+    rlEnd();
+return;
+}
+
 // Draw a plane
 void DrawPlane(Vector3 centerPos, Vector2 size, Color color)
 {

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1370,6 +1370,7 @@ RLAPI void DrawSphereEx(Vector3 centerPos, float radius, int rings, int slices, 
 RLAPI void DrawSphereWires(Vector3 centerPos, float radius, int rings, int slices, Color color);         // Draw sphere wires
 RLAPI void DrawCylinder(Vector3 position, float radiusTop, float radiusBottom, float height, int slices, Color color); // Draw a cylinder/cone
 RLAPI void DrawCylinderWires(Vector3 position, float radiusTop, float radiusBottom, float height, int slices, Color color); // Draw a cylinder/cone wires
+RLAPI void DrawArc(Vector3 v1, Vector3 v2, float iradius, float theta, int steps, Color color);          // Draws an arc between two points
 RLAPI void DrawPlane(Vector3 centerPos, Vector2 size, Color color);                                      // Draw a plane XZ
 RLAPI void DrawRay(Ray ray, Color color);                                                                // Draw a ray line
 RLAPI void DrawGrid(int slices, float spacing);                                                          // Draw a grid (centered at (0, 0, 0))

--- a/src/raymath.h
+++ b/src/raymath.h
@@ -641,7 +641,7 @@ RMDEF Vector3 Vector3Slerp(Vector3 v1, Vector3 v2, float t, float iradius, float
 
     if (Vector3LengthSqr(Vector3Subtract(incept,midpoint))<0.1) {  //If our midpoint and axis intercept are very close together, displace the midpoint slightly so that normalization of F does not result in divide-by-zero or G=0 because F={1,0,0}
         midpoint=Vector3Add(v1,Vector3Scale(L,0.49));
-        midpoint=Vector3Add(midpoint,Vector3CrossProduct(midpoint,{0.2,0.0,0.0}));
+        midpoint=Vector3Add(midpoint,Vector3CrossProduct(midpoint,(Vector3){0.2,0.0,0.0}));
     }
     F=Vector3Normalize(Vector3Subtract(incept,midpoint)); // First orthogonal vector
     G=Vector3Normalize(Vector3CrossProduct(L,F));   // Second orthogonal vector

--- a/src/raymath.h
+++ b/src/raymath.h
@@ -621,32 +621,36 @@ RMDEF float3 Vector3ToFloatV(Vector3 v)
     return buffer;
 }
 
-RMDEF Vector3 Vector3Slerp(Vector3 v1, Vector3 v2, float t, float iradius, float theta) {
-
+RMDEF Vector3 Vector3Slerp(Vector3 v1, Vector3 v2, float t, float iradius, float theta) 
+{
     if (Vector3LengthSqr(Vector3Subtract(v2,v1))==0.0) return v1; //If our two points are the same, simply return v1
 
-    Vector3 r,a,b,incept,F,G;
-    Vector3 L=Vector3Subtract(v2,v1);  // L=v2-v1
-    Vector3 midpoint=Vector3Add(v1,Vector3Scale(L,0.5)); // midpoint=v1+L*0.5
-    float D=-1*Vector3DotProduct(L,midpoint);  //Solve plane equation for D
-    if (L.x!=0.0) {  //Find intercept of midpoint and x-axis as long as the plane isn't parallel to the x-axis
-        incept=(Vector3){-D/L.x,0.0,0.0};
+    Vector3 r,a,b,incept,f,g;
+    Vector3 l=Vector3Subtract(v2,v1);  // l=v2-v1
+    Vector3 midpoint=Vector3Add(v1,Vector3Scale(l,0.5)); // midpoint=v1+l*0.5
+    float d=-1*Vector3DotProduct(l,midpoint);  //Solve plane equation for d
+    if (l.x!=0.0) //Find intercept of midpoint and x-axis as long as the plane isn't parallel to the x-axis
+    {  
+        incept=(Vector3){-d/l.x,0.0,0.0};
     }
-    else if (L.y!=0.0) { //Otherwise use y-axis
-        incept=(Vector3){0.0,-D/L.y,0.0};
+    else if (l.y!=0.0) //Otherwise use y-axis
+    { 
+        incept=(Vector3){0.0,-d/l.y,0.0};
     }
-    else { //or z-axis.  All three cannot be zero because of the first if-statement in routine
-        incept=(Vector3){0.0,0.0,-D/L.z};
+    else 
+    { //or z-axis.  All three cannot be zero because of the first if-statement in routine
+        incept=(Vector3){0.0,0.0,-d/l.z};
     }
 
-    if (Vector3LengthSqr(Vector3Subtract(incept,midpoint))<0.1) {  //If our midpoint and axis intercept are very close together, displace the midpoint slightly so that normalization of F does not result in divide-by-zero or G=0 because F={1,0,0}
-        midpoint=Vector3Add(v1,Vector3Scale(L,0.49));
+    if (Vector3LengthSqr(Vector3Subtract(incept,midpoint))<0.1) //If our midpoint and axis intercept are very close together, displace the midpoint slightly so that normalization of f does not result in divide-by-zero nor g=0 because f={1,0,0}
+    {  
+        midpoint=Vector3Add(v1,Vector3Scale(l,0.49));
         midpoint=Vector3Add(midpoint,Vector3CrossProduct(midpoint,(Vector3){0.2,0.0,0.0}));
     }
-    F=Vector3Normalize(Vector3Subtract(incept,midpoint)); // First orthogonal vector
-    G=Vector3Normalize(Vector3CrossProduct(L,F));   // Second orthogonal vector
+    f=Vector3Normalize(Vector3Subtract(incept,midpoint)); // First orthogonal vector
+    g=Vector3Normalize(Vector3CrossProduct(l,f));   // Second orthogonal vector
 
-    Vector3 perp=Vector3Add(midpoint,Vector3Scale(Vector3Add( Vector3Scale(F,cos(theta)),Vector3Scale(G,sin(theta))),iradius)); //perp=midpoint+(F*cos(theta)+G*sin(theta))*iradius
+    Vector3 perp=Vector3Add(midpoint,Vector3Scale(Vector3Add( Vector3Scale(f,cos(theta)),Vector3Scale(g,sin(theta))),iradius)); //perp=midpoint+(f*cos(theta)+g*sin(theta))*iradius
     a=Vector3Subtract(v1,perp); //translate coordinates to center at perp
     b=Vector3Subtract(v2,perp);
     float om=acos( Vector3DotProduct(a,b) / (Vector3Length(a)*Vector3Length(b)) ); //Apply slerp formula for points at origin


### PR DESCRIPTION
I wrote a Vector3Slerp() function which provides spherical linear interpolation between two points without using quaternions.  It also provides more options for the curve.  

The iradius parameter allows increasing the radius of the arc, so flatter or rounder curves can be drawn.  When iradius=0.0, the curve is a semi-circle with its center on the midpoint of the line between point 1 and point 2. Larger values relocate the center of the curve off the midpoint, producing a flatter curve.

The theta parameter allows the direction of the arc to be rotated in any direction perpendicular to the line between the two points (like a jump rope).

DrawArc() seemed like a natural next step, so I added that too.  The only additional parameters here are Color, and the number of segments to use for the arc, similar to the options you provide for circles.

I offer it to you if you find it useful for inclusion.  Hopefully I did everything right in the pull request! :-)