### PR TITLE
[web] bugfix: ensure resizedLastFrame is cleared

### DIFF
--- a/src/rcore.c
+++ b/src/rcore.c
@@ -4717,14 +4717,16 @@ void PollInputEvents(void)
         }
     }
 
-    CORE.Window.resizedLastFrame = false;
-
 #if defined(SUPPORT_EVENTS_WAITING)
     glfwWaitEvents();
 #else
     glfwPollEvents();       // Register keyboard/mouse events (callbacks)... and window events!
 #endif
 #endif  // PLATFORM_DESKTOP
+
+#if defined(PLATFORM_DESKTOP) || defined(PLATFORM_WEB)
+    CORE.Window.resizedLastFrame = false;
+#else
 
 // Gamepad support using emscripten API
 // NOTE: GLFW3 joystick functionality not available in web


### PR DESCRIPTION
With new emscripten callbacks, resizedLastFrame is now set to true on web platform but is never cleared, resulting in IsWindowResized always returning true. The fix resets the flag in PollInputEvents.