### PR TITLE
Implement loop point in `Music` struct

### DIFF
--- a/src/raudio.c
+++ b/src/raudio.c
@@ -1779,6 +1779,7 @@ void UpdateMusicStream(Music music)
     {
         StopMusicStream(music);                     // Stop music (and reset)
         if (music.looping) PlayMusicStream(music);  // Play again
+		if (music.loopPoint != 0.0f) SeekMusicStream(music, music.loopPoint) // Skip to loop point
     }
     else
     {

--- a/src/raudio.c
+++ b/src/raudio.c
@@ -1779,7 +1779,7 @@ void UpdateMusicStream(Music music)
     {
         StopMusicStream(music);                     // Stop music (and reset)
         if (music.looping) PlayMusicStream(music);  // Play again
-		if (music.loopPoint != 0.0f) SeekMusicStream(music, music.loopPoint) // Skip to loop point
+		if (music.loopPoint != 0.0f) SeekMusicStream(music, music.loopPoint); // Skip to loop point
     }
     else
     {

--- a/src/raudio.c
+++ b/src/raudio.c
@@ -1779,7 +1779,7 @@ void UpdateMusicStream(Music music)
     {
         StopMusicStream(music);                     // Stop music (and reset)
         if (music.looping) PlayMusicStream(music);  // Play again
-		if (music.loopPoint != 0.0f) SeekMusicStream(music, music.loopPoint); // Skip to loop point
+        if (music.loopPoint != 0.0f) SeekMusicStream(music, music.loopPoint); // Skip to loop point
     }
     else
     {

--- a/src/raudio.h
+++ b/src/raudio.h
@@ -108,6 +108,7 @@ typedef struct Sound {
 typedef struct Music {
     AudioStream stream;         // Audio stream
     unsigned int frameCount;    // Total number of frames (considering channels)
+    float loopPoint;            // Position (in seconds) to return to after looping
     bool looping;               // Music looping enable
 
     int ctxType;                // Type of music context (audio filetype)

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -445,6 +445,7 @@ typedef struct Sound {
 typedef struct Music {
     AudioStream stream;         // Audio stream
     unsigned int frameCount;    // Total number of frames (considering channels)
+    float loopPoint;            // Position (in seconds) to return to after looping
     bool looping;               // Music looping enable
 
     int ctxType;                // Type of music context (audio filetype)


### PR DESCRIPTION
This allows the user to set an optional variable in the `Music` struct with the position in seconds to which the music will immediately seek to after looping. Thus you could have a track with a beginning that plays once and the remainder always looping.

Feedback would be good as always.