### PR TITLE
Letterboxing window flag

### DIFF
--- a/src/raylib.h
+++ b/src/raylib.h
@@ -497,6 +497,7 @@ typedef enum {
     FLAG_WINDOW_ALWAYS_RUN  = 0x00000100,   // Set to allow windows running while minimized
     FLAG_WINDOW_TRANSPARENT = 0x00000010,   // Set to allow transparent framebuffer
     FLAG_WINDOW_HIGHDPI     = 0x00002000,   // Set to support HighDPI
+    FLAG_FIXED_RENDER_SIZE  = 0x00004000,   // Set to lock the render size (aka letterbox-resize the whole window)
     FLAG_MSAA_4X_HINT       = 0x00000020,   // Set to try enabling MSAA 4X
     FLAG_INTERLACED_HINT    = 0x00010000    // Set to try enabling interlaced video format (for V3D)
 } ConfigFlags;

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -2234,7 +2234,7 @@ void BeginScissorMode(int x, int y, int width, int height)
     Vector2 scale = { 1, 1 };
     if ((CORE.Window.flags & FLAG_WINDOW_HIGHDPI) > 0)
     {
-        Vector2 scale = GetWindowScaleDPI();
+        scale = GetWindowScaleDPI();
     }
 
     if (CORE.Window.flags & FLAG_FIXED_RENDER_SIZE)


### PR DESCRIPTION
Take this with a pinch of salt.

This is a simple change to allow the game to resize with the window without manually having to implement letterboxing, for my applications and I believe many others it's sometimes convenient to let the content automatically resize to fit the window.
This is done simply by NOT changing CORE.Window.render size in SetupViewport if the flag FLAG_FIXED_RENDER_SIZE has been set.

BeginScissorMode has been changed accordingly as well as GetMousePosition.

This is a change that I keep stashing at every update, hope it can get integrated.
Mind that it has been tested only for PLATFORM_WEB and WINDOWS DESKTOP.

Cheers,
Mich