### PR TITLE
Change comment about custom blend modes in rlgl.h

### DIFF
--- a/src/rlgl.h
+++ b/src/rlgl.h
@@ -433,7 +433,7 @@ typedef enum {
     RL_BLEND_MULTIPLIED,               // Blend textures multiplying colors
     RL_BLEND_ADD_COLORS,               // Blend textures adding colors (alternative)
     RL_BLEND_SUBTRACT_COLORS,          // Blend textures subtracting colors (alternative)
-    RL_BLEND_CUSTOM                    // Belnd textures using custom src/dst factors (use SetBlendModeCustom())
+    RL_BLEND_CUSTOM                    // Blend textures using custom src/dst factors (use rlSetBlendFactors())
 } rlBlendMode;
 
 // Shader location point type


### PR DESCRIPTION
Changed a reference to a now non-existent function in rlgl.h to the one that should be used to set custom blend modes. Also fixed the typo.