### PR TITLE
Fix #2190 - Add GetRaylibVersion function

### DIFF
--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1015,6 +1015,7 @@ RLAPI int GetRandomValue(int min, int max);                       // Get a rando
 RLAPI void SetRandomSeed(unsigned int seed);                      // Set the seed for the random number generator
 RLAPI void TakeScreenshot(const char *fileName);                  // Takes a screenshot of current screen (filename extension defines format)
 RLAPI void SetConfigFlags(unsigned int flags);                    // Setup init configuration flags (view FLAGS)
+RLAPI const char *GetRaylibVersion();                             // Get Raylib version (for non-C bindings)
 
 RLAPI void TraceLog(int logLevel, const char *text, ...);         // Show trace log messages (LOG_DEBUG, LOG_INFO, LOG_WARNING, LOG_ERROR...)
 RLAPI void SetTraceLogLevel(int logLevel);                        // Set the current threshold (minimum) log level

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -6855,3 +6855,10 @@ const char *TextFormat(const char *text, ...)
     return currentBuffer;
 }
 #endif // !SUPPORT_MODULE_RTEXT
+
+// Get the release of raylib that this library is built with, to assist in non-C bindings determining
+// a mismatch of structures and/or parameters.
+const char*GetRaylibVersion()
+{
+    return RAYLIB_VERSION;
+}


### PR DESCRIPTION
 For bindings other than C which do not read the header file, but may use the compiled binary library.

E.g. in raylib's D bindings, we can link directly against the C library, but because C has no name mangling, changes to function parameters can allow a mismatched library to link, but have disastrous effects (such as memory corruption). Same thing with struct layout changes.

This at least provides a way to verify the binary raylib version matches what the binding expects.