### PR TITLE
Fix scissor mode for high DPI screens

### DIFF
--- a/src/rcore.c
+++ b/src/rcore.c
@@ -601,6 +601,8 @@ static bool InitGraphicsDevice(int width, int height);  // Initialize graphics d
 static void SetupFramebuffer(int width, int height);    // Setup main framebuffer
 static void SetupViewport(int width, int height);       // Set viewport for a provided width and height
 
+static void SetHighDPIFromWindowScale(void);            // Helper function to set window high DPI flag from window scale
+
 #if defined(PLATFORM_DESKTOP) || defined(PLATFORM_WEB)
 static void ErrorCallback(int error, const char *description);                             // GLFW3 Error Callback, runs on GLFW3 error
 // Window callbacks events
@@ -805,6 +807,7 @@ void InitWindow(int width, int height, const char *title)
     SetShapesTexture(texture, (Rectangle){ 0.0f, 0.0f, 1.0f, 1.0f });
 #endif
 #if defined(PLATFORM_DESKTOP)
+    SetHighDPIFromWindowScale();
     if ((CORE.Window.flags & FLAG_WINDOW_HIGHDPI) > 0)
     {
         // Set default font texture filter for HighDPI (blurry)
@@ -1452,6 +1455,13 @@ void ClearWindowState(unsigned int flags)
         TRACELOG(LOG_WARNING, "RPI: Interlaced mode can only by configured before window initialization");
     }
 #endif
+}
+
+// Helper function to set window high DPI flag from window scale
+void SetHighDPIFromWindowScale()
+{
+    Vector2 scale = GetWindowScaleDPI();
+    if (scale.x > 1 || scale.y > 1) SetConfigFlags(FLAG_WINDOW_HIGHDPI);
 }
 
 // Set icon for window (only PLATFORM_DESKTOP)
@@ -2188,7 +2198,8 @@ void BeginScissorMode(int x, int y, int width, int height)
     {
         Vector2 scale = GetWindowScaleDPI();
 
-        rlScissor((int)(x*scale.x), (int)(CORE.Window.currentFbo.height - (y + height)*scale.y), (int)(width*scale.x), (int)(height*scale.y));
+        rlScissor((int)(x*scale.x), (int)(CORE.Window.currentFbo.height - y*scale.y - height/scale.y),
+                  (int)(width*scale.x), (int)(height*scale.y));
     }
     else
     {


### PR DESCRIPTION
I was running the [core scissor test](https://github.com/raysan5/raylib/blob/master/examples/core/core_scissor_test.c) example on a MacBook Pro (macOS Big Sur Intel) which is high DPI (2x). When running the test the scissor square was not lined up with the mouse square outline. I've raised issue (#2142)  and submitted a screenshot. I found that the [rlScissor](https://github.com/raysan5/raylib/blob/6342cf103a4d8b407e84a87fd711e10d8df940e2/src/rcore.c#L2191) call wasn't quite right. Also that line wasn't being called because the [CORE.Window.flags hadn't had the FLAG_WINDOW_HIGHDPI set](https://github.com/raysan5/raylib/blob/6342cf103a4d8b407e84a87fd711e10d8df940e2/src/rcore.c#L2187).

Note that I've added code to set the FLAG_WINDOW_HIGHDPI CORE.Window.flags, but only on desktop (via the PLATFORM_DESKTOP define). The reason for desktop restriction, was that I wasn't sure of the impact of that code for broader deployments other than desktop.

This was only tested on macOS Big Sur with HIGH DPI.