### PR TITLE
Revert "reset resizedLastFrame on web platform (#2020)"

### DIFF
--- a/src/rcore.c
+++ b/src/rcore.c
@@ -4724,16 +4724,14 @@ void PollInputEvents(void)
         }
     }
 
+    CORE.Window.resizedLastFrame = false;
+
 #if defined(SUPPORT_EVENTS_WAITING)
     glfwWaitEvents();
 #else
     glfwPollEvents();       // Register keyboard/mouse events (callbacks)... and window events!
 #endif
 #endif  // PLATFORM_DESKTOP
-
-#if defined(PLATFORM_DESKTOP) || defined(PLATFORM_WEB)
-    CORE.Window.resizedLastFrame = false;
-#endif
 
 // Gamepad support using emscripten API
 // NOTE: GLFW3 joystick functionality not available in web


### PR DESCRIPTION
Apologies @raysan5 , it looks like my fix for web resize has broken desktop resize, the flag needs to be cleared before polling events as it looks like those events actually set it.

Please kindly revert my fix and I will PR a proper one once I had a chance to test properly.