### PR TITLE
Fix dynamic library issues on Macos

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -496,7 +496,7 @@ else
             endif
             ifeq ($(PLATFORM_OS),OSX)
 				$(CC) -dynamiclib -o $(RAYLIB_RELEASE_PATH)/lib$(RAYLIB_LIB_NAME).$(RAYLIB_VERSION).dylib $(OBJS) $(LDFLAGS) -compatibility_version $(RAYLIB_API_VERSION) -current_version $(RAYLIB_VERSION) -framework OpenGL -framework Cocoa -framework IOKit -framework CoreAudio -framework CoreVideo
-				install_name_tool -id "lib$(RAYLIB_LIB_NAME).$(VERSION).dylib" $(RAYLIB_RELEASE_PATH)/lib$(RAYLIB_LIB_NAME).$(RAYLIB_VERSION).dylib
+				install_name_tool -id "@rpath/lib$(RAYLIB_LIB_NAME).$(RAYLIB_API_VERSION).dylib" $(RAYLIB_RELEASE_PATH)/lib$(RAYLIB_LIB_NAME).$(RAYLIB_VERSION).dylib
 				@echo "raylib shared library generated (lib$(RAYLIB_LIB_NAME).$(RAYLIB_VERSION).dylib)!"
 				cd $(RAYLIB_RELEASE_PATH) && ln -fs lib$(RAYLIB_LIB_NAME).$(RAYLIB_VERSION).dylib lib$(RAYLIB_LIB_NAME).$(RAYLIB_API_VERSION).dylib
 				cd $(RAYLIB_RELEASE_PATH) && ln -fs lib$(RAYLIB_LIB_NAME).$(RAYLIB_VERSION).dylib lib$(RAYLIB_LIB_NAME).dylib


### PR DESCRIPTION
On my system, when linking against the 3.7.0 binary downloaded library, the name recorded inside the library is `libraylib..dylib` instead of `libraylib.370.dylib` as the installed symlink is named.

This is due to the use of `$VERSION` which is not set inside the Makefile. I think this was a typo, because there is no symlink built that uses that name.

The binary download for 3.0.0 works fine, but when I build locally 3.0.0, the same problem occurs. I feel the person who generated the raylib binary release must have hand-fixed the issue for the 3.0.0 version, but not the 3.7.0 version.

In addition, adding the `@rpath/` prefix allows you to use DYLIB_LIBRARY_PATH or LD_LIBRARY_PATH to refer to the dynamic library. If you look at the 3.0.0 binary release, it has this prefix in it.

For sure the change from `VERSION` to `RAYLIB_API_VERSION` is correct. I'm not sure what the intent of the original author of this makefile had for the `@rpath` name prefix, but clearly whoever built the binary release thought it should be in there. Without that, you must have the dylib in your local path.

I think the 3.7.0 binary should also be fixed, so that one doesn't have to wait for a new release to have this corrected. Although, this is against master, I'm not sure if you maintain a branch for 3.7.