### PR TITLE
Check before freeing image.data

### DIFF
--- a/src/rtextures.c
+++ b/src/rtextures.c
@@ -457,7 +457,7 @@ Image LoadImageFromScreen(void)
 // Unload image from CPU memory (RAM)
 void UnloadImage(Image image)
 {
-    RL_FREE(image.data);
+    if (image.data != NULL) RL_FREE(image.data);
 }
 
 // Export image data to file


### PR DESCRIPTION
Hi, while [trying](https://github.com/greenfork/nimraylib_now/issues/56) to make RAII like resource management for the Nim bindings, I noticed that not all Unload functions check for not nil before freeing. Others that need checks are the ones for Mesh, Material, Model and ModelAnimation structs.