### PR TITLE
Fix scissor on macos

### DIFF
--- a/src/raylib.h
+++ b/src/raylib.h
@@ -928,6 +928,8 @@ RLAPI void SetWindowSize(int width, int height);                  // Set window 
 RLAPI void *GetWindowHandle(void);                                // Get native window handle
 RLAPI int GetScreenWidth(void);                                   // Get current screen width
 RLAPI int GetScreenHeight(void);                                  // Get current screen height
+RLAPI int GetRenderWidth(void);                                   // Get current render width
+RLAPI int GetRenderHeight(void);                                  // Get current render height
 RLAPI int GetMonitorCount(void);                                  // Get number of connected monitors
 RLAPI int GetCurrentMonitor(void);                                // Get current connected monitor
 RLAPI Vector2 GetMonitorPosition(int monitor);                    // Get specified monitor position

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -2191,7 +2191,7 @@ void BeginScissorMode(int x, int y, int width, int height)
             (int)(GetScreenHeight() * scale.y - (((y + height) * scale.y))),
             (int)(width*scale.x),
             (int)(height*scale.y));
-#elif
+#else
     if ((CORE.Window.flags & FLAG_WINDOW_HIGHDPI) > 0)
     {
         Vector2 scale = GetWindowScaleDPI();

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -2184,6 +2184,14 @@ void BeginScissorMode(int x, int y, int width, int height)
 
     rlEnableScissorTest();
 
+#if defined(__APPLE__)
+    Vector2 scale = GetWindowScaleDPI();
+    rlScissor(
+            (int)(x*scale.x),
+            (int)(GetScreenHeight() * scale.y - (((y + height) * scale.y))),
+            (int)(width*scale.x),
+            (int)(height*scale.y));
+#elif
     if ((CORE.Window.flags & FLAG_WINDOW_HIGHDPI) > 0)
     {
         Vector2 scale = GetWindowScaleDPI();
@@ -2194,6 +2202,7 @@ void BeginScissorMode(int x, int y, int width, int height)
     {
         rlScissor(x, CORE.Window.currentFbo.height - (y + height), width, height);
     }
+#endif
 }
 
 // End scissor mode


### PR DESCRIPTION
@raysan5 @lukekras 

This fixes https://github.com/raysan5/raylib/issues/2142

I've tested on a macbook with a 4k screen, but maybe a better solution would be to use the `GetRenderHeight` function here:
```c
    if ((CORE.Window.flags & FLAG_WINDOW_HIGHDPI) > 0)
    {
        Vector2 scale = GetWindowScaleDPI();

        rlScissor((int)(x*scale.x), (int)(CORE.Window.currentFbo.height - (y + height)*scale.y), (int)(width*scale.x), (int)(height*scale.y));
                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    }
```

but we would need to change the implementation of GetRenderHeight to something like this:
```c
#if defined(__APPLE__)
    Vector2 scale = GetWindowScaleDPI();
    return CORE.Window.render.height * scale.y;
#elif
    return CORE.Window.render.height;
#endif
```

I'm not entirely sure because I don't have everything in mind and I don't have time.

But for now this PR should work as expected.


