### PR TITLE
Change GetColor to take unsigned int

### DIFF
--- a/parser/raylib_api.txt
+++ b/parser/raylib_api.txt
@@ -2505,7 +2505,7 @@ Function 308: GetColor() (1 input parameters)
   Name: GetColor
   Return type: Color
   Description: Get Color structure from hexadecimal value
-  Param[1]: hexValue (type: int)
+  Param[1]: hexValue (type: unsigned int)
 Function 309: GetPixelColor() (2 input parameters)
   Name: GetPixelColor
   Return type: Color

--- a/projects/Notepad++/raylib_npp_parser/raylib_to_parse.h
+++ b/projects/Notepad++/raylib_npp_parser/raylib_to_parse.h
@@ -389,7 +389,7 @@ RLAPI Vector3 ColorToHSV(Color color);                                      // R
 RLAPI Color ColorFromHSV(float hue, float saturation, float value);         // Returns a Color from HSV values
 RLAPI Color ColorAlpha(Color color, float alpha);                           // Returns color with alpha applied, alpha goes from 0.0f to 1.0f
 RLAPI Color ColorAlphaBlend(Color dst, Color src, Color tint);              // Returns src alpha-blended into dst color with tint
-RLAPI Color GetColor(int hexValue);                                         // Get Color structure from hexadecimal value
+RLAPI Color GetColor(unsigned int hexValue);                                         // Get Color structure from hexadecimal value
 RLAPI Color GetPixelColor(void *srcPtr, int format);                        // Get Color from a source pixel pointer of certain format
 RLAPI void SetPixelColor(void *dstPtr, Color color, int format);            // Set color formatted into destination pixel pointer
 RLAPI int GetPixelDataSize(int width, int height, int format);              // Get pixel data size in bytes for certain format

--- a/src/extras/raygui.h
+++ b/src/extras/raygui.h
@@ -1154,7 +1154,7 @@ static const char *GetDirectoryPath(const char *filePath);  // -- GuiLoadStyle()
 
 // raylib functions already implemented in raygui
 //-------------------------------------------------------------------------------
-static Color GetColor(int hexValue);                // Returns a Color struct from hexadecimal value
+static Color GetColor(unsigned int hexValue);                // Returns a Color struct from hexadecimal value
 static int ColorToInt(Color color);                 // Returns hexadecimal value for a Color
 static Color Fade(Color color, float alpha);        // Color fade-in or fade-out, alpha goes from 0.0f to 1.0f
 static bool CheckCollisionPointRec(Vector2 point, Rectangle rec);   // Check if point is inside rectangle
@@ -4061,7 +4061,7 @@ static Vector3 ConvertHSVtoRGB(Vector3 hsv)
 
 #if defined(RAYGUI_STANDALONE)
 // Returns a Color struct from hexadecimal value
-static Color GetColor(int hexValue)
+static Color GetColor(unsigned int hexValue)
 {
     Color color;
 

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1297,7 +1297,7 @@ RLAPI Vector3 ColorToHSV(Color color);                                      // G
 RLAPI Color ColorFromHSV(float hue, float saturation, float value);         // Get a Color from HSV values, hue [0..360], saturation/value [0..1]
 RLAPI Color ColorAlpha(Color color, float alpha);                           // Get color with alpha applied, alpha goes from 0.0f to 1.0f
 RLAPI Color ColorAlphaBlend(Color dst, Color src, Color tint);              // Get src alpha-blended into dst color with tint
-RLAPI Color GetColor(int hexValue);                                         // Get Color structure from hexadecimal value
+RLAPI Color GetColor(unsigned int hexValue);                                         // Get Color structure from hexadecimal value
 RLAPI Color GetPixelColor(void *srcPtr, int format);                        // Get Color from a source pixel pointer of certain format
 RLAPI void SetPixelColor(void *dstPtr, Color color, int format);            // Set color formatted into destination pixel pointer
 RLAPI int GetPixelDataSize(int width, int height, int format);              // Get pixel data size in bytes for certain format

--- a/src/textures.c
+++ b/src/textures.c
@@ -3711,7 +3711,7 @@ Color ColorAlphaBlend(Color dst, Color src, Color tint)
 }
 
 // Get a Color struct from hexadecimal value
-Color GetColor(int hexValue)
+Color GetColor(unsigned int hexValue)
 {
     Color color;
 


### PR DESCRIPTION
This fixes a problem in the auto generated Python binding where the user has to convert the int to unsigned manually in order to use GetColor.  I can just patch it in the binding, but I figured if it might be worth changing upstream if it makes sense.  I don't know enough about Raylib/C to know if this is a good idea or whether there is a reason to prefer signed ints!