### PR TITLE
Implemented GetGamepadName() for emscripten

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -461,6 +461,9 @@ typedef struct CoreData {
             int streamId[MAX_GAMEPADS];     // Gamepad device file descriptor
             char name[64];                  // Gamepad name holder
 #endif
+#if defined(PLATFORM_WEB)
+            char gamepadNames[MAX_GAMEPADS][64];
+#endif
         } Gamepad;
     } Input;
     struct {
@@ -3276,6 +3279,9 @@ const char *GetGamepadName(int gamepad)
     if (CORE.Input.Gamepad.ready[gamepad]) ioctl(CORE.Input.Gamepad.streamId[gamepad], JSIOCGNAME(64), &CORE.Input.Gamepad.name);
     return CORE.Input.Gamepad.name;
 #endif
+#if defined(PLATFORM_WEB)
+    return CORE.Input.Gamepad.gamepadNames[gamepad];
+#endif
     return NULL;
 }
 
@@ -5400,7 +5406,13 @@ static EM_BOOL EmscriptenGamepadCallback(int eventType, const EmscriptenGamepadE
     for (int i = 0; i < gamepadEvent->numButtons; ++i) TRACELOGD("Button %d: Digital: %d, Analog: %g", i, gamepadEvent->digitalButton[i], gamepadEvent->analogButton[i]);
     */
 
-    if ((gamepadEvent->connected) && (gamepadEvent->index < MAX_GAMEPADS)) CORE.Input.Gamepad.ready[gamepadEvent->index] = true;
+    if ((gamepadEvent->connected) && (gamepadEvent->index < MAX_GAMEPADS))
+    {
+        CORE.Input.Gamepad.ready[gamepadEvent->index] = true;
+#if defined(PLATFORM_WEB)
+        sprintf(CORE.Input.Gamepad.gamepadNames[gamepadEvent->index],"%s",gamepadEvent->id);
+#endif
+    } 
     else CORE.Input.Gamepad.ready[gamepadEvent->index] = false;
 
     // TODO: Test gamepadEvent->index

--- a/src/core.c
+++ b/src/core.c
@@ -5406,9 +5406,7 @@ static EM_BOOL EmscriptenGamepadCallback(int eventType, const EmscriptenGamepadE
     if ((gamepadEvent->connected) && (gamepadEvent->index < MAX_GAMEPADS))
     {
         CORE.Input.Gamepad.ready[gamepadEvent->index] = true;
-#if defined(PLATFORM_WEB)
         sprintf(CORE.Input.Gamepad.name[gamepadEvent->index],"%s",gamepadEvent->id);
-#endif
     } 
     else CORE.Input.Gamepad.ready[gamepadEvent->index] = false;
 

--- a/src/core.c
+++ b/src/core.c
@@ -456,13 +456,10 @@ typedef struct CoreData {
             char currentButtonState[MAX_GAMEPADS][MAX_GAMEPAD_BUTTONS];     // Current gamepad buttons state
             char previousButtonState[MAX_GAMEPADS][MAX_GAMEPAD_BUTTONS];    // Previous gamepad buttons state
             float axisState[MAX_GAMEPADS][MAX_GAMEPAD_AXIS];                // Gamepad axis state
-#if defined(PLATFORM_RPI) || defined(PLATFORM_DRM)
+#if defined(PLATFORM_RPI) || defined(PLATFORM_DRM) || defined(PLATFORM_WEB)
             pthread_t threadId;             // Gamepad reading thread id
             int streamId[MAX_GAMEPADS];     // Gamepad device file descriptor
-            char name[64];                  // Gamepad name holder
-#endif
-#if defined(PLATFORM_WEB)
-            char gamepadNames[MAX_GAMEPADS][64];
+            char name[MAX_GAMEPADS][64];                  // Gamepad name holder
 #endif
         } Gamepad;
     } Input;
@@ -3276,11 +3273,11 @@ const char *GetGamepadName(int gamepad)
     else return NULL;
 #endif
 #if defined(PLATFORM_RPI) || defined(PLATFORM_DRM)
-    if (CORE.Input.Gamepad.ready[gamepad]) ioctl(CORE.Input.Gamepad.streamId[gamepad], JSIOCGNAME(64), &CORE.Input.Gamepad.name);
-    return CORE.Input.Gamepad.name;
+    if (CORE.Input.Gamepad.ready[gamepad]) ioctl(CORE.Input.Gamepad.streamId[gamepad], JSIOCGNAME(64), &CORE.Input.Gamepad.name[gamepad]);
+    return CORE.Input.Gamepad.name[gamepad];
 #endif
 #if defined(PLATFORM_WEB)
-    return CORE.Input.Gamepad.gamepadNames[gamepad];
+    return CORE.Input.Gamepad.name[gamepad];
 #endif
     return NULL;
 }
@@ -5410,7 +5407,7 @@ static EM_BOOL EmscriptenGamepadCallback(int eventType, const EmscriptenGamepadE
     {
         CORE.Input.Gamepad.ready[gamepadEvent->index] = true;
 #if defined(PLATFORM_WEB)
-        sprintf(CORE.Input.Gamepad.gamepadNames[gamepadEvent->index],"%s",gamepadEvent->id);
+        sprintf(CORE.Input.Gamepad.name[gamepadEvent->index],"%s",gamepadEvent->id);
 #endif
     } 
     else CORE.Input.Gamepad.ready[gamepadEvent->index] = false;


### PR DESCRIPTION
When building for HTML the GetGamepadName() function currently returns null:

![ray2](https://user-images.githubusercontent.com/10982154/132946730-d00c14ec-0b82-4d0b-91c1-8e5075c1c192.JPG)

This implements that function by capturing it when the device is detected from the gamepadEvent object. Now the name will return correctly:

![ray1](https://user-images.githubusercontent.com/10982154/132946746-83c1227d-3329-449b-a111-6560c24c0486.JPG)
