### PR TITLE
Fix scissor mode for high DPI screens (refactored)

### DIFF
--- a/examples/core/core_scissor_test.c
+++ b/examples/core/core_scissor_test.c
@@ -20,6 +20,9 @@ int main(void)
     const int screenWidth = 800;
     const int screenHeight = 450;
 
+    // If you have a high DPI screen you'll have to set the High DPI flag.
+    // SetConfigFlags(FLAG_WINDOW_HIGHDPI);
+
     InitWindow(screenWidth, screenHeight, "raylib [core] example - scissor test");
 
     Rectangle scissorArea = { 0, 0, 300, 300 };

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -2188,7 +2188,8 @@ void BeginScissorMode(int x, int y, int width, int height)
     {
         Vector2 scale = GetWindowScaleDPI();
 
-        rlScissor((int)(x*scale.x), (int)(CORE.Window.currentFbo.height - (y + height)*scale.y), (int)(width*scale.x), (int)(height*scale.y));
+        rlScissor((int)(x*scale.x), (int)(CORE.Window.currentFbo.height - y*scale.y - height/scale.y),
+                  (int)(width*scale.x), (int)(height*scale.y));
     }
     else
     {


### PR DESCRIPTION
This is a refactored version of PR `Fix scissor mode for high DPI screens` #2141

From #2141 :
I was running the core scissor test example on a MacBook Pro (macOS Big Sur Intel) which is high DPI (2x). When running the test the scissor square was not lined up with the mouse square outline. I've raised issue (#2142) and submitted a screenshot. I found that the rlScissor call wasn't quite right. Also that line wasn't being called because the CORE.Window.flags hadn't had the FLAG_WINDOW_HIGHDPI set.