### PR TITLE
[Documentation] Move older and abandoned bindings to new section at the end of the file

### DIFF
--- a/BINDINGS.md
+++ b/BINDINGS.md
@@ -16,6 +16,7 @@ Some people ported raylib to other languages in form of bindings or wrappers to 
 | raylua             | 3.7 | [Lua](http://www.lua.org/)            | https://github.com/Rabios/raylua          |
 | nelua-raylib       | 3.7 | [nelua](https://nelua.io/)            | https://github.com/AKDev21/nelua-raylib |
 | NimraylibNow!      | 3.7 | [Nim](https://nim-lang.org/)          | https://github.com/greenfork/nimraylib_now        |
+| raylib-Forever     | auto | [Nim](https://nim-lang.org/)          | https://github.com/Guevara-chan/Raylib-Forever    |
 | Ray4Laz            | 3.7 | [Pascal](https://en.wikipedia.org/wiki/Pascal_(programming_language))         | https://github.com/GuvaCode/Ray4Laz      | 
 | pyraylib          | 3.7 | [Python](https://www.python.org/)        |   https://github.com/Ho011/pyraylib       |
 | raylib-python-cffi | 3.7 | [Python](https://www.python.org/)        | https://github.com/electronstudio/raylib-python-cffi    |
@@ -63,7 +64,6 @@ These are older raylib bindings that are more than 2 versions old or have not be
 | raylib-nelua       | 3.0 | [Nelua](https://nelua.io/)            | https://github.com/Andre-LA/raylib-nelua     |
 | raylib-nim         | 2.0 | [Nim](https://nim-lang.org/)          | https://github.com/Skrylar/raylib-nim                  |
 | raylib-Nim         | 1.7 | [Nim](https://nim-lang.org/)          | https://gitlab.com/define-private-public/raylib-Nim     |
-| raylib-Forever     | 3.1-dev | [Nim](https://nim-lang.org/)          | https://github.com/Guevara-chan/Raylib-Forever    |
 | nim-raylib         | 3.1-dev | [Nim](https://nim-lang.org/)          | https://github.com/tomc1998/nim-raylib            |
 | raylib-haskell     | 2.0 | [Haskell](https://www.haskell.org/)   | https://github.com/DevJac/raylib-haskell |
 | raylib-cr          | 2.5-dev | [Crystal](https://crystal-lang.org/)  | https://github.com/AregevDev/raylib-cr      |


### PR DESCRIPTION
This PR, reorders the bindings file to move bindings that are abandoned or use older versions down to the bottom of the file, so that people don't have to search though a ton of old bindings to find what they are looking for.
Bindings more than 2 versions old are considered abandoned (older than v3.5), or if there is a binding for the language that targets a newer ersion.

The file can be seen in markdown here.
https://github.com/JeffM2501/raylib/blob/bindings_update/BINDINGS.md