### PR TITLE
[rlgl] restore draw batch state after limit check

### DIFF
--- a/src/rlgl.h
+++ b/src/rlgl.h
@@ -2548,8 +2548,15 @@ bool rlCheckRenderBatchLimit(int vCount)
     if ((RLGL.currentBatch->vertexBuffer[RLGL.currentBatch->currentBuffer].vCounter + vCount) >=
         (RLGL.currentBatch->vertexBuffer[RLGL.currentBatch->currentBuffer].elementCount*4))
     {
+        int currentMode = RLGL.currentBatch->draws[RLGL.currentBatch->drawCounter - 1].mode;
+        int currentTexture = RLGL.currentBatch->draws[RLGL.currentBatch->drawCounter - 1].textureId;
+
         overflow = true;
         rlDrawRenderBatch(RLGL.currentBatch);    // NOTE: Stereo rendering is checked inside
+
+        // restore state of last batch so we can continue adding vertices
+        RLGL.currentBatch->draws[RLGL.currentBatch->drawCounter - 1].mode = currentMode;
+        RLGL.currentBatch->draws[RLGL.currentBatch->drawCounter - 1].textureId = currentTexture;
     }
 #endif
 


### PR DESCRIPTION
The intention behind rlCheckRenderBatchLimit is to occasionally call it to ensure buffer space is available for the next set of vertices to be sent, however if that threshold is reached and rlDrawRenderBatch called to draw existing buffers, the state of all draw batches is reset to default (RL_QUADS and default texture).
This means calling code needs to call rlBegin / rlSetTexture after each rlCheckRenderBatchLimit which returned true; proposed fix automatically restores mode and texture of the active batch so calling code won't need to care if batch did overflow or not.