### PR TITLE
Generic raylib_parser

### DIFF
--- a/src/raymath.h
+++ b/src/raymath.h
@@ -135,8 +135,13 @@
 #endif
 
 // NOTE: Helper types to be used instead of array return types for *ToFloat functions
-typedef struct float3 { float v[3]; } float3;
-typedef struct float16 { float v[16]; } float16;
+typedef struct float3 {
+	float v[3];
+} float3;
+
+typedef struct float16 {
+	float v[16];
+} float16;
 
 #include <math.h>       // Required for: sinf(), cosf(), tan(), atan2f(), sqrtf(), fminf(), fmaxf(), fabs()
 


### PR DESCRIPTION
This PR makes `raylib_parser` generic, so it can parse not only raylib.h, but the most of packaged in raylib headers. To do so it adds `-d/--define` CLI key for functions define which defaults to `RLAPI` (define for raylib.h). Another changes: 
* moved maximum functions paramters, maximum struct fields and maximum field values to defines
* increased max struct fields (16->32), max enum values (128->512)
* removed useless code (line 220)
* updated help
* splited float3/float16 structs in raymath.h to allow parser to work with this file

Tested on files:
* raylib.h `-d RLAPI` (OK)
* raymath.h  `-d RMDEF` (OK, needed to split float3/float16 struct typedefs)
* rlgl.h `-d RLAPI` (CRASHES)
* extras/easings.h `-d EASEDEF` (OK)
* extras/physac.h `-d PHYSACDEF` (OK)
* extras/raygui.h `-d RAYGUIDEF` (OK)
* extras/ricons.h (OK)
* extras/rmem.h  `-d RMEMAPI` (OK)
* extras/rnet `-d RNETAPI` (OK, if RNETAPI added before functions)