### PR TITLE
ExportMesh only exported 1/3 of the faces

### DIFF
--- a/src/rmodels.c
+++ b/src/rmodels.c
@@ -1651,7 +1651,7 @@ bool ExportMesh(Mesh mesh, const char *fileName)
                        mesh.triangleCount/3* (int)strlen("f 00000/00000/00000 00000/00000/00000 00000/00000/00000");
 
         // NOTE: Text data buffer size is estimated considering mesh data size
-        char *txtData = (char *)RL_CALLOC(dataSize + 2000, sizeof(char));
+        char *txtData = (char *)RL_CALLOC(dataSize + 2000, sizeof(char)*4);
 
         int byteCount = 0;
         byteCount += sprintf(txtData + byteCount, "# //////////////////////////////////////////////////////////////////////////////////\n");
@@ -1684,9 +1684,9 @@ bool ExportMesh(Mesh mesh, const char *fileName)
             byteCount += sprintf(txtData + byteCount, "vn %.3f %.3f %.3f\n", mesh.normals[v], mesh.normals[v + 1], mesh.normals[v + 2]);
         }
 
-        for (int i = 0; i < mesh.triangleCount; i += 3)
+        for (int i = 0; i < mesh.vertexCount; i += 3)
         {
-            byteCount += sprintf(txtData + byteCount, "f %i/%i/%i %i/%i/%i %i/%i/%i\n", i, i, i, i + 1, i + 1, i + 1, i + 2, i + 2, i + 2);
+            byteCount += sprintf(txtData + byteCount, "f %i/%i/%i %i/%i/%i %i/%i/%i\n", i+1, i+1, i+1, i + 2, i + 2, i + 2, i + 3, i + 3, i + 3);
         }
 
         byteCount += sprintf(txtData + byteCount, "\n");


### PR DESCRIPTION
ExportMesh was only exporting partial face lists for unique faces, should iterate the vertex/3 not facelist/3

This might be the indented functionality for connected meshes? I don't think it would work in that case either though. I only tested with procedural meshes, that seemed to not  return connected faces. Which makes sense for opengl.
like
`GenMeshSphere(1.0, 12,12);`

I'll have to see if there is also a better way to collect a proper export textData size, for now calloc(datasize,4) worked ok, without this it was causing a crash (on windows)

A optimization step to fuse duplicate vertex data would be nice in the future.

Tested the changes on windows/mingw64 seemed to be fine.