### PR TITLE
raylib.h: Add relevant defines to types

### DIFF
--- a/src/extras/physac.h
+++ b/src/extras/physac.h
@@ -130,6 +130,7 @@ typedef struct Vector2 {
     float x;
     float y;
 } Vector2;
+#define RL_VECTOR2_TYPE
 #endif
 
 // Matrix2x2 type (used for polygon shape rotation matrix)

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -131,18 +131,6 @@
     #define CLITERAL(type)      (type)
 #endif
 
-// NOTE: We set some defines with some data types declared by raylib
-// Other modules (raymath, rlgl) also require some of those types, so,
-// to be able to use those other modules as standalone (not depending on raylib)
-// this defines are very useful for internal check and avoid type (re)definitions
-#define RL_COLOR_TYPE
-#define RL_RECTANGLE_TYPE
-#define RL_VECTOR2_TYPE
-#define RL_VECTOR3_TYPE
-#define RL_VECTOR4_TYPE
-#define RL_QUATERNION_TYPE
-#define RL_MATRIX_TYPE
-
 // Some Basic Colors
 // NOTE: Custom raylib color palette for amazing visuals on WHITE background
 #define LIGHTGRAY  CLITERAL(Color){ 200, 200, 200, 255 }   // Light Gray
@@ -184,19 +172,30 @@
     #define RL_BOOL_TYPE
 #endif
 
+// NOTE: We set some defines with some data types declared by raylib
+// Other modules (raymath, rlgl) also require some of those types, so,
+// to be able to use those other modules as standalone (not depending on raylib)
+// this defines are very useful for internal check and avoid type (re)definitions
+#if !defined(RL_VECTOR2_TYPE)
 // Vector2, 2 components
 typedef struct Vector2 {
     float x;                // Vector x component
     float y;                // Vector y component
 } Vector2;
+#define RL_VECTOR2_TYPE
+#endif
 
+#if !defined(RL_VECTOR3_TYPE)
 // Vector3, 3 components
 typedef struct Vector3 {
     float x;                // Vector x component
     float y;                // Vector y component
     float z;                // Vector z component
 } Vector3;
+#define RL_VECTOR3_TYPE
+#endif
 
+#if !defined(RL_VECTOR4_TYPE)
 // Vector4, 4 components
 typedef struct Vector4 {
     float x;                // Vector x component
@@ -204,10 +203,16 @@ typedef struct Vector4 {
     float z;                // Vector z component
     float w;                // Vector w component
 } Vector4;
+#define RL_VECTOR4_TYPE
+#endif
 
+#if !defined(RL_QUATERNION_TYPE)
 // Quaternion, 4 components (Vector4 alias)
 typedef Vector4 Quaternion;
+#define RL_QUATERNION_TYPE
+#endif
 
+#if !defined(RL_MATRIX_TYPE)
 // Matrix, 4x4 components, column major, OpenGL style, right handed
 typedef struct Matrix {
     float m0, m4, m8, m12;  // Matrix first row (4 components)
@@ -215,7 +220,10 @@ typedef struct Matrix {
     float m2, m6, m10, m14; // Matrix third row (4 components)
     float m3, m7, m11, m15; // Matrix fourth row (4 components)
 } Matrix;
+#define RL_MATRIX_TYPE
+#endif
 
+#if !defined(RL_COLOR_TYPE)
 // Color, 4 components, R8G8B8A8 (32bit)
 typedef struct Color {
     unsigned char r;        // Color red value
@@ -223,7 +231,10 @@ typedef struct Color {
     unsigned char b;        // Color blue value
     unsigned char a;        // Color alpha value
 } Color;
+#define RL_COLOR_TYPE
+#endif
 
+#if !defined(RL_RECTANGLE_TYPE)
 // Rectangle, 4 components
 typedef struct Rectangle {
     float x;                // Rectangle top-left corner position x
@@ -231,6 +242,8 @@ typedef struct Rectangle {
     float width;            // Rectangle width
     float height;           // Rectangle height
 } Rectangle;
+#define RL_RECTANGLE_TYPE
+#endif
 
 // Image, pixel data stored in CPU memory (RAM)
 typedef struct Image {


### PR DESCRIPTION
Allow order-independent includes so that other library files can
be included before raylib.h.

This fixes https://github.com/greenfork/nimraylib_now/issues/12 and https://github.com/greenfork/nimraylib_now/issues/49 of my Nim bindings. The problem is that Nim doesn't know how to include C files in order. And this seems as a generally good approach to use.