### PR TITLE
Protect TextIsEqual from NULLs

### DIFF
--- a/src/rtext.c
+++ b/src/rtext.c
@@ -1142,6 +1142,10 @@ bool TextIsEqual(const char *text1, const char *text2)
 {
     bool result = false;
 
+    if (text1 == NULL || text2 == NULL) {
+        return false;
+    }
+
     if (strcmp(text1, text2) == 0) result = true;
 
     return result;


### PR DESCRIPTION
I was running the [core_input_gamepad](https://github.com/raysan5/raylib/blob/master/examples/core/core_input_gamepad.c) example program with a PS4 Controller and disconnected and reconnected the USB cable. The program crashed with a EXC_BAD_ACCESS (SIGSEGV). The SIGSEGV happens in [core_input_gamepad.c](https://github.com/raysan5/raylib/blob/3f595fda2613cf2620c1d8ed31506a72905ff170/examples/core/core_input_gamepad.c#L65) when [GetGamepadName](https://github.com/raysan5/raylib/blob/3f595fda2613cf2620c1d8ed31506a72905ff170/src/rcore.c#L3378) returns a NULL (when the gamepad is disconnected) and [TextIsEqual](https://github.com/raysan5/raylib/blob/3f595fda2613cf2620c1d8ed31506a72905ff170/src/rtext.c#L1141) attempts to compare two strings with one of them a NULL. TextIsEqual uses [strcmp](https://www.cplusplus.com/reference/cstring/strcmp/) which has undefined behaviour when one or both strings are NULL. It seemed like a good place to put a NULL check was in TextIsEqual. I think that when one of the strings being compared was NULL, returning false would be always the desired behaviour. Also I've returned false instead of the variable result because if one or both of the strings is NULL, you will always want to return false. Someone may change the default result variable to true, and then the check would break.

I've only tested this on macOS Big Sur Intel.