### PR TITLE
LoadRenderTextureEx with custom pixel format and optional depthbuffer

### DIFF
--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1275,7 +1275,8 @@ RLAPI void ImageDrawTextEx(Image *dst, Font font, const char *text, Vector2 posi
 RLAPI Texture2D LoadTexture(const char *fileName);                                                       // Load texture from file into GPU memory (VRAM)
 RLAPI Texture2D LoadTextureFromImage(Image image);                                                       // Load texture from image data
 RLAPI TextureCubemap LoadTextureCubemap(Image image, int layout);                                        // Load cubemap from image, multiple image cubemap layouts supported
-RLAPI RenderTexture2D LoadRenderTexture(int width, int height);                                          // Load texture for rendering (framebuffer)
+RLAPI RenderTexture2D LoadRenderTexture(int width, int height);                                          // Load texture for rendering (framebuffer) with RGBA pixel format and depthbuffer
+RLAPI RenderTexture2D LoadRenderTextureEx(int width, int height, int format, int useDepth);              // Load texture for rendering (framebuffer) with custom pixel format and optional framebuffer
 RLAPI void UnloadTexture(Texture2D texture);                                                             // Unload texture from GPU memory (VRAM)
 RLAPI void UnloadRenderTexture(RenderTexture2D target);                                                  // Unload render texture from GPU memory (VRAM)
 RLAPI void UpdateTexture(Texture2D texture, const void *pixels);                                         // Update GPU texture with new data

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1276,7 +1276,7 @@ RLAPI Texture2D LoadTexture(const char *fileName);                              
 RLAPI Texture2D LoadTextureFromImage(Image image);                                                       // Load texture from image data
 RLAPI TextureCubemap LoadTextureCubemap(Image image, int layout);                                        // Load cubemap from image, multiple image cubemap layouts supported
 RLAPI RenderTexture2D LoadRenderTexture(int width, int height);                                          // Load texture for rendering (framebuffer) with RGBA pixel format and depthbuffer
-RLAPI RenderTexture2D LoadRenderTextureEx(int width, int height, int format, int useDepth);              // Load texture for rendering (framebuffer) with custom pixel format and optional framebuffer
+RLAPI RenderTexture2D LoadRenderTextureEx(int width, int height, int format, bool useDepth);              // Load texture for rendering (framebuffer) with custom pixel format and optional framebuffer
 RLAPI void UnloadTexture(Texture2D texture);                                                             // Unload texture from GPU memory (VRAM)
 RLAPI void UnloadRenderTexture(RenderTexture2D target);                                                  // Unload render texture from GPU memory (VRAM)
 RLAPI void UpdateTexture(Texture2D texture, const void *pixels);                                         // Update GPU texture with new data

--- a/src/rtextures.c
+++ b/src/rtextures.c
@@ -2968,11 +2968,11 @@ TextureCubemap LoadTextureCubemap(Image image, int layout)
 // NOTE: Render texture is loaded by default with RGBA color attachment and depth RenderBuffer
 RenderTexture2D LoadRenderTexture(int width, int height)
 {
-    return LoadRenderTextureEx(width, height, PIXELFORMAT_UNCOMPRESSED_R8G8B8A8, 1);
+    return LoadRenderTextureEx(width, height, PIXELFORMAT_UNCOMPRESSED_R8G8B8A8, true);
 }
 
 // Load texture for rendering (framebuffer)
-RenderTexture2D LoadRenderTextureEx(int width, int height, int format, int useDepth)
+RenderTexture2D LoadRenderTextureEx(int width, int height, int format, bool useDepth)
 {
     RenderTexture2D target = { 0 };
 


### PR DESCRIPTION
The default LoadRenderTexture always creates a framebuffer with an alpha channel, which is not usable due to raylib limited blending capabilities.