### PR TITLE
[CORE] Add a function to return the application directory.

### DIFF
--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1047,6 +1047,7 @@ RLAPI const char *GetFileNameWithoutExt(const char *filePath);    // Get filenam
 RLAPI const char *GetDirectoryPath(const char *filePath);         // Get full path for a given fileName with path (uses static string)
 RLAPI const char *GetPrevDirectoryPath(const char *dirPath);      // Get previous directory path for a given path (uses static string)
 RLAPI const char *GetWorkingDirectory(void);                      // Get current working directory (uses static string)
+RLAPI const char* GetApplicationDirectory(void);                  // Get the directory if the running application (uses static string)
 RLAPI char **GetDirectoryFiles(const char *dirPath, int *count);  // Get filenames in a directory path (memory should be freed)
 RLAPI void ClearDirectoryFiles(void);                             // Clear directory files paths buffers (free memory)
 RLAPI bool ChangeDirectory(const char *dir);                      // Change working directory, return true on success

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -160,6 +160,39 @@
     #define _POSIX_C_SOURCE 199309L // Required for: CLOCK_MONOTONIC if compiled with c99 without gnu ext.
 #endif
 
+
+// platform specific defines to handle GetApplicationDirectory
+#if defined (PLATFORM_DESKTOP)
+    #if defined(_WIN32)
+        #ifndef MAX_PATH
+            #define MAX_PATH 1025
+        #endif
+        void* LoadLibraryA(void* lpLibFileName);
+        void* LoadLibraryW(void* lpLibFileName);
+
+        #ifdef UNICODE
+            #define LoadLibrary  LoadLibraryW
+        #else
+            #define LoadLibrary  LoadLibraryA
+        #endif // !UNICODE
+
+        void* GetProcAddress(void* hModule, void* lpProcName);
+
+        void* GetCurrentProcess(void);
+        bool FreeLibrary(void* hLibModule);
+
+        int  WideCharToMultiByte(unsigned int cp, unsigned long flags, const unsigned short* widestr, int cchwide, char* str, int cbmb, const char* defchar, int* used_default);
+
+        const char PathDelim = '\\';
+    #elif defined(__linux__)
+        #include <unistd.h>
+        const char PathDelim = '/';
+    #elif defined(__APPLE__)
+        #include <sys/syslimits.h>
+        const char PathDelim = '/';
+    #endif // OSs
+#endif // PLATFORM_DESKTOP
+
 #include <stdlib.h>                 // Required for: srand(), rand(), atexit()
 #include <stdio.h>                  // Required for: sprintf() [Used in OpenURL()]
 #include <string.h>                 // Required for: strrchr(), strcmp(), strlen()
@@ -2958,6 +2991,92 @@ const char *GetWorkingDirectory(void)
     char *path = GETCWD(currentDir, MAX_FILEPATH_LENGTH - 1);
 
     return path;
+}
+
+const char* GetApplicationDirectory(void)
+{
+	static char appDir[MAX_FILEPATH_LENGTH] = { 0 };
+	memset(appDir, 0, MAX_FILEPATH_LENGTH);
+
+#if defined(_WIN32)
+	typedef unsigned long(*GetModuleFileNameFunc)(void*, void*, void*, unsigned long);
+
+	GetModuleFileNameFunc getModuleFileNameExWPtr = NULL;
+	void* lib = LoadLibrary(L"psapi.dll");
+	if (lib == NULL)
+	{
+		appDir[0] = '\\';
+	}
+	else
+	{
+#if defined (UNICODE)
+		getModuleFileNameExWPtr = (GetModuleFileNameFunc)GetProcAddress(lib, "GetModuleFileNameExW");
+#else
+        getModuleFileNameExWPtr = (GetModuleFileNameFunc)GetProcAddress(lib, "GetModuleFileNameExA");
+#endif
+
+		if (getModuleFileNameExWPtr == NULL)
+		{
+			appDir[0] = '\\';
+		}
+		else
+		{
+            int len = 0;
+#if defined (UNICODE)
+			unsigned short widePath[MAX_PATH];
+			len = getModuleFileNameExWPtr(GetCurrentProcess(), NULL, widePath, MAX_PATH);
+
+			len = WideCharToMultiByte(0, 0, widePath, len, appDir, MAX_PATH, NULL, NULL);
+#else
+			len = getModuleFileNameExWPtr(GetCurrentProcess(), NULL, appDir, MAX_PATH);
+#endif
+			if (len > 0)
+			{
+				for (int i = len; i >= 0; --i)
+				{
+					if (appDir[i] == '\\')
+					{
+						appDir[i + 1] = '\0';
+						i = -1;
+					}
+				}
+			}
+		}
+		FreeLibrary(lib);
+	}
+#elif defined(__linux__)
+	unsigned int size = sizeof(appDir);
+
+	ssize_t len = readlink("/proc/self/exe", appDir, size);
+	if (len > 0)
+	{
+		for (int i = len; i >= 0; --i)
+		{
+			if (appDir[i] == '/')
+			{
+				appDir[i + 1] = '\0';
+				i = -1;
+			}
+		}
+	}
+#elif defined(__APPLE__)
+	uint32_t size = sizeof(appDir);
+
+	if (_NSGetExecutablePath(appDir, &size) == 0)
+	{
+		int len = strlne(appDir);
+		for (int i = len; i >= 0; --i)
+		{
+			if (appDir[i] == '/')
+			{
+				appDir[i + 1] = '\0';
+				i = -1;
+			}
+		}
+	}
+#endif
+
+    return appDir;
 }
 
 // Get filenames in a directory path

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -3064,7 +3064,7 @@ const char* GetApplicationDirectory(void)
 
 	if (_NSGetExecutablePath(appDir, &size) == 0)
 	{
-		int len = strlne(appDir);
+		int len = strlen(appDir);
 		for (int i = len; i >= 0; --i)
 		{
 			if (appDir[i] == '/')


### PR DESCRIPTION
This PR adds `GetApplicationDirectory `as a function. It uses platform specific code to find the folder that the executable is running in. This is a good path to pass to `ChangeDirectory `so that you ensure you have a good starting working directory.

While this does call platform specific code, it does not include `windows.h`
This is a feature that GLFW should provide, but does not, so we need to provide to to users ourselves.