### PR TITLE
Support create OpenGL debug context in OpenGL 4.3

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -84,6 +84,10 @@
 //------------------------------------------------------------------------------------
 // Module: rlgl - Configuration values
 //------------------------------------------------------------------------------------
+
+// Enable OpenGL Debug Context (only OpenGL 4.3)
+//#define RLGL_ENABLE_OPENGL_DEBUG_CONTEXT       1
+
 // Show OpenGL extensions and capabilities detailed logs on init
 //#define RLGL_SHOW_GL_DETAILS_INFO        1
 

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -498,9 +498,7 @@ typedef enum {
     FLAG_WINDOW_TRANSPARENT = 0x00000010,   // Set to allow transparent framebuffer
     FLAG_WINDOW_HIGHDPI     = 0x00002000,   // Set to support HighDPI
     FLAG_MSAA_4X_HINT       = 0x00000020,   // Set to try enabling MSAA 4X
-    FLAG_INTERLACED_HINT    = 0x00010000,   // Set to try enabling interlaced video format (for V3D)
-    FLAG_OPENGL_DEBUG       = 0x00004000,   // Set to support GL_DEBUG_OUTPUT - Faster version but not useful for breakpoints
-    FLAG_OPENGL_DEBUG_SYNC  = 0x00008000    // Set to support GL_DEBUG_OUTPUT_SYNCHRONOUS - Callback is in sync with errors, so a breakpoint can be placed on the callback in order to get a stacktrace for the GL error.
+    FLAG_INTERLACED_HINT    = 0x00010000    // Set to try enabling interlaced video format (for V3D)
 } ConfigFlags;
 
 // Trace log level

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -3708,49 +3708,6 @@ int GetTouchPointCount(void)
 //----------------------------------------------------------------------------------
 // Module specific Functions Definition
 //----------------------------------------------------------------------------------
-#if defined(GRAPHICS_API_OPENGL_43) && defined(PLATFORM_DESKTOP)
-static void GLAPIENTRY DebugMessageCallback(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const GLchar* message, const void* user_param)
-{
-    // ignore non-significant error/warning codes
-    if (id == 131169 || id == 131185 || id == 131218 || id == 131204) return;
-
-    const char* msgSource = NULL;
-    switch (source)
-    {
-    case GL_DEBUG_SOURCE_API: msgSource = "API"; break;
-    case GL_DEBUG_SOURCE_WINDOW_SYSTEM: msgSource = "WINDOW_SYSTEM"; break;
-    case GL_DEBUG_SOURCE_SHADER_COMPILER: msgSource = "SHADER_COMPILER"; break;
-    case GL_DEBUG_SOURCE_THIRD_PARTY: msgSource = "THIRD_PARTY"; break;
-    case GL_DEBUG_SOURCE_APPLICATION: msgSource = "APPLICATION"; break;
-    case GL_DEBUG_SOURCE_OTHER: msgSource = "OTHER"; break;
-    }
-
-    const char* msgType = NULL;
-    switch (type)
-    {
-    case GL_DEBUG_TYPE_ERROR: msgType = "ERROR"; break;
-    case GL_DEBUG_TYPE_DEPRECATED_BEHAVIOR: msgType = "DEPRECATED_BEHAVIOR"; break;
-    case GL_DEBUG_TYPE_UNDEFINED_BEHAVIOR: msgType = "UNDEFINED_BEHAVIOR"; break;
-    case GL_DEBUG_TYPE_PORTABILITY: msgType = "PORTABILITY"; break;
-    case GL_DEBUG_TYPE_PERFORMANCE: msgType = "PERFORMANCE"; break;
-    case GL_DEBUG_TYPE_MARKER: msgType = "MARKER"; break;
-    case GL_DEBUG_TYPE_PUSH_GROUP: msgType = "PUSH_GROUP"; break;
-    case GL_DEBUG_TYPE_POP_GROUP: msgType = "POP_GROUP"; break;
-    case GL_DEBUG_TYPE_OTHER: msgType = "OTHER"; break;
-    }
-
-    const char* msgSeverity = "DEFAULT";
-    switch (severity)
-    {
-    case GL_DEBUG_SEVERITY_LOW: msgSeverity = "LOW"; break;
-    case GL_DEBUG_SEVERITY_MEDIUM: msgSeverity = "MEDIUM"; break;
-    case GL_DEBUG_SEVERITY_HIGH: msgSeverity = "HIGH"; break;
-    case GL_DEBUG_SEVERITY_NOTIFICATION: msgSeverity = "NOTIFICATION"; break;
-    }
-
-    TRACELOG(LOG_WARNING, "OpenGL Debug Message: %s, type = %s, source = %s, severity = %s", message, msgType, msgSource, msgSeverity);
-}
-#endif // GRAPHICS_API_OPENGL_43 && PLATFORM_DESKTOP
 
 // Initialize display device and framebuffer
 // NOTE: width and height represent the screen (framebuffer) desired size, not actual display size
