### PR TITLE
Fix for premature resizing with glfw (For some desktop environments)

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -3792,6 +3792,9 @@ static bool InitGraphicsDevice(int width, int height)
         if (CORE.Window.handle)
         {
 #if defined(PLATFORM_DESKTOP)
+            // Set Window size again to prevent GLFW resizing if a different monitor than the primary monitor
+            // is used for starting the application
+            glfwSetWindowSize(CORE.Window.handle,CORE.Window.screen.width,CORE.Window.screen.height);
             // Center window on screen
             int windowPosX = CORE.Window.display.width/2 - CORE.Window.screen.width/2;
             int windowPosY = CORE.Window.display.height/2 - CORE.Window.screen.height/2;


### PR DESCRIPTION
# Overview
- [Problem](#problem)
    - Description
    - Examples
- [Solution](#solution)
    - Implementation
    - Example with fix
- [Potential Issues](#potential-issues-with-this-solution)    

# Problem
### Description
When starting the application program on a different monitor than the primary monitor as returned by `glfwPrimaryMonitor`, then glfw automatically resizes the window after creation to fit the aspect ratio of the monitor which opened the window.

This results in the window being weirdly squashed when opening the application on a monitor that is in portrait mode.

## This is not the case for all Desktop Environments because glfw gets different information on when to resize the window.

### Example: Opening a 640x480 window. PrimaryMon: 1920x1080 and OpeningMon 1080x1920.

<img src="https://user-images.githubusercontent.com/17803932/131220593-4e2d1aef-df63-445b-83c9-003faf27a0ef.png" width=250/>
In this scenario the window resize is directly called after window creation by glfw to set the window size:

```
DEBUG: GLFW: End of InitWindow
DEBUG: GLFW: Resize Screen to 358x851
DEBUG: GLFW: Setup Viewport Matrix Ortho 358,851
```

Even if the resizing is deactivated.

### Different example when using `InitWindow(0,0,...)`
<img src="https://user-images.githubusercontent.com/17803932/131221101-0c7d63ae-5f47-4563-9122-d139fbcbc4cb.png" width=250/>


# Solution
### Implementation
After a lot of experimenting with the Window and how it is behaving, I came to the conclusion that settings the window size again is the best solution for this problem.

```c
CORE.Window.handle = glfwCreateWindow(CORE.Window.screen.width, CORE.Window.screen.height, (CORE.Window.title != 0)? CORE.Window.title : " ", NULL, NULL);
// [...]
glfwSetWindowSize(CORE.Window.handle,CORE.Window.screen.width,CORE.Window.screen.height);
```
https://github.com/MrDiver/raylib/blob/0033bbb6bf844a4b2c7aaa02a2b2d0d9fe2567cd/src/core.c#L3788-L3810

In theory, this change shouldn't affect anything else because the desired window size is still defined by `Window.screen.width` and `Window.screen.height`, which are both calculated beforehand in the code to have the desired size for the window.

This fix results in glfw not attempting to resize the window after the creation because it has now a set size for the window.

### Example: with solution implemented
<img src="https://user-images.githubusercontent.com/17803932/131220972-6916b959-9ff8-433a-89f0-2c46b85e302f.png" width=300/>

### Example when using `InitWindow(0,0,...)` with solution implemented
<img src="https://user-images.githubusercontent.com/17803932/131221189-35acacc1-5b29-40a0-a2a6-6d63d6cd5c66.png" width=300/>


# Potential issues with this solution
The case when we use `InitWindow(0,0,...)` resulting in a window of size 1080x1920 could actually be a desired effect. But the window position is set to always be on the PrimaryMonitor which is then of the wrong resolution.

To have an exhaustive fix for this problem, the window initialization procedure must include a way to set the actual monitor that is used for creation.

For now this fix is working fine because the window is always positioned on the primary monitor and selection of the monitor is as far as I know it not possible except for `SetWindowMonitor`#1036 which automatically resizes the window again to the screen resolution which therefore doesn't conflict with this fix.

~ I would still suggest adding the monitor selection feature in the future with a function that maybe `InitWindowPro(width,height,monitor,name)` which then is also used by `InitWindow()`.
