### PR TITLE
Fix Makefile to build WASM examples.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,12 @@ packages/
 *.bc
 *.so
 
+# Ignore wasm data in examples/
+examples/**/*.wasm
+examples/**/*.data
+examples/**/*.js
+examples/**/*.html
+
 # Ignore files build by xcode
 *.mode*v*
 *.pbxuser

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -244,7 +244,7 @@ ifeq ($(PLATFORM),PLATFORM_WEB)
     # --memory-init-file 0       # to avoid an external memory initialization code file (.mem)
     # --preload-file resources   # specify a resources folder for data compilation
     # --source-map-base          # allow debugging in browser with source map
-    CFLAGS += -s USE_GLFW=3 -s ASYNCIFY -s TOTAL_MEMORY=67108864 -s FORCE_FILESYSTEM=1 $(dir $<)resources@resources
+    CFLAGS += -s USE_GLFW=3 -s ASYNCIFY -s TOTAL_MEMORY=67108864 -s FORCE_FILESYSTEM=1 --preload-file $(dir $<)resources@resources
 
     # NOTE: Simple raylib examples are compiled to be interpreter with asyncify, that way,
     # we can compile same code for ALL platforms with no change required, but, working on bigger


### PR DESCRIPTION
- Add --preload-file flag before specifying the resource dir
- Add empty resource dir to `shapes/` (otherwise wasm-ld will fail)
- Add wasm outputs to .gitigore
