### PR TITLE
Fix dll exports so that raylib builds in visual studio again.

### DIFF
--- a/src/raylib.h
+++ b/src/raylib.h
@@ -83,11 +83,6 @@
 
 #define RAYLIB_VERSION  "4.0"
 
-// Function specifiers definition
-#ifndef RLAPI
-    #define RLAPI       // Functions defined as 'extern' by default (implicit specifiers)
-#endif
-
 // Function specifiers in case library is build/used as a shared library (Windows)
 // NOTE: Microsoft specifiers to tell compiler that symbols are imported/exported from a .dll
 #if defined(_WIN32)
@@ -95,7 +90,11 @@
         #define RLAPI __declspec(dllexport)     // We are building the library as a Win32 shared library (.dll)
     #elif defined(USE_LIBTYPE_SHARED)
         #define RLAPI __declspec(dllimport)     // We are using the library as a Win32 shared library (.dll)
+    #else
+        #define RLAPI       // Functions defined as 'extern' by default (implicit specifiers)
     #endif
+#else 
+    #define RLAPI       // Functions defined as 'extern' by default (implicit specifiers)
 #endif
 
 //----------------------------------------------------------------------------------

--- a/src/raymath.h
+++ b/src/raymath.h
@@ -52,29 +52,24 @@
 #endif
 
 // Function specifiers definition
-#ifndef RMAPI
-    #if defined(RAYMATH_IMPLEMENTATION)
-        #define RMAPI extern inline         // Functions defined as 'extern inline' by default
-
-        // Function specifiers in case library is build/used as a shared library (Windows)
-        // NOTE: Microsoft specifiers to tell compiler that symbols are imported/exported from a .dll
-        #if defined(_WIN32)
-            #if defined(BUILD_LIBTYPE_SHARED)
-                #define RMAPI __declspec(dllexport)     // We are building the library as a Win32 shared library (.dll)
-            #elif defined(USE_LIBTYPE_SHARED)
-                #define RMAPI __declspec(dllimport)     // We are using the library as a Win32 shared library (.dll)
-            #endif
-        #endif
-    #elif defined(RAYMATH_STATIC_INLINE)
-        #define RMAPI static inline         // Functions may be inlined, no external out-of-line definition
+#if defined(RAYMATH_IMPLEMENTATION)
+    #if defined(_WIN32) && defined(BUILD_LIBTYPE_SHARED)
+        #define RMAPI __declspec(dllexport) extern inline // We are building raylib as a Win32 shared library (.dll).
+    #elif defined(_WIN32) && defined(USE_LIBTYPE_SHARED)
+        #define RMAPI __declspec(dllimport)         // We are using raylib as a Win32 shared library (.dll)
     #else
-        #if defined(__TINYC__)
-            #define RMAPI static inline     // WARNING: Plain inline not supported by tinycc (See issue #435)
-        #else
-            #define RMAPI inline
-        #endif
+        #define RMAPI extern inline // Provide external definition
+    #endif
+#elif defined(RAYMATH_STATIC_INLINE)
+    #define RMAPI static inline // Functions may be inlined, no external out-of-line definition
+#else
+    #if defined(__TINYC__)
+        #define RMAPI static inline // plain inline not supported by tinycc (See issue #435)
+    #else
+        #define RMAPI inline        // Functions may be inlined or external definition used
     #endif
 #endif
+	
 
 //----------------------------------------------------------------------------------
 // Defines and Macros


### PR DESCRIPTION
This PR fixes some issues with the API #defs for raylib and raymath.
Presently, raylib will not build in visual studio 2019 as a dll, because the raymath functions get inlined into both rcore.c and rmodel.c. 

![image](https://user-images.githubusercontent.com/322174/136433099-93550e60-43ed-4e48-b712-f9e6a3bf7624.png)

This PR fixes this issue.

This pr also removes a warning about duplicate raylib api #defines in raylib.h