@@ -3902,13 +3859,9 @@ static bool InitGraphicsDevice(int width, int height)
         glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
         glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GLFW_FALSE);
 
-#if defined(GRAPHICS_API_OPENGL_43) && defined(PLATFORM_DESKTOP)
-        // Enable OpenGl Debug Context
-        if ((CORE.Window.flags & FLAG_OPENGL_DEBUG) || (CORE.Window.flags & FLAG_OPENGL_DEBUG_SYNC))
-        {
-            glfwWindowHint(GLFW_OPENGL_DEBUG_CONTEXT, GLFW_TRUE);
-        }
-#endif // GRAPHICS_API_OPENGL_43 && PLATFORM_DESKTOP
+#if defined(RLGL_ENABLE_OPENGL_DEBUG_CONTEXT)
+        glfwWindowHint(GLFW_OPENGL_DEBUG_CONTEXT, GLFW_TRUE);   // Enable OpenGL Debug Context
+#endif
     }
     else if (rlGetVersion() == OPENGL_ES_20)                    // Request OpenGL ES 2.0 context
     {
@@ -4457,22 +4410,6 @@ static bool InitGraphicsDevice(int width, int height)
     rlLoadExtensions(glfwGetProcAddress);
 #else
     rlLoadExtensions(eglGetProcAddress);
-#endif
-
-#if defined(GRAPHICS_API_OPENGL_43) && defined(PLATFORM_DESKTOP)
-    if (glDebugMessageCallback != NULL && glDebugMessageControl != NULL)
-    {
-        if ((CORE.Window.flags & FLAG_OPENGL_DEBUG) || (CORE.Window.flags & FLAG_OPENGL_DEBUG_SYNC))
-        {
-            glDebugMessageCallback(DebugMessageCallback, 0);
-            // glDebugMessageControl(GL_DEBUG_SOURCE_API, GL_DEBUG_TYPE_ERROR, GL_DEBUG_SEVERITY_HIGH, 0, 0, GL_TRUE); // TODO: filter message
-
-            // GL_DEBUG_OUTPUT - Faster version but not useful for breakpoints
-            // GL_DEBUG_OUTPUT_SYNCHRONUS - Callback is in sync with errors, so a breakpoint can be placed on the callback in order to get a stacktrace for the GL error.
-            glEnable(GL_DEBUG_OUTPUT);
-            if (CORE.Window.flags & FLAG_OPENGL_DEBUG_SYNC) glEnable(GL_DEBUG_OUTPUT_SYNCHRONOUS);
-        } 
-    }
 #endif
 
     int fbWidth = CORE.Window.screen.width;

--- a/src/rlgl.h
+++ b/src/rlgl.h
@@ -1798,12 +1798,74 @@ void rlSetBlendFactors(int glSrcFactor, int glDstFactor, int glEquation)
 }
 
 //----------------------------------------------------------------------------------
