### PR TITLE
`SeekMusicStream` function

### DIFF
--- a/src/raudio.c
+++ b/src/raudio.c
@@ -1656,6 +1656,28 @@ void StopMusicStream(Music music)
     }
 }
 
+// Seek music to a certain position (in seconds)
+void SeekMusicStream(Music music, float position)
+{
+    unsigned int positionInFrames = (unsigned int)(position * music.stream.sampleRate);
+    switch (music.ctxType)
+    {
+#if defined(SUPPORT_FILEFORMAT_WAV)
+        case MUSIC_AUDIO_WAV: drwav_seek_to_pcm_frame((drwav *)music.ctxData, positionInFrames); break;
+#endif
+#if defined(SUPPORT_FILEFORMAT_OGG)
+        case MUSIC_AUDIO_OGG: stb_vorbis_seek_frame((stb_vorbis *)music.ctxData, positionInFrames); break;
+#endif
+#if defined(SUPPORT_FILEFORMAT_FLAC)
+        case MUSIC_AUDIO_FLAC: drflac_seek_to_pcm_frame((drflac *)music.ctxData, positionInFrames); break;
+#endif
+#if defined(SUPPORT_FILEFORMAT_MP3)
+        case MUSIC_AUDIO_MP3: drmp3_seek_to_pcm_frame((drmp3 *)music.ctxData, positionInFrames); break;
+#endif
+        default: break;
+    }
+}
+
 // Update (re-fill) music buffers if data already processed
 void UpdateMusicStream(Music music)
 {

--- a/src/raudio.h
+++ b/src/raudio.h
@@ -171,6 +171,7 @@ void UpdateMusicStream(Music music);                            // Updates buffe
 void StopMusicStream(Music music);                              // Stop music playing
 void PauseMusicStream(Music music);                             // Pause music playing
 void ResumeMusicStream(Music music);                            // Resume playing paused music
+void SeekMusicStream(Music music, float position);              // Seek music to a position (in seconds)
 void SetMusicVolume(Music music, float volume);                 // Set volume for music (1.0 is max level)
 void SetMusicPitch(Music music, float pitch);                   // Set pitch for a music (1.0 is base level)
 float GetMusicTimeLength(Music music);                          // Get music time length (in seconds)

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1501,6 +1501,7 @@ RLAPI void UpdateMusicStream(Music music);                            // Updates
 RLAPI void StopMusicStream(Music music);                              // Stop music playing
 RLAPI void PauseMusicStream(Music music);                             // Pause music playing
 RLAPI void ResumeMusicStream(Music music);                            // Resume playing paused music
+RLAPI void SeekMusicStream(Music music, float position);              // Seek music to a position (in seconds)
 RLAPI void SetMusicVolume(Music music, float volume);                 // Set volume for music (1.0 is max level)
 RLAPI void SetMusicPitch(Music music, float pitch);                   // Set pitch for a music (1.0 is base level)
 RLAPI float GetMusicTimeLength(Music music);                          // Get music time length (in seconds)


### PR DESCRIPTION
This function allows you to seek into a position in seconds on a music stream, something commonly used for music player programs to allow you to get to a certain point of your tune.

Unfortunately it does not support *module-based* formats **(.XM, .MOD)** as they work pretty differently than most others and did not have functions for seeking anyways. (Even the functions for going back to the start are an addition from **Ray** too anyways)

Any _feedback_ (heh!) would be greatly appreciated, specially as this function could prove quite useful to many.