### PR TITLE
Add *.so.* to .gitignore to ignore build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ packages/
 *.a
 *.bc
 *.so
+*.so.*
 
 # Ignore wasm data in examples/
 examples/**/*.wasm


### PR DESCRIPTION
When building a shared Raylib library on Linux, the build process
produces 3 files: libraylib.so (symlink), libraylib.so.381 (symlink)
and libraylib.so.3.8.1 (the library).

Only the first one of these (.so) is currently ignored by Git.
Adding \*.so.\* to .gitinore makes Git ignore the rest of them as
well.