### PR TITLE
Reset resizedLastFrame on web platform

### DIFF
--- a/src/rcore.c
+++ b/src/rcore.c
@@ -4849,6 +4849,10 @@ void PollInputEvents(void)
 #endif
 #endif  // PLATFORM_DESKTOP
 
+#if defined(PLATFORM_WEB)
+    CORE.Window.resizedLastFrame = false;
+#endif  // PLATFORM_WEB
+
 // Gamepad support using emscripten API
 // NOTE: GLFW3 joystick functionality not available in web
 #if defined(PLATFORM_WEB)


### PR DESCRIPTION
With new emscripten callbacks, resizedLastFrame is now set on web platform but is never cleared. The fix resets the flag in PollInputEvents (resubmitting fixed PR).
