### PR TITLE
Add missing file extensions for drag-and-drop support

### DIFF
--- a/examples/models/models_loading.c
+++ b/examples/models/models_loading.c
@@ -74,6 +74,8 @@ int main(void)
             {
                 if (IsFileExtension(droppedFiles[0], ".obj") ||
                     IsFileExtension(droppedFiles[0], ".gltf") ||
+                    IsFileExtension(droppedFiles[0], ".glb") ||
+                    IsFileExtension(droppedFiles[0], ".vox") ||
                     IsFileExtension(droppedFiles[0], ".iqm"))       // Model file formats supported
                 {
                     UnloadModel(model);                     // Unload previous model


### PR DESCRIPTION
When trying to test some of my models, I noticed that .glb was missing from the extensions that it checks for upon dropping a file on the window. This PR also checks for the missing extensions.