### PR TITLE
Fix for Issue #1918

### DIFF
--- a/src/extras/physac.h
+++ b/src/extras/physac.h
@@ -256,8 +256,8 @@ PHYSACDEF Vector2 GetPhysicsShapeVertex(PhysicsBody body, int vertex);          
     #include <time.h>                   // Required for: time(), clock_gettime()
     #if defined(_WIN32)
         // Functions required to query time on Windows
-        int __stdcall QueryPerformanceCounter(unsigned long long int *lpPerformanceCount);
-        int __stdcall QueryPerformanceFrequency(unsigned long long int *lpFrequency);
+        PHYSACDEF int __stdcall QueryPerformanceCounter(unsigned long long int *lpPerformanceCount);
+        PHYSACDEF int __stdcall QueryPerformanceFrequency(unsigned long long int *lpFrequency);
     #endif
     #if defined(__linux__) || defined(__FreeBSD__)
         #if _POSIX_C_SOURCE < 199309L


### PR DESCRIPTION
I added PHYSACDEF in front of `QueryPerformanceCounter` and `QueryPerformanceFrequency` in to fix issue #1918.
Those two function declarations are causing name mangling, because they don't have `extern "C"`.
