### PR TITLE
[models] LoadGLTF fixed missing transformations and nonroot skinning problem

### DIFF
--- a/src/models.c
+++ b/src/models.c
@@ -5485,7 +5485,7 @@ void LoadGLTFNode(cgltf_data *data, cgltf_node *node, Model *outModel, Matrix cu
     {
         // Check if skinning is enabled and load Mesh accordingly
         Matrix vertexTransform = currentTransform;
-        if(node->skin != NULL && node->parent != NULL)
+        if((node->skin != NULL) && (node->parent != NULL))
         {
             vertexTransform = localTransform;
             TRACELOG(LOG_WARNING,"MODEL: GLTF Node %s is skinned but not root node! Parent transformations will be ignored (NODE_SKINNED_MESH_NON_ROOT)",node->name);

--- a/src/models.c
+++ b/src/models.c
@@ -5446,34 +5446,52 @@ void LoadGLTFMesh(cgltf_data *data, cgltf_mesh *mesh, Model *outModel, Matrix cu
     }
 }
 
-void LoadGLTFNode(cgltf_data *data, cgltf_node *node, Model *outModel, Matrix currentTransform, int *primitiveIndex, const char *fileName)
+static Matrix GetNodeTransformationMatrix(cgltf_node *node, Matrix current)
 {
-    // Apply the transforms if they exist (Will still be applied even if no mesh is present to support emptys and bone structures)
-    if(node->has_matrix){
+    if (node->has_matrix)
+    {
         Matrix nodeTransform = {
         node->matrix[0], node->matrix[4], node->matrix[8], node->matrix[12],
         node->matrix[1], node->matrix[5], node->matrix[9], node->matrix[13],
         node->matrix[2], node->matrix[6], node->matrix[10], node->matrix[14],
         node->matrix[3], node->matrix[7], node->matrix[11], node->matrix[15] };
-        currentTransform = MatrixMultiply(nodeTransform, currentTransform);
+        current= MatrixMultiply(nodeTransform, current);
     }
-    if(node->has_translation){
+    if (node->has_translation)
+    {
         Matrix tl = MatrixTranslate(node->translation[0],node->translation[1],node->translation[2]);
-        currentTransform = MatrixMultiply(tl, currentTransform);
+        current = MatrixMultiply(tl, current);
     }
-    if(node->has_rotation){
+    if (node->has_rotation)
+    {
         Matrix rot = QuaternionToMatrix((Quaternion){node->rotation[0],node->rotation[1],node->rotation[2],node->rotation[3]});
-        currentTransform = MatrixMultiply(rot, currentTransform);
+        current = MatrixMultiply(rot, current);
     }
-    if(node->has_scale){
+    if (node->has_scale)
+    {
         Matrix scale = MatrixScale(node->scale[0],node->scale[1],node->scale[2]);
-        currentTransform = MatrixMultiply(scale, currentTransform);
+        current = MatrixMultiply(scale, current);
     }
-    // Load mesh if it exists
-    if (node->mesh != NULL){
-        LoadGLTFMesh(data, node->mesh, outModel, currentTransform, primitiveIndex, fileName);
-    }
+    return current;
+}
 
+void LoadGLTFNode(cgltf_data *data, cgltf_node *node, Model *outModel, Matrix currentTransform, int *primitiveIndex, const char *fileName)
+{
+    // Apply the transforms if they exist (Will still be applied even if no mesh is present to support emptys and bone structures)
+    Matrix localTransform = GetNodeTransformationMatrix(node, MatrixIdentity());
+    currentTransform = MatrixMultiply(localTransform, currentTransform);
+    // Load mesh if it exists
+    if (node->mesh != NULL)
+    {
+        // Check if skinning is enabled and load Mesh accordingly
+        Matrix vertexTransform = currentTransform;
+        if(node->skin != NULL && node->parent != NULL)
+        {
+            vertexTransform = localTransform;
+            TRACELOG(LOG_WARNING,"MODEL: GLTF Node %s is skinned but not root node! Parent transformations will be ignored (NODE_SKINNED_MESH_NON_ROOT)",node->name);
+        }
+        LoadGLTFMesh(data, node->mesh, outModel, vertexTransform, primitiveIndex, fileName);
+    }
     for (unsigned int i = 0; i < node->children_count; i++) LoadGLTFNode(data, node->children[i], outModel, currentTransform, primitiveIndex, fileName);
 }
 


### PR DESCRIPTION
I found the issue with the transforms. `LoadGLTFNode` assumed that every single transformation would automatically be saved in to the matrix, but this wasn't the case. I added the missing transforms with checks if they exist to ensure that all the transforms are applied on Load.

Heres a file that I used for testing which has all things that
[all_test.zip](https://github.com/raysan5/raylib/files/7071277/all_test.zip)

Currently a problem remains with the bones that the vertex data is already transformed on meshes that are a child of a bone structure, which results in the transformation being applied twice.

## Current result
![image](https://user-images.githubusercontent.com/17803932/131228119-d92cb7f8-82ed-4a40-a9a9-bb9ba521ae03.png)


## What the scene should look like if the bone error is fixed
![image](https://user-images.githubusercontent.com/17803932/131228145-d25ffcd0-7248-4f6a-9132-fb1bdebfdfe3.png)

There is some further information on this transform in the glTF file because sites like https://www.gltfviewer.com/ load the file perfectly fine.

But I really don't know where to find that data right now. But this is the first step in the right direction.

This is the current state of my raylib to figure out where everything goes wrong.
https://github.com/MrDiver/raylib/tree/gltf-recovery

This is a snippet of the loaded data from the glTF file and we can see that the vertices of the cube.004 are already transformed to the right position.
```
============= Model: NODE TRANSFORM pi: 5 ==============
Node Name: Armature
HAS TRANSLATION
[[ 1 0 0 0 ]
 [ 0 1 0 5 ]
 [ 0 0 1 0 ]
 [ 0 0 0 1 ]]

HAS ROTATION
[[ 0.707     0.5       0.5       0         ]
 [ -2.98E-08 0.707     -0.707    0         ]
 [ -0.707    0.5       0.5       0         ]
 [ 0         0         0         1         ]]

Current Transform
[[ 0.707     0.5       0.5       0         ]
 [ -2.98E-08 0.707     -0.707    5         ]
 [ -0.707    0.5       0.5       0         ]
 [ 0         0         0         1         ]]

=== Children of Armature
============= Model: NODE TRANSFORM pi: 5 ==============
Node Name: Cube.004
Current Transform
[[ 0.707     0.5       0.5       0         ]
 [ -2.98E-08 0.707     -0.707    5         ]
 [ -0.707    0.5       0.5       0         ]
 [ 0         0         0         1         ]]

IS MESH
Using Transform on vertex 0 : (-0.707107,4.500000,0.000000) to (1.750000,8.181980,2.750000)
Using Transform on vertex 1 : (-0.707107,4.500000,0.000000) to (1.750000,8.181980,2.750000)
Using Transform on vertex 2 : (-0.707107,4.500000,0.000000) to (1.750000,8.181980,2.750000)
Using Transform on vertex 3 : (0.000000,4.500000,0.707107) to (2.603554,7.681980,2.603554)
Using Transform on vertex 4 : (0.000000,4.500000,0.707107) to (2.603554,7.681980,2.603554)
Using Transform on vertex 5 : (0.000000,4.500000,0.707107) to (2.603554,7.681980,2.603554)
Using Transform on vertex 6 : (-0.707107,5.500000,0.000000) to (2.250001,8.889087,3.250000)
Using Transform on vertex 7 : (-0.707107,5.500000,0.000000) to (2.250001,8.889087,3.250000)
Using Transform on vertex 8 : (-0.707107,5.500000,0.000000) to (2.250001,8.889087,3.250000)
Using Transform on vertex 9 : (0.000000,5.500000,0.707107) to (3.103554,8.389087,3.103554)
Using Transform on vertex 10 : (0.000000,5.500000,0.707107) to (3.103554,8.389087,3.103554)
Using Transform on vertex 11 : (0.000000,5.500000,0.707107) to (3.103554,8.389087,3.103554)
Using Transform on vertex 12 : (0.000000,4.500000,-0.707107) to (1.896447,8.681980,1.896447)
Using Transform on vertex 13 : (0.000000,4.500000,-0.707107) to (1.896447,8.681980,1.896447)
Using Transform on vertex 14 : (0.000000,4.500000,-0.707107) to (1.896447,8.681980,1.896447)
Using Transform on vertex 15 : (0.707107,4.500000,-0.000000) to (2.750000,8.181980,1.750000)
Using Transform on vertex 16 : (0.707107,4.500000,-0.000000) to (2.750000,8.181980,1.750000)
Using Transform on vertex 17 : (0.707107,4.500000,-0.000000) to (2.750000,8.181980,1.750000)
Using Transform on vertex 18 : (0.000000,5.500000,-0.707107) to (2.396447,9.389087,2.396447)
Using Transform on vertex 19 : (0.000000,5.500000,-0.707107) to (2.396447,9.389087,2.396447)
Using Transform on vertex 20 : (0.000000,5.500000,-0.707107) to (2.396447,9.389087,2.396447)
Using Transform on vertex 21 : (0.707107,5.500000,-0.000000) to (3.250001,8.889087,2.250000)
Using Transform on vertex 22 : (0.707107,5.500000,-0.000000) to (3.250001,8.889087,2.250000)
Using Transform on vertex 23 : (0.707107,5.500000,-0.000000) to (3.250001,8.889087,2.250000)
=== Children of Cube.004
================= end node Cube.004 ==================
```
