### PR TITLE
Fix use of undeclared variable in rmodels.

### DIFF
--- a/src/rmodels.c
+++ b/src/rmodels.c
@@ -4409,7 +4409,7 @@ static Image LoadImageFromCgltfImage(cgltf_image *image, const char *texPath, Co
             n += stride;
         }
 
-        rimage = LoadImageFromMemory(".png", data, size);
+        rimage = LoadImageFromMemory(".png", data, (int)image->buffer_view->size );
         RL_FREE(data);
 
         // TODO: Tint shouldn't be applied here!


### PR DESCRIPTION
Broken by de173a93c86fbda92b7d93a5fc202e80d4a16f24.