+// Module Functions Definition - OpenGL Debug
+//----------------------------------------------------------------------------------
+
+#if defined(RLGL_ENABLE_OPENGL_DEBUG_CONTEXT) && defined(GRAPHICS_API_OPENGL_43)
+static void GLAPIENTRY rlDebugMessageCallback(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const GLchar *message, const void *userParam)
+{
+    // ignore non-significant error/warning codes
+    if (id == 131169 || id == 131185 || id == 131218 || id == 131204) return;
+
+    const char *msgSource = NULL;
+    switch (source)
+    {
+    case GL_DEBUG_SOURCE_API:             msgSource = "API"; break;
+    case GL_DEBUG_SOURCE_WINDOW_SYSTEM:   msgSource = "WINDOW_SYSTEM"; break;
+    case GL_DEBUG_SOURCE_SHADER_COMPILER: msgSource = "SHADER_COMPILER"; break;
+    case GL_DEBUG_SOURCE_THIRD_PARTY:     msgSource = "THIRD_PARTY"; break;
+    case GL_DEBUG_SOURCE_APPLICATION:     msgSource = "APPLICATION"; break;
+    case GL_DEBUG_SOURCE_OTHER:           msgSource = "OTHER"; break;
+    }
+
+    const char *msgType = NULL;
+    switch (type)
+    {
+    case GL_DEBUG_TYPE_ERROR:               msgType = "ERROR"; break;
+    case GL_DEBUG_TYPE_DEPRECATED_BEHAVIOR: msgType = "DEPRECATED_BEHAVIOR"; break;
+    case GL_DEBUG_TYPE_UNDEFINED_BEHAVIOR:  msgType = "UNDEFINED_BEHAVIOR"; break;
+    case GL_DEBUG_TYPE_PORTABILITY:         msgType = "PORTABILITY"; break;
+    case GL_DEBUG_TYPE_PERFORMANCE:         msgType = "PERFORMANCE"; break;
+    case GL_DEBUG_TYPE_MARKER:              msgType = "MARKER"; break;
+    case GL_DEBUG_TYPE_PUSH_GROUP:          msgType = "PUSH_GROUP"; break;
+    case GL_DEBUG_TYPE_POP_GROUP:           msgType = "POP_GROUP"; break;
+    case GL_DEBUG_TYPE_OTHER:               msgType = "OTHER"; break;
+    }
+
+    const char *msgSeverity = "DEFAULT";
+    switch (severity)
+    {
+    case GL_DEBUG_SEVERITY_LOW:          msgSeverity = "LOW"; break;
+    case GL_DEBUG_SEVERITY_MEDIUM:       msgSeverity = "MEDIUM"; break;
+    case GL_DEBUG_SEVERITY_HIGH:         msgSeverity = "HIGH"; break;
+    case GL_DEBUG_SEVERITY_NOTIFICATION: msgSeverity = "NOTIFICATION"; break;
+    }
+
+    TRACELOG(LOG_WARNING, "OpenGL Debug Message: %s, type = %s, source = %s, severity = %s", message, msgType, msgSource, msgSeverity);
+}
+#endif
+
+//----------------------------------------------------------------------------------
 // Module Functions Definition - rlgl functionality
 //----------------------------------------------------------------------------------
 
 // Initialize rlgl: OpenGL extensions, default buffers/shaders/textures, OpenGL states
 void rlglInit(int width, int height)
 {
+    // Enable OpenGL Debug Context
+#if defined(RLGL_ENABLE_OPENGL_DEBUG_CONTEXT) && defined(GRAPHICS_API_OPENGL_43)
+    if (glDebugMessageCallback != NULL && glDebugMessageControl != NULL)
+    {
+        glDebugMessageCallback(rlDebugMessageCallback, 0);
+        // glDebugMessageControl(GL_DEBUG_SOURCE_API, GL_DEBUG_TYPE_ERROR, GL_DEBUG_SEVERITY_HIGH, 0, 0, GL_TRUE); // TODO: filter message
+
+        // GL_DEBUG_OUTPUT - Faster version but not useful for breakpoints
+        // GL_DEBUG_OUTPUT_SYNCHRONUS - Callback is in sync with errors, so a breakpoint can be placed on the callback in order to get a stacktrace for the GL error.
+        glEnable(GL_DEBUG_OUTPUT);
+        glEnable(GL_DEBUG_OUTPUT_SYNCHRONOUS);
+    }
+#endif
+
 #if defined(GRAPHICS_API_OPENGL_33) || defined(GRAPHICS_API_OPENGL_ES2)
     // Init default white texture
     unsigned char pixels[4] = { 255, 255, 255, 255 };   // 1 pixel RGBA (4 bytes)


### PR DESCRIPTION
Support enable  OpenGL debug context.
More details: https://www.khronos.org/opengl/wiki/Debug_Output
Only works with GRAPHICS_API_OPENGL_43 and PLATFORM_DESKTOP. I'm not sure if the extension is available on mobile or web. 
FLAG_OPENGL_DEBUG_SYNC allows you to put a brickpoint inside the debugMessageCallback function with the help of which you can find the place of the call with an error. 

To enable this mode:
SetConfigFlags(FLAG_OPENGL_DEBUG_SYNC);
InitWindow(screenWidth, screenHeight, "Example");

It immediately finds two problems in the raylib code:

Function rlEnableTextureCubemap(), Line glEnable(GL_TEXTURE_CUBE_MAP); ==> OpenGL Debug Message: Error has been generated. GL error GL_INVALID_ENUM in Enable: (ID: 1452659001) Generic error, type = ERROR, source = API, severity = HIGH
Function rlDisableTextureCubemap(), Line glDisable(GL_TEXTURE_CUBE_MAP); ==> OpenGL Debug Message: Error has been generated. GL error GL_INVALID_ENUM in Disable: (ID: 1328517522) Generic error, type = ERROR, source = API, severity = HIGH

I'm not sure, but if we remove glEnable (GL_TEXTURE_CUBE_MAP) and glDisable (GL_TEXTURE_CUBE_MAP), then there is no more error, and the cube map works. Haven't done anything about it yet.


And Function rlUnloadRenderBatch(), glDisableVertexAttribArray => OpenGL Debug Message: Error has been generated. GL error GL_INVALID_OPERATION in DisableVertexAttribArray: (ID: 3860911800) Generic error, type = ERROR, source = API, severity = HIGH
In documentation (https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glEnableVertexAttribArray.xhtml) ==>
GL_INVALID_OPERATION is generated by glEnableVertexAttribArray and glDisableVertexAttribArray if no vertex array object is bound.
