### PR TITLE
Vector2Angle returns degrees instead of radians, but all other raymath

### DIFF
--- a/src/raymath.h
+++ b/src/raymath.h
@@ -281,9 +281,9 @@ RMAPI float Vector2Distance(Vector2 v1, Vector2 v2)
 // Calculate angle from two vectors in X-axis
 RMAPI float Vector2Angle(Vector2 v1, Vector2 v2)
 {
-    float result = atan2f(v2.y - v1.y, v2.x - v1.x)*(180.0f/PI);
+    float result = atan2f(v2.y - v1.y, v2.x - v1.x);
 
-    if (result < 0) result += 360.0f;
+    if (result < 0) result += 2 * PI;
 
     return result;
 }


### PR DESCRIPTION
functions use radians, making this awkward to use.

Per discussion on discord, raymath should always use radians. I found this one was left out by searching for `180` and `360`.