### PR TITLE
Add missing #endif to windows API defines

### DIFF
--- a/src/raylib.h
+++ b/src/raylib.h
@@ -90,6 +90,7 @@
         #define RLAPI __declspec(dllexport)     // We are building the library as a Win32 shared library (.dll)
     #elif defined(USE_LIBTYPE_SHARED)
         #define RLAPI __declspec(dllimport)     // We are using the library as a Win32 shared library (.dll)
+    #endif
 #endif
 
 #ifndef RLAPI


### PR DESCRIPTION
This PR makes raylib build on windows again.