### PR TITLE
[rlgl] Allow GL4.3 capabilities to be shown

### DIFF
--- a/src/rlgl.h
+++ b/src/rlgl.h
@@ -2160,13 +2160,12 @@ void rlLoadExtensions(void *loader)
     for (int i = 0; i < capability; i++) TRACELOG(RL_LOG_INFO, "        %s", rlGetCompressedFormatName(compFormats[i]));
     RL_FREE(compFormats);
 
-    /*
-    // Following capabilities are only supported by OpenGL 4.3 or greater
+#if defined(GRAPHICS_API_OPENGL_43)
     glGetIntegerv(GL_MAX_VERTEX_ATTRIB_BINDINGS, &capability);
     TRACELOG(RL_LOG_INFO, "    GL_MAX_VERTEX_ATTRIB_BINDINGS: %i", capability);
     glGetIntegerv(GL_MAX_UNIFORM_LOCATIONS, &capability);
     TRACELOG(RL_LOG_INFO, "    GL_MAX_UNIFORM_LOCATIONS: %i", capability);
-    */
+#endif  // GRAPHICS_API_OPENGL_43
 #else   // RLGL_SHOW_GL_DETAILS_INFO
 
     // Show some basic info about GL supported features


### PR DESCRIPTION
Since 4.3 was added the commented out capabilities can be shown.