### PR TITLE
improved blending support

### DIFF
--- a/src/raylib.h
+++ b/src/raylib.h
@@ -839,8 +839,7 @@ typedef enum {
     BLEND_MULTIPLIED,               // Blend textures multiplying colors
     BLEND_ADD_COLORS,               // Blend textures adding colors (alternative)
     BLEND_SUBTRACT_COLORS,          // Blend textures subtracting colors (alternative)
-    BLEND_CUSTOM,                   // Blend textures using custom src/dst factors (use rlSetBlendMode())
-    BLEND_CUSTOM_SEPARATED          // Blend textures using separate custom src/dst factors
+    BLEND_CUSTOM                    // Belnd textures using custom src/dst factors (use rlSetBlendMode())
 } BlendMode;
 
 // Gesture

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -839,7 +839,8 @@ typedef enum {
     BLEND_MULTIPLIED,               // Blend textures multiplying colors
     BLEND_ADD_COLORS,               // Blend textures adding colors (alternative)
     BLEND_SUBTRACT_COLORS,          // Blend textures subtracting colors (alternative)
-    BLEND_CUSTOM                    // Belnd textures using custom src/dst factors (use rlSetBlendMode())
+    BLEND_CUSTOM,                   // Blend textures using custom src/dst factors (use rlSetBlendMode())
+    BLEND_CUSTOM_SEPARATED          // Blend textures using separate custom src/dst factors
 } BlendMode;
 
 // Gesture

--- a/src/rlgl.h
+++ b/src/rlgl.h
@@ -1815,7 +1815,7 @@ void rlSetBlendMode(int mode)
             case RL_BLEND_ADD_COLORS: glBlendFunc(GL_ONE, GL_ONE); glBlendEquation(GL_FUNC_ADD); break;
             case RL_BLEND_SUBTRACT_COLORS: glBlendFunc(GL_ONE, GL_ONE); glBlendEquation(GL_FUNC_SUBTRACT); break;
             case RL_BLEND_CUSTOM: glBlendFunc(RLGL.State.glBlendSrcFactor, RLGL.State.glBlendDstFactor); glBlendEquation(RLGL.State.glBlendEquation); break;
-            case RL_BLEND_CUSTOM: 
+            case RL_BLEND_CUSTOM_SEPARATED: 
                 glBlendFuncSeparate(
                     RLGL.State.glBlendSrcFactorColor, RLGL.State.glBlendDstFactorColor,
                     RLGL.State.glBlendSrcFactorAlpha, RLGL.State.glBlendDstFactorAlpha,

--- a/src/rlgl.h
+++ b/src/rlgl.h
@@ -1819,7 +1819,7 @@ void rlSetBlendMode(int mode)
             case RL_BLEND_CUSTOM_SEPARATED: 
                 glBlendFuncSeparate(
                     RLGL.State.glBlendSrcFactorColor, RLGL.State.glBlendDstFactorColor,
-                    RLGL.State.glBlendSrcFactorAlpha, RLGL.State.glBlendDstFactorAlpha,
+                    RLGL.State.glBlendSrcFactorAlpha, RLGL.State.glBlendDstFactorAlpha
                 ); 
                 glBlendEquationSeparate(
                     RLGL.State.glBlendEquationColor,

--- a/src/rlgl.h
+++ b/src/rlgl.h
@@ -618,6 +618,7 @@ RLAPI void rlSetBlendMode(int mode);                    // Set blending mode
 RLAPI void rlSetBlendFactors(int glSrcFactor, int glDstFactor, int glEquation); // Set blending mode factor and equation (using OpenGL factors)
 RLAPI void rlSetBlendColorFactors(int glSrcFactor, int glDstFactor, int glEquation); // Set blending mode factor and equation for colors
 RLAPI void rlSetBlendAlphaFactors(int glSrcFactor, int glDstFactor, int glEquation); // Set blending mode factor and equation for alpha
+RLAPI void rlSetBlendConstant(float r, float g, float b, float a); // Set the color used for constant factors
 
 //------------------------------------------------------------------------------------
 // Functions Declaration - rlgl functionality
@@ -1860,6 +1861,14 @@ void rlSetBlendAlphaFactors(int glSrcFactor, int glDstFactor, int glEquation)
     RLGL.State.glBlendSrcFactorAlpha = glSrcFactor;
     RLGL.State.glBlendDstFactorAlpha = glDstFactor;
     RLGL.State.glBlendEquationAlpha = glEquation;
+#endif
+}
+
+// Set the color used for constant factors
+void rlSetBlendConstant(float r, float g, float b, float a)
+{
+#if defined(GRAPHICS_API_OPENGL_33) || defined(GRAPHICS_API_OPENGL_ES2)
+    glBlendColor(r, g, b, a);
 #endif
 }
 


### PR DESCRIPTION
Adds more blending options. 
- Doesn't change anything already present, and works exactly the same way. 
- Added matching GL defines for custom modes. (unsure of the names)
- Added support to set factors for colors and alpha separately.

I didn't notice the core had a few blend functions until I was pretty much finished. I tried to think of a way to improve those, but unless we can add the blend defines over there I can't think of any way to make that work. Unless you want to use one of the predefined modes, they're kinda useless atm.

Seems to be working fine for me on vs2020, can't test on anything else.
Also, this is my first contribution ever, so let me know if I'm doing something wrong...