### PR TITLE
fix bug in rlMatrixMode

### DIFF
--- a/src/rlgl.h
+++ b/src/rlgl.h
@@ -1034,7 +1034,13 @@ void rlMultMatrixf(float *matf) { glMultMatrixf(matf); }
 void rlMatrixMode(int mode)
 {
     if (mode == RL_PROJECTION) RLGL.State.currentMatrix = &RLGL.State.projection;
-    else if (mode == RL_MODELVIEW) RLGL.State.currentMatrix = &RLGL.State.modelview;
+    else if (mode == RL_MODELVIEW) {
+        if (RLGL.State.stackCounter == 0) {
+            RLGL.State.currentMatrix = &RLGL.State.modelview;
+        } else {
+            RLGL.State.currentMatrix = &RLGL.State.transform;
+        }
+    }
     //else if (mode == RL_TEXTURE) // Not supported
 
     RLGL.State.currentMatrixMode = mode;


### PR DESCRIPTION
in GL_33 and ES2, the matrix mode would always set the model matrix to modelview matrix

this leads to incorrectly setting the matrix when a matrix has been pushed

when a matrix is pushed, the model matrix is set to the transform matrix

if a matrixMode is done on the model matrix then the model matrix is set to the modelview matrix instead of the transform matrix

when a matrix is popped, if zero count, the model matrix gets set to modelview

NOTE: GL_11 uses a seperate stack for each matrix as stated in https://www.khronos.org/registry/OpenGL-Refpages/gl2.1/xhtml/glMatrixMode.xml

```
Specifies which matrix stack is the target for subsequent matrix operations

GL_MODELVIEW

    Applies subsequent matrix operations to the modelview matrix stack. 
GL_PROJECTION

    Applies subsequent matrix operations to the projection matrix stack. 
GL_TEXTURE

    Applies subsequent matrix operations to the texture matrix stack. 
```

additionally https://www.khronos.org/registry/OpenGL-Refpages/gl2.1/xhtml/glPushMatrix.xml

`There is a stack of matrices for each of the matrix modes`

GL_33 and ES2 implementation combines this to a single stack making this not set in the following case

(and possibly other cases)

```
// set current matrix to model
rlMatrixMode(RL_MODELVIEW);
// push to model stack
// this sets current matrix to transform since we are in model
rlPushMatrix();

// set current matrix to projection
rlMatrixMode(RL_PROJECTION);
// push to projection stack
// this sets current matrix to projection
rlPushMatrix();

// set current matrix to transform
rlMatrixMode(RL_MODELVIEW);
// pop from model stack
// this fails to set the model back to model view since
// the stack depth is not 0 as the GL_33 and ES2
// stack implementation represents a combined stack
// instead of seperate stacks
// the matrix is instead set to the projection matrix that we just pushed
rlPopMatrix();
```