### PR TITLE
Fixes camera direction for first person camera mode.

### DIFF
--- a/src/camera.h
+++ b/src/camera.h
@@ -204,6 +204,7 @@ typedef struct {
     float targetDistance;           // Camera distance from position to target
     float playerEyesPosition;       // Player eyes position from ground (in meters)
     Vector2 angle;                  // Camera angle in plane XZ
+    Vector2 previousMousePosition;  // Previous mouse position
 
     // Camera movement control keys
     int moveControl[6];             // Move controls (CAMERA_FIRST_PERSON)
@@ -220,6 +221,7 @@ static CameraData CAMERA = {        // Global CAMERA state context
     .targetDistance = 0,
     .playerEyesPosition = 1.85f,
     .angle = { 0 },
+    .previousMousePosition = { 0 },
     .moveControl = { 'W', 'S', 'D', 'A', 'E', 'Q' },
     .smoothZoomControl = 341,       // raylib: KEY_LEFT_CONTROL
     .altControl = 342,              // raylib: KEY_LEFT_ALT
@@ -263,6 +265,8 @@ void SetCameraMode(Camera camera, int mode)
 
     CAMERA.playerEyesPosition = camera.position.y;          // Init player eyes position to camera Y position
 
+    CAMERA.previousMousePosition = GetMousePosition();      // Init mouse position
+
     // Lock cursor for first person and third person cameras
     if ((mode == CAMERA_FIRST_PERSON) || (mode == CAMERA_THIRD_PERSON)) DisableCursor();
     else EnableCursor();
@@ -279,7 +283,6 @@ void SetCameraMode(Camera camera, int mode)
 void UpdateCamera(Camera *camera)
 {
     static int swingCounter = 0;    // Used for 1st person swinging movement
-    static Vector2 previousMousePosition = { 0.0f, 0.0f };
 
     // TODO: Compute CAMERA.targetDistance and CAMERA.angle here (?)
 
@@ -302,10 +305,10 @@ void UpdateCamera(Camera *camera)
 
     if (CAMERA.mode != CAMERA_CUSTOM)
     {
-        mousePositionDelta.x = mousePosition.x - previousMousePosition.x;
-        mousePositionDelta.y = mousePosition.y - previousMousePosition.y;
+        mousePositionDelta.x = mousePosition.x - CAMERA.previousMousePosition.x;
+        mousePositionDelta.y = mousePosition.y - CAMERA.previousMousePosition.y;
 
-        previousMousePosition = mousePosition;
+        CAMERA.previousMousePosition = mousePosition;
     }
 
     // Support for multiple automatic camera modes


### PR DESCRIPTION
Previous mouse position was initialized to (0, 0) and caused camera direction vector to move first time scene initializes.
Watch the difference on a core_3d_camera_first_person example.