### PR TITLE
Remove TODO on Makefile

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -606,7 +606,6 @@ android_native_app_glue.o : $(NATIVE_APP_GLUE)/android_native_app_glue.c
 # for compilation and enable runtime linking with -rpath, LD_LIBRARY_PATH, or ldconfig.
 # HINT: Add -L$(RAYLIB_INSTALL_PATH) -I$(RAYLIB_H_INSTALL_PATH) to your own makefiles.
 # See below and ../examples/Makefile for more information.
-# TODO: Add other platforms. Remove sudo requirement, i.e. add USER mode.
 
 # RAYLIB_INSTALL_PATH should be the desired full path to libraylib. No relative paths.
 DESTDIR ?= /usr/local


### PR DESCRIPTION
Justification: original comment said the following
"TODO: Add other platforms. Remove sudo requirement, i.e. add USER mode."

For the other platforms part, installing is included on unix-like systems, so for example Windows doesn't have a path where to install libraries.

Removing the requirement for sudo is also quite contradictory since we're writing files to directories which require root. Not sure what the original commiter meant by USER mode.