### PR TITLE
add LoadImageAnimDelays() with int **frameDelays parameter

### DIFF
--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1200,6 +1200,7 @@ RLAPI Rectangle GetCollisionRec(Rectangle rec1, Rectangle rec2);                
 RLAPI Image LoadImage(const char *fileName);                                                             // Load image from file into CPU memory (RAM)
 RLAPI Image LoadImageRaw(const char *fileName, int width, int height, int format, int headerSize);       // Load image from RAW file data
 RLAPI Image LoadImageAnim(const char *fileName, int *frames);                                            // Load image sequence from file (frames appended to image.data)
+RLAPI Image LoadImageAnimDelays(const char *fileName, int *frames, int **frameDelays);                   // Load image sequence from file and also return delays between image frames
 RLAPI Image LoadImageFromMemory(const char *fileType, const unsigned char *fileData, int dataSize);      // Load image from memory buffer, fileType refers to extension: i.e. '.png'
 RLAPI Image LoadImageFromTexture(Texture2D texture);                                                     // Load image from GPU texture data
 RLAPI Image LoadImageFromScreen(void);                                                                   // Load image from screen buffer and (screenshot)

--- a/src/textures.c
+++ b/src/textures.c
@@ -292,8 +292,9 @@ Image LoadImageAnimDelays(const char *fileName, int *frames, int **frameDelays)
 Image LoadImageAnim(const char *fileName, int *frames)
 {
     int *delays = NULL;
-    LoadImageAnimDelays(fileName, frames, &delays);
+    Image image = LoadImageAnimDelays(fileName, frames, &delays);
     RL_FREE(delays);
+    return image;
 }
 
 // Load image from memory buffer, fileType refers to extension: i.e. ".png"

--- a/src/textures.c
+++ b/src/textures.c
@@ -250,8 +250,8 @@ Image LoadImageRaw(const char *fileName, int width, int height, int format, int 
 //  - Image.data buffer includes all frames: [image#0][image#1][image#2][...]
 //  - Number of frames is returned through 'frames' parameter
 //  - All frames are returned in RGBA format
-//  - Frames delay data is discarded
-Image LoadImageAnim(const char *fileName, int *frames)
+//  - Frames delay data is returned though 'frameDelays' parameter, a pointer to an array of ints that the function will declare with length equal to the number of frames, that represents the delay per frame in miliseconds
+Image LoadImageAnimDelays(const char *fileName, int *frames, int **frameDelays)
 {
     Image image = { 0 };
     int framesCount = 1;
@@ -265,14 +265,12 @@ Image LoadImageAnim(const char *fileName, int *frames)
         if (fileData != NULL)
         {
             int comp = 0;
-            int **delays = NULL;
-            image.data = stbi_load_gif_from_memory(fileData, dataSize, delays, &image.width, &image.height, &framesCount, &comp, 4);
+            image.data = stbi_load_gif_from_memory(fileData, dataSize, frameDelays, &image.width, &image.height, &framesCount, &comp, 4);
 
             image.mipmaps = 1;
             image.format = PIXELFORMAT_UNCOMPRESSED_R8G8B8A8;
 
             RL_FREE(fileData);
-            RL_FREE(delays);        // NOTE: Frames delays are discarded
         }
     }
 #else
@@ -284,6 +282,18 @@ Image LoadImageAnim(const char *fileName, int *frames)
 
     *frames = framesCount;
     return image;
+}
+
+// Load animated image data
+//  - Image.data buffer includes all frames: [image#0][image#1][image#2][...]
+//  - Number of frames is returned through 'frames' parameter
+//  - All frames are returned in RGBA format
+//  - Frames delay data is discarded
+Image LoadImageAnim(const char *fileName, int *frames)
+{
+    int *delays = NULL;
+    LoadImageAnimDelays(fileName, frames, &delays);
+    RL_FREE(delays);
 }
 
 // Load image from memory buffer, fileType refers to extension: i.e. ".png"


### PR DESCRIPTION
LoadImageAnim() discards the int **delays parameter to stbi_load_gif_from_memory(). I personally needed to use this parameter to determine how long I should display each frame of a gif and thought maybe other people could use it as well.

I added a new function LoadImageAnimDelays(), that replaces LoadImageAnim() (which now calls LoadImageAnimDelays() for backwards compatibility). This function is the same as the old LoadImageAnim(), except that it also returns the frame delays of a gif so it is possible to calculate/know when the next frame should be rendered.

I only tested this change on windows.

This is my first time making a PR so in case I did anything wrong please let me know.