### PR TITLE
Add ImageFloodFill function

### DIFF
--- a/src/rtextures.c
+++ b/src/rtextures.c
@@ -2074,62 +2074,59 @@ void ImageColorReplace(Image *image, Color color, Color replace)
     ImageFormat(image, format);
 }
 // Flood-fills from the given position
-void ImageFloodFill(Image *dst, int startPosX, int startPosY, Color color){
+void ImageFloodFill(Image *dst, int startPosX, int startPosY, Color color)
+{
     if ((dst->data == NULL) || (startPosX < 0) || (startPosX >= dst->width) || (startPosY < 0) || (startPosY >= dst->height)) return;
-    
+
     int bpp = GetPixelDataSize(1,1,dst->format);
     void *start_pixel_address = (dst->data + bpp*(startPosX + dst->width*startPosY));
-    
+
     Color startColor = GetPixelColor(start_pixel_address, dst->format);
     if (startColor.r == color.r && startColor.g == color.g && startColor.b == color.b && startColor.a == color.a) return;
-    
-    struct flood_fill_pixel_pos {
-        int x, y;
-    };
-    
+
     // x,y array for pixels which we just flood-filled, conservatively sized
     // TODO: research and implement ring buffer, size could maybe be as low as ~5 * smallest image side
-    struct flood_fill_pixel_pos *a_star_edge_list = RL_MALLOC(dst->width*dst->height*sizeof(*a_star_edge_list));
+    int *a_star_edge_list = RL_MALLOC(dst->width*dst->height*2*sizeof(*a_star_edge_list));
     if (a_star_edge_list == NULL) return;
-    a_star_edge_list[0].x = startPosX;
-    a_star_edge_list[0].y = startPosY;
-    
-    for (int flood = 0, pool = 1; flood < pool; flood++)
+    a_star_edge_list[0] = startPosX;
+    a_star_edge_list[1] = startPosY;
+
+    for (int flood = 0, pool = 1; flood < pool; flood+=2)
     {
         int x = a_star_edge_list[flood].x;
         int y = a_star_edge_list[flood].y;
         void *pixel_address = 0;
-        
+
         // clockwise check and color the 4 neighbours, then record
-        struct flood_fill_pixel_pos neighbours[4] = {
-            {x, y - 1},
-            {x + 1, y},
-            {x, y + 1},
-            {x - 1, y},
+        int neighbours[4*2] = {
+            x, y - 1,
+            x + 1, y,
+            x, y + 1,
+            x - 1, y,
         };
-        
+
         Color sc = GetPixelColor(start_pixel_address, dst->format);
-        
-        for(int n = 0; n < 4; n++)
+
+        for (int n = 0; n < 4*2; n+=2)
         {
-            if(!((neighbours[n].x < 0) || (neighbours[n].x >= dst->width) || (neighbours[n].y < 0) || (neighbours[n].y >= dst->height) || ((neighbours[n].x == startPosX) && (neighbours[n].y == startPosY))))
+            if (!((neighbours[n] < 0) || (neighbours[n] >= dst->width) || (neighbours[n + 1] < 0) || (neighbours[n + 1] >= dst->height) || ((neighbours[n] == startPosX) && (neighbours[n + 1] == startPosY))))
             {
-                pixel_address = (dst->data + bpp*(neighbours[n].x + dst->width*neighbours[n].y));
-                
+                pixel_address = (dst->data + bpp*(neighbours[n] + dst->width*neighbours[n + 1]));
+
                 Color cc = GetPixelColor(pixel_address, dst->format);
                 if (cc.r == sc.r && cc.g == sc.g && cc.b == sc.b && cc.a == sc.a)
                 {
-                    a_star_edge_list[pool].x = neighbours[n].x;
-                    a_star_edge_list[pool].y = neighbours[n].y;
+                    a_star_edge_list[pool] = neighbours[n];
+                    a_star_edge_list[pool + 1] = neighbours[n + 1];
                     SetPixelColor(pixel_address, color, dst->format);
-                    pool += 1;
+                    pool += 2;
                 }
             }
         }
     }
     // color the center last
     SetPixelColor(start_pixel_address, color, dst->format);
-    
+
     RL_FREE(a_star_edge_list);
 }
 #endif      // SUPPORT_IMAGE_MANIPULATION

--- a/src/rtextures.c
+++ b/src/rtextures.c
@@ -2073,29 +2073,30 @@ void ImageColorReplace(Image *image, Color color, Color replace)
 
     ImageFormat(image, format);
 }
+
 // Flood-fills from the given position
 void ImageFloodFill(Image *dst, int startPosX, int startPosY, Color color)
 {
     if ((dst->data == NULL) || (startPosX < 0) || (startPosX >= dst->width) || (startPosY < 0) || (startPosY >= dst->height)) return;
 
     int bpp = GetPixelDataSize(1,1,dst->format);
-    void *start_pixel_address = (dst->data + bpp*(startPosX + dst->width*startPosY));
+    void *startPixelAddress = (dst->data + bpp*(startPosX + dst->width*startPosY));
 
-    Color startColor = GetPixelColor(start_pixel_address, dst->format);
+    Color startColor = GetPixelColor(startPixelAddress, dst->format);
     if (startColor.r == color.r && startColor.g == color.g && startColor.b == color.b && startColor.a == color.a) return;
 
     // x,y array for pixels which we just flood-filled, conservatively sized
     // TODO: research and implement ring buffer, size could maybe be as low as ~5 * smallest image side
-    int *a_star_edge_list = RL_MALLOC(dst->width*dst->height*2*sizeof(*a_star_edge_list));
-    if (a_star_edge_list == NULL) return;
-    a_star_edge_list[0] = startPosX;
-    a_star_edge_list[1] = startPosY;
+    int *aStarEdgeList = RL_MALLOC(dst->width*dst->height*2*sizeof(*aStarEdgeList));
+    if (aStarEdgeList == NULL) return;
+    aStarEdgeList[0] = startPosX;
+    aStarEdgeList[1] = startPosY;
 
-    for (int flood = 0, pool = 1; flood < pool; flood+=2)
+    for (int flood = 0, pool = 2; flood < pool; flood+=2)
     {
-        int x = a_star_edge_list[flood].x;
-        int y = a_star_edge_list[flood].y;
-        void *pixel_address = 0;
+        int x = aStarEdgeList[flood].x;
+        int y = aStarEdgeList[flood].y;
+        void *pixelAddress = 0;
 
         // clockwise check and color the 4 neighbours, then record
         int neighbours[4*2] = {
@@ -2105,29 +2106,29 @@ void ImageFloodFill(Image *dst, int startPosX, int startPosY, Color color)
             x - 1, y,
         };
 
-        Color sc = GetPixelColor(start_pixel_address, dst->format);
+        Color sc = GetPixelColor(startPixelAddress, dst->format);
 
         for (int n = 0; n < 4*2; n+=2)
         {
             if (!((neighbours[n] < 0) || (neighbours[n] >= dst->width) || (neighbours[n + 1] < 0) || (neighbours[n + 1] >= dst->height) || ((neighbours[n] == startPosX) && (neighbours[n + 1] == startPosY))))
             {
-                pixel_address = (dst->data + bpp*(neighbours[n] + dst->width*neighbours[n + 1]));
+                pixelAddress = (dst->data + bpp*(neighbours[n] + dst->width*neighbours[n + 1]));
 
-                Color cc = GetPixelColor(pixel_address, dst->format);
+                Color cc = GetPixelColor(pixelAdress, dst->format);
                 if (cc.r == sc.r && cc.g == sc.g && cc.b == sc.b && cc.a == sc.a)
                 {
-                    a_star_edge_list[pool] = neighbours[n];
-                    a_star_edge_list[pool + 1] = neighbours[n + 1];
-                    SetPixelColor(pixel_address, color, dst->format);
+                    aStarEdgeList[pool] = neighbours[n];
+                    aStarEdgeList[pool + 1] = neighbours[n + 1];
+                    SetPixelColor(pixelAddress, color, dst->format);
                     pool += 2;
                 }
             }
         }
     }
     // color the center last
-    SetPixelColor(start_pixel_address, color, dst->format);
+    SetPixelColor(startPixelAddress, color, dst->format);
 
-    RL_FREE(a_star_edge_list);
+    RL_FREE(aStarEdgeList);
 }
 #endif      // SUPPORT_IMAGE_MANIPULATION
 

--- a/src/rtextures.c
+++ b/src/rtextures.c
@@ -2108,7 +2108,7 @@ void ImageFloodFill(Image *dst, int startPosX, int startPosY, Color color){
             {x - 1, y},
         };
         
-        Color sc = *((Color *)start_pixel_address);
+        Color sc = GetPixelColor(start_pixel_address, dst->format);
         
         for(int n = 0; n < 4; n++)
         {


### PR DESCRIPTION
ImageFloodFill fills all pixels adjacent to the given position which have the same colour, recursively.

I did my best to make it pixel format agnostic and style guide conforming. I put it with the manipulation functions (inside their ifdef); if wrong then I'll change that.
The math around the worst case A* memory scenario was weird and inconclusive (as in: there's always a worse case thinkable), so I did the safe thing and allocated the maximum needed. 

I hope it's helpful. 

Here's it in action:
![FloodFillTest](https://user-images.githubusercontent.com/63983202/146656358-a4061de4-4ce9-41cc-9e2e-64306845485b.png)
I might be slow to respond atm, but I definitely will.
