### PR TITLE
[Feature] Draw text with shadows

### DIFF
--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1330,6 +1330,8 @@ RLAPI void DrawText(const char *text, int posX, int posY, int fontSize, Color co
 RLAPI void DrawTextEx(Font font, const char *text, Vector2 position, float fontSize, float spacing, Color tint); // Draw text using font and additional parameters
 RLAPI void DrawTextPro(Font font, const char *text, Vector2 position, Vector2 origin, float rotation, float fontSize, float spacing, Color tint); // Draw text using Font and pro parameters (rotation)
 RLAPI void DrawTextCodepoint(Font font, int codepoint, Vector2 position, float fontSize, Color tint); // Draw one character (codepoint)
+RLAPI void DrawTextShadowed (const char* text, Vector2 position, Vector2 offset, float fontSize, float spacing, Color tint, Color shadowTint); // Draw text with a shadow
+RLAPI void DrawTextShadowedEx (Font font, const char* text, Vector2 position, Vector2 offset, float fontSize, float spacing, Color tint, Color shadowTint); // Draw text with a shadow using Font parameter
 
 // Text font info functions
 RLAPI int MeasureText(const char *text, int fontSize);                                      // Measure string width for default font

--- a/src/rtext.c
+++ b/src/rtext.c
@@ -931,6 +931,24 @@ void DrawTextCodepoint(Font font, int codepoint, Vector2 position, float fontSiz
     DrawTexturePro(font.texture, srcRec, dstRec, (Vector2){ 0, 0 }, 0.0f, tint);
 }
 
+// Draw text with a shadow
+void DrawTextShadowed (const char* text, Vector2 position, Vector2 offset, float fontSize, float spacing, Color tint, Color shadowTint)
+{
+    // Draw the shadow
+    DrawText (text, position.x + offset.x, position.y + offset.y, fontSize, shadowTint);
+    // Draw the actual text
+    DrawText (text, position.x, position.y, fontSize, tint);
+}
+
+// Draw text with a shadow using Font parameter
+void DrawTextShadowedEx (Font font, const char* text, Vector2 position, Vector2 offset, float fontSize, float spacing, Color tint, Color shadowTint)
+{
+    // Draw the shadow
+    DrawTextEx (font, text, (Vector2){position.x + offset.x, position.y + offset.y}, fontSize, spacing, shadowTint);
+    // Draw the actual text
+    DrawTextEx (font, text, position, fontSize, spacing, tint);
+}
+
 // Measure string width for default font
 int MeasureText(const char *text, int fontSize)
 {


### PR DESCRIPTION
Added new functions:
`DrawTextShadowed()` and `DrawTextShadowedEx()`
Tested on Windows and works fine, further inspection maybe required.
Both take an `offset` value which is a `Vector2` and deviates the shadow from it's original position by the offset.
![shadow_text](https://user-images.githubusercontent.com/81076342/147488569-2a1659b1-6823-4177-8c66-e69edfcdee53.png)
