### PR TITLE
Add advanced textbox and input box based on stb_textedit

### DIFF
--- a/src/extras/raygui.h
+++ b/src/extras/raygui.h
@@ -1427,7 +1427,6 @@ static int rstb_InsertChars(rstb_String *str, int start, int *chars, int count)
 {
     assert(start >= 0);
     assert(count > 0);
-    assert(str->used + count < str->capacity);
 
     int success = 0;
     // TODO(dbechrd): Unicode support, currently assumes ASCII
@@ -1460,9 +1459,9 @@ static int rstb_InsertChars(rstb_String *str, int start, int *chars, int count)
             memcpy(str->buffer + start, chars, count);
         }
         success = 1;
+        str->used += count;
     }
 
-    str->used += count;
     assert(str->used < str->capacity);
     return success;
 }


### PR DESCRIPTION
** NOT INTENDED TO MERGE **
This PR is for the purpose of example. I wanted to share the code in case Ray decides to add a fancier textbox later and any of this work was at all useful to him.

Example usage:
```c
#define TEXT_LENGTH_MAX 32

Rectangle rect = { 10.0f, 10.0f, 800.0f, font.baseSize + 4.0f };

static int textLen = 0;
static char text[TEXT_LENGTH_MAX]{};

static GuiTextBoxAdvancedState chatInputState;
if (GuiTextBoxAdvanced(&chatInputState, rect, text, &textLen, TEXT_LENGTH_MAX, false)) {
    if (textLen) {
        printf("User submitted text: %.*s\n", textLen, text);
        memset(text, 0, textLen);
        textLen = 0;
    }
}
```

Side note: Pass `io.WantCaptureKeyboard` to the readOnly argument if you want to use this in combination with ImGui for some reason (e.g. if your in-game UI is raygui but you have ImGui debug tools rendering on top).