### PR TITLE
Changed keyboard functions to use unsigned int.

### DIFF
--- a/projects/Notepad++/raylib_npp_parser/raylib_to_parse.h
+++ b/projects/Notepad++/raylib_npp_parser/raylib_to_parse.h
@@ -158,11 +158,11 @@ RLAPI void OpenURL(const char *url);                              // Open URL wi
 //------------------------------------------------------------------------------------
 
 // Input-related functions: keyboard
-RLAPI bool IsKeyPressed(int key);                             // Detect if a key has been pressed once
-RLAPI bool IsKeyDown(int key);                                // Detect if a key is being pressed
-RLAPI bool IsKeyReleased(int key);                            // Detect if a key has been released once
-RLAPI bool IsKeyUp(int key);                                  // Detect if a key is NOT being pressed
-RLAPI void SetExitKey(int key);                               // Set a custom key to exit program (default is ESC)
+RLAPI bool IsKeyPressed(unsigned int key);                    // Detect if a key has been pressed once
+RLAPI bool IsKeyDown(unsigned int key);                       // Detect if a key is being pressed
+RLAPI bool IsKeyReleased(unsigned int key);                   // Detect if a key has been released once
+RLAPI bool IsKeyUp(unsigned int key);                         // Detect if a key is NOT being pressed
+RLAPI void SetExitKey(unsigned int key);                      // Set a custom key to exit program (default is ESC)
 RLAPI int GetKeyPressed(void);                                // Get key pressed (keycode), call it multiple times for keys queued
 RLAPI int GetCharPressed(void);                               // Get char pressed (unicode), call it multiple times for chars queued
 

--- a/src/core.c
+++ b/src/core.c
@@ -3151,7 +3151,7 @@ void OpenURL(const char *url)
 // Module Functions Definition - Input (Keyboard, Mouse, Gamepad) Functions
 //----------------------------------------------------------------------------------
 // Check if a key has been pressed once
-bool IsKeyPressed(int key)
+bool IsKeyPressed(unsigned int key)
 {
     bool pressed = false;
 
@@ -3162,14 +3162,14 @@ bool IsKeyPressed(int key)
 }
 
 // Check if a key is being pressed (key held down)
-bool IsKeyDown(int key)
+bool IsKeyDown(unsigned int key)
 {
     if (CORE.Input.Keyboard.currentKeyState[key] == 1) return true;
     else return false;
 }
 
 // Check if a key has been released once
-bool IsKeyReleased(int key)
+bool IsKeyReleased(unsigned int key)
 {
     bool released = false;
 
@@ -3180,7 +3180,7 @@ bool IsKeyReleased(int key)
 }
 
 // Check if a key is NOT being pressed (key not held down)
-bool IsKeyUp(int key)
+bool IsKeyUp(unsigned int key)
 {
     if (CORE.Input.Keyboard.currentKeyState[key] == 0) return true;
     else return false;
@@ -3232,7 +3232,7 @@ int GetCharPressed(void)
 
 // Set a custom key to exit program
 // NOTE: default exitKey is ESCAPE
-void SetExitKey(int key)
+void SetExitKey(unsigned int key)
 {
 #if !defined(PLATFORM_ANDROID)
     CORE.Input.Keyboard.exitKey = key;

--- a/src/extras/raygui.h
+++ b/src/extras/raygui.h
@@ -1125,8 +1125,8 @@ static bool IsMouseButtonDown(int button);
 static bool IsMouseButtonPressed(int button);
 static bool IsMouseButtonReleased(int button);
 
-static bool IsKeyDown(int key);
-static bool IsKeyPressed(int key);
+static bool IsKeyDown(unsigned int key);
+static bool IsKeyPressed(unsigned int key);
 static int GetCharPressed(void);         // -- GuiTextBox(), GuiTextBoxMulti(), GuiValueBox()
 //-------------------------------------------------------------------------------
 

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1064,11 +1064,11 @@ RLAPI void OpenURL(const char *url);                              // Open URL wi
 //------------------------------------------------------------------------------------
 
 // Input-related functions: keyboard
-RLAPI bool IsKeyPressed(int key);                             // Check if a key has been pressed once
-RLAPI bool IsKeyDown(int key);                                // Check if a key is being pressed
-RLAPI bool IsKeyReleased(int key);                            // Check if a key has been released once
-RLAPI bool IsKeyUp(int key);                                  // Check if a key is NOT being pressed
-RLAPI void SetExitKey(int key);                               // Set a custom key to exit program (default is ESC)
+RLAPI bool IsKeyPressed(unsigned int key);                    // Check if a key has been pressed once
+RLAPI bool IsKeyDown(unsigned int key);                       // Check if a key is being pressed
+RLAPI bool IsKeyReleased(unsigned int key);                   // Check if a key has been released once
+RLAPI bool IsKeyUp(unsigned int key);                         // Check if a key is NOT being pressed
+RLAPI void SetExitKey(unsigned int key);                      // Set a custom key to exit program (default is ESC)
 RLAPI int GetKeyPressed(void);                                // Get key pressed (keycode), call it multiple times for keys queued, returns 0 when the queue is empty
 RLAPI int GetCharPressed(void);                               // Get char pressed (unicode), call it multiple times for chars queued, returns 0 when the queue is empty
 


### PR DESCRIPTION
Other programs and languages use unsigned int for keyboard functions, so it would make sense for raylib to do the same thing.