### PR TITLE
[web] fix: reset resizedLastFrame

### DIFF
--- a/src/rcore.c
+++ b/src/rcore.c
@@ -4717,14 +4717,16 @@ void PollInputEvents(void)
         }
     }
 
-    CORE.Window.resizedLastFrame = false;
-
 #if defined(SUPPORT_EVENTS_WAITING)
     glfwWaitEvents();
 #else
     glfwPollEvents();       // Register keyboard/mouse events (callbacks)... and window events!
 #endif
 #endif  // PLATFORM_DESKTOP
+
+#if defined(PLATFORM_DESKTOP) || defined(PLATFORM_WEB)
+    CORE.Window.resizedLastFrame = false;
+#endif
 
 // Gamepad support using emscripten API
 // NOTE: GLFW3 joystick functionality not available in web


### PR DESCRIPTION
With new emscripten callbacks, resizedLastFrame is now set on web platform but is never cleared. The fix resets the flag in PollInputEvents.