### PR TITLE
Add SetRandomSeed(unsigned int seed) function

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -2669,6 +2669,12 @@ int GetRandomValue(int min, int max)
     return (rand()%(abs(max - min) + 1) + min);
 }
 
+// Set the seed for the random number generator
+void SetRandomSeed(unsigned int seed)
+{
+    srand(seed);
+}
+
 // Check if the file exists
 bool FileExists(const char *fileName)
 {

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1009,6 +1009,7 @@ RLAPI double GetTime(void);                                       // Get elapsed
 
 // Misc. functions
 RLAPI int GetRandomValue(int min, int max);                       // Get a random value between min and max (both included)
+RLAPI void SetRandomSeed(unsigned int seed);                      // Set the seed for the random number generator
 RLAPI void TakeScreenshot(const char *fileName);                  // Takes a screenshot of current screen (filename extension defines format)
 RLAPI void SetConfigFlags(unsigned int flags);                    // Setup init configuration flags (view FLAGS)
 


### PR DESCRIPTION
This is a proposal for a new public API function `SetRandomSeed(unsigned int seed)`.

**Rationale:**

Specifying a fixed seed for the random number generator is often used in games for various reasons, for example when replaying the same randomly generated world or when competing in games that are random by nature (and the random element is undesired).

By adding an API function for seeding the random number generator we solve two different problems regarding the use case:

**1.** The underlying RNG implementation does not leak to client code (as would be the case if we called `srand` directly from the client code). This prevents client code from breaking in the case where the implementation would change.

**2.** Seeding the RNG would be possible and simple from other programming languages (especially in cases where calling libc functions is non-trivial). 

Also, since raylib provides a function for fetching random numbers (`GetRandomValue`) it would feel natural for it to provide a function for seeding the random number generator as well (which would be totally optional to use).