### PR TITLE
Add Zig build file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,10 @@ build
 GPATH
 GRTAGS
 GTAGS
+
+# Zig programming language
+zig-cache/
+zig-out/
+build/
+build-*/
+docgen_tmp/

--- a/src/build.zig
+++ b/src/build.zig
@@ -1,0 +1,58 @@
+const std = @import("std");
+
+pub fn build(b: *std.build.Builder) void {
+    // Standard target options allows the person running `zig build` to choose
+    // what target to build for. Here we do not override the defaults, which
+    // means any target is allowed, and the default is native. Other options
+    // for restricting supported target set are available.
+    const target = b.standardTargetOptions(.{});
+
+    // Standard release options allow the person running `zig build` to select
+    // between Debug, ReleaseSafe, ReleaseFast, and ReleaseSmall.
+    const mode = b.standardReleaseOptions();
+
+    const raylib_flags = &[_][]const u8{
+        "-std=gnu99",
+        "-DPLATFORM_DESKTOP",
+        "-DGL_SILENCE_DEPRECATION",
+        "-fno-sanitize=undefined", // https://github.com/raysan5/raylib/issues/1891
+    };
+
+    const raylib = b.addStaticLibrary("raylib", "raylib.h");
+    raylib.setTarget(target);
+    raylib.setBuildMode(mode);
+    raylib.linkLibC();
+
+    raylib.addIncludeDir("external/glfw/include");
+
+    raylib.addCSourceFile("rcore.c", raylib_flags);
+    raylib.addCSourceFile("rmodels.c", raylib_flags);
+    raylib.addCSourceFile("raudio.c", raylib_flags);
+    raylib.addCSourceFile("rshapes.c", raylib_flags);
+    raylib.addCSourceFile("rtext.c", raylib_flags);
+    raylib.addCSourceFile("rtextures.c", raylib_flags);
+    raylib.addCSourceFile("utils.c", raylib_flags);
+    raylib.addCSourceFile("rglfw.c", raylib_flags);
+
+    switch (raylib.target.toTarget().os.tag) {
+        .windows => {
+            raylib.linkSystemLibrary("winmm");
+            raylib.linkSystemLibrary("gdi32");
+            raylib.linkSystemLibrary("opengl32");
+            raylib.addIncludeDir("external/glfw/deps/mingw");
+        },
+        .linux => {
+            raylib.linkSystemLibrary("GL");
+            raylib.linkSystemLibrary("rt");
+            raylib.linkSystemLibrary("dl");
+            raylib.linkSystemLibrary("m");
+            raylib.linkSystemLibrary("X11");
+        },
+        else => {
+            @panic("Unsupported OS");
+        },
+    }
+
+    raylib.setOutputDir("./");
+    raylib.install();
+}


### PR DESCRIPTION
@raysan5 as discussed on Discord:

This commit adds a `build.zig` file in `src/` which can be used by the Zig build system to build Raylib. In it's current form it's able to build Raylib into a static library for Windows and Linux.

This has been tested with Zig 0.8.1 in WSL2 on a Windows machine.

How to use:

`cd src/`
`zig build`

This produces a debug build in `src/`. Add one of the following switches to `zig build` command to specify release build type:
`-Drelease-small=true`
`-Drelease-safe=true`
`-Drelease-fast=true`

The Zig compiler has first class support for cross-compilation. Here are some cross-compilation
Cross-compilation examples:

To windows target:
`zig build -Dtarget=native-windows-gnu`

To linux target:
`zig build -Dtarget=native-linux-gnu`