### PR TITLE
[Feature] Added SetWindowOpacity(float opacity)

### DIFF
--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1331,8 +1331,6 @@ RLAPI void DrawText(const char *text, int posX, int posY, int fontSize, Color co
 RLAPI void DrawTextEx(Font font, const char *text, Vector2 position, float fontSize, float spacing, Color tint); // Draw text using font and additional parameters
 RLAPI void DrawTextPro(Font font, const char *text, Vector2 position, Vector2 origin, float rotation, float fontSize, float spacing, Color tint); // Draw text using Font and pro parameters (rotation)
 RLAPI void DrawTextCodepoint(Font font, int codepoint, Vector2 position, float fontSize, Color tint); // Draw one character (codepoint)
-RLAPI void DrawTextShadowed (const char* text, Vector2 position, Vector2 offset, float fontSize, float spacing, Color tint, Color shadowTint); // Draw text with a shadow
-RLAPI void DrawTextShadowedEx (Font font, const char* text, Vector2 position, Vector2 offset, float fontSize, float spacing, Color tint, Color shadowTint); // Draw text with a shadow using Font parameter
 
 // Text font info functions
 RLAPI int MeasureText(const char *text, int fontSize);                                      // Measure string width for default font

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -925,6 +925,7 @@ RLAPI void SetWindowPosition(int x, int y);                       // Set window 
 RLAPI void SetWindowMonitor(int monitor);                         // Set monitor for the current window (fullscreen mode)
 RLAPI void SetWindowMinSize(int width, int height);               // Set window minimum dimensions (for FLAG_WINDOW_RESIZABLE)
 RLAPI void SetWindowSize(int width, int height);                  // Set window dimensions
+RLAPI void SetWindowOpacity(float opacity);                       // Set window opacity, value opacity is between 0.0 and 1.0 (only PLATFORM_DESKTOP)
 RLAPI void *GetWindowHandle(void);                                // Get native window handle
 RLAPI int GetScreenWidth(void);                                   // Get current screen width
 RLAPI int GetScreenHeight(void);                                  // Get current screen height

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1330,6 +1330,8 @@ RLAPI void DrawText(const char *text, int posX, int posY, int fontSize, Color co
 RLAPI void DrawTextEx(Font font, const char *text, Vector2 position, float fontSize, float spacing, Color tint); // Draw text using font and additional parameters
 RLAPI void DrawTextPro(Font font, const char *text, Vector2 position, Vector2 origin, float rotation, float fontSize, float spacing, Color tint); // Draw text using Font and pro parameters (rotation)
 RLAPI void DrawTextCodepoint(Font font, int codepoint, Vector2 position, float fontSize, Color tint); // Draw one character (codepoint)
+RLAPI void DrawTextShadowed (const char* text, Vector2 position, Vector2 offset, float fontSize, float spacing, Color tint, Color shadowTint); // Draw text with a shadow
+RLAPI void DrawTextShadowedEx (Font font, const char* text, Vector2 position, Vector2 offset, float fontSize, float spacing, Color tint, Color shadowTint); // Draw text with a shadow using Font parameter
 
 // Text font info functions
 RLAPI int MeasureText(const char *text, int fontSize);                                      // Measure string width for default font

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -1534,6 +1534,16 @@ void SetWindowSize(int width, int height)
 #endif
 }
 
+// Set window opacity, value opacity is between 0.0 and 1.0
+void SetWindowOpacity (float opacity)
+{
+#if defined(PLATFORM_DESKTOP)
+    if (opacity >= 1.0) opacity = 1.0;
+    else if (opacity <= 0.0) opacity = 0.0;
+    glfwSetWindowOpacity(CORE.Window.handle, opacity);
+#endif
+}
+
 // Get current screen width
 int GetScreenWidth(void)
 {

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -1535,11 +1535,11 @@ void SetWindowSize(int width, int height)
 }
 
 // Set window opacity, value opacity is between 0.0 and 1.0
-void SetWindowOpacity (float opacity)
+void SetWindowOpacity(float opacity)
 {
 #if defined(PLATFORM_DESKTOP)
-    if (opacity >= 1.0) opacity = 1.0;
-    else if (opacity <= 0.0) opacity = 0.0;
+    if (opacity >= 1.0f) opacity = 1.0f;
+    else if (opacity <= 0.0f) opacity = 0.0f;
     glfwSetWindowOpacity(CORE.Window.handle, opacity);
 #endif
 }

--- a/src/rtext.c
+++ b/src/rtext.c
@@ -931,6 +931,24 @@ void DrawTextCodepoint(Font font, int codepoint, Vector2 position, float fontSiz
     DrawTexturePro(font.texture, srcRec, dstRec, (Vector2){ 0, 0 }, 0.0f, tint);
 }
 
+// Draw text with a shadow
+void DrawTextShadowed (const char* text, Vector2 position, Vector2 offset, float fontSize, float spacing, Color tint, Color shadowTint)
+{
+    // Draw the shadow
+    DrawText (text, position.x + offset.x, position.y + offset.y, fontSize, shadowTint);
+    // Draw the actual text
+    DrawText (text, position.x, position.y, fontSize, tint);
+}
+
+// Draw text with a shadow using Font parameter
+void DrawTextShadowedEx (Font font, const char* text, Vector2 position, Vector2 offset, float fontSize, float spacing, Color tint, Color shadowTint)
+{
+    // Draw the shadow
+    DrawTextEx (font, text, (Vector2){position.x + offset.x, position.y + offset.y}, fontSize, spacing, shadowTint);
+    // Draw the actual text
+    DrawTextEx (font, text, position, fontSize, spacing, tint);
+}
+
 // Measure string width for default font
 int MeasureText(const char *text, int fontSize)
 {

--- a/src/rtext.c
+++ b/src/rtext.c
@@ -931,24 +931,6 @@ void DrawTextCodepoint(Font font, int codepoint, Vector2 position, float fontSiz
     DrawTexturePro(font.texture, srcRec, dstRec, (Vector2){ 0, 0 }, 0.0f, tint);
 }
 
-// Draw text with a shadow
-void DrawTextShadowed (const char* text, Vector2 position, Vector2 offset, float fontSize, float spacing, Color tint, Color shadowTint)
-{
-    // Draw the shadow
-    DrawText (text, position.x + offset.x, position.y + offset.y, fontSize, shadowTint);
-    // Draw the actual text
-    DrawText (text, position.x, position.y, fontSize, tint);
-}
-
-// Draw text with a shadow using Font parameter
-void DrawTextShadowedEx (Font font, const char* text, Vector2 position, Vector2 offset, float fontSize, float spacing, Color tint, Color shadowTint)
-{
-    // Draw the shadow
-    DrawTextEx (font, text, (Vector2){position.x + offset.x, position.y + offset.y}, fontSize, spacing, shadowTint);
-    // Draw the actual text
-    DrawTextEx (font, text, position, fontSize, spacing, tint);
-}
-
 // Measure string width for default font
 int MeasureText(const char *text, int fontSize)
 {


### PR DESCRIPTION
`SetWindowOpacity()` takes `opacity`(`float`) as a parameter. Value of `opacity` must fall under 0 and 1. If it exceeds 1; it will be equal 1, similarly if it's smaller than 0; opacity is equal to 0.
Random Screenshots (*READ THE VALUE INSIDE SetWindowOpacity()*):
![set_window_opacity_0](https://user-images.githubusercontent.com/81076342/147740777-44cb2091-d182-40be-89c6-3c9aa1526428.png)
![set_window_opacity_1](https://user-images.githubusercontent.com/81076342/147740784-a9b78e91-f4a1-497e-9bac-3e4935653778.png)
![set_window_opacity_2](https://user-images.githubusercontent.com/81076342/147740791-21a237c8-7181-40b6-a6ae-2de84027b0ba.png)
![set_window_opacity_3](https://user-images.githubusercontent.com/81076342/147740799-02a6e868-e475-4072-94c4-9d25f3d231dd.png)
 `SetWindowOpacity(99999999.0)` goes same as `SetWindowOpacity(1.0)`.

Thank you