### PR TITLE
Add DrawTriangleGradient()

### DIFF
--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1174,7 +1174,6 @@ RLAPI void DrawRectangleLinesEx(Rectangle rec, float lineThick, Color color);   
 RLAPI void DrawRectangleRounded(Rectangle rec, float roundness, int segments, Color color);              // Draw rectangle with rounded edges
 RLAPI void DrawRectangleRoundedLines(Rectangle rec, float roundness, int segments, float lineThick, Color color); // Draw rectangle with rounded edges outline
 RLAPI void DrawTriangle(Vector2 v1, Vector2 v2, Vector2 v3, Color color);                                // Draw a color-filled triangle (vertex in counter-clockwise order!)
-RLAPI void DrawTriangleGradient(Vector2 v1, Vector2 v2, Vector2 v3, Color c1, Color c2, Color c3);       // Draw a gradient-filled triangle with custom vertex colors (vertex in counter-clockwise order!)
 RLAPI void DrawTriangleLines(Vector2 v1, Vector2 v2, Vector2 v3, Color color);                           // Draw triangle outline (vertex in counter-clockwise order!)
 RLAPI void DrawTriangleFan(Vector2 *points, int pointCount, Color color);                                // Draw a triangle fan defined by points (first vertex is the center)
 RLAPI void DrawTriangleStrip(Vector2 *points, int pointCount, Color color);                              // Draw a triangle strip defined by points

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1174,6 +1174,7 @@ RLAPI void DrawRectangleLinesEx(Rectangle rec, float lineThick, Color color);   
 RLAPI void DrawRectangleRounded(Rectangle rec, float roundness, int segments, Color color);              // Draw rectangle with rounded edges
 RLAPI void DrawRectangleRoundedLines(Rectangle rec, float roundness, int segments, float lineThick, Color color); // Draw rectangle with rounded edges outline
 RLAPI void DrawTriangle(Vector2 v1, Vector2 v2, Vector2 v3, Color color);                                // Draw a color-filled triangle (vertex in counter-clockwise order!)
+RLAPI void DrawTriangleGradient(Vector2 v1, Vector2 v2, Vector2 v3, Color c1, Color c2, Color c3);       // Draw a gradient-filled triangle with custom vertex colors (vertex in counter-clockwise order!)
 RLAPI void DrawTriangleLines(Vector2 v1, Vector2 v2, Vector2 v3, Color color);                           // Draw triangle outline (vertex in counter-clockwise order!)
 RLAPI void DrawTriangleFan(Vector2 *points, int pointCount, Color color);                                // Draw a triangle fan defined by points (first vertex is the center)
 RLAPI void DrawTriangleStrip(Vector2 *points, int pointCount, Color color);                              // Draw a triangle strip defined by points

