### PR TITLE
Remove unused UWP defines

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -224,4 +224,3 @@
 // utils: Configuration values
 //------------------------------------------------------------------------------------
 #define MAX_TRACELOG_MSG_LENGTH          128    // Max length of one trace-log message
-#define MAX_UWP_MESSAGES                 512    // Max UWP messages to process

--- a/src/utils.c
+++ b/src/utils.c
@@ -56,9 +56,6 @@
 #ifndef MAX_TRACELOG_MSG_LENGTH
     #define MAX_TRACELOG_MSG_LENGTH     128     // Max length of one trace-log message
 #endif
-#ifndef MAX_UWP_MESSAGES
-    #define MAX_UWP_MESSAGES            512     // Max UWP messages to process
-#endif
 
 //----------------------------------------------------------------------------------
 // Global Variables Definition


### PR DESCRIPTION
**UWP** is not available on `master` branch anymore so these definitions don't do anything. 
I'm curious if stating *Raylib* supports **UWP** on `raylib.h` is still ok since a branch does exist with the platform supported?