### PR TITLE
[Core] Allow PollEvents to use wait logic

### DIFF
--- a/src/raylib.h
+++ b/src/raylib.h
@@ -946,7 +946,7 @@ RLAPI const char *GetClipboardText(void);                         // Get clipboa
 // By default EndDrawing() does this job: draws everything + SwapScreenBuffer() + manage frame timming + PollInputEvents()
 // To avoid that behaviour and control frame processes manually, enable in config.h: SUPPORT_CUSTOM_FRAME_CONTROL
 RLAPI void SwapScreenBuffer(void);                                // Swap back buffer with front buffer (screen drawing)
-RLAPI void PollInputEvents(void);                                 // Register all input events
+RLAPI void PollInputEvents(bool waitForEvents);                   // Register all input events
 RLAPI void WaitTime(float ms);                                    // Wait for some milliseconds (halt program execution)
 
 // Cursor-related functions

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -2001,7 +2001,12 @@ void EndDrawing(void)
         CORE.Time.frame += waitTime;    // Total frame time: update + draw + wait
     }
 
-    PollInputEvents();      // Poll user events (before next frame update)
+    bool wait = false;
+#if defined(SUPPORT_EVENTS_WAITING)
+    wait = true;
+#endif
+
+    PollInputEvents(wait);      // Poll user events (before next frame update)
 #endif
 
 #if defined(SUPPORT_EVENTS_AUTOMATION)
@@ -4573,7 +4578,7 @@ void SwapScreenBuffer(void)
 }
 
 // Register all input events
-void PollInputEvents(void)
+void PollInputEvents(bool waitForEvents)
 {
 #if defined(SUPPORT_GESTURES_SYSTEM)
     // NOTE: Gestures update must be called every frame to reset gestures correctly
@@ -4719,11 +4724,10 @@ void PollInputEvents(void)
 
     CORE.Window.resizedLastFrame = false;
 
-#if defined(SUPPORT_EVENTS_WAITING)
-    glfwWaitEvents();
-#else
-    glfwPollEvents();       // Register keyboard/mouse events (callbacks)... and window events!
-#endif
+    if (waitForEvents)
+        glfwWaitEvents();
+    else
+        glfwPollEvents();       // Register keyboard/mouse events (callbacks)... and window events!
 #endif  // PLATFORM_DESKTOP
 
 // Gamepad support using emscripten API


### PR DESCRIPTION
This PR moves the test to use the glfw wait logic outside of the PollEvents call and into the EndDrawing. This way people who are using the advanced timing feature can choose to use wait or poll depending on program state not a build flag.