### PR TITLE
[Models] Better Fix for GenMeshTangents issue #1876

### DIFF
--- a/src/models.c
+++ b/src/models.c
@@ -2652,20 +2652,7 @@ BoundingBox GetMeshBoundingBox(Mesh mesh)
 // Implementation base don: https://answers.unity.com/questions/7789/calculating-tangents-vector4.html
 void GenMeshTangents(Mesh* mesh)
 {
-    /*
-     * Check and see if the mesh already has tangents.
-     * If the mesh does not have tangents we can simply alloate the space for the data.
-     * 
-     * If the mesh did have tangents, we can not readily depend on the current vertexCount
-     * to be the actual length of the existing tangent data as the mesh vertices could
-     * have been altered and now contain less or more vertices which would result in
-     * either updating to few tangents, or attempting to over-run the space allocated
-     * for the tangents previously. In order to account for this the memory for the
-     * current tangent data must be freed as well as the previously assigned VertexBuffer,
-     * and then we can recreate the tangent data with the new size designated by vertexCount
-     * and create a new VertexBuffer to assign for the tangents.
-     * 
-     */
+
     if (mesh->tangents == NULL)
     {
         mesh->tangents = (float*)RL_MALLOC(mesh->vertexCount * 4 * sizeof(float));
@@ -2747,9 +2734,7 @@ void GenMeshTangents(Mesh* mesh)
     // Load a new tangent attributes buffer
     mesh->vboId[SHADER_LOC_VERTEX_TANGENT] = rlLoadVertexBuffer(mesh->tangents, mesh->vertexCount * 4 * sizeof(float), false);
     
-    /*
-     * Upate the tangets on the GPU.
-     */
+    
     rlEnableVertexArray(mesh->vaoId);
     rlSetVertexAttribute(4, 4, RL_FLOAT, 0, 0, 0);
     rlEnableVertexAttribute(4);

--- a/src/models.c
+++ b/src/models.c
@@ -2650,33 +2650,34 @@ BoundingBox GetMeshBoundingBox(Mesh mesh)
 // Compute mesh tangents
 // NOTE: To calculate mesh tangents and binormals we need mesh vertex positions and texture coordinates
 // Implementation base don: https://answers.unity.com/questions/7789/calculating-tangents-vector4.html
-void GenMeshTangents(Mesh* mesh)
+void GenMeshTangents(Mesh *mesh)
 {
 
     if (mesh->tangents == NULL)
     {
-        mesh->tangents = (float*)RL_MALLOC(mesh->vertexCount * 4 * sizeof(float));
+        mesh->tangents = (float*)RL_MALLOC(mesh->vertexCount*4*sizeof(float));
     }
-    else {
+	else
+	{
         rlUnloadVertexBuffer(mesh->vboId[SHADER_LOC_VERTEX_TANGENT]);
         RL_FREE(mesh->tangents);
-        mesh->tangents = (float*)RL_MALLOC(mesh->vertexCount * 4 * sizeof(float));
+        mesh->tangents = (float*)RL_MALLOC(mesh->vertexCount*4*sizeof(float));
     }
 
-    Vector3* tan1 = (Vector3*)RL_MALLOC(mesh->vertexCount * sizeof(Vector3));
-    Vector3* tan2 = (Vector3*)RL_MALLOC(mesh->vertexCount * sizeof(Vector3));
+    Vector3* tan1 = (Vector3*)RL_MALLOC(mesh->vertexCount*sizeof(Vector3));
+    Vector3* tan2 = (Vector3*)RL_MALLOC(mesh->vertexCount*sizeof(Vector3));
 
     for (int i = 0; i < mesh->vertexCount; i += 3)
     {
         // Get triangle vertices
-        Vector3 v1 = { mesh->vertices[(i + 0) * 3 + 0], mesh->vertices[(i + 0) * 3 + 1], mesh->vertices[(i + 0) * 3 + 2] };
-        Vector3 v2 = { mesh->vertices[(i + 1) * 3 + 0], mesh->vertices[(i + 1) * 3 + 1], mesh->vertices[(i + 1) * 3 + 2] };
-        Vector3 v3 = { mesh->vertices[(i + 2) * 3 + 0], mesh->vertices[(i + 2) * 3 + 1], mesh->vertices[(i + 2) * 3 + 2] };
+        Vector3 v1 = { mesh->vertices[(i + 0)*3 + 0], mesh->vertices[(i + 0)*3 + 1], mesh->vertices[(i + 0)*3 + 2] };
+        Vector3 v2 = { mesh->vertices[(i + 1)*3 + 0], mesh->vertices[(i + 1)*3 + 1], mesh->vertices[(i + 1)*3 + 2] };
+        Vector3 v3 = { mesh->vertices[(i + 2)*3 + 0], mesh->vertices[(i + 2)*3 + 1], mesh->vertices[(i + 2)*3 + 2] };
 
         // Get triangle texcoords
-        Vector2 uv1 = { mesh->texcoords[(i + 0) * 2 + 0], mesh->texcoords[(i + 0) * 2 + 1] };
-        Vector2 uv2 = { mesh->texcoords[(i + 1) * 2 + 0], mesh->texcoords[(i + 1) * 2 + 1] };
-        Vector2 uv3 = { mesh->texcoords[(i + 2) * 2 + 0], mesh->texcoords[(i + 2) * 2 + 1] };
+        Vector2 uv1 = { mesh->texcoords[(i + 0)*2 + 0], mesh->texcoords[(i + 0)*2 + 1] };
+        Vector2 uv2 = { mesh->texcoords[(i + 1)*2 + 0], mesh->texcoords[(i + 1)*2 + 1] };
+        Vector2 uv3 = { mesh->texcoords[(i + 2)*2 + 0], mesh->texcoords[(i + 2)*2 + 1] };
 
         float x1 = v2.x - v1.x;
         float y1 = v2.y - v1.y;
@@ -2690,11 +2691,11 @@ void GenMeshTangents(Mesh* mesh)
         float s2 = uv3.x - uv1.x;
         float t2 = uv3.y - uv1.y;
 
-        float div = s1 * t2 - s2 * t1;
+        float div = s1*t2 - s2*t1;
         float r = (div == 0.0f) ? 0.0f : 1.0f / div;
 
-        Vector3 sdir = { (t2 * x1 - t1 * x2) * r, (t2 * y1 - t1 * y2) * r, (t2 * z1 - t1 * z2) * r };
-        Vector3 tdir = { (s1 * x2 - s2 * x1) * r, (s1 * y2 - s2 * y1) * r, (s1 * z2 - s2 * z1) * r };
+        Vector3 sdir = { (t2*x1 - t1*x2)* r, (t2*y1 - t1*y2)* r, (t2*z1 - t1*z2)* r };
+        Vector3 tdir = { (s1*x2 - s2*x1)* r, (s1*y2 - s2*y1)* r, (s1*z2 - s2*z1)* r };
 
         tan1[i + 0] = sdir;
         tan1[i + 1] = sdir;
@@ -2708,23 +2709,23 @@ void GenMeshTangents(Mesh* mesh)
     // Compute tangents considering normals
     for (int i = 0; i < mesh->vertexCount; ++i)
     {
-        Vector3 normal = { mesh->normals[i * 3 + 0], mesh->normals[i * 3 + 1], mesh->normals[i * 3 + 2] };
+        Vector3 normal = { mesh->normals[i*3 + 0], mesh->normals[i*3 + 1], mesh->normals[i*3 + 2] };
         Vector3 tangent = tan1[i];
 
         // TODO: Review, not sure if tangent computation is right, just used reference proposed maths...
 #if defined(COMPUTE_TANGENTS_METHOD_01)
         Vector3 tmp = Vector3Subtract(tangent, Vector3Scale(normal, Vector3DotProduct(normal, tangent)));
         tmp = Vector3Normalize(tmp);
-        mesh->tangents[i * 4 + 0] = tmp.x;
-        mesh->tangents[i * 4 + 1] = tmp.y;
-        mesh->tangents[i * 4 + 2] = tmp.z;
-        mesh->tangents[i * 4 + 3] = 1.0f;
+        mesh->tangents[i*4 + 0] = tmp.x;
+        mesh->tangents[i*4 + 1] = tmp.y;
+        mesh->tangents[i*4 + 2] = tmp.z;
+        mesh->tangents[i*4 + 3] = 1.0f;
 #else
         Vector3OrthoNormalize(&normal, &tangent);
-        mesh->tangents[i * 4 + 0] = tangent.x;
-        mesh->tangents[i * 4 + 1] = tangent.y;
-        mesh->tangents[i * 4 + 2] = tangent.z;
-        mesh->tangents[i * 4 + 3] = (Vector3DotProduct(Vector3CrossProduct(normal, tangent), tan2[i]) < 0.0f) ? -1.0f : 1.0f;
+        mesh->tangents[i*4 + 0] = tangent.x;
+        mesh->tangents[i*4 + 1] = tangent.y;
+        mesh->tangents[i*4 + 2] = tangent.z;
+        mesh->tangents[i*4 + 3] = (Vector3DotProduct(Vector3CrossProduct(normal, tangent), tan2[i]) < 0.0f) ? -1.0f : 1.0f;
 #endif
     }
 
@@ -2732,7 +2733,7 @@ void GenMeshTangents(Mesh* mesh)
     RL_FREE(tan2);
 
     // Load a new tangent attributes buffer
-    mesh->vboId[SHADER_LOC_VERTEX_TANGENT] = rlLoadVertexBuffer(mesh->tangents, mesh->vertexCount * 4 * sizeof(float), false);
+    mesh->vboId[SHADER_LOC_VERTEX_TANGENT] = rlLoadVertexBuffer(mesh->tangents, mesh->vertexCount*4*sizeof(float), false);
     
     
     rlEnableVertexArray(mesh->vaoId);

--- a/src/models.c
+++ b/src/models.c
@@ -2737,7 +2737,7 @@ void GenMeshTangents(Mesh *mesh)
 		if (mesh->vboId[SHADER_LOC_VERTEX_TANGENT] != 0)
 		{
 			// Upate existing vertex buffer
-			rlUpdateVertexBuffer(mesh->vboId, mesh->tangents, mesh->vertexCount * 4 * sizeof(float), 0);
+			rlUpdateVertexBuffer(mesh->vboId, mesh->tangents, mesh->vertexCount*4*sizeof(float), 0);
 		}
 		else
 		{

--- a/src/models.c
+++ b/src/models.c
@@ -2659,7 +2659,6 @@ void GenMeshTangents(Mesh *mesh)
     }
 	else
 	{
-        rlUnloadVertexBuffer(mesh->vboId[SHADER_LOC_VERTEX_TANGENT]);
         RL_FREE(mesh->tangents);
         mesh->tangents = (float*)RL_MALLOC(mesh->vertexCount*4*sizeof(float));
     }
@@ -2732,14 +2731,27 @@ void GenMeshTangents(Mesh *mesh)
     RL_FREE(tan1);
     RL_FREE(tan2);
 
-    // Load a new tangent attributes buffer
-    mesh->vboId[SHADER_LOC_VERTEX_TANGENT] = rlLoadVertexBuffer(mesh->tangents, mesh->vertexCount*4*sizeof(float), false);
+	if (mesh->vboId != NULL)
+	{
+		
+		if (mesh->vboId[SHADER_LOC_VERTEX_TANGENT] != 0)
+		{
+			// Upate existing vertex buffer
+			rlUpdateVertexBuffer(mesh->vboId, mesh->tangents, mesh->vertexCount * 4 * sizeof(float), 0);
+		}
+		else
+		{
+			// Load a new tangent attributes buffer
+			mesh->vboId[SHADER_LOC_VERTEX_TANGENT] = rlLoadVertexBuffer(mesh->tangents, mesh->vertexCount*4*sizeof(float), false);	
+		}
+		
+		rlEnableVertexArray(mesh->vaoId);
+		rlSetVertexAttribute(4, 4, RL_FLOAT, 0, 0, 0);
+		rlEnableVertexAttribute(4);
+		rlDisableVertexArray();
+	}
     
     
-    rlEnableVertexArray(mesh->vaoId);
-    rlSetVertexAttribute(4, 4, RL_FLOAT, 0, 0, 0);
-    rlEnableVertexAttribute(4);
-    rlDisableVertexArray();
 
     TRACELOG(LOG_INFO, "MESH: Tangents data computed for provided mesh");
 }

--- a/src/models.c
+++ b/src/models.c
@@ -2653,7 +2653,6 @@ BoundingBox GetMeshBoundingBox(Mesh mesh)
 void GenMeshTangents(Mesh* mesh)
 {
     /*
-     * Added - 7/16/2021 - Jason Penick
      * Check and see if the mesh already has tangents.
      * If the mesh does not have tangents we can simply alloate the space for the data.
      * 
@@ -2749,9 +2748,7 @@ void GenMeshTangents(Mesh* mesh)
     mesh->vboId[SHADER_LOC_VERTEX_TANGENT] = rlLoadVertexBuffer(mesh->tangents, mesh->vertexCount * 4 * sizeof(float), false);
     
     /*
-     * Added - 7/16/2021 - Jason Penick
      * Upate the tangets on the GPU.
-     * Issue raised by Kenneth on discord.
      */
     rlEnableVertexArray(mesh->vaoId);
     rlSetVertexAttribute(4, 4, RL_FLOAT, 0, 0, 0);

--- a/src/models.c
+++ b/src/models.c
@@ -2738,7 +2738,7 @@ void GenMeshTangents(Mesh *mesh)
 		if (mesh->vboId[SHADER_LOC_VERTEX_TANGENT] != 0)
 		{
 			// Upate existing vertex buffer
-			rlUpdateVertexBuffer(mesh->vboId, mesh->tangents, mesh->vertexCount*4*sizeof(float), 0);
+			rlUpdateVertexBuffer(mesh->vboId[SHADER_LOC_VERTEX_TANGENT], mesh->tangents, mesh->vertexCount*4*sizeof(float), 0);
 		}
 		else
 		{

--- a/src/models.c
+++ b/src/models.c
@@ -2692,7 +2692,7 @@ void GenMeshTangents(Mesh *mesh)
         float t2 = uv3.y - uv1.y;
 
         float div = s1*t2 - s2*t1;
-        float r = (div == 0.0f) ? 0.0f : 1.0f/div;
+        float r = (div == 0.0f)? 0.0f : 1.0f/div;
 
         Vector3 sdir = { (t2*x1 - t1*x2)*r, (t2*y1 - t1*y2)*r, (t2*z1 - t1*z2)*r };
         Vector3 tdir = { (s1*x2 - s2*x1)*r, (s1*y2 - s2*y1)*r, (s1*z2 - s2*z1)*r };
@@ -2713,20 +2713,20 @@ void GenMeshTangents(Mesh *mesh)
         Vector3 tangent = tan1[i];
 
         // TODO: Review, not sure if tangent computation is right, just used reference proposed maths...
-	#if defined(COMPUTE_TANGENTS_METHOD_01)
+	  #if defined(COMPUTE_TANGENTS_METHOD_01)
         Vector3 tmp = Vector3Subtract(tangent, Vector3Scale(normal, Vector3DotProduct(normal, tangent)));
         tmp = Vector3Normalize(tmp);
         mesh->tangents[i*4 + 0] = tmp.x;
         mesh->tangents[i*4 + 1] = tmp.y;
         mesh->tangents[i*4 + 2] = tmp.z;
         mesh->tangents[i*4 + 3] = 1.0f;
-	#else
+	  #else
         Vector3OrthoNormalize(&normal, &tangent);
         mesh->tangents[i*4 + 0] = tangent.x;
         mesh->tangents[i*4 + 1] = tangent.y;
         mesh->tangents[i*4 + 2] = tangent.z;
         mesh->tangents[i*4 + 3] = (Vector3DotProduct(Vector3CrossProduct(normal, tangent), tan2[i]) < 0.0f) ? -1.0f : 1.0f;
-	#endif
+	  #endif
     }
 
     RL_FREE(tan1);

--- a/src/models.c
+++ b/src/models.c
@@ -2692,10 +2692,10 @@ void GenMeshTangents(Mesh *mesh)
         float t2 = uv3.y - uv1.y;
 
         float div = s1*t2 - s2*t1;
-        float r = (div == 0.0f) ? 0.0f : 1.0f / div;
+        float r = (div == 0.0f) ? 0.0f : 1.0f/div;
 
-        Vector3 sdir = { (t2*x1 - t1*x2)* r, (t2*y1 - t1*y2)* r, (t2*z1 - t1*z2)* r };
-        Vector3 tdir = { (s1*x2 - s2*x1)* r, (s1*y2 - s2*y1)* r, (s1*z2 - s2*z1)* r };
+        Vector3 sdir = { (t2*x1 - t1*x2)*r, (t2*y1 - t1*y2)*r, (t2*z1 - t1*z2)*r };
+        Vector3 tdir = { (s1*x2 - s2*x1)*r, (s1*y2 - s2*y1)*r, (s1*z2 - s2*z1)*r };
 
         tan1[i + 0] = sdir;
         tan1[i + 1] = sdir;
@@ -2713,20 +2713,20 @@ void GenMeshTangents(Mesh *mesh)
         Vector3 tangent = tan1[i];
 
         // TODO: Review, not sure if tangent computation is right, just used reference proposed maths...
-#if defined(COMPUTE_TANGENTS_METHOD_01)
+	#if defined(COMPUTE_TANGENTS_METHOD_01)
         Vector3 tmp = Vector3Subtract(tangent, Vector3Scale(normal, Vector3DotProduct(normal, tangent)));
         tmp = Vector3Normalize(tmp);
         mesh->tangents[i*4 + 0] = tmp.x;
         mesh->tangents[i*4 + 1] = tmp.y;
         mesh->tangents[i*4 + 2] = tmp.z;
         mesh->tangents[i*4 + 3] = 1.0f;
-#else
+	#else
         Vector3OrthoNormalize(&normal, &tangent);
         mesh->tangents[i*4 + 0] = tangent.x;
         mesh->tangents[i*4 + 1] = tangent.y;
         mesh->tangents[i*4 + 2] = tangent.z;
         mesh->tangents[i*4 + 3] = (Vector3DotProduct(Vector3CrossProduct(normal, tangent), tan2[i]) < 0.0f) ? -1.0f : 1.0f;
-#endif
+	#endif
     }
 
     RL_FREE(tan1);

--- a/src/models.c
+++ b/src/models.c
@@ -2650,25 +2650,47 @@ BoundingBox GetMeshBoundingBox(Mesh mesh)
 // Compute mesh tangents
 // NOTE: To calculate mesh tangents and binormals we need mesh vertex positions and texture coordinates
 // Implementation base don: https://answers.unity.com/questions/7789/calculating-tangents-vector4.html
-void GenMeshTangents(Mesh *mesh)
+void GenMeshTangents(Mesh* mesh)
 {
-    if (mesh->tangents == NULL) mesh->tangents = (float *)RL_MALLOC(mesh->vertexCount*4*sizeof(float));
-    else TRACELOG(LOG_WARNING, "MESH: Tangents data already available, re-writting");
+    /*
+     * Added - 7/16/2021 - Jason Penick
+     * Check and see if the mesh already has tangents.
+     * If the mesh does not have tangents we can simply alloate the space for the data.
+     * 
+     * If the mesh did have tangents, we can not readily depend on the current vertexCount
+     * to be the actual length of the existing tangent data as the mesh vertices could
+     * have been altered and now contain less or more vertices which would result in
+     * either updating to few tangents, or attempting to over-run the space allocated
+     * for the tangents previously. In order to account for this the memory for the
+     * current tangent data must be freed as well as the previously assigned VertexBuffer,
+     * and then we can recreate the tangent data with the new size designated by vertexCount
+     * and create a new VertexBuffer to assign for the tangents.
+     * 
+     */
+    if (mesh->tangents == NULL)
+    {
+        mesh->tangents = (float*)RL_MALLOC(mesh->vertexCount * 4 * sizeof(float));
+    }
+    else {
+        rlUnloadVertexBuffer(mesh->vboId[SHADER_LOC_VERTEX_TANGENT]);
+        RL_FREE(mesh->tangents);
+        mesh->tangents = (float*)RL_MALLOC(mesh->vertexCount * 4 * sizeof(float));
+    }
 
-    Vector3 *tan1 = (Vector3 *)RL_MALLOC(mesh->vertexCount*sizeof(Vector3));
-    Vector3 *tan2 = (Vector3 *)RL_MALLOC(mesh->vertexCount*sizeof(Vector3));
+    Vector3* tan1 = (Vector3*)RL_MALLOC(mesh->vertexCount * sizeof(Vector3));
+    Vector3* tan2 = (Vector3*)RL_MALLOC(mesh->vertexCount * sizeof(Vector3));
 
     for (int i = 0; i < mesh->vertexCount; i += 3)
     {
         // Get triangle vertices
-        Vector3 v1 = { mesh->vertices[(i + 0)*3 + 0], mesh->vertices[(i + 0)*3 + 1], mesh->vertices[(i + 0)*3 + 2] };
-        Vector3 v2 = { mesh->vertices[(i + 1)*3 + 0], mesh->vertices[(i + 1)*3 + 1], mesh->vertices[(i + 1)*3 + 2] };
-        Vector3 v3 = { mesh->vertices[(i + 2)*3 + 0], mesh->vertices[(i + 2)*3 + 1], mesh->vertices[(i + 2)*3 + 2] };
+        Vector3 v1 = { mesh->vertices[(i + 0) * 3 + 0], mesh->vertices[(i + 0) * 3 + 1], mesh->vertices[(i + 0) * 3 + 2] };
+        Vector3 v2 = { mesh->vertices[(i + 1) * 3 + 0], mesh->vertices[(i + 1) * 3 + 1], mesh->vertices[(i + 1) * 3 + 2] };
+        Vector3 v3 = { mesh->vertices[(i + 2) * 3 + 0], mesh->vertices[(i + 2) * 3 + 1], mesh->vertices[(i + 2) * 3 + 2] };
 
         // Get triangle texcoords
-        Vector2 uv1 = { mesh->texcoords[(i + 0)*2 + 0], mesh->texcoords[(i + 0)*2 + 1] };
-        Vector2 uv2 = { mesh->texcoords[(i + 1)*2 + 0], mesh->texcoords[(i + 1)*2 + 1] };
-        Vector2 uv3 = { mesh->texcoords[(i + 2)*2 + 0], mesh->texcoords[(i + 2)*2 + 1] };
+        Vector2 uv1 = { mesh->texcoords[(i + 0) * 2 + 0], mesh->texcoords[(i + 0) * 2 + 1] };
+        Vector2 uv2 = { mesh->texcoords[(i + 1) * 2 + 0], mesh->texcoords[(i + 1) * 2 + 1] };
+        Vector2 uv3 = { mesh->texcoords[(i + 2) * 2 + 0], mesh->texcoords[(i + 2) * 2 + 1] };
 
         float x1 = v2.x - v1.x;
         float y1 = v2.y - v1.y;
@@ -2682,11 +2704,11 @@ void GenMeshTangents(Mesh *mesh)
         float s2 = uv3.x - uv1.x;
         float t2 = uv3.y - uv1.y;
 
-        float div = s1*t2 - s2*t1;
-        float r = (div == 0.0f)? 0.0f : 1.0f/div;
+        float div = s1 * t2 - s2 * t1;
+        float r = (div == 0.0f) ? 0.0f : 1.0f / div;
 
-        Vector3 sdir = { (t2*x1 - t1*x2)*r, (t2*y1 - t1*y2)*r, (t2*z1 - t1*z2)*r };
-        Vector3 tdir = { (s1*x2 - s2*x1)*r, (s1*y2 - s2*y1)*r, (s1*z2 - s2*z1)*r };
+        Vector3 sdir = { (t2 * x1 - t1 * x2) * r, (t2 * y1 - t1 * y2) * r, (t2 * z1 - t1 * z2) * r };
+        Vector3 tdir = { (s1 * x2 - s2 * x1) * r, (s1 * y2 - s2 * y1) * r, (s1 * z2 - s2 * z1) * r };
 
         tan1[i + 0] = sdir;
         tan1[i + 1] = sdir;
@@ -2700,31 +2722,41 @@ void GenMeshTangents(Mesh *mesh)
     // Compute tangents considering normals
     for (int i = 0; i < mesh->vertexCount; ++i)
     {
-        Vector3 normal = { mesh->normals[i*3 + 0], mesh->normals[i*3 + 1], mesh->normals[i*3 + 2] };
+        Vector3 normal = { mesh->normals[i * 3 + 0], mesh->normals[i * 3 + 1], mesh->normals[i * 3 + 2] };
         Vector3 tangent = tan1[i];
 
         // TODO: Review, not sure if tangent computation is right, just used reference proposed maths...
-    #if defined(COMPUTE_TANGENTS_METHOD_01)
+#if defined(COMPUTE_TANGENTS_METHOD_01)
         Vector3 tmp = Vector3Subtract(tangent, Vector3Scale(normal, Vector3DotProduct(normal, tangent)));
         tmp = Vector3Normalize(tmp);
-        mesh->tangents[i*4 + 0] = tmp.x;
-        mesh->tangents[i*4 + 1] = tmp.y;
-        mesh->tangents[i*4 + 2] = tmp.z;
-        mesh->tangents[i*4 + 3] = 1.0f;
-    #else
+        mesh->tangents[i * 4 + 0] = tmp.x;
+        mesh->tangents[i * 4 + 1] = tmp.y;
+        mesh->tangents[i * 4 + 2] = tmp.z;
+        mesh->tangents[i * 4 + 3] = 1.0f;
+#else
         Vector3OrthoNormalize(&normal, &tangent);
-        mesh->tangents[i*4 + 0] = tangent.x;
-        mesh->tangents[i*4 + 1] = tangent.y;
-        mesh->tangents[i*4 + 2] = tangent.z;
-        mesh->tangents[i*4 + 3] = (Vector3DotProduct(Vector3CrossProduct(normal, tangent), tan2[i]) < 0.0f)? -1.0f : 1.0f;
-    #endif
+        mesh->tangents[i * 4 + 0] = tangent.x;
+        mesh->tangents[i * 4 + 1] = tangent.y;
+        mesh->tangents[i * 4 + 2] = tangent.z;
+        mesh->tangents[i * 4 + 3] = (Vector3DotProduct(Vector3CrossProduct(normal, tangent), tan2[i]) < 0.0f) ? -1.0f : 1.0f;
+#endif
     }
 
     RL_FREE(tan1);
     RL_FREE(tan2);
 
     // Load a new tangent attributes buffer
-    mesh->vboId[SHADER_LOC_VERTEX_TANGENT] = rlLoadVertexBuffer(mesh->tangents, mesh->vertexCount*4*sizeof(float), false);
+    mesh->vboId[SHADER_LOC_VERTEX_TANGENT] = rlLoadVertexBuffer(mesh->tangents, mesh->vertexCount * 4 * sizeof(float), false);
+    
+    /*
+     * Added - 7/16/2021 - Jason Penick
+     * Upate the tangets on the GPU.
+     * Issue raised by Kenneth on discord.
+     */
+    rlEnableVertexArray(mesh->vaoId);
+    rlSetVertexAttribute(4, 4, RL_FLOAT, 0, 0, 0);
+    rlEnableVertexAttribute(4);
+    rlDisableVertexArray();
 
     TRACELOG(LOG_INFO, "MESH: Tangents data computed for provided mesh");
 }

--- a/src/models.c
+++ b/src/models.c
@@ -2658,6 +2658,7 @@ void GenMeshTangents(Mesh *mesh)
         mesh->tangents = (float*)RL_MALLOC(mesh->vertexCount*4*sizeof(float));
     }
 	else
+	{
         RL_FREE(mesh->tangents);
         mesh->tangents = (float*)RL_MALLOC(mesh->vertexCount*4*sizeof(float));
     }


### PR DESCRIPTION
This is a better fix for issue #1876 and the GenMeshTangents function in general. 

The function was assuming that the mesh had already been uploaded to the GPU and was attempting to access the vboId field without ever verifying that it had actually been allocated.

Additionally if the vboId has been allocated, and the tangents already have a vertex buffer, instead of releasing the old one and creating a new one, this now simply updates the existing buffer.