--- a/src/rshapes.c
+++ b/src/rshapes.c
@@ -741,6 +741,8 @@ void DrawRectangleGradientH(int posX, int posY, int width, int height, Color col
 // NOTE: Colors refer to corners, starting at top-lef corner and counter-clockwise
 void DrawRectangleGradientEx(Rectangle rec, Color col1, Color col2, Color col3, Color col4)
 {
+    rlCheckRenderBatchLimit(4);
+    
     rlSetTexture(texShapes.id);
 
     rlPushMatrix();

--- a/src/rshapes.c
+++ b/src/rshapes.c
@@ -1323,47 +1323,6 @@ void DrawTriangle(Vector2 v1, Vector2 v2, Vector2 v3, Color color)
 #endif
 }
 
-// Draw a gradient-filled triangle
-// NOTE: Vertex must be provided in counter-clockwise order
-void DrawTriangleGradient(Vector2 v1, Vector2 v2, Vector2 v3, Color c1, Color c2, Color c3)
-{
-    rlCheckRenderBatchLimit(4);
-
-#if defined(SUPPORT_QUADS_DRAW_MODE)
-    rlSetTexture(texShapes.id);
-
-    rlBegin(RL_QUADS);
-
-    rlColor4ub(c1.r, c1.g, c1.b, c1.a);
-    rlTexCoord2f(texShapesRec.x/texShapes.width, texShapesRec.y/texShapes.height);
-    rlVertex2f(v1.x, v1.y);
-
-    rlColor4ub(c2.r, c2.g, c2.b, c2.a);
-    rlTexCoord2f(texShapesRec.x/texShapes.width, (texShapesRec.y + texShapesRec.height)/texShapes.height);
-    rlVertex2f(v2.x, v2.y);
-
-    rlColor4ub(c2.r, c2.g, c2.b, c2.a);
-    rlTexCoord2f((texShapesRec.x + texShapesRec.width)/texShapes.width, (texShapesRec.y + texShapesRec.height)/texShapes.height);
-    rlVertex2f(v2.x, v2.y);
-
-    rlColor4ub(c3.r, c3.g, c3.b, c3.a);
-    rlTexCoord2f((texShapesRec.x + texShapesRec.width)/texShapes.width, texShapesRec.y/texShapes.height);
-    rlVertex2f(v3.x, v3.y);
-    rlEnd();
-
-    rlSetTexture(0);
-#else
-    rlBegin(RL_TRIANGLES);
-        rlColor4ub(c1.r, c1.g, c1.b, c1.a);
-        rlVertex2f(v1.x, v1.y);
-        rlColor4ub(c2.r, c2.g, c2.b, c2.a);
-        rlVertex2f(v2.x, v2.y);
-        rlColor4ub(c3.r, c3.g, c3.b, c3.a);
-        rlVertex2f(v3.x, v3.y);
-    rlEnd();
-#endif
-}
-
 // Draw a triangle using lines
 // NOTE: Vertex must be provided in counter-clockwise order
 void DrawTriangleLines(Vector2 v1, Vector2 v2, Vector2 v3, Color color)

--- a/src/rshapes.c
+++ b/src/rshapes.c
@@ -1323,6 +1323,47 @@ void DrawTriangle(Vector2 v1, Vector2 v2, Vector2 v3, Color color)
 #endif
 }
 
+// Draw a gradient-filled triangle
+// NOTE: Vertex must be provided in counter-clockwise order
+void DrawTriangleGradient(Vector2 v1, Vector2 v2, Vector2 v3, Color c1, Color c2, Color c3)
+{
+    rlCheckRenderBatchLimit(4);
+
+#if defined(SUPPORT_QUADS_DRAW_MODE)
+    rlSetTexture(texShapes.id);
+
+    rlBegin(RL_QUADS);
+
+    rlColor4ub(c1.r, c1.g, c1.b, c1.a);
+    rlTexCoord2f(texShapesRec.x/texShapes.width, texShapesRec.y/texShapes.height);
+    rlVertex2f(v1.x, v1.y);
+
+    rlColor4ub(c2.r, c2.g, c2.b, c2.a);
+    rlTexCoord2f(texShapesRec.x/texShapes.width, (texShapesRec.y + texShapesRec.height)/texShapes.height);
+    rlVertex2f(v2.x, v2.y);
+
+    rlColor4ub(c2.r, c2.g, c2.b, c2.a);
+    rlTexCoord2f((texShapesRec.x + texShapesRec.width)/texShapes.width, (texShapesRec.y + texShapesRec.height)/texShapes.height);
+    rlVertex2f(v2.x, v2.y);
+
+    rlColor4ub(c3.r, c3.g, c3.b, c3.a);
+    rlTexCoord2f((texShapesRec.x + texShapesRec.width)/texShapes.width, texShapesRec.y/texShapes.height);
+    rlVertex2f(v3.x, v3.y);
+    rlEnd();
+
+    rlSetTexture(0);
+#else
+    rlBegin(RL_TRIANGLES);
+        rlColor4ub(c1.r, c1.g, c1.b, c1.a);
+        rlVertex2f(v1.x, v1.y);
+        rlColor4ub(c2.r, c2.g, c2.b, c2.a);
+        rlVertex2f(v2.x, v2.y);
+        rlColor4ub(c3.r, c3.g, c3.b, c3.a);
+        rlVertex2f(v3.x, v3.y);
+    rlEnd();
+#endif
+}
+
 // Draw a triangle using lines
 // NOTE: Vertex must be provided in counter-clockwise order
 void DrawTriangleLines(Vector2 v1, Vector2 v2, Vector2 v3, Color color)


### PR DESCRIPTION
Currently it's only possible to draw rectangles with gradients that aren't rotated. You can get around that by for example rendering to a texture and rotating it, but DrawTriangleGradient() skips that and lets you directly draw a triangle with a gradient. if you want to draw a rotated rectangle with a gradient you can just draw two triangles

(Also drawing Triangles with gradiants was impossible before I think)