### PR TITLE
[models] Fixed counting loop for face amount per material in `LoadOBJ`

### DIFF
--- a/src/models.c
+++ b/src/models.c
@@ -3491,6 +3491,11 @@ RayCollision GetRayCollisionQuad(Ray ray, Vector3 p1, Vector3 p2, Vector3 p3, Ve
 //----------------------------------------------------------------------------------
 #if defined(SUPPORT_FILEFORMAT_OBJ)
 // Load OBJ mesh data
+//
+// Keep the following information in mind when reading this
+//  - A mesh is created for every material present in the obj file
+//  - the model.meshCount is therefore the materialCount returned from tinyobj
+//  - the mesh is automatically triangulated by tinyobj
 static Model LoadOBJ(const char *fileName)
 {
     Model model = { 0 };
@@ -3542,15 +3547,12 @@ static Model LoadOBJ(const char *fileName)
         // Count the faces for each material
         int *matFaces = RL_CALLOC(materialCount, sizeof(int));
 
-        for (unsigned int mi = 0; mi < meshCount; mi++)
-        {
-            for (unsigned int fi = 0; fi < meshes[mi].length; fi++)
-            {
-                int idx = attrib.material_ids[meshes[mi].face_offset + fi];
-                if (idx == -1) idx = 0; // for no material face (which could be the whole model)
-                matFaces[idx]++;
-            }
+        for(int fi = 0; fi< attrib.num_faces; fi++){
+            tinyobj_vertex_index_t face = attrib.faces[fi];
+            int idx = attrib.material_ids[fi];
+            matFaces[idx]++;
         }
+
         //--------------------------------------
         // Create the material meshes
 


### PR DESCRIPTION
This part of the code from [LoadOBJ](https://github.com/raysan5/raylib/blob/68bcfa119243e716eaf00ffe521d0358c084b74f/src/models.c#L3494) seemed to be out of date with how tinyobj handles meshes.
https://github.com/raysan5/raylib/blob/68bcfa119243e716eaf00ffe521d0358c084b74f/src/models.c#L3545-L3553

Now the correct count of faces for each material is calculated. I tested this on different models, and it seems to work for different amount of objects and materials.

The new version simply iterates over the faces and gathers information that way.
```c
        for(int fi = 0; fi< attrib.num_faces; fi++){
            tinyobj_vertex_index_t face = attrib.faces[fi];
            int idx = attrib.material_ids[fi];
            matFaces[idx]++;
        }
```

This is fixing  #1966

And I also added a comment above the function, which will maybe help understand the function faster when new to the codebase.

