### PR TITLE
Fix Vector2Angle() not working as expected

### DIFF
--- a/src/raymath.h
+++ b/src/raymath.h
@@ -281,7 +281,7 @@ RMAPI float Vector2Distance(Vector2 v1, Vector2 v2)
 // Calculate angle from two vectors in X-axis
 RMAPI float Vector2Angle(Vector2 v1, Vector2 v2)
 {
-    float result = atan2f(v2.y - v1.y, v2.x - v1.x);
+    float result = atan2f(v2.y, v2.x) - atan2f(v1.y, v1.x);
 
     if (result < 0) result += 2 * PI;
 


### PR DESCRIPTION
This pull request fixes `Vector2Angle()` not working as expected. (https://github.com/raysan5/raylib/issues/2172, https://github.com/raysan5/raylib/pull/2193) 

Here's the animation of a simple example I made with the fixed version of `Vector2Angle()`: 

![angle](https://user-images.githubusercontent.com/28700668/144968970-053884ef-11c6-46e4-82f6-400a0b3b0697.gif)

```c
float angle = Vector2Angle((Vector2) { .x = 1 }, Vector2Subtract(GetMousePosition(), SCREEN_CENTER)) * RAD2DEG;
```