### PR TITLE
JSON parser: Use array for function params (#2255)

### DIFF
--- a/parser/raylib_api.json
+++ b/parser/raylib_api.json
@@ -2490,11 +2490,20 @@
       "name": "InitWindow",
       "description": "Initialize window and OpenGL context",
       "returnType": "void",
-      "params": {
-        "width": "int",
-        "height": "int",
-        "title": "const char *"
-      }
+      "params": [
+        {
+          "name": "width",
+          "type": "int"
+        },
+        {
+          "name": "height",
+          "type": "int"
+        },
+        {
+          "name": "title",
+          "type": "const char *"
+        }
+      ]
     },
     {
       "name": "WindowShouldClose",
@@ -2545,25 +2554,34 @@
       "name": "IsWindowState",
       "description": "Check if one specific window flag is enabled",
       "returnType": "bool",
-      "params": {
-        "flag": "unsigned int"
-      }
+      "params": [
+        {
+          "name": "flag",
+          "type": "unsigned int"
+        }
+      ]
     },
     {
       "name": "SetWindowState",
-      "description": "Set window configuration state using flags",
+      "description": "Set window configuration state using flags (only PLATFORM_DESKTOP)",
       "returnType": "void",
-      "params": {
-        "flags": "unsigned int"
-      }
+      "params": [
+        {
+          "name": "flags",
+          "type": "unsigned int"
+        }
+      ]
     },
     {
       "name": "ClearWindowState",
       "description": "Clear window configuration state flags",
       "returnType": "void",
-      "params": {
-        "flags": "unsigned int"
-      }
+      "params": [
+        {
+          "name": "flags",
+          "type": "unsigned int"
+        }
+      ]
     },
     {
       "name": "ToggleFullscreen",
@@ -2589,52 +2607,90 @@
       "name": "SetWindowIcon",
       "description": "Set icon for window (only PLATFORM_DESKTOP)",
       "returnType": "void",
-      "params": {
-        "image": "Image"
-      }
+      "params": [
+        {
+          "name": "image",
+          "type": "Image"
+        }
+      ]
     },
     {
       "name": "SetWindowTitle",
       "description": "Set title for window (only PLATFORM_DESKTOP)",
       "returnType": "void",
-      "params": {
-        "title": "const char *"
-      }
+      "params": [
+        {
+          "name": "title",
+          "type": "const char *"
+        }
+      ]
     },
     {
       "name": "SetWindowPosition",
       "description": "Set window position on screen (only PLATFORM_DESKTOP)",
       "returnType": "void",
-      "params": {
-        "x": "int",
-        "y": "int"
-      }
+      "params": [
+        {
+          "name": "x",
+          "type": "int"
+        },
+        {
+          "name": "y",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "SetWindowMonitor",
       "description": "Set monitor for the current window (fullscreen mode)",
       "returnType": "void",
-      "params": {
-        "monitor": "int"
-      }
+      "params": [
+        {
+          "name": "monitor",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "SetWindowMinSize",
       "description": "Set window minimum dimensions (for FLAG_WINDOW_RESIZABLE)",
       "returnType": "void",
-      "params": {
-        "width": "int",
-        "height": "int"
-      }
+      "params": [
+        {
+          "name": "width",
+          "type": "int"
+        },
+        {
+          "name": "height",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "SetWindowSize",
       "description": "Set window dimensions",
       "returnType": "void",
-      "params": {
-        "width": "int",
-        "height": "int"
-      }
+      "params": [
+        {
+          "name": "width",
+          "type": "int"
+        },
+        {
+          "name": "height",
+          "type": "int"
+        }
+      ]
+    },
+    {
+      "name": "SetWindowOpacity",
+      "description": "Set window opacity [0.0f..1.0f] (only PLATFORM_DESKTOP)",
+      "returnType": "void",
+      "params": [
+        {
+          "name": "opacity",
+          "type": "float"
+        }
+      ]
     },
     {
       "name": "GetWindowHandle",
@@ -2675,49 +2731,67 @@
       "name": "GetMonitorPosition",
       "description": "Get specified monitor position",
       "returnType": "Vector2",
-      "params": {
-        "monitor": "int"
-      }
+      "params": [
+        {
+          "name": "monitor",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "GetMonitorWidth",
       "description": "Get specified monitor width (max available by monitor)",
       "returnType": "int",
-      "params": {
-        "monitor": "int"
-      }
+      "params": [
+        {
+          "name": "monitor",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "GetMonitorHeight",
       "description": "Get specified monitor height (max available by monitor)",
       "returnType": "int",
-      "params": {
-        "monitor": "int"
-      }
+      "params": [
+        {
+          "name": "monitor",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "GetMonitorPhysicalWidth",
       "description": "Get specified monitor physical width in millimetres",
       "returnType": "int",
-      "params": {
-        "monitor": "int"
-      }
+      "params": [
+        {
+          "name": "monitor",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "GetMonitorPhysicalHeight",
       "description": "Get specified monitor physical height in millimetres",
       "returnType": "int",
-      "params": {
-        "monitor": "int"
-      }
+      "params": [
+        {
+          "name": "monitor",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "GetMonitorRefreshRate",
       "description": "Get specified monitor refresh rate",
       "returnType": "int",
-      "params": {
-        "monitor": "int"
-      }
+      "params": [
+        {
+          "name": "monitor",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "GetWindowPosition",
@@ -2733,17 +2807,23 @@
       "name": "GetMonitorName",
       "description": "Get the human-readable, UTF-8 encoded name of the primary monitor",
       "returnType": "const char *",
-      "params": {
-        "monitor": "int"
-      }
+      "params": [
+        {
+          "name": "monitor",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "SetClipboardText",
       "description": "Set clipboard text content",
       "returnType": "void",
-      "params": {
-        "text": "const char *"
-      }
+      "params": [
+        {
+          "name": "text",
+          "type": "const char *"
+        }
+      ]
     },
     {
       "name": "GetClipboardText",
@@ -2764,9 +2844,12 @@
       "name": "WaitTime",
       "description": "Wait for some milliseconds (halt program execution)",
       "returnType": "void",
-      "params": {
-        "ms": "float"
-      }
+      "params": [
+        {
+          "name": "ms",
+          "type": "float"
+        }
+      ]
     },
     {
       "name": "ShowCursor",
@@ -2802,9 +2885,12 @@
       "name": "ClearBackground",
       "description": "Set background color (framebuffer clear color)",
       "returnType": "void",
-      "params": {
-        "color": "Color"
-      }
+      "params": [
+        {
+          "name": "color",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "BeginDrawing",
@@ -2820,9 +2906,12 @@
       "name": "BeginMode2D",
       "description": "Begin 2D mode with custom camera (2D)",
       "returnType": "void",
-      "params": {
-        "camera": "Camera2D"
-      }
+      "params": [
+        {
+          "name": "camera",
+          "type": "Camera2D"
+        }
+      ]
     },
     {
       "name": "EndMode2D",
@@ -2833,9 +2922,12 @@
       "name": "BeginMode3D",
       "description": "Begin 3D mode with custom camera (3D)",
       "returnType": "void",
-      "params": {
-        "camera": "Camera3D"
-      }
+      "params": [
+        {
+          "name": "camera",
+          "type": "Camera3D"
+        }
+      ]
     },
     {
       "name": "EndMode3D",
@@ -2846,9 +2938,12 @@
       "name": "BeginTextureMode",
       "description": "Begin drawing to render texture",
       "returnType": "void",
-      "params": {
-        "target": "RenderTexture2D"
-      }
+      "params": [
+        {
+          "name": "target",
+          "type": "RenderTexture2D"
+        }
+      ]
     },
     {
       "name": "EndTextureMode",
@@ -2859,9 +2954,12 @@
       "name": "BeginShaderMode",
       "description": "Begin custom shader drawing",
       "returnType": "void",
-      "params": {
-        "shader": "Shader"
-      }
+      "params": [
+        {
+          "name": "shader",
+          "type": "Shader"
+        }
+      ]
     },
     {
       "name": "EndShaderMode",
@@ -2872,9 +2970,12 @@
       "name": "BeginBlendMode",
       "description": "Begin blending mode (alpha, additive, multiplied, subtract, custom)",
       "returnType": "void",
-      "params": {
-        "mode": "int"
-      }
+      "params": [
+        {
+          "name": "mode",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "EndBlendMode",
@@ -2885,12 +2986,24 @@
       "name": "BeginScissorMode",
       "description": "Begin scissor mode (define screen area for following drawing)",
       "returnType": "void",
-      "params": {
-        "x": "int",
-        "y": "int",
-        "width": "int",
-        "height": "int"
-      }
+      "params": [
+        {
+          "name": "x",
+          "type": "int"
+        },
+        {
+          "name": "y",
+          "type": "int"
+        },
+        {
+          "name": "width",
+          "type": "int"
+        },
+        {
+          "name": "height",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "EndScissorMode",
@@ -2901,9 +3014,12 @@
       "name": "BeginVrStereoMode",
       "description": "Begin stereo rendering (requires VR simulator)",
       "returnType": "void",
-      "params": {
-        "config": "VrStereoConfig"
-      }
+      "params": [
+        {
+          "name": "config",
+          "type": "VrStereoConfig"
+        }
+      ]
     },
     {
       "name": "EndVrStereoMode",
@@ -2914,175 +3030,298 @@
       "name": "LoadVrStereoConfig",
       "description": "Load VR stereo config for VR simulator device parameters",
       "returnType": "VrStereoConfig",
-      "params": {
-        "device": "VrDeviceInfo"
-      }
+      "params": [
+        {
+          "name": "device",
+          "type": "VrDeviceInfo"
+        }
+      ]
     },
     {
       "name": "UnloadVrStereoConfig",
       "description": "Unload VR stereo config",
       "returnType": "void",
-      "params": {
-        "config": "VrStereoConfig"
-      }
+      "params": [
+        {
+          "name": "config",
+          "type": "VrStereoConfig"
+        }
+      ]
     },
     {
       "name": "LoadShader",
       "description": "Load shader from files and bind default locations",
       "returnType": "Shader",
-      "params": {
-        "vsFileName": "const char *",
-        "fsFileName": "const char *"
-      }
+      "params": [
+        {
+          "name": "vsFileName",
+          "type": "const char *"
+        },
+        {
+          "name": "fsFileName",
+          "type": "const char *"
+        }
+      ]
     },
     {
       "name": "LoadShaderFromMemory",
       "description": "Load shader from code strings and bind default locations",
       "returnType": "Shader",
-      "params": {
-        "vsCode": "const char *",
-        "fsCode": "const char *"
-      }
+      "params": [
+        {
+          "name": "vsCode",
+          "type": "const char *"
+        },
+        {
+          "name": "fsCode",
+          "type": "const char *"
+        }
+      ]
     },
     {
       "name": "GetShaderLocation",
       "description": "Get shader uniform location",
       "returnType": "int",
-      "params": {
-        "shader": "Shader",
-        "uniformName": "const char *"
-      }
+      "params": [
+        {
+          "name": "shader",
+          "type": "Shader"
+        },
+        {
+          "name": "uniformName",
+          "type": "const char *"
+        }
+      ]
     },
     {
       "name": "GetShaderLocationAttrib",
       "description": "Get shader attribute location",
       "returnType": "int",
-      "params": {
-        "shader": "Shader",
-        "attribName": "const char *"
-      }
+      "params": [
+        {
+          "name": "shader",
+          "type": "Shader"
+        },
+        {
+          "name": "attribName",
+          "type": "const char *"
+        }
+      ]
     },
     {
       "name": "SetShaderValue",
       "description": "Set shader uniform value",
       "returnType": "void",
-      "params": {
-        "shader": "Shader",
-        "locIndex": "int",
-        "value": "const void *",
-        "uniformType": "int"
-      }
+      "params": [
+        {
+          "name": "shader",
+          "type": "Shader"
+        },
+        {
+          "name": "locIndex",
+          "type": "int"
+        },
+        {
+          "name": "value",
+          "type": "const void *"
+        },
+        {
+          "name": "uniformType",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "SetShaderValueV",
       "description": "Set shader uniform value vector",
       "returnType": "void",
-      "params": {
-        "shader": "Shader",
-        "locIndex": "int",
-        "value": "const void *",
-        "uniformType": "int",
-        "count": "int"
-      }
+      "params": [
+        {
+          "name": "shader",
+          "type": "Shader"
+        },
+        {
+          "name": "locIndex",
+          "type": "int"
+        },
+        {
+          "name": "value",
+          "type": "const void *"
+        },
+        {
+          "name": "uniformType",
+          "type": "int"
+        },
+        {
+          "name": "count",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "SetShaderValueMatrix",
       "description": "Set shader uniform value (matrix 4x4)",
       "returnType": "void",
-      "params": {
-        "shader": "Shader",
-        "locIndex": "int",
-        "mat": "Matrix"
-      }
+      "params": [
+        {
+          "name": "shader",
+          "type": "Shader"
+        },
+        {
+          "name": "locIndex",
+          "type": "int"
+        },
+        {
+          "name": "mat",
+          "type": "Matrix"
+        }
+      ]
     },
     {
       "name": "SetShaderValueTexture",
       "description": "Set shader uniform value for texture (sampler2d)",
       "returnType": "void",
-      "params": {
-        "shader": "Shader",
-        "locIndex": "int",
-        "texture": "Texture2D"
-      }
+      "params": [
+        {
+          "name": "shader",
+          "type": "Shader"
+        },
+        {
+          "name": "locIndex",
+          "type": "int"
+        },
+        {
+          "name": "texture",
+          "type": "Texture2D"
+        }
+      ]
     },
     {
       "name": "UnloadShader",
       "description": "Unload shader from GPU memory (VRAM)",
       "returnType": "void",
-      "params": {
-        "shader": "Shader"
-      }
+      "params": [
+        {
+          "name": "shader",
+          "type": "Shader"
+        }
+      ]
     },
     {
       "name": "GetMouseRay",
       "description": "Get a ray trace from mouse position",
       "returnType": "Ray",
-      "params": {
-        "mousePosition": "Vector2",
-        "camera": "Camera"
-      }
+      "params": [
+        {
+          "name": "mousePosition",
+          "type": "Vector2"
+        },
+        {
+          "name": "camera",
+          "type": "Camera"
+        }
+      ]
     },
     {
       "name": "GetCameraMatrix",
       "description": "Get camera transform matrix (view matrix)",
       "returnType": "Matrix",
-      "params": {
-        "camera": "Camera"
-      }
+      "params": [
+        {
+          "name": "camera",
+          "type": "Camera"
+        }
+      ]
     },
     {
       "name": "GetCameraMatrix2D",
       "description": "Get camera 2d transform matrix",
       "returnType": "Matrix",
-      "params": {
-        "camera": "Camera2D"
-      }
+      "params": [
+        {
+          "name": "camera",
+          "type": "Camera2D"
+        }
+      ]
     },
     {
       "name": "GetWorldToScreen",
       "description": "Get the screen space position for a 3d world space position",
       "returnType": "Vector2",
-      "params": {
-        "position": "Vector3",
-        "camera": "Camera"
-      }
+      "params": [
+        {
+          "name": "position",
+          "type": "Vector3"
+        },
+        {
+          "name": "camera",
+          "type": "Camera"
+        }
+      ]
     },
     {
       "name": "GetWorldToScreenEx",
       "description": "Get size position for a 3d world space position",
       "returnType": "Vector2",
-      "params": {
-        "position": "Vector3",
-        "camera": "Camera",
-        "width": "int",
-        "height": "int"
-      }
+      "params": [
+        {
+          "name": "position",
+          "type": "Vector3"
+        },
+        {
+          "name": "camera",
+          "type": "Camera"
+        },
+        {
+          "name": "width",
+          "type": "int"
+        },
+        {
+          "name": "height",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "GetWorldToScreen2D",
       "description": "Get the screen space position for a 2d camera world space position",
       "returnType": "Vector2",
-      "params": {
-        "position": "Vector2",
-        "camera": "Camera2D"
-      }
+      "params": [
+        {
+          "name": "position",
+          "type": "Vector2"
+        },
+        {
+          "name": "camera",
+          "type": "Camera2D"
+        }
+      ]
     },
     {
       "name": "GetScreenToWorld2D",
       "description": "Get the world space position for a 2d camera screen space position",
       "returnType": "Vector2",
-      "params": {
-        "position": "Vector2",
-        "camera": "Camera2D"
-      }
+      "params": [
+        {
+          "name": "position",
+          "type": "Vector2"
+        },
+        {
+          "name": "camera",
+          "type": "Camera2D"
+        }
+      ]
     },
     {
       "name": "SetTargetFPS",
       "description": "Set target FPS (maximum)",
       "returnType": "void",
-      "params": {
-        "fps": "int"
-      }
+      "params": [
+        {
+          "name": "fps",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "GetFPS",
@@ -3103,234 +3342,345 @@
       "name": "GetRandomValue",
       "description": "Get a random value between min and max (both included)",
       "returnType": "int",
-      "params": {
-        "min": "int",
-        "max": "int"
-      }
+      "params": [
+        {
+          "name": "min",
+          "type": "int"
+        },
+        {
+          "name": "max",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "SetRandomSeed",
       "description": "Set the seed for the random number generator",
       "returnType": "void",
-      "params": {
-        "seed": "unsigned int"
-      }
+      "params": [
+        {
+          "name": "seed",
+          "type": "unsigned int"
+        }
+      ]
     },
     {
       "name": "TakeScreenshot",
       "description": "Takes a screenshot of current screen (filename extension defines format)",
       "returnType": "void",
-      "params": {
-        "fileName": "const char *"
-      }
+      "params": [
+        {
+          "name": "fileName",
+          "type": "const char *"
+        }
+      ]
     },
     {
       "name": "SetConfigFlags",
       "description": "Setup init configuration flags (view FLAGS)",
       "returnType": "void",
-      "params": {
-        "flags": "unsigned int"
-      }
+      "params": [
+        {
+          "name": "flags",
+          "type": "unsigned int"
+        }
+      ]
     },
     {
       "name": "TraceLog",
       "description": "Show trace log messages (LOG_DEBUG, LOG_INFO, LOG_WARNING, LOG_ERROR...)",
       "returnType": "void",
-      "params": {
-        "logLevel": "int",
-        "text": "const char *",
-        "": ""
-      }
+      "params": [
+        {
+          "name": "logLevel",
+          "type": "int"
+        },
+        {
+          "name": "text",
+          "type": "const char *"
+        },
+        {
+          "name": "",
+          "type": ""
+        }
+      ]
     },
     {
       "name": "SetTraceLogLevel",
       "description": "Set the current threshold (minimum) log level",
       "returnType": "void",
-      "params": {
-        "logLevel": "int"
-      }
+      "params": [
+        {
+          "name": "logLevel",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "MemAlloc",
       "description": "Internal memory allocator",
       "returnType": "void *",
-      "params": {
-        "size": "int"
-      }
+      "params": [
+        {
+          "name": "size",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "MemRealloc",
       "description": "Internal memory reallocator",
       "returnType": "void *",
-      "params": {
-        "ptr": "void *",
-        "size": "int"
-      }
+      "params": [
+        {
+          "name": "ptr",
+          "type": "void *"
+        },
+        {
+          "name": "size",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "MemFree",
       "description": "Internal memory free",
       "returnType": "void",
-      "params": {
-        "ptr": "void *"
-      }
+      "params": [
+        {
+          "name": "ptr",
+          "type": "void *"
+        }
+      ]
     },
     {
       "name": "SetTraceLogCallback",
       "description": "Set custom trace log",
       "returnType": "void",
-      "params": {
-        "callback": "TraceLogCallback"
-      }
+      "params": [
+        {
+          "name": "callback",
+          "type": "TraceLogCallback"
+        }
+      ]
     },
     {
       "name": "SetLoadFileDataCallback",
       "description": "Set custom file binary data loader",
       "returnType": "void",
-      "params": {
-        "callback": "LoadFileDataCallback"
-      }
+      "params": [
+        {
+          "name": "callback",
+          "type": "LoadFileDataCallback"
+        }
+      ]
     },
     {
       "name": "SetSaveFileDataCallback",
       "description": "Set custom file binary data saver",
       "returnType": "void",
-      "params": {
-        "callback": "SaveFileDataCallback"
-      }
+      "params": [
+        {
+          "name": "callback",
+          "type": "SaveFileDataCallback"
+        }
+      ]
     },
     {
       "name": "SetLoadFileTextCallback",
       "description": "Set custom file text data loader",
       "returnType": "void",
-      "params": {
-        "callback": "LoadFileTextCallback"
-      }
+      "params": [
+        {
+          "name": "callback",
+          "type": "LoadFileTextCallback"
+        }
+      ]
     },
     {
       "name": "SetSaveFileTextCallback",
       "description": "Set custom file text data saver",
       "returnType": "void",
-      "params": {
-        "callback": "SaveFileTextCallback"
-      }
+      "params": [
+        {
+          "name": "callback",
+          "type": "SaveFileTextCallback"
+        }
+      ]
     },
     {
       "name": "LoadFileData",
       "description": "Load file data as byte array (read)",
       "returnType": "unsigned char *",
-      "params": {
-        "fileName": "const char *",
-        "bytesRead": "unsigned int *"
-      }
+      "params": [
+        {
+          "name": "fileName",
+          "type": "const char *"
+        },
+        {
+          "name": "bytesRead",
+          "type": "unsigned int *"
+        }
+      ]
     },
     {
       "name": "UnloadFileData",
       "description": "Unload file data allocated by LoadFileData()",
       "returnType": "void",
-      "params": {
-        "data": "unsigned char *"
-      }
+      "params": [
+        {
+          "name": "data",
+          "type": "unsigned char *"
+        }
+      ]
     },
     {
       "name": "SaveFileData",
       "description": "Save data to file from byte array (write), returns true on success",
       "returnType": "bool",
-      "params": {
-        "fileName": "const char *",
-        "data": "void *",
-        "bytesToWrite": "unsigned int"
-      }
+      "params": [
+        {
+          "name": "fileName",
+          "type": "const char *"
+        },
+        {
+          "name": "data",
+          "type": "void *"
+        },
+        {
+          "name": "bytesToWrite",
+          "type": "unsigned int"
+        }
+      ]
     },
     {
       "name": "LoadFileText",
       "description": "Load text data from file (read), returns a '\\0' terminated string",
       "returnType": "char *",
-      "params": {
-        "fileName": "const char *"
-      }
+      "params": [
+        {
+          "name": "fileName",
+          "type": "const char *"
+        }
+      ]
     },
     {
       "name": "UnloadFileText",
       "description": "Unload file text data allocated by LoadFileText()",
       "returnType": "void",
-      "params": {
-        "text": "char *"
-      }
+      "params": [
+        {
+          "name": "text",
+          "type": "char *"
+        }
+      ]
     },
     {
       "name": "SaveFileText",
       "description": "Save text data to file (write), string must be '\\0' terminated, returns true on success",
       "returnType": "bool",
-      "params": {
-        "fileName": "const char *",
-        "text": "char *"
-      }
+      "params": [
+        {
+          "name": "fileName",
+          "type": "const char *"
+        },
+        {
+          "name": "text",
+          "type": "char *"
+        }
+      ]
     },
     {
       "name": "FileExists",
       "description": "Check if file exists",
       "returnType": "bool",
-      "params": {
-        "fileName": "const char *"
-      }
+      "params": [
+        {
+          "name": "fileName",
+          "type": "const char *"
+        }
+      ]
     },
     {
       "name": "DirectoryExists",
       "description": "Check if a directory path exists",
       "returnType": "bool",
-      "params": {
-        "dirPath": "const char *"
-      }
+      "params": [
+        {
+          "name": "dirPath",
+          "type": "const char *"
+        }
+      ]
     },
     {
       "name": "IsFileExtension",
       "description": "Check file extension (including point: .png, .wav)",
       "returnType": "bool",
-      "params": {
-        "fileName": "const char *",
-        "ext": "const char *"
-      }
+      "params": [
+        {
+          "name": "fileName",
+          "type": "const char *"
+        },
+        {
+          "name": "ext",
+          "type": "const char *"
+        }
+      ]
     },
     {
       "name": "GetFileExtension",
       "description": "Get pointer to extension for a filename string (includes dot: '.png')",
       "returnType": "const char *",
-      "params": {
-        "fileName": "const char *"
-      }
+      "params": [
+        {
+          "name": "fileName",
+          "type": "const char *"
+        }
+      ]
     },
     {
       "name": "GetFileName",
       "description": "Get pointer to filename for a path string",
       "returnType": "const char *",
-      "params": {
-        "filePath": "const char *"
-      }
+      "params": [
+        {
+          "name": "filePath",
+          "type": "const char *"
+        }
+      ]
     },
     {
       "name": "GetFileNameWithoutExt",
       "description": "Get filename string without extension (uses static string)",
       "returnType": "const char *",
-      "params": {
-        "filePath": "const char *"
-      }
+      "params": [
+        {
+          "name": "filePath",
+          "type": "const char *"
+        }
+      ]
     },
     {
       "name": "GetDirectoryPath",
       "description": "Get full path for a given fileName with path (uses static string)",
       "returnType": "const char *",
-      "params": {
-        "filePath": "const char *"
-      }
+      "params": [
+        {
+          "name": "filePath",
+          "type": "const char *"
+        }
+      ]
     },
     {
       "name": "GetPrevDirectoryPath",
       "description": "Get previous directory path for a given path (uses static string)",
       "returnType": "const char *",
-      "params": {
-        "dirPath": "const char *"
-      }
+      "params": [
+        {
+          "name": "dirPath",
+          "type": "const char *"
+        }
+      ]
     },
     {
       "name": "GetWorkingDirectory",
@@ -3341,10 +3691,16 @@
       "name": "GetDirectoryFiles",
       "description": "Get filenames in a directory path (memory should be freed)",
       "returnType": "char **",
-      "params": {
-        "dirPath": "const char *",
-        "count": "int *"
-      }
+      "params": [
+        {
+          "name": "dirPath",
+          "type": "const char *"
+        },
+        {
+          "name": "count",
+          "type": "int *"
+        }
+      ]
     },
     {
       "name": "ClearDirectoryFiles",
@@ -3355,9 +3711,12 @@
       "name": "ChangeDirectory",
       "description": "Change working directory, return true on success",
       "returnType": "bool",
-      "params": {
-        "dir": "const char *"
-      }
+      "params": [
+        {
+          "name": "dir",
+          "type": "const char *"
+        }
+      ]
     },
     {
       "name": "IsFileDropped",
@@ -3368,9 +3727,12 @@
       "name": "GetDroppedFiles",
       "description": "Get dropped files names (memory should be freed)",
       "returnType": "char **",
-      "params": {
-        "count": "int *"
-      }
+      "params": [
+        {
+          "name": "count",
+          "type": "int *"
+        }
+      ]
     },
     {
       "name": "ClearDroppedFiles",
@@ -3381,113 +3743,176 @@
       "name": "GetFileModTime",
       "description": "Get file modification time (last write time)",
       "returnType": "long",
-      "params": {
-        "fileName": "const char *"
-      }
+      "params": [
+        {
+          "name": "fileName",
+          "type": "const char *"
+        }
+      ]
     },
     {
       "name": "CompressData",
       "description": "Compress data (DEFLATE algorithm)",
       "returnType": "unsigned char *",
-      "params": {
-        "data": "unsigned char *",
-        "dataLength": "int",
-        "compDataLength": "int *"
-      }
+      "params": [
+        {
+          "name": "data",
+          "type": "unsigned char *"
+        },
+        {
+          "name": "dataLength",
+          "type": "int"
+        },
+        {
+          "name": "compDataLength",
+          "type": "int *"
+        }
+      ]
     },
     {
       "name": "DecompressData",
       "description": "Decompress data (DEFLATE algorithm)",
       "returnType": "unsigned char *",
-      "params": {
-        "compData": "unsigned char *",
-        "compDataLength": "int",
-        "dataLength": "int *"
-      }
+      "params": [
+        {
+          "name": "compData",
+          "type": "unsigned char *"
+        },
+        {
+          "name": "compDataLength",
+          "type": "int"
+        },
+        {
+          "name": "dataLength",
+          "type": "int *"
+        }
+      ]
     },
     {
       "name": "EncodeDataBase64",
       "description": "Encode data to Base64 string",
       "returnType": "char *",
-      "params": {
-        "data": "const unsigned char *",
-        "dataLength": "int",
-        "outputLength": "int *"
-      }
+      "params": [
+        {
+          "name": "data",
+          "type": "const unsigned char *"
+        },
+        {
+          "name": "dataLength",
+          "type": "int"
+        },
+        {
+          "name": "outputLength",
+          "type": "int *"
+        }
+      ]
     },
     {
       "name": "DecodeDataBase64",
       "description": "Decode Base64 string data",
       "returnType": "unsigned char *",
-      "params": {
-        "data": "unsigned char *",
-        "outputLength": "int *"
-      }
+      "params": [
+        {
+          "name": "data",
+          "type": "unsigned char *"
+        },
+        {
+          "name": "outputLength",
+          "type": "int *"
+        }
+      ]
     },
     {
       "name": "SaveStorageValue",
       "description": "Save integer value to storage file (to defined position), returns true on success",
       "returnType": "bool",
-      "params": {
-        "position": "unsigned int",
-        "value": "int"
-      }
+      "params": [
+        {
+          "name": "position",
+          "type": "unsigned int"
+        },
+        {
+          "name": "value",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "LoadStorageValue",
       "description": "Load integer value from storage file (from defined position)",
       "returnType": "int",
-      "params": {
-        "position": "unsigned int"
-      }
+      "params": [
+        {
+          "name": "position",
+          "type": "unsigned int"
+        }
+      ]
     },
     {
       "name": "OpenURL",
       "description": "Open URL with default system browser (if available)",
       "returnType": "void",
-      "params": {
-        "url": "const char *"
-      }
+      "params": [
+        {
+          "name": "url",
+          "type": "const char *"
+        }
+      ]
     },
     {
       "name": "IsKeyPressed",
       "description": "Check if a key has been pressed once",
       "returnType": "bool",
-      "params": {
-        "key": "int"
-      }
+      "params": [
+        {
+          "name": "key",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "IsKeyDown",
       "description": "Check if a key is being pressed",
       "returnType": "bool",
-      "params": {
-        "key": "int"
-      }
+      "params": [
+        {
+          "name": "key",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "IsKeyReleased",
       "description": "Check if a key has been released once",
       "returnType": "bool",
-      "params": {
-        "key": "int"
-      }
+      "params": [
+        {
+          "name": "key",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "IsKeyUp",
       "description": "Check if a key is NOT being pressed",
       "returnType": "bool",
-      "params": {
-        "key": "int"
-      }
+      "params": [
+        {
+          "name": "key",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "SetExitKey",
       "description": "Set a custom key to exit program (default is ESC)",
       "returnType": "void",
-      "params": {
-        "key": "int"
-      }
+      "params": [
+        {
+          "name": "key",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "GetKeyPressed",
@@ -3503,53 +3928,83 @@
       "name": "IsGamepadAvailable",
       "description": "Check if a gamepad is available",
       "returnType": "bool",
-      "params": {
-        "gamepad": "int"
-      }
+      "params": [
+        {
+          "name": "gamepad",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "GetGamepadName",
       "description": "Get gamepad internal name id",
       "returnType": "const char *",
-      "params": {
-        "gamepad": "int"
-      }
+      "params": [
+        {
+          "name": "gamepad",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "IsGamepadButtonPressed",
       "description": "Check if a gamepad button has been pressed once",
       "returnType": "bool",
-      "params": {
-        "gamepad": "int",
-        "button": "int"
-      }
+      "params": [
+        {
+          "name": "gamepad",
+          "type": "int"
+        },
+        {
+          "name": "button",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "IsGamepadButtonDown",
       "description": "Check if a gamepad button is being pressed",
       "returnType": "bool",
-      "params": {
-        "gamepad": "int",
-        "button": "int"
-      }
+      "params": [
+        {
+          "name": "gamepad",
+          "type": "int"
+        },
+        {
+          "name": "button",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "IsGamepadButtonReleased",
       "description": "Check if a gamepad button has been released once",
       "returnType": "bool",
-      "params": {
-        "gamepad": "int",
-        "button": "int"
-      }
+      "params": [
+        {
+          "name": "gamepad",
+          "type": "int"
+        },
+        {
+          "name": "button",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "IsGamepadButtonUp",
       "description": "Check if a gamepad button is NOT being pressed",
       "returnType": "bool",
-      "params": {
-        "gamepad": "int",
-        "button": "int"
-      }
+      "params": [
+        {
+          "name": "gamepad",
+          "type": "int"
+        },
+        {
+          "name": "button",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "GetGamepadButtonPressed",
@@ -3560,58 +4015,82 @@
       "name": "GetGamepadAxisCount",
       "description": "Get gamepad axis count for a gamepad",
       "returnType": "int",
-      "params": {
-        "gamepad": "int"
-      }
+      "params": [
+        {
+          "name": "gamepad",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "GetGamepadAxisMovement",
       "description": "Get axis movement value for a gamepad axis",
       "returnType": "float",
-      "params": {
-        "gamepad": "int",
-        "axis": "int"
-      }
+      "params": [
+        {
+          "name": "gamepad",
+          "type": "int"
+        },
+        {
+          "name": "axis",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "SetGamepadMappings",
       "description": "Set internal gamepad mappings (SDL_GameControllerDB)",
       "returnType": "int",
-      "params": {
-        "mappings": "const char *"
-      }
+      "params": [
+        {
+          "name": "mappings",
+          "type": "const char *"
+        }
+      ]
     },
     {
       "name": "IsMouseButtonPressed",
       "description": "Check if a mouse button has been pressed once",
       "returnType": "bool",
-      "params": {
-        "button": "int"
-      }
+      "params": [
+        {
+          "name": "button",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "IsMouseButtonDown",
       "description": "Check if a mouse button is being pressed",
       "returnType": "bool",
-      "params": {
-        "button": "int"
-      }
+      "params": [
+        {
+          "name": "button",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "IsMouseButtonReleased",
       "description": "Check if a mouse button has been released once",
       "returnType": "bool",
-      "params": {
-        "button": "int"
-      }
+      "params": [
+        {
+          "name": "button",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "IsMouseButtonUp",
       "description": "Check if a mouse button is NOT being pressed",
       "returnType": "bool",
-      "params": {
-        "button": "int"
-      }
+      "params": [
+        {
+          "name": "button",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "GetMouseX",
@@ -3637,28 +4116,46 @@
       "name": "SetMousePosition",
       "description": "Set mouse position XY",
       "returnType": "void",
-      "params": {
-        "x": "int",
-        "y": "int"
-      }
+      "params": [
+        {
+          "name": "x",
+          "type": "int"
+        },
+        {
+          "name": "y",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "SetMouseOffset",
       "description": "Set mouse offset",
       "returnType": "void",
-      "params": {
-        "offsetX": "int",
-        "offsetY": "int"
-      }
+      "params": [
+        {
+          "name": "offsetX",
+          "type": "int"
+        },
+        {
+          "name": "offsetY",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "SetMouseScale",
       "description": "Set mouse scaling",
       "returnType": "void",
-      "params": {
-        "scaleX": "float",
-        "scaleY": "float"
-      }
+      "params": [
+        {
+          "name": "scaleX",
+          "type": "float"
+        },
+        {
+          "name": "scaleY",
+          "type": "float"
+        }
+      ]
     },
     {
       "name": "GetMouseWheelMove",
@@ -3669,9 +4166,12 @@
       "name": "SetMouseCursor",
       "description": "Set mouse cursor",
       "returnType": "void",
-      "params": {
-        "cursor": "int"
-      }
+      "params": [
+        {
+          "name": "cursor",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "GetTouchX",
@@ -3687,17 +4187,23 @@
       "name": "GetTouchPosition",
       "description": "Get touch position XY for a touch point index (relative to screen size)",
       "returnType": "Vector2",
-      "params": {
-        "index": "int"
-      }
+      "params": [
+        {
+          "name": "index",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "GetTouchPointId",
       "description": "Get touch point identifier for given index",
       "returnType": "int",
-      "params": {
-        "index": "int"
-      }
+      "params": [
+        {
+          "name": "index",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "GetTouchPointCount",
@@ -3708,17 +4214,23 @@
       "name": "SetGesturesEnabled",
       "description": "Enable a set of gestures using flags",
       "returnType": "void",
-      "params": {
-        "flags": "unsigned int"
-      }
+      "params": [
+        {
+          "name": "flags",
+          "type": "unsigned int"
+        }
+      ]
     },
     {
       "name": "IsGestureDetected",
       "description": "Check if a gesture have been detected",
       "returnType": "bool",
-      "params": {
-        "gesture": "int"
-      }
+      "params": [
+        {
+          "name": "gesture",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "GetGestureDetected",
@@ -3754,627 +4266,1287 @@
       "name": "SetCameraMode",
       "description": "Set camera mode (multiple camera modes available)",
       "returnType": "void",
-      "params": {
-        "camera": "Camera",
-        "mode": "int"
-      }
+      "params": [
+        {
+          "name": "camera",
+          "type": "Camera"
+        },
+        {
+          "name": "mode",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "UpdateCamera",
       "description": "Update camera position for selected mode",
       "returnType": "void",
-      "params": {
-        "camera": "Camera *"
-      }
+      "params": [
+        {
+          "name": "camera",
+          "type": "Camera *"
+        }
+      ]
     },
     {
       "name": "SetCameraPanControl",
       "description": "Set camera pan key to combine with mouse movement (free camera)",
       "returnType": "void",
-      "params": {
-        "keyPan": "int"
-      }
+      "params": [
+        {
+          "name": "keyPan",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "SetCameraAltControl",
       "description": "Set camera alt key to combine with mouse movement (free camera)",
       "returnType": "void",
-      "params": {
-        "keyAlt": "int"
-      }
+      "params": [
+        {
+          "name": "keyAlt",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "SetCameraSmoothZoomControl",
       "description": "Set camera smooth zoom key to combine with mouse (free camera)",
       "returnType": "void",
-      "params": {
-        "keySmoothZoom": "int"
-      }
+      "params": [
+        {
+          "name": "keySmoothZoom",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "SetCameraMoveControls",
       "description": "Set camera move controls (1st person and 3rd person cameras)",
       "returnType": "void",
-      "params": {
-        "keyFront": "int",
-        "keyBack": "int",
-        "keyRight": "int",
-        "keyLeft": "int",
-        "keyUp": "int",
-        "keyDown": "int"
-      }
+      "params": [
+        {
+          "name": "keyFront",
+          "type": "int"
+        },
+        {
+          "name": "keyBack",
+          "type": "int"
+        },
+        {
+          "name": "keyRight",
+          "type": "int"
+        },
+        {
+          "name": "keyLeft",
+          "type": "int"
+        },
+        {
+          "name": "keyUp",
+          "type": "int"
+        },
+        {
+          "name": "keyDown",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "SetShapesTexture",
       "description": "Set texture and rectangle to be used on shapes drawing",
       "returnType": "void",
-      "params": {
-        "texture": "Texture2D",
-        "source": "Rectangle"
-      }
+      "params": [
+        {
+          "name": "texture",
+          "type": "Texture2D"
+        },
+        {
+          "name": "source",
+          "type": "Rectangle"
+        }
+      ]
     },
     {
       "name": "DrawPixel",
       "description": "Draw a pixel",
       "returnType": "void",
-      "params": {
-        "posX": "int",
-        "posY": "int",
-        "color": "Color"
-      }
+      "params": [
+        {
+          "name": "posX",
+          "type": "int"
+        },
+        {
+          "name": "posY",
+          "type": "int"
+        },
+        {
+          "name": "color",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "DrawPixelV",
       "description": "Draw a pixel (Vector version)",
       "returnType": "void",
-      "params": {
-        "position": "Vector2",
-        "color": "Color"
-      }
+      "params": [
+        {
+          "name": "position",
+          "type": "Vector2"
+        },
+        {
+          "name": "color",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "DrawLine",
       "description": "Draw a line",
       "returnType": "void",
-      "params": {
-        "startPosX": "int",
-        "startPosY": "int",
-        "endPosX": "int",
-        "endPosY": "int",
-        "color": "Color"
-      }
+      "params": [
+        {
+          "name": "startPosX",
+          "type": "int"
+        },
+        {
+          "name": "startPosY",
+          "type": "int"
+        },
+        {
+          "name": "endPosX",
+          "type": "int"
+        },
+        {
+          "name": "endPosY",
+          "type": "int"
+        },
+        {
+          "name": "color",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "DrawLineV",
       "description": "Draw a line (Vector version)",
       "returnType": "void",
-      "params": {
-        "startPos": "Vector2",
-        "endPos": "Vector2",
-        "color": "Color"
-      }
+      "params": [
+        {
+          "name": "startPos",
+          "type": "Vector2"
+        },
+        {
+          "name": "endPos",
+          "type": "Vector2"
+        },
+        {
+          "name": "color",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "DrawLineEx",
       "description": "Draw a line defining thickness",
       "returnType": "void",
-      "params": {
-        "startPos": "Vector2",
-        "endPos": "Vector2",
-        "thick": "float",
-        "color": "Color"
-      }
+      "params": [
+        {
+          "name": "startPos",
+          "type": "Vector2"
+        },
+        {
+          "name": "endPos",
+          "type": "Vector2"
+        },
+        {
+          "name": "thick",
+          "type": "float"
+        },
+        {
+          "name": "color",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "DrawLineBezier",
       "description": "Draw a line using cubic-bezier curves in-out",
       "returnType": "void",
-      "params": {
-        "startPos": "Vector2",
-        "endPos": "Vector2",
-        "thick": "float",
-        "color": "Color"
-      }
+      "params": [
+        {
+          "name": "startPos",
+          "type": "Vector2"
+        },
+        {
+          "name": "endPos",
+          "type": "Vector2"
+        },
+        {
+          "name": "thick",
+          "type": "float"
+        },
+        {
+          "name": "color",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "DrawLineBezierQuad",
       "description": "Draw line using quadratic bezier curves with a control point",
       "returnType": "void",
-      "params": {
-        "startPos": "Vector2",
-        "endPos": "Vector2",
-        "controlPos": "Vector2",
-        "thick": "float",
-        "color": "Color"
-      }
+      "params": [
+        {
+          "name": "startPos",
+          "type": "Vector2"
+        },
+        {
+          "name": "endPos",
+          "type": "Vector2"
+        },
+        {
+          "name": "controlPos",
+          "type": "Vector2"
+        },
+        {
+          "name": "thick",
+          "type": "float"
+        },
+        {
+          "name": "color",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "DrawLineBezierCubic",
       "description": "Draw line using cubic bezier curves with 2 control points",
       "returnType": "void",
-      "params": {
-        "startPos": "Vector2",
-        "endPos": "Vector2",
-        "startControlPos": "Vector2",
-        "endControlPos": "Vector2",
-        "thick": "float",
-        "color": "Color"
-      }
+      "params": [
+        {
+          "name": "startPos",
+          "type": "Vector2"
+        },
+        {
+          "name": "endPos",
+          "type": "Vector2"
+        },
+        {
+          "name": "startControlPos",
+          "type": "Vector2"
+        },
+        {
+          "name": "endControlPos",
+          "type": "Vector2"
+        },
+        {
+          "name": "thick",
+          "type": "float"
+        },
+        {
+          "name": "color",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "DrawLineStrip",
       "description": "Draw lines sequence",
       "returnType": "void",
-      "params": {
-        "points": "Vector2 *",
-        "pointCount": "int",
-        "color": "Color"
-      }
+      "params": [
+        {
+          "name": "points",
+          "type": "Vector2 *"
+        },
+        {
+          "name": "pointCount",
+          "type": "int"
+        },
+        {
+          "name": "color",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "DrawCircle",
       "description": "Draw a color-filled circle",
       "returnType": "void",
-      "params": {
-        "centerX": "int",
-        "centerY": "int",
-        "radius": "float",
-        "color": "Color"
-      }
+      "params": [
+        {
+          "name": "centerX",
+          "type": "int"
+        },
+        {
+          "name": "centerY",
+          "type": "int"
+        },
+        {
+          "name": "radius",
+          "type": "float"
+        },
+        {
+          "name": "color",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "DrawCircleSector",
       "description": "Draw a piece of a circle",
       "returnType": "void",
-      "params": {
-        "center": "Vector2",
-        "radius": "float",
-        "startAngle": "float",
-        "endAngle": "float",
-        "segments": "int",
-        "color": "Color"
-      }
+      "params": [
+        {
+          "name": "center",
+          "type": "Vector2"
+        },
+        {
+          "name": "radius",
+          "type": "float"
+        },
+        {
+          "name": "startAngle",
+          "type": "float"
+        },
+        {
+          "name": "endAngle",
+          "type": "float"
+        },
+        {
+          "name": "segments",
+          "type": "int"
+        },
+        {
+          "name": "color",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "DrawCircleSectorLines",
       "description": "Draw circle sector outline",
       "returnType": "void",
-      "params": {
-        "center": "Vector2",
-        "radius": "float",
-        "startAngle": "float",
-        "endAngle": "float",
-        "segments": "int",
-        "color": "Color"
-      }
+      "params": [
+        {
+          "name": "center",
+          "type": "Vector2"
+        },
+        {
+          "name": "radius",
+          "type": "float"
+        },
+        {
+          "name": "startAngle",
+          "type": "float"
+        },
+        {
+          "name": "endAngle",
+          "type": "float"
+        },
+        {
+          "name": "segments",
+          "type": "int"
+        },
+        {
+          "name": "color",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "DrawCircleGradient",
       "description": "Draw a gradient-filled circle",
       "returnType": "void",
-      "params": {
-        "centerX": "int",
-        "centerY": "int",
-        "radius": "float",
-        "color1": "Color",
-        "color2": "Color"
-      }
+      "params": [
+        {
+          "name": "centerX",
+          "type": "int"
+        },
+        {
+          "name": "centerY",
+          "type": "int"
+        },
+        {
+          "name": "radius",
+          "type": "float"
+        },
+        {
+          "name": "color1",
+          "type": "Color"
+        },
+        {
+          "name": "color2",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "DrawCircleV",
       "description": "Draw a color-filled circle (Vector version)",
       "returnType": "void",
-      "params": {
-        "center": "Vector2",
-        "radius": "float",
-        "color": "Color"
-      }
+      "params": [
+        {
+          "name": "center",
+          "type": "Vector2"
+        },
+        {
+          "name": "radius",
+          "type": "float"
+        },
+        {
+          "name": "color",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "DrawCircleLines",
       "description": "Draw circle outline",
       "returnType": "void",
-      "params": {
-        "centerX": "int",
-        "centerY": "int",
-        "radius": "float",
-        "color": "Color"
-      }
+      "params": [
+        {
+          "name": "centerX",
+          "type": "int"
+        },
+        {
+          "name": "centerY",
+          "type": "int"
+        },
+        {
+          "name": "radius",
+          "type": "float"
+        },
+        {
+          "name": "color",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "DrawEllipse",
       "description": "Draw ellipse",
       "returnType": "void",
-      "params": {
-        "centerX": "int",
-        "centerY": "int",
-        "radiusH": "float",
-        "radiusV": "float",
-        "color": "Color"
-      }
+      "params": [
+        {
+          "name": "centerX",
+          "type": "int"
+        },
+        {
+          "name": "centerY",
+          "type": "int"
+        },
+        {
+          "name": "radiusH",
+          "type": "float"
+        },
+        {
+          "name": "radiusV",
+          "type": "float"
+        },
+        {
+          "name": "color",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "DrawEllipseLines",
       "description": "Draw ellipse outline",
       "returnType": "void",
-      "params": {
-        "centerX": "int",
-        "centerY": "int",
-        "radiusH": "float",
-        "radiusV": "float",
-        "color": "Color"
-      }
+      "params": [
+        {
+          "name": "centerX",
+          "type": "int"
+        },
+        {
+          "name": "centerY",
+          "type": "int"
+        },
+        {
+          "name": "radiusH",
+          "type": "float"
+        },
+        {
+          "name": "radiusV",
+          "type": "float"
+        },
+        {
+          "name": "color",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "DrawRing",
       "description": "Draw ring",
       "returnType": "void",
-      "params": {
-        "center": "Vector2",
-        "innerRadius": "float",
-        "outerRadius": "float",
-        "startAngle": "float",
-        "endAngle": "float",
-        "segments": "int",
-        "color": "Color"
-      }
+      "params": [
+        {
+          "name": "center",
+          "type": "Vector2"
+        },
+        {
+          "name": "innerRadius",
+          "type": "float"
+        },
+        {
+          "name": "outerRadius",
+          "type": "float"
+        },
+        {
+          "name": "startAngle",
+          "type": "float"
+        },
+        {
+          "name": "endAngle",
+          "type": "float"
+        },
+        {
+          "name": "segments",
+          "type": "int"
+        },
+        {
+          "name": "color",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "DrawRingLines",
       "description": "Draw ring outline",
       "returnType": "void",
-      "params": {
-        "center": "Vector2",
-        "innerRadius": "float",
-        "outerRadius": "float",
-        "startAngle": "float",
-        "endAngle": "float",
-        "segments": "int",
-        "color": "Color"
-      }
+      "params": [
+        {
+          "name": "center",
+          "type": "Vector2"
+        },
+        {
+          "name": "innerRadius",
+          "type": "float"
+        },
+        {
+          "name": "outerRadius",
+          "type": "float"
+        },
+        {
+          "name": "startAngle",
+          "type": "float"
+        },
+        {
+          "name": "endAngle",
+          "type": "float"
+        },
+        {
+          "name": "segments",
+          "type": "int"
+        },
+        {
+          "name": "color",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "DrawRectangle",
       "description": "Draw a color-filled rectangle",
       "returnType": "void",
-      "params": {
-        "posX": "int",
-        "posY": "int",
-        "width": "int",
-        "height": "int",
-        "color": "Color"
-      }
+      "params": [
+        {
+          "name": "posX",
+          "type": "int"
+        },
+        {
+          "name": "posY",
+          "type": "int"
+        },
+        {
+          "name": "width",
+          "type": "int"
+        },
+        {
+          "name": "height",
+          "type": "int"
+        },
+        {
+          "name": "color",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "DrawRectangleV",
       "description": "Draw a color-filled rectangle (Vector version)",
       "returnType": "void",
-      "params": {
-        "position": "Vector2",
-        "size": "Vector2",
-        "color": "Color"
-      }
+      "params": [
+        {
+          "name": "position",
+          "type": "Vector2"
+        },
+        {
+          "name": "size",
+          "type": "Vector2"
+        },
+        {
+          "name": "color",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "DrawRectangleRec",
       "description": "Draw a color-filled rectangle",
       "returnType": "void",
-      "params": {
-        "rec": "Rectangle",
-        "color": "Color"
-      }
+      "params": [
+        {
+          "name": "rec",
+          "type": "Rectangle"
+        },
+        {
+          "name": "color",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "DrawRectanglePro",
       "description": "Draw a color-filled rectangle with pro parameters",
       "returnType": "void",
-      "params": {
-        "rec": "Rectangle",
-        "origin": "Vector2",
-        "rotation": "float",
-        "color": "Color"
-      }
+      "params": [
+        {
+          "name": "rec",
+          "type": "Rectangle"
+        },
+        {
+          "name": "origin",
+          "type": "Vector2"
+        },
+        {
+          "name": "rotation",
+          "type": "float"
+        },
+        {
+          "name": "color",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "DrawRectangleGradientV",
       "description": "Draw a vertical-gradient-filled rectangle",
       "returnType": "void",
-      "params": {
-        "posX": "int",
-        "posY": "int",
-        "width": "int",
-        "height": "int",
-        "color1": "Color",
-        "color2": "Color"
-      }
+      "params": [
+        {
+          "name": "posX",
+          "type": "int"
+        },
+        {
+          "name": "posY",
+          "type": "int"
+        },
+        {
+          "name": "width",
+          "type": "int"
+        },
+        {
+          "name": "height",
+          "type": "int"
+        },
+        {
+          "name": "color1",
+          "type": "Color"
+        },
+        {
+          "name": "color2",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "DrawRectangleGradientH",
       "description": "Draw a horizontal-gradient-filled rectangle",
       "returnType": "void",
-      "params": {
-        "posX": "int",
-        "posY": "int",
-        "width": "int",
-        "height": "int",
-        "color1": "Color",
-        "color2": "Color"
-      }
+      "params": [
+        {
+          "name": "posX",
+          "type": "int"
+        },
+        {
+          "name": "posY",
+          "type": "int"
+        },
+        {
+          "name": "width",
+          "type": "int"
+        },
+        {
+          "name": "height",
+          "type": "int"
+        },
+        {
+          "name": "color1",
+          "type": "Color"
+        },
+        {
+          "name": "color2",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "DrawRectangleGradientEx",
       "description": "Draw a gradient-filled rectangle with custom vertex colors",
       "returnType": "void",
-      "params": {
-        "rec": "Rectangle",
-        "col1": "Color",
-        "col2": "Color",
-        "col3": "Color",
-        "col4": "Color"
-      }
+      "params": [
+        {
+          "name": "rec",
+          "type": "Rectangle"
+        },
+        {
+          "name": "col1",
+          "type": "Color"
+        },
+        {
+          "name": "col2",
+          "type": "Color"
+        },
+        {
+          "name": "col3",
+          "type": "Color"
+        },
+        {
+          "name": "col4",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "DrawRectangleLines",
       "description": "Draw rectangle outline",
       "returnType": "void",
-      "params": {
-        "posX": "int",
-        "posY": "int",
-        "width": "int",
-        "height": "int",
-        "color": "Color"
-      }
+      "params": [
+        {
+          "name": "posX",
+          "type": "int"
+        },
+        {
+          "name": "posY",
+          "type": "int"
+        },
+        {
+          "name": "width",
+          "type": "int"
+        },
+        {
+          "name": "height",
+          "type": "int"
+        },
+        {
+          "name": "color",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "DrawRectangleLinesEx",
       "description": "Draw rectangle outline with extended parameters",
       "returnType": "void",
-      "params": {
-        "rec": "Rectangle",
-        "lineThick": "float",
-        "color": "Color"
-      }
+      "params": [
+        {
+          "name": "rec",
+          "type": "Rectangle"
+        },
+        {
+          "name": "lineThick",
+          "type": "float"
+        },
+        {
+          "name": "color",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "DrawRectangleRounded",
       "description": "Draw rectangle with rounded edges",
       "returnType": "void",
-      "params": {
-        "rec": "Rectangle",
-        "roundness": "float",
-        "segments": "int",
-        "color": "Color"
-      }
+      "params": [
+        {
+          "name": "rec",
+          "type": "Rectangle"
+        },
+        {
+          "name": "roundness",
+          "type": "float"
+        },
+        {
+          "name": "segments",
+          "type": "int"
+        },
+        {
+          "name": "color",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "DrawRectangleRoundedLines",
       "description": "Draw rectangle with rounded edges outline",
       "returnType": "void",
-      "params": {
-        "rec": "Rectangle",
-        "roundness": "float",
-        "segments": "int",
-        "lineThick": "float",
-        "color": "Color"
-      }
+      "params": [
+        {
+          "name": "rec",
+          "type": "Rectangle"
+        },
+        {
+          "name": "roundness",
+          "type": "float"
+        },
+        {
+          "name": "segments",
+          "type": "int"
+        },
+        {
+          "name": "lineThick",
+          "type": "float"
+        },
+        {
+          "name": "color",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "DrawTriangle",
       "description": "Draw a color-filled triangle (vertex in counter-clockwise order!)",
       "returnType": "void",
-      "params": {
-        "v1": "Vector2",
-        "v2": "Vector2",
-        "v3": "Vector2",
-        "color": "Color"
-      }
+      "params": [
+        {
+          "name": "v1",
+          "type": "Vector2"
+        },
+        {
+          "name": "v2",
+          "type": "Vector2"
+        },
+        {
+          "name": "v3",
+          "type": "Vector2"
+        },
+        {
+          "name": "color",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "DrawTriangleLines",
       "description": "Draw triangle outline (vertex in counter-clockwise order!)",
       "returnType": "void",
-      "params": {
-        "v1": "Vector2",
-        "v2": "Vector2",
-        "v3": "Vector2",
-        "color": "Color"
-      }
+      "params": [
+        {
+          "name": "v1",
+          "type": "Vector2"
+        },
+        {
+          "name": "v2",
+          "type": "Vector2"
+        },
+        {
+          "name": "v3",
+          "type": "Vector2"
+        },
+        {
+          "name": "color",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "DrawTriangleFan",
       "description": "Draw a triangle fan defined by points (first vertex is the center)",
       "returnType": "void",
-      "params": {
-        "points": "Vector2 *",
-        "pointCount": "int",
-        "color": "Color"
-      }
+      "params": [
+        {
+          "name": "points",
+          "type": "Vector2 *"
+        },
+        {
+          "name": "pointCount",
+          "type": "int"
+        },
+        {
+          "name": "color",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "DrawTriangleStrip",
       "description": "Draw a triangle strip defined by points",
       "returnType": "void",
-      "params": {
-        "points": "Vector2 *",
-        "pointCount": "int",
-        "color": "Color"
-      }
+      "params": [
+        {
+          "name": "points",
+          "type": "Vector2 *"
+        },
+        {
+          "name": "pointCount",
+          "type": "int"
+        },
+        {
+          "name": "color",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "DrawPoly",
       "description": "Draw a regular polygon (Vector version)",
       "returnType": "void",
-      "params": {
-        "center": "Vector2",
-        "sides": "int",
-        "radius": "float",
-        "rotation": "float",
-        "color": "Color"
-      }
+      "params": [
+        {
+          "name": "center",
+          "type": "Vector2"
+        },
+        {
+          "name": "sides",
+          "type": "int"
+        },
+        {
+          "name": "radius",
+          "type": "float"
+        },
+        {
+          "name": "rotation",
+          "type": "float"
+        },
+        {
+          "name": "color",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "DrawPolyLines",
       "description": "Draw a polygon outline of n sides",
       "returnType": "void",
-      "params": {
-        "center": "Vector2",
-        "sides": "int",
-        "radius": "float",
-        "rotation": "float",
-        "color": "Color"
-      }
+      "params": [
+        {
+          "name": "center",
+          "type": "Vector2"
+        },
+        {
+          "name": "sides",
+          "type": "int"
+        },
+        {
+          "name": "radius",
+          "type": "float"
+        },
+        {
+          "name": "rotation",
+          "type": "float"
+        },
+        {
+          "name": "color",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "DrawPolyLinesEx",
       "description": "Draw a polygon outline of n sides with extended parameters",
       "returnType": "void",
-      "params": {
-        "center": "Vector2",
-        "sides": "int",
-        "radius": "float",
-        "rotation": "float",
-        "lineThick": "float",
-        "color": "Color"
-      }
+      "params": [
+        {
+          "name": "center",
+          "type": "Vector2"
+        },
+        {
+          "name": "sides",
+          "type": "int"
+        },
+        {
+          "name": "radius",
+          "type": "float"
+        },
+        {
+          "name": "rotation",
+          "type": "float"
+        },
+        {
+          "name": "lineThick",
+          "type": "float"
+        },
+        {
+          "name": "color",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "CheckCollisionRecs",
       "description": "Check collision between two rectangles",
       "returnType": "bool",
-      "params": {
-        "rec1": "Rectangle",
-        "rec2": "Rectangle"
-      }
+      "params": [
+        {
+          "name": "rec1",
+          "type": "Rectangle"
+        },
+        {
+          "name": "rec2",
+          "type": "Rectangle"
+        }
+      ]
     },
     {
       "name": "CheckCollisionCircles",
       "description": "Check collision between two circles",
       "returnType": "bool",
-      "params": {
-        "center1": "Vector2",
-        "radius1": "float",
-        "center2": "Vector2",
-        "radius2": "float"
-      }
+      "params": [
+        {
+          "name": "center1",
+          "type": "Vector2"
+        },
+        {
+          "name": "radius1",
+          "type": "float"
+        },
+        {
+          "name": "center2",
+          "type": "Vector2"
+        },
+        {
+          "name": "radius2",
+          "type": "float"
+        }
+      ]
     },
     {
       "name": "CheckCollisionCircleRec",
       "description": "Check collision between circle and rectangle",
       "returnType": "bool",
-      "params": {
-        "center": "Vector2",
-        "radius": "float",
-        "rec": "Rectangle"
-      }
+      "params": [
+        {
+          "name": "center",
+          "type": "Vector2"
+        },
+        {
+          "name": "radius",
+          "type": "float"
+        },
+        {
+          "name": "rec",
+          "type": "Rectangle"
+        }
+      ]
     },
     {
       "name": "CheckCollisionPointRec",
       "description": "Check if point is inside rectangle",
       "returnType": "bool",
-      "params": {
-        "point": "Vector2",
-        "rec": "Rectangle"
-      }
+      "params": [
+        {
+          "name": "point",
+          "type": "Vector2"
+        },
+        {
+          "name": "rec",
+          "type": "Rectangle"
+        }
+      ]
     },
     {
       "name": "CheckCollisionPointCircle",
       "description": "Check if point is inside circle",
       "returnType": "bool",
-      "params": {
-        "point": "Vector2",
-        "center": "Vector2",
-        "radius": "float"
-      }
+      "params": [
+        {
+          "name": "point",
+          "type": "Vector2"
+        },
+        {
+          "name": "center",
+          "type": "Vector2"
+        },
+        {
+          "name": "radius",
+          "type": "float"
+        }
+      ]
     },
     {
       "name": "CheckCollisionPointTriangle",
       "description": "Check if point is inside a triangle",
       "returnType": "bool",
-      "params": {
-        "point": "Vector2",
-        "p1": "Vector2",
-        "p2": "Vector2",
-        "p3": "Vector2"
-      }
+      "params": [
+        {
+          "name": "point",
+          "type": "Vector2"
+        },
+        {
+          "name": "p1",
+          "type": "Vector2"
+        },
+        {
+          "name": "p2",
+          "type": "Vector2"
+        },
+        {
+          "name": "p3",
+          "type": "Vector2"
+        }
+      ]
     },
     {
       "name": "CheckCollisionLines",
       "description": "Check the collision between two lines defined by two points each, returns collision point by reference",
       "returnType": "bool",
-      "params": {
-        "startPos1": "Vector2",
-        "endPos1": "Vector2",
-        "startPos2": "Vector2",
-        "endPos2": "Vector2",
-        "collisionPoint": "Vector2 *"
-      }
+      "params": [
+        {
+          "name": "startPos1",
+          "type": "Vector2"
+        },
+        {
+          "name": "endPos1",
+          "type": "Vector2"
+        },
+        {
+          "name": "startPos2",
+          "type": "Vector2"
+        },
+        {
+          "name": "endPos2",
+          "type": "Vector2"
+        },
+        {
+          "name": "collisionPoint",
+          "type": "Vector2 *"
+        }
+      ]
     },
     {
       "name": "CheckCollisionPointLine",
       "description": "Check if point belongs to line created between two points [p1] and [p2] with defined margin in pixels [threshold]",
       "returnType": "bool",
-      "params": {
-        "point": "Vector2",
-        "p1": "Vector2",
-        "p2": "Vector2",
-        "threshold": "int"
-      }
+      "params": [
+        {
+          "name": "point",
+          "type": "Vector2"
+        },
+        {
+          "name": "p1",
+          "type": "Vector2"
+        },
+        {
+          "name": "p2",
+          "type": "Vector2"
+        },
+        {
+          "name": "threshold",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "GetCollisionRec",
       "description": "Get collision rectangle for two rectangles collision",
       "returnType": "Rectangle",
-      "params": {
-        "rec1": "Rectangle",
-        "rec2": "Rectangle"
-      }
+      "params": [
+        {
+          "name": "rec1",
+          "type": "Rectangle"
+        },
+        {
+          "name": "rec2",
+          "type": "Rectangle"
+        }
+      ]
     },
     {
       "name": "LoadImage",
       "description": "Load image from file into CPU memory (RAM)",
       "returnType": "Image",
-      "params": {
-        "fileName": "const char *"
-      }
+      "params": [
+        {
+          "name": "fileName",
+          "type": "const char *"
+        }
+      ]
     },
     {
       "name": "LoadImageRaw",
       "description": "Load image from RAW file data",
       "returnType": "Image",
-      "params": {
-        "fileName": "const char *",
-        "width": "int",
-        "height": "int",
-        "format": "int",
-        "headerSize": "int"
-      }
+      "params": [
+        {
+          "name": "fileName",
+          "type": "const char *"
+        },
+        {
+          "name": "width",
+          "type": "int"
+        },
+        {
+          "name": "height",
+          "type": "int"
+        },
+        {
+          "name": "format",
+          "type": "int"
+        },
+        {
+          "name": "headerSize",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "LoadImageAnim",
       "description": "Load image sequence from file (frames appended to image.data)",
       "returnType": "Image",
-      "params": {
-        "fileName": "const char *",
-        "frames": "int *"
-      }
+      "params": [
+        {
+          "name": "fileName",
+          "type": "const char *"
+        },
+        {
+          "name": "frames",
+          "type": "int *"
+        }
+      ]
     },
     {
       "name": "LoadImageFromMemory",
       "description": "Load image from memory buffer, fileType refers to extension: i.e. '.png'",
       "returnType": "Image",
-      "params": {
-        "fileType": "const char *",
-        "fileData": "const unsigned char *",
-        "dataSize": "int"
-      }
+      "params": [
+        {
+          "name": "fileType",
+          "type": "const char *"
+        },
+        {
+          "name": "fileData",
+          "type": "const unsigned char *"
+        },
+        {
+          "name": "dataSize",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "LoadImageFromTexture",
       "description": "Load image from GPU texture data",
       "returnType": "Image",
-      "params": {
-        "texture": "Texture2D"
-      }
+      "params": [
+        {
+          "name": "texture",
+          "type": "Texture2D"
+        }
+      ]
     },
     {
       "name": "LoadImageFromScreen",
@@ -4385,869 +5557,1625 @@
       "name": "UnloadImage",
       "description": "Unload image from CPU memory (RAM)",
       "returnType": "void",
-      "params": {
-        "image": "Image"
-      }
+      "params": [
+        {
+          "name": "image",
+          "type": "Image"
+        }
+      ]
     },
     {
       "name": "ExportImage",
       "description": "Export image data to file, returns true on success",
       "returnType": "bool",
-      "params": {
-        "image": "Image",
-        "fileName": "const char *"
-      }
+      "params": [
+        {
+          "name": "image",
+          "type": "Image"
+        },
+        {
+          "name": "fileName",
+          "type": "const char *"
+        }
+      ]
     },
     {
       "name": "ExportImageAsCode",
       "description": "Export image as code file defining an array of bytes, returns true on success",
       "returnType": "bool",
-      "params": {
-        "image": "Image",
-        "fileName": "const char *"
-      }
+      "params": [
+        {
+          "name": "image",
+          "type": "Image"
+        },
+        {
+          "name": "fileName",
+          "type": "const char *"
+        }
+      ]
     },
     {
       "name": "GenImageColor",
       "description": "Generate image: plain color",
       "returnType": "Image",
-      "params": {
-        "width": "int",
-        "height": "int",
-        "color": "Color"
-      }
+      "params": [
+        {
+          "name": "width",
+          "type": "int"
+        },
+        {
+          "name": "height",
+          "type": "int"
+        },
+        {
+          "name": "color",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "GenImageGradientV",
       "description": "Generate image: vertical gradient",
       "returnType": "Image",
-      "params": {
-        "width": "int",
-        "height": "int",
-        "top": "Color",
-        "bottom": "Color"
-      }
+      "params": [
+        {
+          "name": "width",
+          "type": "int"
+        },
+        {
+          "name": "height",
+          "type": "int"
+        },
+        {
+          "name": "top",
+          "type": "Color"
+        },
+        {
+          "name": "bottom",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "GenImageGradientH",
       "description": "Generate image: horizontal gradient",
       "returnType": "Image",
-      "params": {
-        "width": "int",
-        "height": "int",
-        "left": "Color",
-        "right": "Color"
-      }
+      "params": [
+        {
+          "name": "width",
+          "type": "int"
+        },
+        {
+          "name": "height",
+          "type": "int"
+        },
+        {
+          "name": "left",
+          "type": "Color"
+        },
+        {
+          "name": "right",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "GenImageGradientRadial",
       "description": "Generate image: radial gradient",
       "returnType": "Image",
-      "params": {
-        "width": "int",
-        "height": "int",
-        "density": "float",
-        "inner": "Color",
-        "outer": "Color"
-      }
+      "params": [
+        {
+          "name": "width",
+          "type": "int"
+        },
+        {
+          "name": "height",
+          "type": "int"
+        },
+        {
+          "name": "density",
+          "type": "float"
+        },
+        {
+          "name": "inner",
+          "type": "Color"
+        },
+        {
+          "name": "outer",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "GenImageChecked",
       "description": "Generate image: checked",
       "returnType": "Image",
-      "params": {
-        "width": "int",
-        "height": "int",
-        "checksX": "int",
-        "checksY": "int",
-        "col1": "Color",
-        "col2": "Color"
-      }
+      "params": [
+        {
+          "name": "width",
+          "type": "int"
+        },
+        {
+          "name": "height",
+          "type": "int"
+        },
+        {
+          "name": "checksX",
+          "type": "int"
+        },
+        {
+          "name": "checksY",
+          "type": "int"
+        },
+        {
+          "name": "col1",
+          "type": "Color"
+        },
+        {
+          "name": "col2",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "GenImageWhiteNoise",
       "description": "Generate image: white noise",
       "returnType": "Image",
-      "params": {
-        "width": "int",
-        "height": "int",
-        "factor": "float"
-      }
+      "params": [
+        {
+          "name": "width",
+          "type": "int"
+        },
+        {
+          "name": "height",
+          "type": "int"
+        },
+        {
+          "name": "factor",
+          "type": "float"
+        }
+      ]
     },
     {
       "name": "GenImageCellular",
       "description": "Generate image: cellular algorithm, bigger tileSize means bigger cells",
       "returnType": "Image",
-      "params": {
-        "width": "int",
-        "height": "int",
-        "tileSize": "int"
-      }
+      "params": [
+        {
+          "name": "width",
+          "type": "int"
+        },
+        {
+          "name": "height",
+          "type": "int"
+        },
+        {
+          "name": "tileSize",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "ImageCopy",
       "description": "Create an image duplicate (useful for transformations)",
       "returnType": "Image",
-      "params": {
-        "image": "Image"
-      }
+      "params": [
+        {
+          "name": "image",
+          "type": "Image"
+        }
+      ]
     },
     {
       "name": "ImageFromImage",
       "description": "Create an image from another image piece",
       "returnType": "Image",
-      "params": {
-        "image": "Image",
-        "rec": "Rectangle"
-      }
+      "params": [
+        {
+          "name": "image",
+          "type": "Image"
+        },
+        {
+          "name": "rec",
+          "type": "Rectangle"
+        }
+      ]
     },
     {
       "name": "ImageText",
       "description": "Create an image from text (default font)",
       "returnType": "Image",
-      "params": {
-        "text": "const char *",
-        "fontSize": "int",
-        "color": "Color"
-      }
+      "params": [
+        {
+          "name": "text",
+          "type": "const char *"
+        },
+        {
+          "name": "fontSize",
+          "type": "int"
+        },
+        {
+          "name": "color",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "ImageTextEx",
       "description": "Create an image from text (custom sprite font)",
       "returnType": "Image",
-      "params": {
-        "font": "Font",
-        "text": "const char *",
-        "fontSize": "float",
-        "spacing": "float",
-        "tint": "Color"
-      }
+      "params": [
+        {
+          "name": "font",
+          "type": "Font"
+        },
+        {
+          "name": "text",
+          "type": "const char *"
+        },
+        {
+          "name": "fontSize",
+          "type": "float"
+        },
+        {
+          "name": "spacing",
+          "type": "float"
+        },
+        {
+          "name": "tint",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "ImageFormat",
       "description": "Convert image data to desired format",
       "returnType": "void",
-      "params": {
-        "image": "Image *",
-        "newFormat": "int"
-      }
+      "params": [
+        {
+          "name": "image",
+          "type": "Image *"
+        },
+        {
+          "name": "newFormat",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "ImageToPOT",
       "description": "Convert image to POT (power-of-two)",
       "returnType": "void",
-      "params": {
-        "image": "Image *",
-        "fill": "Color"
-      }
+      "params": [
+        {
+          "name": "image",
+          "type": "Image *"
+        },
+        {
+          "name": "fill",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "ImageCrop",
       "description": "Crop an image to a defined rectangle",
       "returnType": "void",
-      "params": {
-        "image": "Image *",
-        "crop": "Rectangle"
-      }
+      "params": [
+        {
+          "name": "image",
+          "type": "Image *"
+        },
+        {
+          "name": "crop",
+          "type": "Rectangle"
+        }
+      ]
     },
     {
       "name": "ImageAlphaCrop",
       "description": "Crop image depending on alpha value",
       "returnType": "void",
-      "params": {
-        "image": "Image *",
-        "threshold": "float"
-      }
+      "params": [
+        {
+          "name": "image",
+          "type": "Image *"
+        },
+        {
+          "name": "threshold",
+          "type": "float"
+        }
+      ]
     },
     {
       "name": "ImageAlphaClear",
       "description": "Clear alpha channel to desired color",
       "returnType": "void",
-      "params": {
-        "image": "Image *",
-        "color": "Color",
-        "threshold": "float"
-      }
+      "params": [
+        {
+          "name": "image",
+          "type": "Image *"
+        },
+        {
+          "name": "color",
+          "type": "Color"
+        },
+        {
+          "name": "threshold",
+          "type": "float"
+        }
+      ]
     },
     {
       "name": "ImageAlphaMask",
       "description": "Apply alpha mask to image",
       "returnType": "void",
-      "params": {
-        "image": "Image *",
-        "alphaMask": "Image"
-      }
+      "params": [
+        {
+          "name": "image",
+          "type": "Image *"
+        },
+        {
+          "name": "alphaMask",
+          "type": "Image"
+        }
+      ]
     },
     {
       "name": "ImageAlphaPremultiply",
       "description": "Premultiply alpha channel",
       "returnType": "void",
-      "params": {
-        "image": "Image *"
-      }
+      "params": [
+        {
+          "name": "image",
+          "type": "Image *"
+        }
+      ]
     },
     {
       "name": "ImageResize",
       "description": "Resize image (Bicubic scaling algorithm)",
       "returnType": "void",
-      "params": {
-        "image": "Image *",
-        "newWidth": "int",
-        "newHeight": "int"
-      }
+      "params": [
+        {
+          "name": "image",
+          "type": "Image *"
+        },
+        {
+          "name": "newWidth",
+          "type": "int"
+        },
+        {
+          "name": "newHeight",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "ImageResizeNN",
       "description": "Resize image (Nearest-Neighbor scaling algorithm)",
       "returnType": "void",
-      "params": {
-        "image": "Image *",
-        "newWidth": "int",
-        "newHeight": "int"
-      }
+      "params": [
+        {
+          "name": "image",
+          "type": "Image *"
+        },
+        {
+          "name": "newWidth",
+          "type": "int"
+        },
+        {
+          "name": "newHeight",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "ImageResizeCanvas",
       "description": "Resize canvas and fill with color",
       "returnType": "void",
-      "params": {
-        "image": "Image *",
-        "newWidth": "int",
-        "newHeight": "int",
-        "offsetX": "int",
-        "offsetY": "int",
-        "fill": "Color"
-      }
+      "params": [
+        {
+          "name": "image",
+          "type": "Image *"
+        },
+        {
+          "name": "newWidth",
+          "type": "int"
+        },
+        {
+          "name": "newHeight",
+          "type": "int"
+        },
+        {
+          "name": "offsetX",
+          "type": "int"
+        },
+        {
+          "name": "offsetY",
+          "type": "int"
+        },
+        {
+          "name": "fill",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "ImageMipmaps",
       "description": "Compute all mipmap levels for a provided image",
       "returnType": "void",
-      "params": {
-        "image": "Image *"
-      }
+      "params": [
+        {
+          "name": "image",
+          "type": "Image *"
+        }
+      ]
     },
     {
       "name": "ImageDither",
       "description": "Dither image data to 16bpp or lower (Floyd-Steinberg dithering)",
       "returnType": "void",
-      "params": {
-        "image": "Image *",
-        "rBpp": "int",
-        "gBpp": "int",
-        "bBpp": "int",
-        "aBpp": "int"
-      }
+      "params": [
+        {
+          "name": "image",
+          "type": "Image *"
+        },
+        {
+          "name": "rBpp",
+          "type": "int"
+        },
+        {
+          "name": "gBpp",
+          "type": "int"
+        },
+        {
+          "name": "bBpp",
+          "type": "int"
+        },
+        {
+          "name": "aBpp",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "ImageFlipVertical",
       "description": "Flip image vertically",
       "returnType": "void",
-      "params": {
-        "image": "Image *"
-      }
+      "params": [
+        {
+          "name": "image",
+          "type": "Image *"
+        }
+      ]
     },
     {
       "name": "ImageFlipHorizontal",
       "description": "Flip image horizontally",
       "returnType": "void",
-      "params": {
-        "image": "Image *"
-      }
+      "params": [
+        {
+          "name": "image",
+          "type": "Image *"
+        }
+      ]
     },
     {
       "name": "ImageRotateCW",
       "description": "Rotate image clockwise 90deg",
       "returnType": "void",
-      "params": {
-        "image": "Image *"
-      }
+      "params": [
+        {
+          "name": "image",
+          "type": "Image *"
+        }
+      ]
     },
     {
       "name": "ImageRotateCCW",
       "description": "Rotate image counter-clockwise 90deg",
       "returnType": "void",
-      "params": {
-        "image": "Image *"
-      }
+      "params": [
+        {
+          "name": "image",
+          "type": "Image *"
+        }
+      ]
     },
     {
       "name": "ImageColorTint",
       "description": "Modify image color: tint",
       "returnType": "void",
-      "params": {
-        "image": "Image *",
-        "color": "Color"
-      }
+      "params": [
+        {
+          "name": "image",
+          "type": "Image *"
+        },
+        {
+          "name": "color",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "ImageColorInvert",
       "description": "Modify image color: invert",
       "returnType": "void",
-      "params": {
-        "image": "Image *"
-      }
+      "params": [
+        {
+          "name": "image",
+          "type": "Image *"
+        }
+      ]
     },
     {
       "name": "ImageColorGrayscale",
       "description": "Modify image color: grayscale",
       "returnType": "void",
-      "params": {
-        "image": "Image *"
-      }
+      "params": [
+        {
+          "name": "image",
+          "type": "Image *"
+        }
+      ]
     },
     {
       "name": "ImageColorContrast",
       "description": "Modify image color: contrast (-100 to 100)",
       "returnType": "void",
-      "params": {
-        "image": "Image *",
-        "contrast": "float"
-      }
+      "params": [
+        {
+          "name": "image",
+          "type": "Image *"
+        },
+        {
+          "name": "contrast",
+          "type": "float"
+        }
+      ]
     },
     {
       "name": "ImageColorBrightness",
       "description": "Modify image color: brightness (-255 to 255)",
       "returnType": "void",
-      "params": {
-        "image": "Image *",
-        "brightness": "int"
-      }
+      "params": [
+        {
+          "name": "image",
+          "type": "Image *"
+        },
+        {
+          "name": "brightness",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "ImageColorReplace",
       "description": "Modify image color: replace color",
       "returnType": "void",
-      "params": {
-        "image": "Image *",
-        "color": "Color",
-        "replace": "Color"
-      }
+      "params": [
+        {
+          "name": "image",
+          "type": "Image *"
+        },
+        {
+          "name": "color",
+          "type": "Color"
+        },
+        {
+          "name": "replace",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "LoadImageColors",
       "description": "Load color data from image as a Color array (RGBA - 32bit)",
       "returnType": "Color *",
-      "params": {
-        "image": "Image"
-      }
+      "params": [
+        {
+          "name": "image",
+          "type": "Image"
+        }
+      ]
     },
     {
       "name": "LoadImagePalette",
       "description": "Load colors palette from image as a Color array (RGBA - 32bit)",
       "returnType": "Color *",
-      "params": {
-        "image": "Image",
-        "maxPaletteSize": "int",
-        "colorCount": "int *"
-      }
+      "params": [
+        {
+          "name": "image",
+          "type": "Image"
+        },
+        {
+          "name": "maxPaletteSize",
+          "type": "int"
+        },
+        {
+          "name": "colorCount",
+          "type": "int *"
+        }
+      ]
     },
     {
       "name": "UnloadImageColors",
       "description": "Unload color data loaded with LoadImageColors()",
       "returnType": "void",
-      "params": {
-        "colors": "Color *"
-      }
+      "params": [
+        {
+          "name": "colors",
+          "type": "Color *"
+        }
+      ]
     },
     {
       "name": "UnloadImagePalette",
       "description": "Unload colors palette loaded with LoadImagePalette()",
       "returnType": "void",
-      "params": {
-        "colors": "Color *"
-      }
+      "params": [
+        {
+          "name": "colors",
+          "type": "Color *"
+        }
+      ]
     },
     {
       "name": "GetImageAlphaBorder",
       "description": "Get image alpha border rectangle",
       "returnType": "Rectangle",
-      "params": {
-        "image": "Image",
-        "threshold": "float"
-      }
+      "params": [
+        {
+          "name": "image",
+          "type": "Image"
+        },
+        {
+          "name": "threshold",
+          "type": "float"
+        }
+      ]
     },
     {
       "name": "GetImageColor",
       "description": "Get image pixel color at (x, y) position",
       "returnType": "Color",
-      "params": {
-        "image": "Image",
-        "x": "int",
-        "y": "int"
-      }
+      "params": [
+        {
+          "name": "image",
+          "type": "Image"
+        },
+        {
+          "name": "x",
+          "type": "int"
+        },
+        {
+          "name": "y",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "ImageClearBackground",
       "description": "Clear image background with given color",
       "returnType": "void",
-      "params": {
-        "dst": "Image *",
-        "color": "Color"
-      }
+      "params": [
+        {
+          "name": "dst",
+          "type": "Image *"
+        },
+        {
+          "name": "color",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "ImageDrawPixel",
       "description": "Draw pixel within an image",
       "returnType": "void",
-      "params": {
-        "dst": "Image *",
-        "posX": "int",
-        "posY": "int",
-        "color": "Color"
-      }
+      "params": [
+        {
+          "name": "dst",
+          "type": "Image *"
+        },
+        {
+          "name": "posX",
+          "type": "int"
+        },
+        {
+          "name": "posY",
+          "type": "int"
+        },
+        {
+          "name": "color",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "ImageDrawPixelV",
       "description": "Draw pixel within an image (Vector version)",
       "returnType": "void",
-      "params": {
-        "dst": "Image *",
-        "position": "Vector2",
-        "color": "Color"
-      }
+      "params": [
+        {
+          "name": "dst",
+          "type": "Image *"
+        },
+        {
+          "name": "position",
+          "type": "Vector2"
+        },
+        {
+          "name": "color",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "ImageDrawLine",
       "description": "Draw line within an image",
       "returnType": "void",
-      "params": {
-        "dst": "Image *",
-        "startPosX": "int",
-        "startPosY": "int",
-        "endPosX": "int",
-        "endPosY": "int",
-        "color": "Color"
-      }
+      "params": [
+        {
+          "name": "dst",
+          "type": "Image *"
+        },
+        {
+          "name": "startPosX",
+          "type": "int"
+        },
+        {
+          "name": "startPosY",
+          "type": "int"
+        },
+        {
+          "name": "endPosX",
+          "type": "int"
+        },
+        {
+          "name": "endPosY",
+          "type": "int"
+        },
+        {
+          "name": "color",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "ImageDrawLineV",
       "description": "Draw line within an image (Vector version)",
       "returnType": "void",
-      "params": {
-        "dst": "Image *",
-        "start": "Vector2",
-        "end": "Vector2",
-        "color": "Color"
-      }
+      "params": [
+        {
+          "name": "dst",
+          "type": "Image *"
+        },
+        {
+          "name": "start",
+          "type": "Vector2"
+        },
+        {
+          "name": "end",
+          "type": "Vector2"
+        },
+        {
+          "name": "color",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "ImageDrawCircle",
       "description": "Draw circle within an image",
       "returnType": "void",
-      "params": {
-        "dst": "Image *",
-        "centerX": "int",
-        "centerY": "int",
-        "radius": "int",
-        "color": "Color"
-      }
+      "params": [
+        {
+          "name": "dst",
+          "type": "Image *"
+        },
+        {
+          "name": "centerX",
+          "type": "int"
+        },
+        {
+          "name": "centerY",
+          "type": "int"
+        },
+        {
+          "name": "radius",
+          "type": "int"
+        },
+        {
+          "name": "color",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "ImageDrawCircleV",
       "description": "Draw circle within an image (Vector version)",
       "returnType": "void",
-      "params": {
-        "dst": "Image *",
-        "center": "Vector2",
-        "radius": "int",
-        "color": "Color"
-      }
+      "params": [
+        {
+          "name": "dst",
+          "type": "Image *"
+        },
+        {
+          "name": "center",
+          "type": "Vector2"
+        },
+        {
+          "name": "radius",
+          "type": "int"
+        },
+        {
+          "name": "color",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "ImageDrawRectangle",
       "description": "Draw rectangle within an image",
       "returnType": "void",
-      "params": {
-        "dst": "Image *",
-        "posX": "int",
-        "posY": "int",
-        "width": "int",
-        "height": "int",
-        "color": "Color"
-      }
+      "params": [
+        {
+          "name": "dst",
+          "type": "Image *"
+        },
+        {
+          "name": "posX",
+          "type": "int"
+        },
+        {
+          "name": "posY",
+          "type": "int"
+        },
+        {
+          "name": "width",
+          "type": "int"
+        },
+        {
+          "name": "height",
+          "type": "int"
+        },
+        {
+          "name": "color",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "ImageDrawRectangleV",
       "description": "Draw rectangle within an image (Vector version)",
       "returnType": "void",
-      "params": {
-        "dst": "Image *",
-        "position": "Vector2",
-        "size": "Vector2",
-        "color": "Color"
-      }
+      "params": [
+        {
+          "name": "dst",
+          "type": "Image *"
+        },
+        {
+          "name": "position",
+          "type": "Vector2"
+        },
+        {
+          "name": "size",
+          "type": "Vector2"
+        },
+        {
+          "name": "color",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "ImageDrawRectangleRec",
       "description": "Draw rectangle within an image",
       "returnType": "void",
-      "params": {
-        "dst": "Image *",
-        "rec": "Rectangle",
-        "color": "Color"
-      }
+      "params": [
+        {
+          "name": "dst",
+          "type": "Image *"
+        },
+        {
+          "name": "rec",
+          "type": "Rectangle"
+        },
+        {
+          "name": "color",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "ImageDrawRectangleLines",
       "description": "Draw rectangle lines within an image",
       "returnType": "void",
-      "params": {
-        "dst": "Image *",
-        "rec": "Rectangle",
-        "thick": "int",
-        "color": "Color"
-      }
+      "params": [
+        {
+          "name": "dst",
+          "type": "Image *"
+        },
+        {
+          "name": "rec",
+          "type": "Rectangle"
+        },
+        {
+          "name": "thick",
+          "type": "int"
+        },
+        {
+          "name": "color",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "ImageDraw",
       "description": "Draw a source image within a destination image (tint applied to source)",
       "returnType": "void",
-      "params": {
-        "dst": "Image *",
-        "src": "Image",
-        "srcRec": "Rectangle",
-        "dstRec": "Rectangle",
-        "tint": "Color"
-      }
+      "params": [
+        {
+          "name": "dst",
+          "type": "Image *"
+        },
+        {
+          "name": "src",
+          "type": "Image"
+        },
+        {
+          "name": "srcRec",
+          "type": "Rectangle"
+        },
+        {
+          "name": "dstRec",
+          "type": "Rectangle"
+        },
+        {
+          "name": "tint",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "ImageDrawText",
       "description": "Draw text (using default font) within an image (destination)",
       "returnType": "void",
-      "params": {
-        "dst": "Image *",
-        "text": "const char *",
-        "posX": "int",
-        "posY": "int",
-        "fontSize": "int",
-        "color": "Color"
-      }
+      "params": [
+        {
+          "name": "dst",
+          "type": "Image *"
+        },
+        {
+          "name": "text",
+          "type": "const char *"
+        },
+        {
+          "name": "posX",
+          "type": "int"
+        },
+        {
+          "name": "posY",
+          "type": "int"
+        },
+        {
+          "name": "fontSize",
+          "type": "int"
+        },
+        {
+          "name": "color",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "ImageDrawTextEx",
       "description": "Draw text (custom sprite font) within an image (destination)",
       "returnType": "void",
-      "params": {
-        "dst": "Image *",
-        "font": "Font",
-        "text": "const char *",
-        "position": "Vector2",
-        "fontSize": "float",
-        "spacing": "float",
-        "tint": "Color"
-      }
+      "params": [
+        {
+          "name": "dst",
+          "type": "Image *"
+        },
+        {
+          "name": "font",
+          "type": "Font"
+        },
+        {
+          "name": "text",
+          "type": "const char *"
+        },
+        {
+          "name": "position",
+          "type": "Vector2"
+        },
+        {
+          "name": "fontSize",
+          "type": "float"
+        },
+        {
+          "name": "spacing",
+          "type": "float"
+        },
+        {
+          "name": "tint",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "LoadTexture",
       "description": "Load texture from file into GPU memory (VRAM)",
       "returnType": "Texture2D",
-      "params": {
-        "fileName": "const char *"
-      }
+      "params": [
+        {
+          "name": "fileName",
+          "type": "const char *"
+        }
+      ]
     },
     {
       "name": "LoadTextureFromImage",
       "description": "Load texture from image data",
       "returnType": "Texture2D",
-      "params": {
-        "image": "Image"
-      }
+      "params": [
+        {
+          "name": "image",
+          "type": "Image"
+        }
+      ]
     },
     {
       "name": "LoadTextureCubemap",
       "description": "Load cubemap from image, multiple image cubemap layouts supported",
       "returnType": "TextureCubemap",
-      "params": {
-        "image": "Image",
-        "layout": "int"
-      }
+      "params": [
+        {
+          "name": "image",
+          "type": "Image"
+        },
+        {
+          "name": "layout",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "LoadRenderTexture",
       "description": "Load texture for rendering (framebuffer)",
       "returnType": "RenderTexture2D",
-      "params": {
-        "width": "int",
-        "height": "int"
-      }
+      "params": [
+        {
+          "name": "width",
+          "type": "int"
+        },
+        {
+          "name": "height",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "UnloadTexture",
       "description": "Unload texture from GPU memory (VRAM)",
       "returnType": "void",
-      "params": {
-        "texture": "Texture2D"
-      }
+      "params": [
+        {
+          "name": "texture",
+          "type": "Texture2D"
+        }
+      ]
     },
     {
       "name": "UnloadRenderTexture",
       "description": "Unload render texture from GPU memory (VRAM)",
       "returnType": "void",
-      "params": {
-        "target": "RenderTexture2D"
-      }
+      "params": [
+        {
+          "name": "target",
+          "type": "RenderTexture2D"
+        }
+      ]
     },
     {
       "name": "UpdateTexture",
       "description": "Update GPU texture with new data",
       "returnType": "void",
-      "params": {
-        "texture": "Texture2D",
-        "pixels": "const void *"
-      }
+      "params": [
+        {
+          "name": "texture",
+          "type": "Texture2D"
+        },
+        {
+          "name": "pixels",
+          "type": "const void *"
+        }
+      ]
     },
     {
       "name": "UpdateTextureRec",
       "description": "Update GPU texture rectangle with new data",
       "returnType": "void",
-      "params": {
-        "texture": "Texture2D",
-        "rec": "Rectangle",
-        "pixels": "const void *"
-      }
+      "params": [
+        {
+          "name": "texture",
+          "type": "Texture2D"
+        },
+        {
+          "name": "rec",
+          "type": "Rectangle"
+        },
+        {
+          "name": "pixels",
+          "type": "const void *"
+        }
+      ]
     },
     {
       "name": "GenTextureMipmaps",
       "description": "Generate GPU mipmaps for a texture",
       "returnType": "void",
-      "params": {
-        "texture": "Texture2D *"
-      }
+      "params": [
+        {
+          "name": "texture",
+          "type": "Texture2D *"
+        }
+      ]
     },
     {
       "name": "SetTextureFilter",
       "description": "Set texture scaling filter mode",
       "returnType": "void",
-      "params": {
-        "texture": "Texture2D",
-        "filter": "int"
-      }
+      "params": [
+        {
+          "name": "texture",
+          "type": "Texture2D"
+        },
+        {
+          "name": "filter",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "SetTextureWrap",
       "description": "Set texture wrapping mode",
       "returnType": "void",
-      "params": {
-        "texture": "Texture2D",
-        "wrap": "int"
-      }
+      "params": [
+        {
+          "name": "texture",
+          "type": "Texture2D"
+        },
+        {
+          "name": "wrap",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "DrawTexture",
       "description": "Draw a Texture2D",
       "returnType": "void",
-      "params": {
-        "texture": "Texture2D",
-        "posX": "int",
-        "posY": "int",
-        "tint": "Color"
-      }
+      "params": [
+        {
+          "name": "texture",
+          "type": "Texture2D"
+        },
+        {
+          "name": "posX",
+          "type": "int"
+        },
+        {
+          "name": "posY",
+          "type": "int"
+        },
+        {
+          "name": "tint",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "DrawTextureV",
       "description": "Draw a Texture2D with position defined as Vector2",
       "returnType": "void",
-      "params": {
-        "texture": "Texture2D",
-        "position": "Vector2",
-        "tint": "Color"
-      }
+      "params": [
+        {
+          "name": "texture",
+          "type": "Texture2D"
+        },
+        {
+          "name": "position",
+          "type": "Vector2"
+        },
+        {
+          "name": "tint",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "DrawTextureEx",
       "description": "Draw a Texture2D with extended parameters",
       "returnType": "void",
-      "params": {
-        "texture": "Texture2D",
-        "position": "Vector2",
-        "rotation": "float",
-        "scale": "float",
-        "tint": "Color"
-      }
+      "params": [
+        {
+          "name": "texture",
+          "type": "Texture2D"
+        },
+        {
+          "name": "position",
+          "type": "Vector2"
+        },
+        {
+          "name": "rotation",
+          "type": "float"
+        },
+        {
+          "name": "scale",
+          "type": "float"
+        },
+        {
+          "name": "tint",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "DrawTextureRec",
       "description": "Draw a part of a texture defined by a rectangle",
       "returnType": "void",
-      "params": {
-        "texture": "Texture2D",
-        "source": "Rectangle",
-        "position": "Vector2",
-        "tint": "Color"
-      }
+      "params": [
+        {
+          "name": "texture",
+          "type": "Texture2D"
+        },
+        {
+          "name": "source",
+          "type": "Rectangle"
+        },
+        {
+          "name": "position",
+          "type": "Vector2"
+        },
+        {
+          "name": "tint",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "DrawTextureQuad",
       "description": "Draw texture quad with tiling and offset parameters",
       "returnType": "void",
-      "params": {
-        "texture": "Texture2D",
-        "tiling": "Vector2",
-        "offset": "Vector2",
-        "quad": "Rectangle",
-        "tint": "Color"
-      }
+      "params": [
+        {
+          "name": "texture",
+          "type": "Texture2D"
+        },
+        {
+          "name": "tiling",
+          "type": "Vector2"
+        },
+        {
+          "name": "offset",
+          "type": "Vector2"
+        },
+        {
+          "name": "quad",
+          "type": "Rectangle"
+        },
+        {
+          "name": "tint",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "DrawTextureTiled",
       "description": "Draw part of a texture (defined by a rectangle) with rotation and scale tiled into dest.",
       "returnType": "void",
-      "params": {
-        "texture": "Texture2D",
-        "source": "Rectangle",
-        "dest": "Rectangle",
-        "origin": "Vector2",
-        "rotation": "float",
-        "scale": "float",
-        "tint": "Color"
-      }
+      "params": [
+        {
+          "name": "texture",
+          "type": "Texture2D"
+        },
+        {
+          "name": "source",
+          "type": "Rectangle"
+        },
+        {
+          "name": "dest",
+          "type": "Rectangle"
+        },
+        {
+          "name": "origin",
+          "type": "Vector2"
+        },
+        {
+          "name": "rotation",
+          "type": "float"
+        },
+        {
+          "name": "scale",
+          "type": "float"
+        },
+        {
+          "name": "tint",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "DrawTexturePro",
       "description": "Draw a part of a texture defined by a rectangle with 'pro' parameters",
       "returnType": "void",
-      "params": {
-        "texture": "Texture2D",
-        "source": "Rectangle",
-        "dest": "Rectangle",
-        "origin": "Vector2",
-        "rotation": "float",
-        "tint": "Color"
-      }
+      "params": [
+        {
+          "name": "texture",
+          "type": "Texture2D"
+        },
+        {
+          "name": "source",
+          "type": "Rectangle"
+        },
+        {
+          "name": "dest",
+          "type": "Rectangle"
+        },
+        {
+          "name": "origin",
+          "type": "Vector2"
+        },
+        {
+          "name": "rotation",
+          "type": "float"
+        },
+        {
+          "name": "tint",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "DrawTextureNPatch",
       "description": "Draws a texture (or part of it) that stretches or shrinks nicely",
       "returnType": "void",
-      "params": {
-        "texture": "Texture2D",
-        "nPatchInfo": "NPatchInfo",
-        "dest": "Rectangle",
-        "origin": "Vector2",
-        "rotation": "float",
-        "tint": "Color"
-      }
+      "params": [
+        {
+          "name": "texture",
+          "type": "Texture2D"
+        },
+        {
+          "name": "nPatchInfo",
+          "type": "NPatchInfo"
+        },
+        {
+          "name": "dest",
+          "type": "Rectangle"
+        },
+        {
+          "name": "origin",
+          "type": "Vector2"
+        },
+        {
+          "name": "rotation",
+          "type": "float"
+        },
+        {
+          "name": "tint",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "DrawTexturePoly",
       "description": "Draw a textured polygon",
       "returnType": "void",
-      "params": {
-        "texture": "Texture2D",
-        "center": "Vector2",
-        "points": "Vector2 *",
-        "texcoords": "Vector2 *",
-        "pointCount": "int",
-        "tint": "Color"
-      }
+      "params": [
+        {
+          "name": "texture",
+          "type": "Texture2D"
+        },
+        {
+          "name": "center",
+          "type": "Vector2"
+        },
+        {
+          "name": "points",
+          "type": "Vector2 *"
+        },
+        {
+          "name": "texcoords",
+          "type": "Vector2 *"
+        },
+        {
+          "name": "pointCount",
+          "type": "int"
+        },
+        {
+          "name": "tint",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "Fade",
       "description": "Get color with alpha applied, alpha goes from 0.0f to 1.0f",
       "returnType": "Color",
-      "params": {
-        "color": "Color",
-        "alpha": "float"
-      }
+      "params": [
+        {
+          "name": "color",
+          "type": "Color"
+        },
+        {
+          "name": "alpha",
+          "type": "float"
+        }
+      ]
     },
     {
       "name": "ColorToInt",
       "description": "Get hexadecimal value for a Color",
       "returnType": "int",
-      "params": {
-        "color": "Color"
-      }
+      "params": [
+        {
+          "name": "color",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "ColorNormalize",
       "description": "Get Color normalized as float [0..1]",
       "returnType": "Vector4",
-      "params": {
-        "color": "Color"
-      }
+      "params": [
+        {
+          "name": "color",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "ColorFromNormalized",
       "description": "Get Color from normalized values [0..1]",
       "returnType": "Color",
-      "params": {
-        "normalized": "Vector4"
-      }
+      "params": [
+        {
+          "name": "normalized",
+          "type": "Vector4"
+        }
+      ]
     },
     {
       "name": "ColorToHSV",
       "description": "Get HSV values for a Color, hue [0..360], saturation/value [0..1]",
       "returnType": "Vector3",
-      "params": {
-        "color": "Color"
-      }
+      "params": [
+        {
+          "name": "color",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "ColorFromHSV",
       "description": "Get a Color from HSV values, hue [0..360], saturation/value [0..1]",
       "returnType": "Color",
-      "params": {
-        "hue": "float",
-        "saturation": "float",
-        "value": "float"
-      }
+      "params": [
+        {
+          "name": "hue",
+          "type": "float"
+        },
+        {
+          "name": "saturation",
+          "type": "float"
+        },
+        {
+          "name": "value",
+          "type": "float"
+        }
+      ]
     },
     {
       "name": "ColorAlpha",
       "description": "Get color with alpha applied, alpha goes from 0.0f to 1.0f",
       "returnType": "Color",
-      "params": {
-        "color": "Color",
-        "alpha": "float"
-      }
+      "params": [
+        {
+          "name": "color",
+          "type": "Color"
+        },
+        {
+          "name": "alpha",
+          "type": "float"
+        }
+      ]
     },
     {
       "name": "ColorAlphaBlend",
       "description": "Get src alpha-blended into dst color with tint",
       "returnType": "Color",
-      "params": {
-        "dst": "Color",
-        "src": "Color",
-        "tint": "Color"
-      }
+      "params": [
+        {
+          "name": "dst",
+          "type": "Color"
+        },
+        {
+          "name": "src",
+          "type": "Color"
+        },
+        {
+          "name": "tint",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "GetColor",
       "description": "Get Color structure from hexadecimal value",
       "returnType": "Color",
-      "params": {
-        "hexValue": "unsigned int"
-      }
+      "params": [
+        {
+          "name": "hexValue",
+          "type": "unsigned int"
+        }
+      ]
     },
     {
       "name": "GetPixelColor",
       "description": "Get Color from a source pixel pointer of certain format",
       "returnType": "Color",
-      "params": {
-        "srcPtr": "void *",
-        "format": "int"
-      }
+      "params": [
+        {
+          "name": "srcPtr",
+          "type": "void *"
+        },
+        {
+          "name": "format",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "SetPixelColor",
       "description": "Set color formatted into destination pixel pointer",
       "returnType": "void",
-      "params": {
-        "dstPtr": "void *",
-        "color": "Color",
-        "format": "int"
-      }
+      "params": [
+        {
+          "name": "dstPtr",
+          "type": "void *"
+        },
+        {
+          "name": "color",
+          "type": "Color"
+        },
+        {
+          "name": "format",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "GetPixelDataSize",
       "description": "Get pixel data size in bytes for certain format",
       "returnType": "int",
-      "params": {
-        "width": "int",
-        "height": "int",
-        "format": "int"
-      }
+      "params": [
+        {
+          "name": "width",
+          "type": "int"
+        },
+        {
+          "name": "height",
+          "type": "int"
+        },
+        {
+          "name": "format",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "GetFontDefault",
@@ -5258,959 +7186,1874 @@
       "name": "LoadFont",
       "description": "Load font from file into GPU memory (VRAM)",
       "returnType": "Font",
-      "params": {
-        "fileName": "const char *"
-      }
+      "params": [
+        {
+          "name": "fileName",
+          "type": "const char *"
+        }
+      ]
     },
     {
       "name": "LoadFontEx",
-      "description": "Load font from file with extended parameters",
+      "description": "Load font from file with extended parameters, use NULL for fontChars and 0 for glyphCount to load the default character set",
       "returnType": "Font",
-      "params": {
-        "fileName": "const char *",
-        "fontSize": "int",
-        "fontChars": "int *",
-        "glyphCount": "int"
-      }
+      "params": [
+        {
+          "name": "fileName",
+          "type": "const char *"
+        },
+        {
+          "name": "fontSize",
+          "type": "int"
+        },
+        {
+          "name": "fontChars",
+          "type": "int *"
+        },
+        {
+          "name": "glyphCount",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "LoadFontFromImage",
       "description": "Load font from Image (XNA style)",
       "returnType": "Font",
-      "params": {
-        "image": "Image",
-        "key": "Color",
-        "firstChar": "int"
-      }
+      "params": [
+        {
+          "name": "image",
+          "type": "Image"
+        },
+        {
+          "name": "key",
+          "type": "Color"
+        },
+        {
+          "name": "firstChar",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "LoadFontFromMemory",
       "description": "Load font from memory buffer, fileType refers to extension: i.e. '.ttf'",
       "returnType": "Font",
-      "params": {
-        "fileType": "const char *",
-        "fileData": "const unsigned char *",
-        "dataSize": "int",
-        "fontSize": "int",
-        "fontChars": "int *",
-        "glyphCount": "int"
-      }
+      "params": [
+        {
+          "name": "fileType",
+          "type": "const char *"
+        },
+        {
+          "name": "fileData",
+          "type": "const unsigned char *"
+        },
+        {
+          "name": "dataSize",
+          "type": "int"
+        },
+        {
+          "name": "fontSize",
+          "type": "int"
+        },
+        {
+          "name": "fontChars",
+          "type": "int *"
+        },
+        {
+          "name": "glyphCount",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "LoadFontData",
       "description": "Load font data for further use",
       "returnType": "GlyphInfo *",
-      "params": {
-        "fileData": "const unsigned char *",
-        "dataSize": "int",
-        "fontSize": "int",
-        "fontChars": "int *",
-        "glyphCount": "int",
-        "type": "int"
-      }
+      "params": [
+        {
+          "name": "fileData",
+          "type": "const unsigned char *"
+        },
+        {
+          "name": "dataSize",
+          "type": "int"
+        },
+        {
+          "name": "fontSize",
+          "type": "int"
+        },
+        {
+          "name": "fontChars",
+          "type": "int *"
+        },
+        {
+          "name": "glyphCount",
+          "type": "int"
+        },
+        {
+          "name": "type",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "GenImageFontAtlas",
       "description": "Generate image font atlas using chars info",
       "returnType": "Image",
-      "params": {
-        "chars": "const GlyphInfo *",
-        "recs": "Rectangle **",
-        "glyphCount": "int",
-        "fontSize": "int",
-        "padding": "int",
-        "packMethod": "int"
-      }
+      "params": [
+        {
+          "name": "chars",
+          "type": "const GlyphInfo *"
+        },
+        {
+          "name": "recs",
+          "type": "Rectangle **"
+        },
+        {
+          "name": "glyphCount",
+          "type": "int"
+        },
+        {
+          "name": "fontSize",
+          "type": "int"
+        },
+        {
+          "name": "padding",
+          "type": "int"
+        },
+        {
+          "name": "packMethod",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "UnloadFontData",
       "description": "Unload font chars info data (RAM)",
       "returnType": "void",
-      "params": {
-        "chars": "GlyphInfo *",
-        "glyphCount": "int"
-      }
+      "params": [
+        {
+          "name": "chars",
+          "type": "GlyphInfo *"
+        },
+        {
+          "name": "glyphCount",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "UnloadFont",
-      "description": "Unload Font from GPU memory (VRAM)",
+      "description": "Unload font from GPU memory (VRAM)",
       "returnType": "void",
-      "params": {
-        "font": "Font"
-      }
+      "params": [
+        {
+          "name": "font",
+          "type": "Font"
+        }
+      ]
+    },
+    {
+      "name": "ExportFontAsCode",
+      "description": "Export font as code file, returns true on success",
+      "returnType": "bool",
+      "params": [
+        {
+          "name": "font",
+          "type": "Font"
+        },
+        {
+          "name": "fileName",
+          "type": "const char *"
+        }
+      ]
     },
     {
       "name": "DrawFPS",
       "description": "Draw current FPS",
       "returnType": "void",
-      "params": {
-        "posX": "int",
-        "posY": "int"
-      }
+      "params": [
+        {
+          "name": "posX",
+          "type": "int"
+        },
+        {
+          "name": "posY",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "DrawText",
       "description": "Draw text (using default font)",
       "returnType": "void",
-      "params": {
-        "text": "const char *",
-        "posX": "int",
-        "posY": "int",
-        "fontSize": "int",
-        "color": "Color"
-      }
+      "params": [
+        {
+          "name": "text",
+          "type": "const char *"
+        },
+        {
+          "name": "posX",
+          "type": "int"
+        },
+        {
+          "name": "posY",
+          "type": "int"
+        },
+        {
+          "name": "fontSize",
+          "type": "int"
+        },
+        {
+          "name": "color",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "DrawTextEx",
       "description": "Draw text using font and additional parameters",
       "returnType": "void",
-      "params": {
-        "font": "Font",
-        "text": "const char *",
-        "position": "Vector2",
-        "fontSize": "float",
-        "spacing": "float",
-        "tint": "Color"
-      }
+      "params": [
+        {
+          "name": "font",
+          "type": "Font"
+        },
+        {
+          "name": "text",
+          "type": "const char *"
+        },
+        {
+          "name": "position",
+          "type": "Vector2"
+        },
+        {
+          "name": "fontSize",
+          "type": "float"
+        },
+        {
+          "name": "spacing",
+          "type": "float"
+        },
+        {
+          "name": "tint",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "DrawTextPro",
       "description": "Draw text using Font and pro parameters (rotation)",
       "returnType": "void",
-      "params": {
-        "font": "Font",
-        "text": "const char *",
-        "position": "Vector2",
-        "origin": "Vector2",
-        "rotation": "float",
-        "fontSize": "float",
-        "spacing": "float",
-        "tint": "Color"
-      }
+      "params": [
+        {
+          "name": "font",
+          "type": "Font"
+        },
+        {
+          "name": "text",
+          "type": "const char *"
+        },
+        {
+          "name": "position",
+          "type": "Vector2"
+        },
+        {
+          "name": "origin",
+          "type": "Vector2"
+        },
+        {
+          "name": "rotation",
+          "type": "float"
+        },
+        {
+          "name": "fontSize",
+          "type": "float"
+        },
+        {
+          "name": "spacing",
+          "type": "float"
+        },
+        {
+          "name": "tint",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "DrawTextCodepoint",
       "description": "Draw one character (codepoint)",
       "returnType": "void",
-      "params": {
-        "font": "Font",
-        "codepoint": "int",
-        "position": "Vector2",
-        "fontSize": "float",
-        "tint": "Color"
-      }
+      "params": [
+        {
+          "name": "font",
+          "type": "Font"
+        },
+        {
+          "name": "codepoint",
+          "type": "int"
+        },
+        {
+          "name": "position",
+          "type": "Vector2"
+        },
+        {
+          "name": "fontSize",
+          "type": "float"
+        },
+        {
+          "name": "tint",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "MeasureText",
       "description": "Measure string width for default font",
       "returnType": "int",
-      "params": {
-        "text": "const char *",
-        "fontSize": "int"
-      }
+      "params": [
+        {
+          "name": "text",
+          "type": "const char *"
+        },
+        {
+          "name": "fontSize",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "MeasureTextEx",
       "description": "Measure string size for Font",
       "returnType": "Vector2",
-      "params": {
-        "font": "Font",
-        "text": "const char *",
-        "fontSize": "float",
-        "spacing": "float"
-      }
+      "params": [
+        {
+          "name": "font",
+          "type": "Font"
+        },
+        {
+          "name": "text",
+          "type": "const char *"
+        },
+        {
+          "name": "fontSize",
+          "type": "float"
+        },
+        {
+          "name": "spacing",
+          "type": "float"
+        }
+      ]
     },
     {
       "name": "GetGlyphIndex",
       "description": "Get glyph index position in font for a codepoint (unicode character), fallback to '?' if not found",
       "returnType": "int",
-      "params": {
-        "font": "Font",
-        "codepoint": "int"
-      }
+      "params": [
+        {
+          "name": "font",
+          "type": "Font"
+        },
+        {
+          "name": "codepoint",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "GetGlyphInfo",
       "description": "Get glyph font info data for a codepoint (unicode character), fallback to '?' if not found",
       "returnType": "GlyphInfo",
-      "params": {
-        "font": "Font",
-        "codepoint": "int"
-      }
+      "params": [
+        {
+          "name": "font",
+          "type": "Font"
+        },
+        {
+          "name": "codepoint",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "GetGlyphAtlasRec",
       "description": "Get glyph rectangle in font atlas for a codepoint (unicode character), fallback to '?' if not found",
       "returnType": "Rectangle",
-      "params": {
-        "font": "Font",
-        "codepoint": "int"
-      }
+      "params": [
+        {
+          "name": "font",
+          "type": "Font"
+        },
+        {
+          "name": "codepoint",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "LoadCodepoints",
       "description": "Load all codepoints from a UTF-8 text string, codepoints count returned by parameter",
       "returnType": "int *",
-      "params": {
-        "text": "const char *",
-        "count": "int *"
-      }
+      "params": [
+        {
+          "name": "text",
+          "type": "const char *"
+        },
+        {
+          "name": "count",
+          "type": "int *"
+        }
+      ]
     },
     {
       "name": "UnloadCodepoints",
       "description": "Unload codepoints data from memory",
       "returnType": "void",
-      "params": {
-        "codepoints": "int *"
-      }
+      "params": [
+        {
+          "name": "codepoints",
+          "type": "int *"
+        }
+      ]
     },
     {
       "name": "GetCodepointCount",
       "description": "Get total number of codepoints in a UTF-8 encoded string",
       "returnType": "int",
-      "params": {
-        "text": "const char *"
-      }
+      "params": [
+        {
+          "name": "text",
+          "type": "const char *"
+        }
+      ]
     },
     {
       "name": "GetCodepoint",
       "description": "Get next codepoint in a UTF-8 encoded string, 0x3f('?') is returned on failure",
       "returnType": "int",
-      "params": {
-        "text": "const char *",
-        "bytesProcessed": "int *"
-      }
+      "params": [
+        {
+          "name": "text",
+          "type": "const char *"
+        },
+        {
+          "name": "bytesProcessed",
+          "type": "int *"
+        }
+      ]
     },
     {
       "name": "CodepointToUTF8",
       "description": "Encode one codepoint into UTF-8 byte array (array length returned as parameter)",
       "returnType": "const char *",
-      "params": {
-        "codepoint": "int",
-        "byteSize": "int *"
-      }
+      "params": [
+        {
+          "name": "codepoint",
+          "type": "int"
+        },
+        {
+          "name": "byteSize",
+          "type": "int *"
+        }
+      ]
     },
     {
       "name": "TextCodepointsToUTF8",
       "description": "Encode text as codepoints array into UTF-8 text string (WARNING: memory must be freed!)",
       "returnType": "char *",
-      "params": {
-        "codepoints": "int *",
-        "length": "int"
-      }
+      "params": [
+        {
+          "name": "codepoints",
+          "type": "int *"
+        },
+        {
+          "name": "length",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "TextCopy",
       "description": "Copy one string to another, returns bytes copied",
       "returnType": "int",
-      "params": {
-        "dst": "char *",
-        "src": "const char *"
-      }
+      "params": [
+        {
+          "name": "dst",
+          "type": "char *"
+        },
+        {
+          "name": "src",
+          "type": "const char *"
+        }
+      ]
     },
     {
       "name": "TextIsEqual",
       "description": "Check if two text string are equal",
       "returnType": "bool",
-      "params": {
-        "text1": "const char *",
-        "text2": "const char *"
-      }
+      "params": [
+        {
+          "name": "text1",
+          "type": "const char *"
+        },
+        {
+          "name": "text2",
+          "type": "const char *"
+        }
+      ]
     },
     {
       "name": "TextLength",
       "description": "Get text length, checks for '\\0' ending",
       "returnType": "unsigned int",
-      "params": {
-        "text": "const char *"
-      }
+      "params": [
+        {
+          "name": "text",
+          "type": "const char *"
+        }
+      ]
     },
     {
       "name": "TextFormat",
       "description": "Text formatting with variables (sprintf() style)",
       "returnType": "const char *",
-      "params": {
-        "text": "const char *",
-        "": ""
-      }
+      "params": [
+        {
+          "name": "text",
+          "type": "const char *"
+        },
+        {
+          "name": "",
+          "type": ""
+        }
+      ]
     },
     {
       "name": "TextSubtext",
       "description": "Get a piece of a text string",
       "returnType": "const char *",
-      "params": {
-        "text": "const char *",
-        "position": "int",
-        "length": "int"
-      }
+      "params": [
+        {
+          "name": "text",
+          "type": "const char *"
+        },
+        {
+          "name": "position",
+          "type": "int"
+        },
+        {
+          "name": "length",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "TextReplace",
       "description": "Replace text string (WARNING: memory must be freed!)",
       "returnType": "char *",
-      "params": {
-        "text": "char *",
-        "replace": "const char *",
-        "by": "const char *"
-      }
+      "params": [
+        {
+          "name": "text",
+          "type": "char *"
+        },
+        {
+          "name": "replace",
+          "type": "const char *"
+        },
+        {
+          "name": "by",
+          "type": "const char *"
+        }
+      ]
     },
     {
       "name": "TextInsert",
       "description": "Insert text in a position (WARNING: memory must be freed!)",
       "returnType": "char *",
-      "params": {
-        "text": "const char *",
-        "insert": "const char *",
-        "position": "int"
-      }
+      "params": [
+        {
+          "name": "text",
+          "type": "const char *"
+        },
+        {
+          "name": "insert",
+          "type": "const char *"
+        },
+        {
+          "name": "position",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "TextJoin",
       "description": "Join text strings with delimiter",
       "returnType": "const char *",
-      "params": {
-        "textList": "const char **",
-        "count": "int",
-        "delimiter": "const char *"
-      }
+      "params": [
+        {
+          "name": "textList",
+          "type": "const char **"
+        },
+        {
+          "name": "count",
+          "type": "int"
+        },
+        {
+          "name": "delimiter",
+          "type": "const char *"
+        }
+      ]
     },
     {
       "name": "TextSplit",
       "description": "Split text into multiple strings",
       "returnType": "const char **",
-      "params": {
-        "text": "const char *",
-        "delimiter": "char",
-        "count": "int *"
-      }
+      "params": [
+        {
+          "name": "text",
+          "type": "const char *"
+        },
+        {
+          "name": "delimiter",
+          "type": "char"
+        },
+        {
+          "name": "count",
+          "type": "int *"
+        }
+      ]
     },
     {
       "name": "TextAppend",
       "description": "Append text at specific position and move cursor!",
       "returnType": "void",
-      "params": {
-        "text": "char *",
-        "append": "const char *",
-        "position": "int *"
-      }
+      "params": [
+        {
+          "name": "text",
+          "type": "char *"
+        },
+        {
+          "name": "append",
+          "type": "const char *"
+        },
+        {
+          "name": "position",
+          "type": "int *"
+        }
+      ]
     },
     {
       "name": "TextFindIndex",
       "description": "Find first text occurrence within a string",
       "returnType": "int",
-      "params": {
-        "text": "const char *",
-        "find": "const char *"
-      }
+      "params": [
+        {
+          "name": "text",
+          "type": "const char *"
+        },
+        {
+          "name": "find",
+          "type": "const char *"
+        }
+      ]
     },
     {
       "name": "TextToUpper",
       "description": "Get upper case version of provided string",
       "returnType": "const char *",
-      "params": {
-        "text": "const char *"
-      }
+      "params": [
+        {
+          "name": "text",
+          "type": "const char *"
+        }
+      ]
     },
     {
       "name": "TextToLower",
       "description": "Get lower case version of provided string",
       "returnType": "const char *",
-      "params": {
-        "text": "const char *"
-      }
+      "params": [
+        {
+          "name": "text",
+          "type": "const char *"
+        }
+      ]
     },
     {
       "name": "TextToPascal",
       "description": "Get Pascal case notation version of provided string",
       "returnType": "const char *",
-      "params": {
-        "text": "const char *"
-      }
+      "params": [
+        {
+          "name": "text",
+          "type": "const char *"
+        }
+      ]
     },
     {
       "name": "TextToInteger",
       "description": "Get integer value from text (negative values not supported)",
       "returnType": "int",
-      "params": {
-        "text": "const char *"
-      }
+      "params": [
+        {
+          "name": "text",
+          "type": "const char *"
+        }
+      ]
     },
     {
       "name": "DrawLine3D",
       "description": "Draw a line in 3D world space",
       "returnType": "void",
-      "params": {
-        "startPos": "Vector3",
-        "endPos": "Vector3",
-        "color": "Color"
-      }
+      "params": [
+        {
+          "name": "startPos",
+          "type": "Vector3"
+        },
+        {
+          "name": "endPos",
+          "type": "Vector3"
+        },
+        {
+          "name": "color",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "DrawPoint3D",
       "description": "Draw a point in 3D space, actually a small line",
       "returnType": "void",
-      "params": {
-        "position": "Vector3",
-        "color": "Color"
-      }
+      "params": [
+        {
+          "name": "position",
+          "type": "Vector3"
+        },
+        {
+          "name": "color",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "DrawCircle3D",
       "description": "Draw a circle in 3D world space",
       "returnType": "void",
-      "params": {
-        "center": "Vector3",
-        "radius": "float",
-        "rotationAxis": "Vector3",
-        "rotationAngle": "float",
-        "color": "Color"
-      }
+      "params": [
+        {
+          "name": "center",
+          "type": "Vector3"
+        },
+        {
+          "name": "radius",
+          "type": "float"
+        },
+        {
+          "name": "rotationAxis",
+          "type": "Vector3"
+        },
+        {
+          "name": "rotationAngle",
+          "type": "float"
+        },
+        {
+          "name": "color",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "DrawTriangle3D",
       "description": "Draw a color-filled triangle (vertex in counter-clockwise order!)",
       "returnType": "void",
-      "params": {
-        "v1": "Vector3",
-        "v2": "Vector3",
-        "v3": "Vector3",
-        "color": "Color"
-      }
+      "params": [
+        {
+          "name": "v1",
+          "type": "Vector3"
+        },
+        {
+          "name": "v2",
+          "type": "Vector3"
+        },
+        {
+          "name": "v3",
+          "type": "Vector3"
+        },
+        {
+          "name": "color",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "DrawTriangleStrip3D",
       "description": "Draw a triangle strip defined by points",
       "returnType": "void",
-      "params": {
-        "points": "Vector3 *",
-        "pointCount": "int",
-        "color": "Color"
-      }
+      "params": [
+        {
+          "name": "points",
+          "type": "Vector3 *"
+        },
+        {
+          "name": "pointCount",
+          "type": "int"
+        },
+        {
+          "name": "color",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "DrawCube",
       "description": "Draw cube",
       "returnType": "void",
-      "params": {
-        "position": "Vector3",
-        "width": "float",
-        "height": "float",
-        "length": "float",
-        "color": "Color"
-      }
+      "params": [
+        {
+          "name": "position",
+          "type": "Vector3"
+        },
+        {
+          "name": "width",
+          "type": "float"
+        },
+        {
+          "name": "height",
+          "type": "float"
+        },
+        {
+          "name": "length",
+          "type": "float"
+        },
+        {
+          "name": "color",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "DrawCubeV",
       "description": "Draw cube (Vector version)",
       "returnType": "void",
-      "params": {
-        "position": "Vector3",
-        "size": "Vector3",
-        "color": "Color"
-      }
+      "params": [
+        {
+          "name": "position",
+          "type": "Vector3"
+        },
+        {
+          "name": "size",
+          "type": "Vector3"
+        },
+        {
+          "name": "color",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "DrawCubeWires",
       "description": "Draw cube wires",
       "returnType": "void",
-      "params": {
-        "position": "Vector3",
-        "width": "float",
-        "height": "float",
-        "length": "float",
-        "color": "Color"
-      }
+      "params": [
+        {
+          "name": "position",
+          "type": "Vector3"
+        },
+        {
+          "name": "width",
+          "type": "float"
+        },
+        {
+          "name": "height",
+          "type": "float"
+        },
+        {
+          "name": "length",
+          "type": "float"
+        },
+        {
+          "name": "color",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "DrawCubeWiresV",
       "description": "Draw cube wires (Vector version)",
       "returnType": "void",
-      "params": {
-        "position": "Vector3",
-        "size": "Vector3",
-        "color": "Color"
-      }
+      "params": [
+        {
+          "name": "position",
+          "type": "Vector3"
+        },
+        {
+          "name": "size",
+          "type": "Vector3"
+        },
+        {
+          "name": "color",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "DrawCubeTexture",
       "description": "Draw cube textured",
       "returnType": "void",
-      "params": {
-        "texture": "Texture2D",
-        "position": "Vector3",
-        "width": "float",
-        "height": "float",
-        "length": "float",
-        "color": "Color"
-      }
+      "params": [
+        {
+          "name": "texture",
+          "type": "Texture2D"
+        },
+        {
+          "name": "position",
+          "type": "Vector3"
+        },
+        {
+          "name": "width",
+          "type": "float"
+        },
+        {
+          "name": "height",
+          "type": "float"
+        },
+        {
+          "name": "length",
+          "type": "float"
+        },
+        {
+          "name": "color",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "DrawCubeTextureRec",
       "description": "Draw cube with a region of a texture",
       "returnType": "void",
-      "params": {
-        "texture": "Texture2D",
-        "source": "Rectangle",
-        "position": "Vector3",
-        "width": "float",
-        "height": "float",
-        "length": "float",
-        "color": "Color"
-      }
+      "params": [
+        {
+          "name": "texture",
+          "type": "Texture2D"
+        },
+        {
+          "name": "source",
+          "type": "Rectangle"
+        },
+        {
+          "name": "position",
+          "type": "Vector3"
+        },
+        {
+          "name": "width",
+          "type": "float"
+        },
+        {
+          "name": "height",
+          "type": "float"
+        },
+        {
+          "name": "length",
+          "type": "float"
+        },
+        {
+          "name": "color",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "DrawSphere",
       "description": "Draw sphere",
       "returnType": "void",
-      "params": {
-        "centerPos": "Vector3",
-        "radius": "float",
-        "color": "Color"
-      }
+      "params": [
+        {
+          "name": "centerPos",
+          "type": "Vector3"
+        },
+        {
+          "name": "radius",
+          "type": "float"
+        },
+        {
+          "name": "color",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "DrawSphereEx",
       "description": "Draw sphere with extended parameters",
       "returnType": "void",
-      "params": {
-        "centerPos": "Vector3",
-        "radius": "float",
-        "rings": "int",
-        "slices": "int",
-        "color": "Color"
-      }
+      "params": [
+        {
+          "name": "centerPos",
+          "type": "Vector3"
+        },
+        {
+          "name": "radius",
+          "type": "float"
+        },
+        {
+          "name": "rings",
+          "type": "int"
+        },
+        {
+          "name": "slices",
+          "type": "int"
+        },
+        {
+          "name": "color",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "DrawSphereWires",
       "description": "Draw sphere wires",
       "returnType": "void",
-      "params": {
-        "centerPos": "Vector3",
-        "radius": "float",
-        "rings": "int",
-        "slices": "int",
-        "color": "Color"
-      }
+      "params": [
+        {
+          "name": "centerPos",
+          "type": "Vector3"
+        },
+        {
+          "name": "radius",
+          "type": "float"
+        },
+        {
+          "name": "rings",
+          "type": "int"
+        },
+        {
+          "name": "slices",
+          "type": "int"
+        },
+        {
+          "name": "color",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "DrawCylinder",
       "description": "Draw a cylinder/cone",
       "returnType": "void",
-      "params": {
-        "position": "Vector3",
-        "radiusTop": "float",
-        "radiusBottom": "float",
-        "height": "float",
-        "slices": "int",
-        "color": "Color"
-      }
+      "params": [
+        {
+          "name": "position",
+          "type": "Vector3"
+        },
+        {
+          "name": "radiusTop",
+          "type": "float"
+        },
+        {
+          "name": "radiusBottom",
+          "type": "float"
+        },
+        {
+          "name": "height",
+          "type": "float"
+        },
+        {
+          "name": "slices",
+          "type": "int"
+        },
+        {
+          "name": "color",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "DrawCylinderEx",
       "description": "Draw a cylinder with base at startPos and top at endPos",
       "returnType": "void",
-      "params": {
-        "startPos": "Vector3",
-        "endPos": "Vector3",
-        "startRadius": "float",
-        "endRadius": "float",
-        "sides": "int",
-        "color": "Color"
-      }
+      "params": [
+        {
+          "name": "startPos",
+          "type": "Vector3"
+        },
+        {
+          "name": "endPos",
+          "type": "Vector3"
+        },
+        {
+          "name": "startRadius",
+          "type": "float"
+        },
+        {
+          "name": "endRadius",
+          "type": "float"
+        },
+        {
+          "name": "sides",
+          "type": "int"
+        },
+        {
+          "name": "color",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "DrawCylinderWires",
       "description": "Draw a cylinder/cone wires",
       "returnType": "void",
-      "params": {
-        "position": "Vector3",
-        "radiusTop": "float",
-        "radiusBottom": "float",
-        "height": "float",
-        "slices": "int",
-        "color": "Color"
-      }
+      "params": [
+        {
+          "name": "position",
+          "type": "Vector3"
+        },
+        {
+          "name": "radiusTop",
+          "type": "float"
+        },
+        {
+          "name": "radiusBottom",
+          "type": "float"
+        },
+        {
+          "name": "height",
+          "type": "float"
+        },
+        {
+          "name": "slices",
+          "type": "int"
+        },
+        {
+          "name": "color",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "DrawCylinderWiresEx",
       "description": "Draw a cylinder wires with base at startPos and top at endPos",
       "returnType": "void",
-      "params": {
-        "startPos": "Vector3",
-        "endPos": "Vector3",
-        "startRadius": "float",
-        "endRadius": "float",
-        "sides": "int",
-        "color": "Color"
-      }
+      "params": [
+        {
+          "name": "startPos",
+          "type": "Vector3"
+        },
+        {
+          "name": "endPos",
+          "type": "Vector3"
+        },
+        {
+          "name": "startRadius",
+          "type": "float"
+        },
+        {
+          "name": "endRadius",
+          "type": "float"
+        },
+        {
+          "name": "sides",
+          "type": "int"
+        },
+        {
+          "name": "color",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "DrawPlane",
       "description": "Draw a plane XZ",
       "returnType": "void",
-      "params": {
-        "centerPos": "Vector3",
-        "size": "Vector2",
-        "color": "Color"
-      }
+      "params": [
+        {
+          "name": "centerPos",
+          "type": "Vector3"
+        },
+        {
+          "name": "size",
+          "type": "Vector2"
+        },
+        {
+          "name": "color",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "DrawRay",
       "description": "Draw a ray line",
       "returnType": "void",
-      "params": {
-        "ray": "Ray",
-        "color": "Color"
-      }
+      "params": [
+        {
+          "name": "ray",
+          "type": "Ray"
+        },
+        {
+          "name": "color",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "DrawGrid",
       "description": "Draw a grid (centered at (0, 0, 0))",
       "returnType": "void",
-      "params": {
-        "slices": "int",
-        "spacing": "float"
-      }
+      "params": [
+        {
+          "name": "slices",
+          "type": "int"
+        },
+        {
+          "name": "spacing",
+          "type": "float"
+        }
+      ]
     },
     {
       "name": "LoadModel",
       "description": "Load model from files (meshes and materials)",
       "returnType": "Model",
-      "params": {
-        "fileName": "const char *"
-      }
+      "params": [
+        {
+          "name": "fileName",
+          "type": "const char *"
+        }
+      ]
     },
     {
       "name": "LoadModelFromMesh",
       "description": "Load model from generated mesh (default material)",
       "returnType": "Model",
-      "params": {
-        "mesh": "Mesh"
-      }
+      "params": [
+        {
+          "name": "mesh",
+          "type": "Mesh"
+        }
+      ]
     },
     {
       "name": "UnloadModel",
       "description": "Unload model (including meshes) from memory (RAM and/or VRAM)",
       "returnType": "void",
-      "params": {
-        "model": "Model"
-      }
+      "params": [
+        {
+          "name": "model",
+          "type": "Model"
+        }
+      ]
     },
     {
       "name": "UnloadModelKeepMeshes",
       "description": "Unload model (but not meshes) from memory (RAM and/or VRAM)",
       "returnType": "void",
-      "params": {
-        "model": "Model"
-      }
+      "params": [
+        {
+          "name": "model",
+          "type": "Model"
+        }
+      ]
     },
     {
       "name": "GetModelBoundingBox",
       "description": "Compute model bounding box limits (considers all meshes)",
       "returnType": "BoundingBox",
-      "params": {
-        "model": "Model"
-      }
+      "params": [
+        {
+          "name": "model",
+          "type": "Model"
+        }
+      ]
     },
     {
       "name": "DrawModel",
       "description": "Draw a model (with texture if set)",
       "returnType": "void",
-      "params": {
-        "model": "Model",
-        "position": "Vector3",
-        "scale": "float",
-        "tint": "Color"
-      }
+      "params": [
+        {
+          "name": "model",
+          "type": "Model"
+        },
+        {
+          "name": "position",
+          "type": "Vector3"
+        },
+        {
+          "name": "scale",
+          "type": "float"
+        },
+        {
+          "name": "tint",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "DrawModelEx",
       "description": "Draw a model with extended parameters",
       "returnType": "void",
-      "params": {
-        "model": "Model",
-        "position": "Vector3",
-        "rotationAxis": "Vector3",
-        "rotationAngle": "float",
-        "scale": "Vector3",
-        "tint": "Color"
-      }
+      "params": [
+        {
+          "name": "model",
+          "type": "Model"
+        },
+        {
+          "name": "position",
+          "type": "Vector3"
+        },
+        {
+          "name": "rotationAxis",
+          "type": "Vector3"
+        },
+        {
+          "name": "rotationAngle",
+          "type": "float"
+        },
+        {
+          "name": "scale",
+          "type": "Vector3"
+        },
+        {
+          "name": "tint",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "DrawModelWires",
       "description": "Draw a model wires (with texture if set)",
       "returnType": "void",
-      "params": {
-        "model": "Model",
-        "position": "Vector3",
-        "scale": "float",
-        "tint": "Color"
-      }
+      "params": [
+        {
+          "name": "model",
+          "type": "Model"
+        },
+        {
+          "name": "position",
+          "type": "Vector3"
+        },
+        {
+          "name": "scale",
+          "type": "float"
+        },
+        {
+          "name": "tint",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "DrawModelWiresEx",
       "description": "Draw a model wires (with texture if set) with extended parameters",
       "returnType": "void",
-      "params": {
-        "model": "Model",
-        "position": "Vector3",
-        "rotationAxis": "Vector3",
-        "rotationAngle": "float",
-        "scale": "Vector3",
-        "tint": "Color"
-      }
+      "params": [
+        {
+          "name": "model",
+          "type": "Model"
+        },
+        {
+          "name": "position",
+          "type": "Vector3"
+        },
+        {
+          "name": "rotationAxis",
+          "type": "Vector3"
+        },
+        {
+          "name": "rotationAngle",
+          "type": "float"
+        },
+        {
+          "name": "scale",
+          "type": "Vector3"
+        },
+        {
+          "name": "tint",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "DrawBoundingBox",
       "description": "Draw bounding box (wires)",
       "returnType": "void",
-      "params": {
-        "box": "BoundingBox",
-        "color": "Color"
-      }
+      "params": [
+        {
+          "name": "box",
+          "type": "BoundingBox"
+        },
+        {
+          "name": "color",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "DrawBillboard",
       "description": "Draw a billboard texture",
       "returnType": "void",
-      "params": {
-        "camera": "Camera",
-        "texture": "Texture2D",
-        "position": "Vector3",
-        "size": "float",
-        "tint": "Color"
-      }
+      "params": [
+        {
+          "name": "camera",
+          "type": "Camera"
+        },
+        {
+          "name": "texture",
+          "type": "Texture2D"
+        },
+        {
+          "name": "position",
+          "type": "Vector3"
+        },
+        {
+          "name": "size",
+          "type": "float"
+        },
+        {
+          "name": "tint",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "DrawBillboardRec",
       "description": "Draw a billboard texture defined by source",
       "returnType": "void",
-      "params": {
-        "camera": "Camera",
-        "texture": "Texture2D",
-        "source": "Rectangle",
-        "position": "Vector3",
-        "size": "Vector2",
-        "tint": "Color"
-      }
+      "params": [
+        {
+          "name": "camera",
+          "type": "Camera"
+        },
+        {
+          "name": "texture",
+          "type": "Texture2D"
+        },
+        {
+          "name": "source",
+          "type": "Rectangle"
+        },
+        {
+          "name": "position",
+          "type": "Vector3"
+        },
+        {
+          "name": "size",
+          "type": "Vector2"
+        },
+        {
+          "name": "tint",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "DrawBillboardPro",
       "description": "Draw a billboard texture defined by source and rotation",
       "returnType": "void",
-      "params": {
-        "camera": "Camera",
-        "texture": "Texture2D",
-        "source": "Rectangle",
-        "position": "Vector3",
-        "up": "Vector3",
-        "size": "Vector2",
-        "origin": "Vector2",
-        "rotation": "float",
-        "tint": "Color"
-      }
+      "params": [
+        {
+          "name": "camera",
+          "type": "Camera"
+        },
+        {
+          "name": "texture",
+          "type": "Texture2D"
+        },
+        {
+          "name": "source",
+          "type": "Rectangle"
+        },
+        {
+          "name": "position",
+          "type": "Vector3"
+        },
+        {
+          "name": "up",
+          "type": "Vector3"
+        },
+        {
+          "name": "size",
+          "type": "Vector2"
+        },
+        {
+          "name": "origin",
+          "type": "Vector2"
+        },
+        {
+          "name": "rotation",
+          "type": "float"
+        },
+        {
+          "name": "tint",
+          "type": "Color"
+        }
+      ]
     },
     {
       "name": "UploadMesh",
       "description": "Upload mesh vertex data in GPU and provide VAO/VBO ids",
       "returnType": "void",
-      "params": {
-        "mesh": "Mesh *",
-        "dynamic": "bool"
-      }
+      "params": [
+        {
+          "name": "mesh",
+          "type": "Mesh *"
+        },
+        {
+          "name": "dynamic",
+          "type": "bool"
+        }
+      ]
     },
     {
       "name": "UpdateMeshBuffer",
       "description": "Update mesh vertex data in GPU for a specific buffer index",
       "returnType": "void",
-      "params": {
-        "mesh": "Mesh",
-        "index": "int",
-        "data": "void *",
-        "dataSize": "int",
-        "offset": "int"
-      }
+      "params": [
+        {
+          "name": "mesh",
+          "type": "Mesh"
+        },
+        {
+          "name": "index",
+          "type": "int"
+        },
+        {
+          "name": "data",
+          "type": "void *"
+        },
+        {
+          "name": "dataSize",
+          "type": "int"
+        },
+        {
+          "name": "offset",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "UnloadMesh",
       "description": "Unload mesh data from CPU and GPU",
       "returnType": "void",
-      "params": {
-        "mesh": "Mesh"
-      }
+      "params": [
+        {
+          "name": "mesh",
+          "type": "Mesh"
+        }
+      ]
     },
     {
       "name": "DrawMesh",
       "description": "Draw a 3d mesh with material and transform",
       "returnType": "void",
-      "params": {
-        "mesh": "Mesh",
-        "material": "Material",
-        "transform": "Matrix"
-      }
+      "params": [
+        {
+          "name": "mesh",
+          "type": "Mesh"
+        },
+        {
+          "name": "material",
+          "type": "Material"
+        },
+        {
+          "name": "transform",
+          "type": "Matrix"
+        }
+      ]
     },
     {
       "name": "DrawMeshInstanced",
       "description": "Draw multiple mesh instances with material and different transforms",
       "returnType": "void",
-      "params": {
-        "mesh": "Mesh",
-        "material": "Material",
-        "transforms": "Matrix *",
-        "instances": "int"
-      }
+      "params": [
+        {
+          "name": "mesh",
+          "type": "Mesh"
+        },
+        {
+          "name": "material",
+          "type": "Material"
+        },
+        {
+          "name": "transforms",
+          "type": "Matrix *"
+        },
+        {
+          "name": "instances",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "ExportMesh",
       "description": "Export mesh data to file, returns true on success",
       "returnType": "bool",
-      "params": {
-        "mesh": "Mesh",
-        "fileName": "const char *"
-      }
+      "params": [
+        {
+          "name": "mesh",
+          "type": "Mesh"
+        },
+        {
+          "name": "fileName",
+          "type": "const char *"
+        }
+      ]
     },
     {
       "name": "GetMeshBoundingBox",
       "description": "Compute mesh bounding box limits",
       "returnType": "BoundingBox",
-      "params": {
-        "mesh": "Mesh"
-      }
+      "params": [
+        {
+          "name": "mesh",
+          "type": "Mesh"
+        }
+      ]
     },
     {
       "name": "GenMeshTangents",
       "description": "Compute mesh tangents",
       "returnType": "void",
-      "params": {
-        "mesh": "Mesh *"
-      }
+      "params": [
+        {
+          "name": "mesh",
+          "type": "Mesh *"
+        }
+      ]
     },
     {
       "name": "GenMeshBinormals",
       "description": "Compute mesh binormals",
       "returnType": "void",
-      "params": {
-        "mesh": "Mesh *"
-      }
+      "params": [
+        {
+          "name": "mesh",
+          "type": "Mesh *"
+        }
+      ]
     },
     {
       "name": "GenMeshPoly",
       "description": "Generate polygonal mesh",
       "returnType": "Mesh",
-      "params": {
-        "sides": "int",
-        "radius": "float"
-      }
+      "params": [
+        {
+          "name": "sides",
+          "type": "int"
+        },
+        {
+          "name": "radius",
+          "type": "float"
+        }
+      ]
     },
     {
       "name": "GenMeshPlane",
       "description": "Generate plane mesh (with subdivisions)",
       "returnType": "Mesh",
-      "params": {
-        "width": "float",
-        "length": "float",
-        "resX": "int",
-        "resZ": "int"
-      }
+      "params": [
+        {
+          "name": "width",
+          "type": "float"
+        },
+        {
+          "name": "length",
+          "type": "float"
+        },
+        {
+          "name": "resX",
+          "type": "int"
+        },
+        {
+          "name": "resZ",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "GenMeshCube",
       "description": "Generate cuboid mesh",
       "returnType": "Mesh",
-      "params": {
-        "width": "float",
-        "height": "float",
-        "length": "float"
-      }
+      "params": [
+        {
+          "name": "width",
+          "type": "float"
+        },
+        {
+          "name": "height",
+          "type": "float"
+        },
+        {
+          "name": "length",
+          "type": "float"
+        }
+      ]
     },
     {
       "name": "GenMeshSphere",
       "description": "Generate sphere mesh (standard sphere)",
       "returnType": "Mesh",
-      "params": {
-        "radius": "float",
-        "rings": "int",
-        "slices": "int"
-      }
+      "params": [
+        {
+          "name": "radius",
+          "type": "float"
+        },
+        {
+          "name": "rings",
+          "type": "int"
+        },
+        {
+          "name": "slices",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "GenMeshHemiSphere",
       "description": "Generate half-sphere mesh (no bottom cap)",
       "returnType": "Mesh",
-      "params": {
-        "radius": "float",
-        "rings": "int",
-        "slices": "int"
-      }
+      "params": [
+        {
+          "name": "radius",
+          "type": "float"
+        },
+        {
+          "name": "rings",
+          "type": "int"
+        },
+        {
+          "name": "slices",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "GenMeshCylinder",
       "description": "Generate cylinder mesh",
       "returnType": "Mesh",
-      "params": {
-        "radius": "float",
-        "height": "float",
-        "slices": "int"
-      }
+      "params": [
+        {
+          "name": "radius",
+          "type": "float"
+        },
+        {
+          "name": "height",
+          "type": "float"
+        },
+        {
+          "name": "slices",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "GenMeshCone",
       "description": "Generate cone/pyramid mesh",
       "returnType": "Mesh",
-      "params": {
-        "radius": "float",
-        "height": "float",
-        "slices": "int"
-      }
+      "params": [
+        {
+          "name": "radius",
+          "type": "float"
+        },
+        {
+          "name": "height",
+          "type": "float"
+        },
+        {
+          "name": "slices",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "GenMeshTorus",
       "description": "Generate torus mesh",
       "returnType": "Mesh",
-      "params": {
-        "radius": "float",
-        "size": "float",
-        "radSeg": "int",
-        "sides": "int"
-      }
+      "params": [
+        {
+          "name": "radius",
+          "type": "float"
+        },
+        {
+          "name": "size",
+          "type": "float"
+        },
+        {
+          "name": "radSeg",
+          "type": "int"
+        },
+        {
+          "name": "sides",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "GenMeshKnot",
       "description": "Generate trefoil knot mesh",
       "returnType": "Mesh",
-      "params": {
-        "radius": "float",
-        "size": "float",
-        "radSeg": "int",
-        "sides": "int"
-      }
+      "params": [
+        {
+          "name": "radius",
+          "type": "float"
+        },
+        {
+          "name": "size",
+          "type": "float"
+        },
+        {
+          "name": "radSeg",
+          "type": "int"
+        },
+        {
+          "name": "sides",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "GenMeshHeightmap",
       "description": "Generate heightmap mesh from image data",
       "returnType": "Mesh",
-      "params": {
-        "heightmap": "Image",
-        "size": "Vector3"
-      }
+      "params": [
+        {
+          "name": "heightmap",
+          "type": "Image"
+        },
+        {
+          "name": "size",
+          "type": "Vector3"
+        }
+      ]
     },
     {
       "name": "GenMeshCubicmap",
       "description": "Generate cubes-based map mesh from image data",
       "returnType": "Mesh",
-      "params": {
-        "cubicmap": "Image",
-        "cubeSize": "Vector3"
-      }
+      "params": [
+        {
+          "name": "cubicmap",
+          "type": "Image"
+        },
+        {
+          "name": "cubeSize",
+          "type": "Vector3"
+        }
+      ]
     },
     {
       "name": "LoadMaterials",
       "description": "Load materials from model file",
       "returnType": "Material *",
-      "params": {
-        "fileName": "const char *",
-        "materialCount": "int *"
-      }
+      "params": [
+        {
+          "name": "fileName",
+          "type": "const char *"
+        },
+        {
+          "name": "materialCount",
+          "type": "int *"
+        }
+      ]
     },
     {
       "name": "LoadMaterialDefault",
@@ -6221,165 +9064,300 @@
       "name": "UnloadMaterial",
       "description": "Unload material from GPU memory (VRAM)",
       "returnType": "void",
-      "params": {
-        "material": "Material"
-      }
+      "params": [
+        {
+          "name": "material",
+          "type": "Material"
+        }
+      ]
     },
     {
       "name": "SetMaterialTexture",
       "description": "Set texture for a material map type (MATERIAL_MAP_DIFFUSE, MATERIAL_MAP_SPECULAR...)",
       "returnType": "void",
-      "params": {
-        "material": "Material *",
-        "mapType": "int",
-        "texture": "Texture2D"
-      }
+      "params": [
+        {
+          "name": "material",
+          "type": "Material *"
+        },
+        {
+          "name": "mapType",
+          "type": "int"
+        },
+        {
+          "name": "texture",
+          "type": "Texture2D"
+        }
+      ]
     },
     {
       "name": "SetModelMeshMaterial",
       "description": "Set material for a mesh",
       "returnType": "void",
-      "params": {
-        "model": "Model *",
-        "meshId": "int",
-        "materialId": "int"
-      }
+      "params": [
+        {
+          "name": "model",
+          "type": "Model *"
+        },
+        {
+          "name": "meshId",
+          "type": "int"
+        },
+        {
+          "name": "materialId",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "LoadModelAnimations",
       "description": "Load model animations from file",
       "returnType": "ModelAnimation *",
-      "params": {
-        "fileName": "const char *",
-        "animCount": "unsigned int *"
-      }
+      "params": [
+        {
+          "name": "fileName",
+          "type": "const char *"
+        },
+        {
+          "name": "animCount",
+          "type": "unsigned int *"
+        }
+      ]
     },
     {
       "name": "UpdateModelAnimation",
       "description": "Update model animation pose",
       "returnType": "void",
-      "params": {
-        "model": "Model",
-        "anim": "ModelAnimation",
-        "frame": "int"
-      }
+      "params": [
+        {
+          "name": "model",
+          "type": "Model"
+        },
+        {
+          "name": "anim",
+          "type": "ModelAnimation"
+        },
+        {
+          "name": "frame",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "UnloadModelAnimation",
       "description": "Unload animation data",
       "returnType": "void",
-      "params": {
-        "anim": "ModelAnimation"
-      }
+      "params": [
+        {
+          "name": "anim",
+          "type": "ModelAnimation"
+        }
+      ]
     },
     {
       "name": "UnloadModelAnimations",
       "description": "Unload animation array data",
       "returnType": "void",
-      "params": {
-        "animations": "ModelAnimation*",
-        "count": "unsigned int"
-      }
+      "params": [
+        {
+          "name": "animations",
+          "type": "ModelAnimation*"
+        },
+        {
+          "name": "count",
+          "type": "unsigned int"
+        }
+      ]
     },
     {
       "name": "IsModelAnimationValid",
       "description": "Check model animation skeleton match",
       "returnType": "bool",
-      "params": {
-        "model": "Model",
-        "anim": "ModelAnimation"
-      }
+      "params": [
+        {
+          "name": "model",
+          "type": "Model"
+        },
+        {
+          "name": "anim",
+          "type": "ModelAnimation"
+        }
+      ]
     },
     {
       "name": "CheckCollisionSpheres",
       "description": "Check collision between two spheres",
       "returnType": "bool",
-      "params": {
-        "center1": "Vector3",
-        "radius1": "float",
-        "center2": "Vector3",
-        "radius2": "float"
-      }
+      "params": [
+        {
+          "name": "center1",
+          "type": "Vector3"
+        },
+        {
+          "name": "radius1",
+          "type": "float"
+        },
+        {
+          "name": "center2",
+          "type": "Vector3"
+        },
+        {
+          "name": "radius2",
+          "type": "float"
+        }
+      ]
     },
     {
       "name": "CheckCollisionBoxes",
       "description": "Check collision between two bounding boxes",
       "returnType": "bool",
-      "params": {
-        "box1": "BoundingBox",
-        "box2": "BoundingBox"
-      }
+      "params": [
+        {
+          "name": "box1",
+          "type": "BoundingBox"
+        },
+        {
+          "name": "box2",
+          "type": "BoundingBox"
+        }
+      ]
     },
     {
       "name": "CheckCollisionBoxSphere",
       "description": "Check collision between box and sphere",
       "returnType": "bool",
-      "params": {
-        "box": "BoundingBox",
-        "center": "Vector3",
-        "radius": "float"
-      }
+      "params": [
+        {
+          "name": "box",
+          "type": "BoundingBox"
+        },
+        {
+          "name": "center",
+          "type": "Vector3"
+        },
+        {
+          "name": "radius",
+          "type": "float"
+        }
+      ]
     },
     {
       "name": "GetRayCollisionSphere",
       "description": "Get collision info between ray and sphere",
       "returnType": "RayCollision",
-      "params": {
-        "ray": "Ray",
-        "center": "Vector3",
-        "radius": "float"
-      }
+      "params": [
+        {
+          "name": "ray",
+          "type": "Ray"
+        },
+        {
+          "name": "center",
+          "type": "Vector3"
+        },
+        {
+          "name": "radius",
+          "type": "float"
+        }
+      ]
     },
     {
       "name": "GetRayCollisionBox",
       "description": "Get collision info between ray and box",
       "returnType": "RayCollision",
-      "params": {
-        "ray": "Ray",
-        "box": "BoundingBox"
-      }
+      "params": [
+        {
+          "name": "ray",
+          "type": "Ray"
+        },
+        {
+          "name": "box",
+          "type": "BoundingBox"
+        }
+      ]
     },
     {
       "name": "GetRayCollisionModel",
       "description": "Get collision info between ray and model",
       "returnType": "RayCollision",
-      "params": {
-        "ray": "Ray",
-        "model": "Model"
-      }
+      "params": [
+        {
+          "name": "ray",
+          "type": "Ray"
+        },
+        {
+          "name": "model",
+          "type": "Model"
+        }
+      ]
     },
     {
       "name": "GetRayCollisionMesh",
       "description": "Get collision info between ray and mesh",
       "returnType": "RayCollision",
-      "params": {
-        "ray": "Ray",
-        "mesh": "Mesh",
-        "transform": "Matrix"
-      }
+      "params": [
+        {
+          "name": "ray",
+          "type": "Ray"
+        },
+        {
+          "name": "mesh",
+          "type": "Mesh"
+        },
+        {
+          "name": "transform",
+          "type": "Matrix"
+        }
+      ]
     },
     {
       "name": "GetRayCollisionTriangle",
       "description": "Get collision info between ray and triangle",
       "returnType": "RayCollision",
-      "params": {
-        "ray": "Ray",
-        "p1": "Vector3",
-        "p2": "Vector3",
-        "p3": "Vector3"
-      }
+      "params": [
+        {
+          "name": "ray",
+          "type": "Ray"
+        },
+        {
+          "name": "p1",
+          "type": "Vector3"
+        },
+        {
+          "name": "p2",
+          "type": "Vector3"
+        },
+        {
+          "name": "p3",
+          "type": "Vector3"
+        }
+      ]
     },
     {
       "name": "GetRayCollisionQuad",
       "description": "Get collision info between ray and quad",
       "returnType": "RayCollision",
-      "params": {
-        "ray": "Ray",
-        "p1": "Vector3",
-        "p2": "Vector3",
-        "p3": "Vector3",
-        "p4": "Vector3"
-      }
+      "params": [
+        {
+          "name": "ray",
+          "type": "Ray"
+        },
+        {
+          "name": "p1",
+          "type": "Vector3"
+        },
+        {
+          "name": "p2",
+          "type": "Vector3"
+        },
+        {
+          "name": "p3",
+          "type": "Vector3"
+        },
+        {
+          "name": "p4",
+          "type": "Vector3"
+        }
+      ]
     },
     {
       "name": "InitAudioDevice",
@@ -6400,127 +9378,190 @@
       "name": "SetMasterVolume",
       "description": "Set master volume (listener)",
       "returnType": "void",
-      "params": {
-        "volume": "float"
-      }
+      "params": [
+        {
+          "name": "volume",
+          "type": "float"
+        }
+      ]
     },
     {
       "name": "LoadWave",
       "description": "Load wave data from file",
       "returnType": "Wave",
-      "params": {
-        "fileName": "const char *"
-      }
+      "params": [
+        {
+          "name": "fileName",
+          "type": "const char *"
+        }
+      ]
     },
     {
       "name": "LoadWaveFromMemory",
       "description": "Load wave from memory buffer, fileType refers to extension: i.e. '.wav'",
       "returnType": "Wave",
-      "params": {
-        "fileType": "const char *",
-        "fileData": "const unsigned char *",
-        "dataSize": "int"
-      }
+      "params": [
+        {
+          "name": "fileType",
+          "type": "const char *"
+        },
+        {
+          "name": "fileData",
+          "type": "const unsigned char *"
+        },
+        {
+          "name": "dataSize",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "LoadSound",
       "description": "Load sound from file",
       "returnType": "Sound",
-      "params": {
-        "fileName": "const char *"
-      }
+      "params": [
+        {
+          "name": "fileName",
+          "type": "const char *"
+        }
+      ]
     },
     {
       "name": "LoadSoundFromWave",
       "description": "Load sound from wave data",
       "returnType": "Sound",
-      "params": {
-        "wave": "Wave"
-      }
+      "params": [
+        {
+          "name": "wave",
+          "type": "Wave"
+        }
+      ]
     },
     {
       "name": "UpdateSound",
       "description": "Update sound buffer with new data",
       "returnType": "void",
-      "params": {
-        "sound": "Sound",
-        "data": "const void *",
-        "sampleCount": "int"
-      }
+      "params": [
+        {
+          "name": "sound",
+          "type": "Sound"
+        },
+        {
+          "name": "data",
+          "type": "const void *"
+        },
+        {
+          "name": "sampleCount",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "UnloadWave",
       "description": "Unload wave data",
       "returnType": "void",
-      "params": {
-        "wave": "Wave"
-      }
+      "params": [
+        {
+          "name": "wave",
+          "type": "Wave"
+        }
+      ]
     },
     {
       "name": "UnloadSound",
       "description": "Unload sound",
       "returnType": "void",
-      "params": {
-        "sound": "Sound"
-      }
+      "params": [
+        {
+          "name": "sound",
+          "type": "Sound"
+        }
+      ]
     },
     {
       "name": "ExportWave",
       "description": "Export wave data to file, returns true on success",
       "returnType": "bool",
-      "params": {
-        "wave": "Wave",
-        "fileName": "const char *"
-      }
+      "params": [
+        {
+          "name": "wave",
+          "type": "Wave"
+        },
+        {
+          "name": "fileName",
+          "type": "const char *"
+        }
+      ]
     },
     {
       "name": "ExportWaveAsCode",
       "description": "Export wave sample data to code (.h), returns true on success",
       "returnType": "bool",
-      "params": {
-        "wave": "Wave",
-        "fileName": "const char *"
-      }
+      "params": [
+        {
+          "name": "wave",
+          "type": "Wave"
+        },
+        {
+          "name": "fileName",
+          "type": "const char *"
+        }
+      ]
     },
     {
       "name": "PlaySound",
       "description": "Play a sound",
       "returnType": "void",
-      "params": {
-        "sound": "Sound"
-      }
+      "params": [
+        {
+          "name": "sound",
+          "type": "Sound"
+        }
+      ]
     },
     {
       "name": "StopSound",
       "description": "Stop playing a sound",
       "returnType": "void",
-      "params": {
-        "sound": "Sound"
-      }
+      "params": [
+        {
+          "name": "sound",
+          "type": "Sound"
+        }
+      ]
     },
     {
       "name": "PauseSound",
       "description": "Pause a sound",
       "returnType": "void",
-      "params": {
-        "sound": "Sound"
-      }
+      "params": [
+        {
+          "name": "sound",
+          "type": "Sound"
+        }
+      ]
     },
     {
       "name": "ResumeSound",
       "description": "Resume a paused sound",
       "returnType": "void",
-      "params": {
-        "sound": "Sound"
-      }
+      "params": [
+        {
+          "name": "sound",
+          "type": "Sound"
+        }
+      ]
     },
     {
       "name": "PlaySoundMulti",
       "description": "Play a sound (using multichannel buffer pool)",
       "returnType": "void",
-      "params": {
-        "sound": "Sound"
-      }
+      "params": [
+        {
+          "name": "sound",
+          "type": "Sound"
+        }
+      ]
     },
     {
       "name": "StopSoundMulti",
@@ -6536,291 +9577,447 @@
       "name": "IsSoundPlaying",
       "description": "Check if a sound is currently playing",
       "returnType": "bool",
-      "params": {
-        "sound": "Sound"
-      }
+      "params": [
+        {
+          "name": "sound",
+          "type": "Sound"
+        }
+      ]
     },
     {
       "name": "SetSoundVolume",
       "description": "Set volume for a sound (1.0 is max level)",
       "returnType": "void",
-      "params": {
-        "sound": "Sound",
-        "volume": "float"
-      }
+      "params": [
+        {
+          "name": "sound",
+          "type": "Sound"
+        },
+        {
+          "name": "volume",
+          "type": "float"
+        }
+      ]
     },
     {
       "name": "SetSoundPitch",
       "description": "Set pitch for a sound (1.0 is base level)",
       "returnType": "void",
-      "params": {
-        "sound": "Sound",
-        "pitch": "float"
-      }
+      "params": [
+        {
+          "name": "sound",
+          "type": "Sound"
+        },
+        {
+          "name": "pitch",
+          "type": "float"
+        }
+      ]
     },
     {
       "name": "WaveFormat",
       "description": "Convert wave data to desired format",
       "returnType": "void",
-      "params": {
-        "wave": "Wave *",
-        "sampleRate": "int",
-        "sampleSize": "int",
-        "channels": "int"
-      }
+      "params": [
+        {
+          "name": "wave",
+          "type": "Wave *"
+        },
+        {
+          "name": "sampleRate",
+          "type": "int"
+        },
+        {
+          "name": "sampleSize",
+          "type": "int"
+        },
+        {
+          "name": "channels",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "WaveCopy",
       "description": "Copy a wave to a new wave",
       "returnType": "Wave",
-      "params": {
-        "wave": "Wave"
-      }
+      "params": [
+        {
+          "name": "wave",
+          "type": "Wave"
+        }
+      ]
     },
     {
       "name": "WaveCrop",
       "description": "Crop a wave to defined samples range",
       "returnType": "void",
-      "params": {
-        "wave": "Wave *",
-        "initSample": "int",
-        "finalSample": "int"
-      }
+      "params": [
+        {
+          "name": "wave",
+          "type": "Wave *"
+        },
+        {
+          "name": "initSample",
+          "type": "int"
+        },
+        {
+          "name": "finalSample",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "LoadWaveSamples",
       "description": "Load samples data from wave as a floats array",
       "returnType": "float *",
-      "params": {
-        "wave": "Wave"
-      }
+      "params": [
+        {
+          "name": "wave",
+          "type": "Wave"
+        }
+      ]
     },
     {
       "name": "UnloadWaveSamples",
       "description": "Unload samples data loaded with LoadWaveSamples()",
       "returnType": "void",
-      "params": {
-        "samples": "float *"
-      }
+      "params": [
+        {
+          "name": "samples",
+          "type": "float *"
+        }
+      ]
     },
     {
       "name": "LoadMusicStream",
       "description": "Load music stream from file",
       "returnType": "Music",
-      "params": {
-        "fileName": "const char *"
-      }
+      "params": [
+        {
+          "name": "fileName",
+          "type": "const char *"
+        }
+      ]
     },
     {
       "name": "LoadMusicStreamFromMemory",
       "description": "Load music stream from data",
       "returnType": "Music",
-      "params": {
-        "fileType": "const char *",
-        "data": "unsigned char *",
-        "dataSize": "int"
-      }
+      "params": [
+        {
+          "name": "fileType",
+          "type": "const char *"
+        },
+        {
+          "name": "data",
+          "type": "unsigned char *"
+        },
+        {
+          "name": "dataSize",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "UnloadMusicStream",
       "description": "Unload music stream",
       "returnType": "void",
-      "params": {
-        "music": "Music"
-      }
+      "params": [
+        {
+          "name": "music",
+          "type": "Music"
+        }
+      ]
     },
     {
       "name": "PlayMusicStream",
       "description": "Start music playing",
       "returnType": "void",
-      "params": {
-        "music": "Music"
-      }
+      "params": [
+        {
+          "name": "music",
+          "type": "Music"
+        }
+      ]
     },
     {
       "name": "IsMusicStreamPlaying",
       "description": "Check if music is playing",
       "returnType": "bool",
-      "params": {
-        "music": "Music"
-      }
+      "params": [
+        {
+          "name": "music",
+          "type": "Music"
+        }
+      ]
     },
     {
       "name": "UpdateMusicStream",
       "description": "Updates buffers for music streaming",
       "returnType": "void",
-      "params": {
-        "music": "Music"
-      }
+      "params": [
+        {
+          "name": "music",
+          "type": "Music"
+        }
+      ]
     },
     {
       "name": "StopMusicStream",
       "description": "Stop music playing",
       "returnType": "void",
-      "params": {
-        "music": "Music"
-      }
+      "params": [
+        {
+          "name": "music",
+          "type": "Music"
+        }
+      ]
     },
     {
       "name": "PauseMusicStream",
       "description": "Pause music playing",
       "returnType": "void",
-      "params": {
-        "music": "Music"
-      }
+      "params": [
+        {
+          "name": "music",
+          "type": "Music"
+        }
+      ]
     },
     {
       "name": "ResumeMusicStream",
       "description": "Resume playing paused music",
       "returnType": "void",
-      "params": {
-        "music": "Music"
-      }
+      "params": [
+        {
+          "name": "music",
+          "type": "Music"
+        }
+      ]
     },
     {
       "name": "SeekMusicStream",
       "description": "Seek music to a position (in seconds)",
       "returnType": "void",
-      "params": {
-        "music": "Music",
-        "position": "float"
-      }
+      "params": [
+        {
+          "name": "music",
+          "type": "Music"
+        },
+        {
+          "name": "position",
+          "type": "float"
+        }
+      ]
     },
     {
       "name": "SetMusicVolume",
       "description": "Set volume for music (1.0 is max level)",
       "returnType": "void",
-      "params": {
-        "music": "Music",
-        "volume": "float"
-      }
+      "params": [
+        {
+          "name": "music",
+          "type": "Music"
+        },
+        {
+          "name": "volume",
+          "type": "float"
+        }
+      ]
     },
     {
       "name": "SetMusicPitch",
       "description": "Set pitch for a music (1.0 is base level)",
       "returnType": "void",
-      "params": {
-        "music": "Music",
-        "pitch": "float"
-      }
+      "params": [
+        {
+          "name": "music",
+          "type": "Music"
+        },
+        {
+          "name": "pitch",
+          "type": "float"
+        }
+      ]
     },
     {
       "name": "GetMusicTimeLength",
       "description": "Get music time length (in seconds)",
       "returnType": "float",
-      "params": {
-        "music": "Music"
-      }
+      "params": [
+        {
+          "name": "music",
+          "type": "Music"
+        }
+      ]
     },
     {
       "name": "GetMusicTimePlayed",
       "description": "Get current music time played (in seconds)",
       "returnType": "float",
-      "params": {
-        "music": "Music"
-      }
+      "params": [
+        {
+          "name": "music",
+          "type": "Music"
+        }
+      ]
     },
     {
       "name": "LoadAudioStream",
       "description": "Load audio stream (to stream raw audio pcm data)",
       "returnType": "AudioStream",
-      "params": {
-        "sampleRate": "unsigned int",
-        "sampleSize": "unsigned int",
-        "channels": "unsigned int"
-      }
+      "params": [
+        {
+          "name": "sampleRate",
+          "type": "unsigned int"
+        },
+        {
+          "name": "sampleSize",
+          "type": "unsigned int"
+        },
+        {
+          "name": "channels",
+          "type": "unsigned int"
+        }
+      ]
     },
     {
       "name": "UnloadAudioStream",
       "description": "Unload audio stream and free memory",
       "returnType": "void",
-      "params": {
-        "stream": "AudioStream"
-      }
+      "params": [
+        {
+          "name": "stream",
+          "type": "AudioStream"
+        }
+      ]
     },
     {
       "name": "UpdateAudioStream",
       "description": "Update audio stream buffers with data",
       "returnType": "void",
-      "params": {
-        "stream": "AudioStream",
-        "data": "const void *",
-        "frameCount": "int"
-      }
+      "params": [
+        {
+          "name": "stream",
+          "type": "AudioStream"
+        },
+        {
+          "name": "data",
+          "type": "const void *"
+        },
+        {
+          "name": "frameCount",
+          "type": "int"
+        }
+      ]
     },
     {
       "name": "IsAudioStreamProcessed",
       "description": "Check if any audio stream buffers requires refill",
       "returnType": "bool",
-      "params": {
-        "stream": "AudioStream"
-      }
+      "params": [
+        {
+          "name": "stream",
+          "type": "AudioStream"
+        }
+      ]
     },
     {
       "name": "PlayAudioStream",
       "description": "Play audio stream",
       "returnType": "void",
-      "params": {
-        "stream": "AudioStream"
-      }
+      "params": [
+        {
+          "name": "stream",
+          "type": "AudioStream"
+        }
+      ]
     },
     {
       "name": "PauseAudioStream",
       "description": "Pause audio stream",
       "returnType": "void",
-      "params": {
-        "stream": "AudioStream"
-      }
+      "params": [
+        {
+          "name": "stream",
+          "type": "AudioStream"
+        }
+      ]
     },
     {
       "name": "ResumeAudioStream",
       "description": "Resume audio stream",
       "returnType": "void",
-      "params": {
-        "stream": "AudioStream"
-      }
+      "params": [
+        {
+          "name": "stream",
+          "type": "AudioStream"
+        }
+      ]
     },
     {
       "name": "IsAudioStreamPlaying",
       "description": "Check if audio stream is playing",
       "returnType": "bool",
-      "params": {
-        "stream": "AudioStream"
-      }
+      "params": [
+        {
+          "name": "stream",
+          "type": "AudioStream"
+        }
+      ]
     },
     {
       "name": "StopAudioStream",
       "description": "Stop audio stream",
       "returnType": "void",
-      "params": {
-        "stream": "AudioStream"
-      }
+      "params": [
+        {
+          "name": "stream",
+          "type": "AudioStream"
+        }
+      ]
     },
     {
       "name": "SetAudioStreamVolume",
       "description": "Set volume for audio stream (1.0 is max level)",
       "returnType": "void",
-      "params": {
-        "stream": "AudioStream",
-        "volume": "float"
-      }
+      "params": [
+        {
+          "name": "stream",
+          "type": "AudioStream"
+        },
+        {
+          "name": "volume",
+          "type": "float"
+        }
+      ]
     },
     {
       "name": "SetAudioStreamPitch",
       "description": "Set pitch for audio stream (1.0 is base level)",
       "returnType": "void",
-      "params": {
-        "stream": "AudioStream",
-        "pitch": "float"
-      }
+      "params": [
+        {
+          "name": "stream",
+          "type": "AudioStream"
+        },
+        {
+          "name": "pitch",
+          "type": "float"
+        }
+      ]
     },
     {
       "name": "SetAudioStreamBufferSizeDefault",
       "description": "Default size for new audio streams",
       "returnType": "void",
-      "params": {
-        "size": "int"
-      }
+      "params": [
+        {
+          "name": "size",
+          "type": "int"
+        }
+      ]
     }
   ]
 }

--- a/parser/raylib_api.json
+++ b/parser/raylib_api.json
@@ -5,13 +5,13 @@
       "description": "Vector2, 2 components",
       "fields": [
         {
-          "name": "x",
           "type": "float",
+          "name": "x",
           "description": "Vector x component"
         },
         {
-          "name": "y",
           "type": "float",
+          "name": "y",
           "description": "Vector y component"
         }
       ]
@@ -21,18 +21,18 @@
       "description": "Vector3, 3 components",
       "fields": [
         {
-          "name": "x",
           "type": "float",
+          "name": "x",
           "description": "Vector x component"
         },
         {
-          "name": "y",
           "type": "float",
+          "name": "y",
           "description": "Vector y component"
         },
         {
-          "name": "z",
           "type": "float",
+          "name": "z",
           "description": "Vector z component"
         }
       ]
@@ -42,23 +42,23 @@
       "description": "Vector4, 4 components",
       "fields": [
         {
-          "name": "x",
           "type": "float",
+          "name": "x",
           "description": "Vector x component"
         },
         {
-          "name": "y",
           "type": "float",
+          "name": "y",
           "description": "Vector y component"
         },
         {
-          "name": "z",
           "type": "float",
+          "name": "z",
           "description": "Vector z component"
         },
         {
-          "name": "w",
           "type": "float",
+          "name": "w",
           "description": "Vector w component"
         }
       ]
@@ -68,23 +68,23 @@
       "description": "Matrix, 4x4 components, column major, OpenGL style, right handed",
       "fields": [
         {
-          "name": "m0, m4, m8, m12",
           "type": "float",
+          "name": "m0, m4, m8, m12",
           "description": "Matrix first row (4 components)"
         },
         {
-          "name": "m1, m5, m9, m13",
           "type": "float",
+          "name": "m1, m5, m9, m13",
           "description": "Matrix second row (4 components)"
         },
         {
-          "name": "m2, m6, m10, m14",
           "type": "float",
+          "name": "m2, m6, m10, m14",
           "description": "Matrix third row (4 components)"
         },
         {
-          "name": "m3, m7, m11, m15",
           "type": "float",
+          "name": "m3, m7, m11, m15",
           "description": "Matrix fourth row (4 components)"
         }
       ]
@@ -94,23 +94,23 @@
       "description": "Color, 4 components, R8G8B8A8 (32bit)",
       "fields": [
         {
-          "name": "r",
           "type": "unsigned char",
+          "name": "r",
           "description": "Color red value"
         },
         {
-          "name": "g",
           "type": "unsigned char",
+          "name": "g",
           "description": "Color green value"
         },
         {
-          "name": "b",
           "type": "unsigned char",
+          "name": "b",
           "description": "Color blue value"
         },
         {
-          "name": "a",
           "type": "unsigned char",
+          "name": "a",
           "description": "Color alpha value"
         }
       ]
@@ -120,23 +120,23 @@
       "description": "Rectangle, 4 components",
       "fields": [
         {
-          "name": "x",
           "type": "float",
+          "name": "x",
           "description": "Rectangle top-left corner position x"
         },
         {
-          "name": "y",
           "type": "float",
+          "name": "y",
           "description": "Rectangle top-left corner position y"
         },
         {
-          "name": "width",
           "type": "float",
+          "name": "width",
           "description": "Rectangle width"
         },
         {
-          "name": "height",
           "type": "float",
+          "name": "height",
           "description": "Rectangle height"
         }
       ]
@@ -146,28 +146,28 @@
       "description": "Image, pixel data stored in CPU memory (RAM)",
       "fields": [
         {
-          "name": "data",
           "type": "void *",
+          "name": "data",
           "description": "Image raw data"
         },
         {
-          "name": "width",
           "type": "int",
+          "name": "width",
           "description": "Image base width"
         },
         {
-          "name": "height",
           "type": "int",
+          "name": "height",
           "description": "Image base height"
         },
         {
-          "name": "mipmaps",
           "type": "int",
+          "name": "mipmaps",
           "description": "Mipmap levels, 1 by default"
         },
         {
-          "name": "format",
           "type": "int",
+          "name": "format",
           "description": "Data format (PixelFormat type)"
         }
       ]
@@ -177,28 +177,28 @@
       "description": "Texture, tex data stored in GPU memory (VRAM)",
       "fields": [
         {
-          "name": "id",
           "type": "unsigned int",
+          "name": "id",
           "description": "OpenGL texture id"
         },
         {
-          "name": "width",
           "type": "int",
+          "name": "width",
           "description": "Texture base width"
         },
         {
-          "name": "height",
           "type": "int",
+          "name": "height",
           "description": "Texture base height"
         },
         {
-          "name": "mipmaps",
           "type": "int",
+          "name": "mipmaps",
           "description": "Mipmap levels, 1 by default"
         },
         {
-          "name": "format",
           "type": "int",
+          "name": "format",
           "description": "Data format (PixelFormat type)"
         }
       ]
@@ -208,18 +208,18 @@
       "description": "RenderTexture, fbo for texture rendering",
       "fields": [
         {
-          "name": "id",
           "type": "unsigned int",
+          "name": "id",
           "description": "OpenGL framebuffer object id"
         },
         {
-          "name": "texture",
           "type": "Texture",
+          "name": "texture",
           "description": "Color buffer attachment texture"
         },
         {
-          "name": "depth",
           "type": "Texture",
+          "name": "depth",
           "description": "Depth buffer attachment texture"
         }
       ]
@@ -229,33 +229,33 @@
       "description": "NPatchInfo, n-patch layout info",
       "fields": [
         {
-          "name": "source",
           "type": "Rectangle",
+          "name": "source",
           "description": "Texture source rectangle"
         },
         {
-          "name": "left",
           "type": "int",
+          "name": "left",
           "description": "Left border offset"
         },
         {
-          "name": "top",
           "type": "int",
+          "name": "top",
           "description": "Top border offset"
         },
         {
-          "name": "right",
           "type": "int",
+          "name": "right",
           "description": "Right border offset"
         },
         {
-          "name": "bottom",
           "type": "int",
+          "name": "bottom",
           "description": "Bottom border offset"
         },
         {
-          "name": "layout",
           "type": "int",
+          "name": "layout",
           "description": "Layout of the n-patch: 3x3, 1x3 or 3x1"
         }
       ]
@@ -265,28 +265,28 @@
       "description": "GlyphInfo, font characters glyphs info",
       "fields": [
         {
-          "name": "value",
           "type": "int",
+          "name": "value",
           "description": "Character value (Unicode)"
         },
         {
-          "name": "offsetX",
           "type": "int",
+          "name": "offsetX",
           "description": "Character offset X when drawing"
         },
         {
-          "name": "offsetY",
           "type": "int",
+          "name": "offsetY",
           "description": "Character offset Y when drawing"
         },
         {
-          "name": "advanceX",
           "type": "int",
+          "name": "advanceX",
           "description": "Character advance position X"
         },
         {
-          "name": "image",
           "type": "Image",
+          "name": "image",
           "description": "Character image data"
         }
       ]
@@ -296,33 +296,33 @@
       "description": "Font, font texture and GlyphInfo array data",
       "fields": [
         {
-          "name": "baseSize",
           "type": "int",
+          "name": "baseSize",
           "description": "Base size (default chars height)"
         },
         {
-          "name": "glyphCount",
           "type": "int",
+          "name": "glyphCount",
           "description": "Number of glyph characters"
         },
         {
-          "name": "glyphPadding",
           "type": "int",
+          "name": "glyphPadding",
           "description": "Padding around the glyph characters"
         },
         {
-          "name": "texture",
           "type": "Texture2D",
+          "name": "texture",
           "description": "Texture atlas containing the glyphs"
         },
         {
-          "name": "recs",
           "type": "Rectangle *",
+          "name": "recs",
           "description": "Rectangles in texture for the glyphs"
         },
         {
-          "name": "glyphs",
           "type": "GlyphInfo *",
+          "name": "glyphs",
           "description": "Glyphs info data"
         }
       ]
@@ -332,28 +332,28 @@
       "description": "Camera, defines position/orientation in 3d space",
       "fields": [
         {
-          "name": "position",
           "type": "Vector3",
+          "name": "position",
           "description": "Camera position"
         },
         {
-          "name": "target",
           "type": "Vector3",
+          "name": "target",
           "description": "Camera target it looks-at"
         },
         {
-          "name": "up",
           "type": "Vector3",
+          "name": "up",
           "description": "Camera up vector (rotation over its axis)"
         },
         {
-          "name": "fovy",
           "type": "float",
+          "name": "fovy",
           "description": "Camera field-of-view apperture in Y (degrees) in perspective, used as near plane width in orthographic"
         },
         {
-          "name": "projection",
           "type": "int",
+          "name": "projection",
           "description": "Camera projection: CAMERA_PERSPECTIVE or CAMERA_ORTHOGRAPHIC"
         }
       ]
@@ -363,23 +363,23 @@
       "description": "Camera2D, defines position/orientation in 2d space",
       "fields": [
         {
-          "name": "offset",
           "type": "Vector2",
+          "name": "offset",
           "description": "Camera offset (displacement from target)"
         },
         {
-          "name": "target",
           "type": "Vector2",
+          "name": "target",
           "description": "Camera target (rotation and zoom origin)"
         },
         {
-          "name": "rotation",
           "type": "float",
+          "name": "rotation",
           "description": "Camera rotation in degrees"
         },
         {
-          "name": "zoom",
           "type": "float",
+          "name": "zoom",
           "description": "Camera zoom (scaling), should be 1.0f by default"
         }
       ]
@@ -389,78 +389,78 @@
       "description": "Mesh, vertex data and vao/vbo",
       "fields": [
         {
-          "name": "vertexCount",
           "type": "int",
+          "name": "vertexCount",
           "description": "Number of vertices stored in arrays"
         },
         {
-          "name": "triangleCount",
           "type": "int",
+          "name": "triangleCount",
           "description": "Number of triangles stored (indexed or not)"
         },
         {
-          "name": "vertices",
           "type": "float *",
+          "name": "vertices",
           "description": "Vertex position (XYZ - 3 components per vertex) (shader-location = 0)"
         },
         {
-          "name": "texcoords",
           "type": "float *",
+          "name": "texcoords",
           "description": "Vertex texture coordinates (UV - 2 components per vertex) (shader-location = 1)"
         },
         {
-          "name": "texcoords2",
           "type": "float *",
+          "name": "texcoords2",
           "description": "Vertex second texture coordinates (useful for lightmaps) (shader-location = 5)"
         },
         {
-          "name": "normals",
           "type": "float *",
+          "name": "normals",
           "description": "Vertex normals (XYZ - 3 components per vertex) (shader-location = 2)"
         },
         {
-          "name": "tangents",
           "type": "float *",
+          "name": "tangents",
           "description": "Vertex tangents (XYZW - 4 components per vertex) (shader-location = 4)"
         },
         {
-          "name": "colors",
           "type": "unsigned char *",
+          "name": "colors",
           "description": "Vertex colors (RGBA - 4 components per vertex) (shader-location = 3)"
         },
         {
-          "name": "indices",
           "type": "unsigned short *",
+          "name": "indices",
           "description": "Vertex indices (in case vertex data comes indexed)"
         },
         {
-          "name": "animVertices",
           "type": "float *",
+          "name": "animVertices",
           "description": "Animated vertex positions (after bones transformations)"
         },
         {
-          "name": "animNormals",
           "type": "float *",
+          "name": "animNormals",
           "description": "Animated normals (after bones transformations)"
         },
         {
-          "name": "boneIds",
           "type": "unsigned char *",
+          "name": "boneIds",
           "description": "Vertex bone ids, max 255 bone ids, up to 4 bones influence by vertex (skinning)"
         },
         {
-          "name": "boneWeights",
           "type": "float *",
+          "name": "boneWeights",
           "description": "Vertex bone weight, up to 4 bones influence by vertex (skinning)"
         },
         {
-          "name": "vaoId",
           "type": "unsigned int",
+          "name": "vaoId",
           "description": "OpenGL Vertex Array Object id"
         },
         {
-          "name": "vboId",
           "type": "unsigned int *",
+          "name": "vboId",
           "description": "OpenGL Vertex Buffer Objects id (default vertex data)"
         }
       ]
@@ -470,13 +470,13 @@
       "description": "Shader",
       "fields": [
         {
-          "name": "id",
           "type": "unsigned int",
+          "name": "id",
           "description": "Shader program id"
         },
         {
-          "name": "locs",
           "type": "int *",
+          "name": "locs",
           "description": "Shader locations array (RL_MAX_SHADER_LOCATIONS)"
         }
       ]
@@ -486,18 +486,18 @@
       "description": "MaterialMap",
       "fields": [
         {
-          "name": "texture",
           "type": "Texture2D",
+          "name": "texture",
           "description": "Material map texture"
         },
         {
-          "name": "color",
           "type": "Color",
+          "name": "color",
           "description": "Material map color"
         },
         {
-          "name": "value",
           "type": "float",
+          "name": "value",
           "description": "Material map value"
         }
       ]
@@ -507,18 +507,18 @@
       "description": "Material, includes shader and maps",
       "fields": [
         {
-          "name": "shader",
           "type": "Shader",
+          "name": "shader",
           "description": "Material shader"
         },
         {
-          "name": "maps",
           "type": "MaterialMap *",
+          "name": "maps",
           "description": "Material maps array (MAX_MATERIAL_MAPS)"
         },
         {
-          "name": "params[4]",
           "type": "float",
+          "name": "params[4]",
           "description": "Material generic parameters (if required)"
         }
       ]
@@ -528,18 +528,18 @@
       "description": "Transform, vectex transformation data",
       "fields": [
         {
-          "name": "translation",
           "type": "Vector3",
+          "name": "translation",
           "description": "Translation"
         },
         {
-          "name": "rotation",
           "type": "Quaternion",
+          "name": "rotation",
           "description": "Rotation"
         },
         {
-          "name": "scale",
           "type": "Vector3",
+          "name": "scale",
           "description": "Scale"
         }
       ]
@@ -549,13 +549,13 @@
       "description": "Bone, skeletal animation bone",
       "fields": [
         {
-          "name": "name[32]",
           "type": "char",
+          "name": "name[32]",
           "description": "Bone name"
         },
         {
-          "name": "parent",
           "type": "int",
+          "name": "parent",
           "description": "Bone parent"
         }
       ]
@@ -565,48 +565,48 @@
       "description": "Model, meshes, materials and animation data",
       "fields": [
         {
-          "name": "transform",
           "type": "Matrix",
+          "name": "transform",
           "description": "Local transform matrix"
         },
         {
-          "name": "meshCount",
           "type": "int",
+          "name": "meshCount",
           "description": "Number of meshes"
         },
         {
-          "name": "materialCount",
           "type": "int",
+          "name": "materialCount",
           "description": "Number of materials"
         },
         {
-          "name": "meshes",
           "type": "Mesh *",
+          "name": "meshes",
           "description": "Meshes array"
         },
         {
-          "name": "materials",
           "type": "Material *",
+          "name": "materials",
           "description": "Materials array"
         },
         {
-          "name": "meshMaterial",
           "type": "int *",
+          "name": "meshMaterial",
           "description": "Mesh material number"
         },
         {
-          "name": "boneCount",
           "type": "int",
+          "name": "boneCount",
           "description": "Number of bones"
         },
         {
-          "name": "bones",
           "type": "BoneInfo *",
+          "name": "bones",
           "description": "Bones information (skeleton)"
         },
         {
-          "name": "bindPose",
           "type": "Transform *",
+          "name": "bindPose",
           "description": "Bones base transformation (pose)"
         }
       ]
@@ -616,23 +616,23 @@
       "description": "ModelAnimation",
       "fields": [
         {
-          "name": "boneCount",
           "type": "int",
+          "name": "boneCount",
           "description": "Number of bones"
         },
         {
-          "name": "frameCount",
           "type": "int",
+          "name": "frameCount",
           "description": "Number of animation frames"
         },
         {
-          "name": "bones",
           "type": "BoneInfo *",
+          "name": "bones",
           "description": "Bones information (skeleton)"
         },
         {
-          "name": "framePoses",
           "type": "Transform **",
+          "name": "framePoses",
           "description": "Poses array by frame"
         }
       ]
@@ -642,13 +642,13 @@
       "description": "Ray, ray for raycasting",
       "fields": [
         {
-          "name": "position",
           "type": "Vector3",
+          "name": "position",
           "description": "Ray position (origin)"
         },
         {
-          "name": "direction",
           "type": "Vector3",
+          "name": "direction",
           "description": "Ray direction"
         }
       ]
@@ -658,23 +658,23 @@
       "description": "RayCollision, ray hit information",
       "fields": [
         {
-          "name": "hit",
           "type": "bool",
+          "name": "hit",
           "description": "Did the ray hit something?"
         },
         {
-          "name": "distance",
           "type": "float",
+          "name": "distance",
           "description": "Distance to nearest hit"
         },
         {
-          "name": "point",
           "type": "Vector3",
+          "name": "point",
           "description": "Point of nearest hit"
         },
         {
-          "name": "normal",
           "type": "Vector3",
+          "name": "normal",
           "description": "Surface normal of hit"
         }
       ]
@@ -684,13 +684,13 @@
       "description": "BoundingBox",
       "fields": [
         {
-          "name": "min",
           "type": "Vector3",
+          "name": "min",
           "description": "Minimum vertex box-corner"
         },
         {
-          "name": "max",
           "type": "Vector3",
+          "name": "max",
           "description": "Maximum vertex box-corner"
         }
       ]
@@ -700,28 +700,28 @@
       "description": "Wave, audio wave data",
       "fields": [
         {
-          "name": "frameCount",
           "type": "unsigned int",
+          "name": "frameCount",
           "description": "Total number of frames (considering channels)"
         },
         {
-          "name": "sampleRate",
           "type": "unsigned int",
+          "name": "sampleRate",
           "description": "Frequency (samples per second)"
         },
         {
-          "name": "sampleSize",
           "type": "unsigned int",
+          "name": "sampleSize",
           "description": "Bit depth (bits per sample): 8, 16, 32 (24 not supported)"
         },
         {
-          "name": "channels",
           "type": "unsigned int",
+          "name": "channels",
           "description": "Number of channels (1-mono, 2-stereo, ...)"
         },
         {
-          "name": "data",
           "type": "void *",
+          "name": "data",
           "description": "Buffer data pointer"
         }
       ]
@@ -731,23 +731,23 @@
       "description": "AudioStream, custom audio stream",
       "fields": [
         {
-          "name": "buffer",
           "type": "rAudioBuffer *",
+          "name": "buffer",
           "description": "Pointer to internal data used by the audio system"
         },
         {
-          "name": "sampleRate",
           "type": "unsigned int",
+          "name": "sampleRate",
           "description": "Frequency (samples per second)"
         },
         {
-          "name": "sampleSize",
           "type": "unsigned int",
+          "name": "sampleSize",
           "description": "Bit depth (bits per sample): 8, 16, 32 (24 not supported)"
         },
         {
-          "name": "channels",
           "type": "unsigned int",
+          "name": "channels",
           "description": "Number of channels (1-mono, 2-stereo, ...)"
         }
       ]
@@ -757,13 +757,13 @@
       "description": "Sound",
       "fields": [
         {
-          "name": "stream",
           "type": "AudioStream",
+          "name": "stream",
           "description": "Audio stream"
         },
         {
-          "name": "frameCount",
           "type": "unsigned int",
+          "name": "frameCount",
           "description": "Total number of frames (considering channels)"
         }
       ]
@@ -773,28 +773,28 @@
       "description": "Music, audio stream, anything longer than ~10 seconds should be streamed",
       "fields": [
         {
-          "name": "stream",
           "type": "AudioStream",
+          "name": "stream",
           "description": "Audio stream"
         },
         {
-          "name": "frameCount",
           "type": "unsigned int",
+          "name": "frameCount",
           "description": "Total number of frames (considering channels)"
         },
         {
-          "name": "looping",
           "type": "bool",
+          "name": "looping",
           "description": "Music looping enable"
         },
         {
-          "name": "ctxType",
           "type": "int",
+          "name": "ctxType",
           "description": "Type of music context (audio filetype)"
         },
         {
-          "name": "ctxData",
           "type": "void *",
+          "name": "ctxData",
           "description": "Audio context data, depends on type"
         }
       ]
@@ -804,53 +804,53 @@
       "description": "VrDeviceInfo, Head-Mounted-Display device parameters",
       "fields": [
         {
-          "name": "hResolution",
           "type": "int",
+          "name": "hResolution",
           "description": "Horizontal resolution in pixels"
         },
         {
-          "name": "vResolution",
           "type": "int",
+          "name": "vResolution",
           "description": "Vertical resolution in pixels"
         },
         {
-          "name": "hScreenSize",
           "type": "float",
+          "name": "hScreenSize",
           "description": "Horizontal size in meters"
         },
         {
-          "name": "vScreenSize",
           "type": "float",
+          "name": "vScreenSize",
           "description": "Vertical size in meters"
         },
         {
-          "name": "vScreenCenter",
           "type": "float",
+          "name": "vScreenCenter",
           "description": "Screen center in meters"
         },
         {
-          "name": "eyeToScreenDistance",
           "type": "float",
+          "name": "eyeToScreenDistance",
           "description": "Distance between eye and display in meters"
         },
         {
-          "name": "lensSeparationDistance",
           "type": "float",
+          "name": "lensSeparationDistance",
           "description": "Lens separation distance in meters"
         },
         {
-          "name": "interpupillaryDistance",
           "type": "float",
+          "name": "interpupillaryDistance",
           "description": "IPD (distance between pupils) in meters"
         },
         {
-          "name": "lensDistortionValues[4]",
           "type": "float",
+          "name": "lensDistortionValues[4]",
           "description": "Lens distortion constant parameters"
         },
         {
-          "name": "chromaAbCorrection[4]",
           "type": "float",
+          "name": "chromaAbCorrection[4]",
           "description": "Chromatic aberration correction parameters"
         }
       ]
@@ -860,43 +860,43 @@
       "description": "VrStereoConfig, VR stereo rendering configuration for simulator",
       "fields": [
         {
-          "name": "projection[2]",
           "type": "Matrix",
+          "name": "projection[2]",
           "description": "VR projection matrices (per eye)"
         },
         {
-          "name": "viewOffset[2]",
           "type": "Matrix",
+          "name": "viewOffset[2]",
           "description": "VR view offset matrices (per eye)"
         },
         {
-          "name": "leftLensCenter[2]",
           "type": "float",
+          "name": "leftLensCenter[2]",
           "description": "VR left lens center"
         },
         {
-          "name": "rightLensCenter[2]",
           "type": "float",
+          "name": "rightLensCenter[2]",
           "description": "VR right lens center"
         },
         {
-          "name": "leftScreenCenter[2]",
           "type": "float",
+          "name": "leftScreenCenter[2]",
           "description": "VR left screen center"
         },
         {
-          "name": "rightScreenCenter[2]",
           "type": "float",
+          "name": "rightScreenCenter[2]",
           "description": "VR right screen center"
         },
         {
-          "name": "scale[2]",
           "type": "float",
+          "name": "scale[2]",
           "description": "VR distortion scale"
         },
         {
-          "name": "scaleIn[2]",
           "type": "float",
+          "name": "scaleIn[2]",
           "description": "VR distortion scale in"
         }
       ]
@@ -2492,16 +2492,16 @@
       "returnType": "void",
       "params": [
         {
-          "name": "width",
-          "type": "int"
+          "type": "int",
+          "name": "width"
         },
         {
-          "name": "height",
-          "type": "int"
+          "type": "int",
+          "name": "height"
         },
         {
-          "name": "title",
-          "type": "const char *"
+          "type": "const char *",
+          "name": "title"
         }
       ]
     },
@@ -2556,8 +2556,8 @@
       "returnType": "bool",
       "params": [
         {
-          "name": "flag",
-          "type": "unsigned int"
+          "type": "unsigned int",
+          "name": "flag"
         }
       ]
     },
@@ -2567,8 +2567,8 @@
       "returnType": "void",
       "params": [
         {
-          "name": "flags",
-          "type": "unsigned int"
+          "type": "unsigned int",
+          "name": "flags"
         }
       ]
     },
@@ -2578,8 +2578,8 @@
       "returnType": "void",
       "params": [
         {
-          "name": "flags",
-          "type": "unsigned int"
+          "type": "unsigned int",
+          "name": "flags"
         }
       ]
     },
@@ -2609,8 +2609,8 @@
       "returnType": "void",
       "params": [
         {
-          "name": "image",
-          "type": "Image"
+          "type": "Image",
+          "name": "image"
         }
       ]
     },
@@ -2620,8 +2620,8 @@
       "returnType": "void",
       "params": [
         {
-          "name": "title",
-          "type": "const char *"
+          "type": "const char *",
+          "name": "title"
         }
       ]
     },
@@ -2631,12 +2631,12 @@
       "returnType": "void",
       "params": [
         {
-          "name": "x",
-          "type": "int"
+          "type": "int",
+          "name": "x"
         },
         {
-          "name": "y",
-          "type": "int"
+          "type": "int",
+          "name": "y"
         }
       ]
     },
@@ -2646,8 +2646,8 @@
       "returnType": "void",
       "params": [
         {
-          "name": "monitor",
-          "type": "int"
+          "type": "int",
+          "name": "monitor"
         }
       ]
     },
@@ -2657,12 +2657,12 @@
       "returnType": "void",
       "params": [
         {
-          "name": "width",
-          "type": "int"
+          "type": "int",
+          "name": "width"
         },
         {
-          "name": "height",
-          "type": "int"
+          "type": "int",
+          "name": "height"
         }
       ]
     },
@@ -2672,12 +2672,12 @@
       "returnType": "void",
       "params": [
         {
-          "name": "width",
-          "type": "int"
+          "type": "int",
+          "name": "width"
         },
         {
-          "name": "height",
-          "type": "int"
+          "type": "int",
+          "name": "height"
         }
       ]
     },
@@ -2687,8 +2687,8 @@
       "returnType": "void",
       "params": [
         {
-          "name": "opacity",
-          "type": "float"
+          "type": "float",
+          "name": "opacity"
         }
       ]
     },
@@ -2733,8 +2733,8 @@
       "returnType": "Vector2",
       "params": [
         {
-          "name": "monitor",
-          "type": "int"
+          "type": "int",
+          "name": "monitor"
         }
       ]
     },
@@ -2744,8 +2744,8 @@
       "returnType": "int",
       "params": [
         {
-          "name": "monitor",
-          "type": "int"
+          "type": "int",
+          "name": "monitor"
         }
       ]
     },
@@ -2755,8 +2755,8 @@
       "returnType": "int",
       "params": [
         {
-          "name": "monitor",
-          "type": "int"
+          "type": "int",
+          "name": "monitor"
         }
       ]
     },
@@ -2766,8 +2766,8 @@
       "returnType": "int",
       "params": [
         {
-          "name": "monitor",
-          "type": "int"
+          "type": "int",
+          "name": "monitor"
         }
       ]
     },
@@ -2777,8 +2777,8 @@
       "returnType": "int",
       "params": [
         {
-          "name": "monitor",
-          "type": "int"
+          "type": "int",
+          "name": "monitor"
         }
       ]
     },
@@ -2788,8 +2788,8 @@
       "returnType": "int",
       "params": [
         {
-          "name": "monitor",
-          "type": "int"
+          "type": "int",
+          "name": "monitor"
         }
       ]
     },
@@ -2809,8 +2809,8 @@
       "returnType": "const char *",
       "params": [
         {
-          "name": "monitor",
-          "type": "int"
+          "type": "int",
+          "name": "monitor"
         }
       ]
     },
@@ -2820,8 +2820,8 @@
       "returnType": "void",
       "params": [
         {
-          "name": "text",
-          "type": "const char *"
+          "type": "const char *",
+          "name": "text"
         }
       ]
     },
@@ -2846,8 +2846,8 @@
       "returnType": "void",
       "params": [
         {
-          "name": "ms",
-          "type": "float"
+          "type": "float",
+          "name": "ms"
         }
       ]
     },
@@ -2887,8 +2887,8 @@
       "returnType": "void",
       "params": [
         {
-          "name": "color",
-          "type": "Color"
+          "type": "Color",
+          "name": "color"
         }
       ]
     },
@@ -2908,8 +2908,8 @@
       "returnType": "void",
       "params": [
         {
-          "name": "camera",
-          "type": "Camera2D"
+          "type": "Camera2D",
+          "name": "camera"
         }
       ]
     },
@@ -2924,8 +2924,8 @@
       "returnType": "void",
       "params": [
         {
-          "name": "camera",
-          "type": "Camera3D"
+          "type": "Camera3D",
+          "name": "camera"
         }
       ]
     },
@@ -2940,8 +2940,8 @@
       "returnType": "void",
       "params": [
         {
-          "name": "target",
-          "type": "RenderTexture2D"
+          "type": "RenderTexture2D",
+          "name": "target"
         }
       ]
     },
@@ -2956,8 +2956,8 @@
       "returnType": "void",
       "params": [
         {
-          "name": "shader",
-          "type": "Shader"
+          "type": "Shader",
+          "name": "shader"
         }
       ]
     },
@@ -2972,8 +2972,8 @@
       "returnType": "void",
       "params": [
         {
-          "name": "mode",
-          "type": "int"
+          "type": "int",
+          "name": "mode"
         }
       ]
     },
@@ -2988,20 +2988,20 @@
       "returnType": "void",
       "params": [
         {
-          "name": "x",
-          "type": "int"
+          "type": "int",
+          "name": "x"
         },
         {
-          "name": "y",
-          "type": "int"
+          "type": "int",
+          "name": "y"
         },
         {
-          "name": "width",
-          "type": "int"
+          "type": "int",
+          "name": "width"
         },
         {
-          "name": "height",
-          "type": "int"
+          "type": "int",
+          "name": "height"
         }
       ]
     },
@@ -3016,8 +3016,8 @@
       "returnType": "void",
       "params": [
         {
-          "name": "config",
-          "type": "VrStereoConfig"
+          "type": "VrStereoConfig",
+          "name": "config"
         }
       ]
     },
@@ -3032,8 +3032,8 @@
       "returnType": "VrStereoConfig",
       "params": [
         {
-          "name": "device",
-          "type": "VrDeviceInfo"
+          "type": "VrDeviceInfo",
+          "name": "device"
         }
       ]
     },
@@ -3043,8 +3043,8 @@
       "returnType": "void",
       "params": [
         {
-          "name": "config",
-          "type": "VrStereoConfig"
+          "type": "VrStereoConfig",
+          "name": "config"
         }
       ]
     },
@@ -3054,12 +3054,12 @@
       "returnType": "Shader",
       "params": [
         {
-          "name": "vsFileName",
-          "type": "const char *"
+          "type": "const char *",
+          "name": "vsFileName"
         },
         {
-          "name": "fsFileName",
-          "type": "const char *"
+          "type": "const char *",
+          "name": "fsFileName"
         }
       ]
     },
@@ -3069,12 +3069,12 @@
       "returnType": "Shader",
       "params": [
         {
-          "name": "vsCode",
-          "type": "const char *"
+          "type": "const char *",
+          "name": "vsCode"
         },
         {
-          "name": "fsCode",
-          "type": "const char *"
+          "type": "const char *",
+          "name": "fsCode"
         }
       ]
     },
@@ -3084,12 +3084,12 @@
       "returnType": "int",
       "params": [
         {
-          "name": "shader",
-          "type": "Shader"
+          "type": "Shader",
+          "name": "shader"
         },
         {
-          "name": "uniformName",
-          "type": "const char *"
+          "type": "const char *",
+          "name": "uniformName"
         }
       ]
     },
@@ -3099,12 +3099,12 @@
       "returnType": "int",
       "params": [
         {
-          "name": "shader",
-          "type": "Shader"
+          "type": "Shader",
+          "name": "shader"
         },
         {
-          "name": "attribName",
-          "type": "const char *"
+          "type": "const char *",
+          "name": "attribName"
         }
       ]
     },
@@ -3114,20 +3114,20 @@
       "returnType": "void",
       "params": [
         {
-          "name": "shader",
-          "type": "Shader"
+          "type": "Shader",
+          "name": "shader"
         },
         {
-          "name": "locIndex",
-          "type": "int"
+          "type": "int",
+          "name": "locIndex"
         },
         {
-          "name": "value",
-          "type": "const void *"
+          "type": "const void *",
+          "name": "value"
         },
         {
-          "name": "uniformType",
-          "type": "int"
+          "type": "int",
+          "name": "uniformType"
         }
       ]
     },
@@ -3137,24 +3137,24 @@
       "returnType": "void",
       "params": [
         {
-          "name": "shader",
-          "type": "Shader"
+          "type": "Shader",
+          "name": "shader"
         },
         {
-          "name": "locIndex",
-          "type": "int"
+          "type": "int",
+          "name": "locIndex"
         },
         {
-          "name": "value",
-          "type": "const void *"
+          "type": "const void *",
+          "name": "value"
         },
         {
-          "name": "uniformType",
-          "type": "int"
+          "type": "int",
+          "name": "uniformType"
         },
         {
-          "name": "count",
-          "type": "int"
+          "type": "int",
+          "name": "count"
         }
       ]
     },
@@ -3164,16 +3164,16 @@
       "returnType": "void",
       "params": [
         {
-          "name": "shader",
-          "type": "Shader"
+          "type": "Shader",
+          "name": "shader"
         },
         {
-          "name": "locIndex",
-          "type": "int"
+          "type": "int",
+          "name": "locIndex"
         },
         {
-          "name": "mat",
-          "type": "Matrix"
+          "type": "Matrix",
+          "name": "mat"
         }
       ]
     },
@@ -3183,16 +3183,16 @@
       "returnType": "void",
       "params": [
         {
-          "name": "shader",
-          "type": "Shader"
+          "type": "Shader",
+          "name": "shader"
         },
         {
-          "name": "locIndex",
-          "type": "int"
+          "type": "int",
+          "name": "locIndex"
         },
         {
-          "name": "texture",
-          "type": "Texture2D"
+          "type": "Texture2D",
+          "name": "texture"
         }
       ]
     },
@@ -3202,8 +3202,8 @@
       "returnType": "void",
       "params": [
         {
-          "name": "shader",
-          "type": "Shader"
+          "type": "Shader",
+          "name": "shader"
         }
       ]
     },
@@ -3213,12 +3213,12 @@
       "returnType": "Ray",
       "params": [
         {
-          "name": "mousePosition",
-          "type": "Vector2"
+          "type": "Vector2",
+          "name": "mousePosition"
         },
         {
-          "name": "camera",
-          "type": "Camera"
+          "type": "Camera",
+          "name": "camera"
         }
       ]
     },
@@ -3228,8 +3228,8 @@
       "returnType": "Matrix",
       "params": [
         {
-          "name": "camera",
-          "type": "Camera"
+          "type": "Camera",
+          "name": "camera"
         }
       ]
     },
@@ -3239,8 +3239,8 @@
       "returnType": "Matrix",
       "params": [
         {
-          "name": "camera",
-          "type": "Camera2D"
+          "type": "Camera2D",
+          "name": "camera"
         }
       ]
     },
@@ -3250,12 +3250,12 @@
       "returnType": "Vector2",
       "params": [
         {
-          "name": "position",
-          "type": "Vector3"
+          "type": "Vector3",
+          "name": "position"
         },
         {
-          "name": "camera",
-          "type": "Camera"
+          "type": "Camera",
+          "name": "camera"
         }
       ]
     },
@@ -3265,20 +3265,20 @@
       "returnType": "Vector2",
       "params": [
         {
-          "name": "position",
-          "type": "Vector3"
+          "type": "Vector3",
+          "name": "position"
         },
         {
-          "name": "camera",
-          "type": "Camera"
+          "type": "Camera",
+          "name": "camera"
         },
         {
-          "name": "width",
-          "type": "int"
+          "type": "int",
+          "name": "width"
         },
         {
-          "name": "height",
-          "type": "int"
+          "type": "int",
+          "name": "height"
         }
       ]
     },
@@ -3288,12 +3288,12 @@
       "returnType": "Vector2",
       "params": [
         {
-          "name": "position",
-          "type": "Vector2"
+          "type": "Vector2",
+          "name": "position"
         },
         {
-          "name": "camera",
-          "type": "Camera2D"
+          "type": "Camera2D",
+          "name": "camera"
         }
       ]
     },
@@ -3303,12 +3303,12 @@
       "returnType": "Vector2",
       "params": [
         {
-          "name": "position",
-          "type": "Vector2"
+          "type": "Vector2",
+          "name": "position"
         },
         {
-          "name": "camera",
-          "type": "Camera2D"
+          "type": "Camera2D",
+          "name": "camera"
         }
       ]
     },
@@ -3318,8 +3318,8 @@
       "returnType": "void",
       "params": [
         {
-          "name": "fps",
-          "type": "int"
+          "type": "int",
+          "name": "fps"
         }
       ]
     },
@@ -3344,12 +3344,12 @@
       "returnType": "int",
       "params": [
         {
-          "name": "min",
-          "type": "int"
+          "type": "int",
+          "name": "min"
         },
         {
-          "name": "max",
-          "type": "int"
+          "type": "int",
+          "name": "max"
         }
       ]
     },
@@ -3359,8 +3359,8 @@
       "returnType": "void",
       "params": [
         {
-          "name": "seed",
-          "type": "unsigned int"
+          "type": "unsigned int",
+          "name": "seed"
         }
       ]
     },
@@ -3370,8 +3370,8 @@
       "returnType": "void",
       "params": [
         {
-          "name": "fileName",
-          "type": "const char *"
+          "type": "const char *",
+          "name": "fileName"
         }
       ]
     },
@@ -3381,8 +3381,8 @@
       "returnType": "void",
       "params": [
         {
-          "name": "flags",
-          "type": "unsigned int"
+          "type": "unsigned int",
+          "name": "flags"
         }
       ]
     },
@@ -3392,16 +3392,16 @@
       "returnType": "void",
       "params": [
         {
-          "name": "logLevel",
-          "type": "int"
+          "type": "int",
+          "name": "logLevel"
         },
         {
-          "name": "text",
-          "type": "const char *"
+          "type": "const char *",
+          "name": "text"
         },
         {
-          "name": "",
-          "type": ""
+          "type": "",
+          "name": ""
         }
       ]
     },
@@ -3411,8 +3411,8 @@
       "returnType": "void",
       "params": [
         {
-          "name": "logLevel",
-          "type": "int"
+          "type": "int",
+          "name": "logLevel"
         }
       ]
     },
@@ -3422,8 +3422,8 @@
       "returnType": "void *",
       "params": [
         {
-          "name": "size",
-          "type": "int"
+          "type": "int",
+          "name": "size"
         }
       ]
     },
@@ -3433,12 +3433,12 @@
       "returnType": "void *",
       "params": [
         {
-          "name": "ptr",
-          "type": "void *"
+          "type": "void *",
+          "name": "ptr"
         },
         {
-          "name": "size",
-          "type": "int"
+          "type": "int",
+          "name": "size"
         }
       ]
     },
@@ -3448,8 +3448,8 @@
       "returnType": "void",
       "params": [
         {
-          "name": "ptr",
-          "type": "void *"
+          "type": "void *",
+          "name": "ptr"
         }
       ]
     },
@@ -3459,8 +3459,8 @@
       "returnType": "void",
       "params": [
         {
-          "name": "callback",
-          "type": "TraceLogCallback"
+          "type": "TraceLogCallback",
+          "name": "callback"
         }
       ]
     },
@@ -3470,8 +3470,8 @@
       "returnType": "void",
       "params": [
         {
-          "name": "callback",
-          "type": "LoadFileDataCallback"
+          "type": "LoadFileDataCallback",
+          "name": "callback"
         }
       ]
     },
@@ -3481,8 +3481,8 @@
       "returnType": "void",
       "params": [
         {
-          "name": "callback",
-          "type": "SaveFileDataCallback"
+          "type": "SaveFileDataCallback",
+          "name": "callback"
         }
       ]
     },
@@ -3492,8 +3492,8 @@
       "returnType": "void",
       "params": [
         {
-          "name": "callback",
-          "type": "LoadFileTextCallback"
+          "type": "LoadFileTextCallback",
+          "name": "callback"
         }
       ]
     },
@@ -3503,8 +3503,8 @@
       "returnType": "void",
       "params": [
         {
-          "name": "callback",
-          "type": "SaveFileTextCallback"
+          "type": "SaveFileTextCallback",
+          "name": "callback"
         }
       ]
     },
@@ -3514,12 +3514,12 @@
       "returnType": "unsigned char *",
       "params": [
         {
-          "name": "fileName",
-          "type": "const char *"
+          "type": "const char *",
+          "name": "fileName"
         },
         {
-          "name": "bytesRead",
-          "type": "unsigned int *"
+          "type": "unsigned int *",
+          "name": "bytesRead"
         }
       ]
     },
@@ -3529,8 +3529,8 @@
       "returnType": "void",
       "params": [
         {
-          "name": "data",
-          "type": "unsigned char *"
+          "type": "unsigned char *",
+          "name": "data"
         }
       ]
     },
@@ -3540,16 +3540,16 @@
       "returnType": "bool",
       "params": [
         {
-          "name": "fileName",
-          "type": "const char *"
+          "type": "const char *",
+          "name": "fileName"
         },
         {
-          "name": "data",
-          "type": "void *"
+          "type": "void *",
+          "name": "data"
         },
         {
-          "name": "bytesToWrite",
-          "type": "unsigned int"
+          "type": "unsigned int",
+          "name": "bytesToWrite"
         }
       ]
     },
@@ -3559,8 +3559,8 @@
       "returnType": "char *",
       "params": [
         {
-          "name": "fileName",
-          "type": "const char *"
+          "type": "const char *",
+          "name": "fileName"
         }
       ]
     },
@@ -3570,8 +3570,8 @@
       "returnType": "void",
       "params": [
         {
-          "name": "text",
-          "type": "char *"
+          "type": "char *",
+          "name": "text"
         }
       ]
     },
@@ -3581,12 +3581,12 @@
       "returnType": "bool",
       "params": [
         {
-          "name": "fileName",
-          "type": "const char *"
+          "type": "const char *",
+          "name": "fileName"
         },
         {
-          "name": "text",
-          "type": "char *"
+          "type": "char *",
+          "name": "text"
         }
       ]
     },
@@ -3596,8 +3596,8 @@
       "returnType": "bool",
       "params": [
         {
-          "name": "fileName",
-          "type": "const char *"
+          "type": "const char *",
+          "name": "fileName"
         }
       ]
     },
@@ -3607,8 +3607,8 @@
       "returnType": "bool",
       "params": [
         {
-          "name": "dirPath",
-          "type": "const char *"
+          "type": "const char *",
+          "name": "dirPath"
         }
       ]
     },
@@ -3618,12 +3618,12 @@
       "returnType": "bool",
       "params": [
         {
-          "name": "fileName",
-          "type": "const char *"
+          "type": "const char *",
+          "name": "fileName"
         },
         {
-          "name": "ext",
-          "type": "const char *"
+          "type": "const char *",
+          "name": "ext"
         }
       ]
     },
@@ -3633,8 +3633,8 @@
       "returnType": "const char *",
       "params": [
         {
-          "name": "fileName",
-          "type": "const char *"
+          "type": "const char *",
+          "name": "fileName"
         }
       ]
     },
@@ -3644,8 +3644,8 @@
       "returnType": "const char *",
       "params": [
         {
-          "name": "filePath",
-          "type": "const char *"
+          "type": "const char *",
+          "name": "filePath"
         }
       ]
     },
@@ -3655,8 +3655,8 @@
       "returnType": "const char *",
       "params": [
         {
-          "name": "filePath",
-          "type": "const char *"
+          "type": "const char *",
+          "name": "filePath"
         }
       ]
     },
@@ -3666,8 +3666,8 @@
       "returnType": "const char *",
       "params": [
         {
-          "name": "filePath",
-          "type": "const char *"
+          "type": "const char *",
+          "name": "filePath"
         }
       ]
     },
@@ -3677,8 +3677,8 @@
       "returnType": "const char *",
       "params": [
         {
-          "name": "dirPath",
-          "type": "const char *"
+          "type": "const char *",
+          "name": "dirPath"
         }
       ]
     },
@@ -3693,12 +3693,12 @@
       "returnType": "char **",
       "params": [
         {
-          "name": "dirPath",
-          "type": "const char *"
+          "type": "const char *",
+          "name": "dirPath"
         },
         {
-          "name": "count",
-          "type": "int *"
+          "type": "int *",
+          "name": "count"
         }
       ]
     },
@@ -3713,8 +3713,8 @@
       "returnType": "bool",
       "params": [
         {
-          "name": "dir",
-          "type": "const char *"
+          "type": "const char *",
+          "name": "dir"
         }
       ]
     },
@@ -3729,8 +3729,8 @@
       "returnType": "char **",
       "params": [
         {
-          "name": "count",
-          "type": "int *"
+          "type": "int *",
+          "name": "count"
         }
       ]
     },
@@ -3745,8 +3745,8 @@
       "returnType": "long",
       "params": [
         {
-          "name": "fileName",
-          "type": "const char *"
+          "type": "const char *",
+          "name": "fileName"
         }
       ]
     },
@@ -3756,16 +3756,16 @@
       "returnType": "unsigned char *",
       "params": [
         {
-          "name": "data",
-          "type": "unsigned char *"
+          "type": "unsigned char *",
+          "name": "data"
         },
         {
-          "name": "dataLength",
-          "type": "int"
+          "type": "int",
+          "name": "dataLength"
         },
         {
-          "name": "compDataLength",
-          "type": "int *"
+          "type": "int *",
+          "name": "compDataLength"
         }
       ]
     },
@@ -3775,16 +3775,16 @@
       "returnType": "unsigned char *",
       "params": [
         {
-          "name": "compData",
-          "type": "unsigned char *"
+          "type": "unsigned char *",
+          "name": "compData"
         },
         {
-          "name": "compDataLength",
-          "type": "int"
+          "type": "int",
+          "name": "compDataLength"
         },
         {
-          "name": "dataLength",
-          "type": "int *"
+          "type": "int *",
+          "name": "dataLength"
         }
       ]
     },
@@ -3794,16 +3794,16 @@
       "returnType": "char *",
       "params": [
         {
-          "name": "data",
-          "type": "const unsigned char *"
+          "type": "const unsigned char *",
+          "name": "data"
         },
         {
-          "name": "dataLength",
-          "type": "int"
+          "type": "int",
+          "name": "dataLength"
         },
         {
-          "name": "outputLength",
-          "type": "int *"
+          "type": "int *",
+          "name": "outputLength"
         }
       ]
     },
@@ -3813,12 +3813,12 @@
       "returnType": "unsigned char *",
       "params": [
         {
-          "name": "data",
-          "type": "unsigned char *"
+          "type": "unsigned char *",
+          "name": "data"
         },
         {
-          "name": "outputLength",
-          "type": "int *"
+          "type": "int *",
+          "name": "outputLength"
         }
       ]
     },
@@ -3828,12 +3828,12 @@
       "returnType": "bool",
       "params": [
         {
-          "name": "position",
-          "type": "unsigned int"
+          "type": "unsigned int",
+          "name": "position"
         },
         {
-          "name": "value",
-          "type": "int"
+          "type": "int",
+          "name": "value"
         }
       ]
     },
@@ -3843,8 +3843,8 @@
       "returnType": "int",
       "params": [
         {
-          "name": "position",
-          "type": "unsigned int"
+          "type": "unsigned int",
+          "name": "position"
         }
       ]
     },
@@ -3854,8 +3854,8 @@
       "returnType": "void",
       "params": [
         {
-          "name": "url",
-          "type": "const char *"
+          "type": "const char *",
+          "name": "url"
         }
       ]
     },
@@ -3865,8 +3865,8 @@
       "returnType": "bool",
       "params": [
         {
-          "name": "key",
-          "type": "int"
+          "type": "int",
+          "name": "key"
         }
       ]
     },
@@ -3876,8 +3876,8 @@
       "returnType": "bool",
       "params": [
         {
-          "name": "key",
-          "type": "int"
+          "type": "int",
+          "name": "key"
         }
       ]
     },
@@ -3887,8 +3887,8 @@
       "returnType": "bool",
       "params": [
         {
-          "name": "key",
-          "type": "int"
+          "type": "int",
+          "name": "key"
         }
       ]
     },
@@ -3898,8 +3898,8 @@
       "returnType": "bool",
       "params": [
         {
-          "name": "key",
-          "type": "int"
+          "type": "int",
+          "name": "key"
         }
       ]
     },
@@ -3909,8 +3909,8 @@
       "returnType": "void",
       "params": [
         {
-          "name": "key",
-          "type": "int"
+          "type": "int",
+          "name": "key"
         }
       ]
     },
@@ -3930,8 +3930,8 @@
       "returnType": "bool",
       "params": [
         {
-          "name": "gamepad",
-          "type": "int"
+          "type": "int",
+          "name": "gamepad"
         }
       ]
     },
@@ -3941,8 +3941,8 @@
       "returnType": "const char *",
       "params": [
         {
-          "name": "gamepad",
-          "type": "int"
+          "type": "int",
+          "name": "gamepad"
         }
       ]
     },
@@ -3952,12 +3952,12 @@
       "returnType": "bool",
       "params": [
         {
-          "name": "gamepad",
-          "type": "int"
+          "type": "int",
+          "name": "gamepad"
         },
         {
-          "name": "button",
-          "type": "int"
+          "type": "int",
+          "name": "button"
         }
       ]
     },
@@ -3967,12 +3967,12 @@
       "returnType": "bool",
       "params": [
         {
-          "name": "gamepad",
-          "type": "int"
+          "type": "int",
+          "name": "gamepad"
         },
         {
-          "name": "button",
-          "type": "int"
+          "type": "int",
+          "name": "button"
         }
       ]
     },
@@ -3982,12 +3982,12 @@
       "returnType": "bool",
       "params": [
         {
-          "name": "gamepad",
-          "type": "int"
+          "type": "int",
+          "name": "gamepad"
         },
         {
-          "name": "button",
-          "type": "int"
+          "type": "int",
+          "name": "button"
         }
       ]
     },
@@ -3997,12 +3997,12 @@
       "returnType": "bool",
       "params": [
         {
-          "name": "gamepad",
-          "type": "int"
+          "type": "int",
+          "name": "gamepad"
         },
         {
-          "name": "button",
-          "type": "int"
+          "type": "int",
+          "name": "button"
         }
       ]
     },
@@ -4017,8 +4017,8 @@
       "returnType": "int",
       "params": [
         {
-          "name": "gamepad",
-          "type": "int"
+          "type": "int",
+          "name": "gamepad"
         }
       ]
     },
@@ -4028,12 +4028,12 @@
       "returnType": "float",
       "params": [
         {
-          "name": "gamepad",
-          "type": "int"
+          "type": "int",
+          "name": "gamepad"
         },
         {
-          "name": "axis",
-          "type": "int"
+          "type": "int",
+          "name": "axis"
         }
       ]
     },
@@ -4043,8 +4043,8 @@
       "returnType": "int",
       "params": [
         {
-          "name": "mappings",
-          "type": "const char *"
+          "type": "const char *",
+          "name": "mappings"
         }
       ]
     },
@@ -4054,8 +4054,8 @@
       "returnType": "bool",
       "params": [
         {
-          "name": "button",
-          "type": "int"
+          "type": "int",
+          "name": "button"
         }
       ]
     },
@@ -4065,8 +4065,8 @@
       "returnType": "bool",
       "params": [
         {
-          "name": "button",
-          "type": "int"
+          "type": "int",
+          "name": "button"
         }
       ]
     },
@@ -4076,8 +4076,8 @@
       "returnType": "bool",
       "params": [
         {
-          "name": "button",
-          "type": "int"
+          "type": "int",
+          "name": "button"
         }
       ]
     },
@@ -4087,8 +4087,8 @@
       "returnType": "bool",
       "params": [
         {
-          "name": "button",
-          "type": "int"
+          "type": "int",
+          "name": "button"
         }
       ]
     },
@@ -4118,12 +4118,12 @@
       "returnType": "void",
       "params": [
         {
-          "name": "x",
-          "type": "int"
+          "type": "int",
+          "name": "x"
         },
         {
-          "name": "y",
-          "type": "int"
+          "type": "int",
+          "name": "y"
         }
       ]
     },
@@ -4133,12 +4133,12 @@
       "returnType": "void",
       "params": [
         {
-          "name": "offsetX",
-          "type": "int"
+          "type": "int",
+          "name": "offsetX"
         },
         {
-          "name": "offsetY",
-          "type": "int"
+          "type": "int",
+          "name": "offsetY"
         }
       ]
     },
@@ -4148,12 +4148,12 @@
       "returnType": "void",
       "params": [
         {
-          "name": "scaleX",
-          "type": "float"
+          "type": "float",
+          "name": "scaleX"
         },
         {
-          "name": "scaleY",
-          "type": "float"
+          "type": "float",
+          "name": "scaleY"
         }
       ]
     },
@@ -4168,8 +4168,8 @@
       "returnType": "void",
       "params": [
         {
-          "name": "cursor",
-          "type": "int"
+          "type": "int",
+          "name": "cursor"
         }
       ]
     },
@@ -4189,8 +4189,8 @@
       "returnType": "Vector2",
       "params": [
         {
-          "name": "index",
-          "type": "int"
+          "type": "int",
+          "name": "index"
         }
       ]
     },
@@ -4200,8 +4200,8 @@
       "returnType": "int",
       "params": [
         {
-          "name": "index",
-          "type": "int"
+          "type": "int",
+          "name": "index"
         }
       ]
     },
@@ -4216,8 +4216,8 @@
       "returnType": "void",
       "params": [
         {
-          "name": "flags",
-          "type": "unsigned int"
+          "type": "unsigned int",
+          "name": "flags"
         }
       ]
     },
@@ -4227,8 +4227,8 @@
       "returnType": "bool",
       "params": [
         {
-          "name": "gesture",
-          "type": "int"
+          "type": "int",
+          "name": "gesture"
         }
       ]
     },
@@ -4268,12 +4268,12 @@
       "returnType": "void",
       "params": [
         {
-          "name": "camera",
-          "type": "Camera"
+          "type": "Camera",
+          "name": "camera"
         },
         {
-          "name": "mode",
-          "type": "int"
+          "type": "int",
+          "name": "mode"
         }
       ]
     },
@@ -4283,8 +4283,8 @@
       "returnType": "void",
       "params": [
         {
-          "name": "camera",
-          "type": "Camera *"
+          "type": "Camera *",
+          "name": "camera"
         }
       ]
     },
@@ -4294,8 +4294,8 @@
       "returnType": "void",
       "params": [
         {
-          "name": "keyPan",
-          "type": "int"
+          "type": "int",
+          "name": "keyPan"
         }
       ]
     },
@@ -4305,8 +4305,8 @@
       "returnType": "void",
       "params": [
         {
-          "name": "keyAlt",
-          "type": "int"
+          "type": "int",
+          "name": "keyAlt"
         }
       ]
     },
@@ -4316,8 +4316,8 @@
       "returnType": "void",
       "params": [
         {
-          "name": "keySmoothZoom",
-          "type": "int"
+          "type": "int",
+          "name": "keySmoothZoom"
         }
       ]
     },
@@ -4327,28 +4327,28 @@
       "returnType": "void",
       "params": [
         {
-          "name": "keyFront",
-          "type": "int"
+          "type": "int",
+          "name": "keyFront"
         },
         {
-          "name": "keyBack",
-          "type": "int"
+          "type": "int",
+          "name": "keyBack"
         },
         {
-          "name": "keyRight",
-          "type": "int"
+          "type": "int",
+          "name": "keyRight"
         },
         {
-          "name": "keyLeft",
-          "type": "int"
+          "type": "int",
+          "name": "keyLeft"
         },
         {
-          "name": "keyUp",
-          "type": "int"
+          "type": "int",
+          "name": "keyUp"
         },
         {
-          "name": "keyDown",
-          "type": "int"
+          "type": "int",
+          "name": "keyDown"
         }
       ]
     },
@@ -4358,12 +4358,12 @@
       "returnType": "void",
       "params": [
         {
-          "name": "texture",
-          "type": "Texture2D"
+          "type": "Texture2D",
+          "name": "texture"
         },
         {
-          "name": "source",
-          "type": "Rectangle"
+          "type": "Rectangle",
+          "name": "source"
         }
       ]
     },
@@ -4373,16 +4373,16 @@
       "returnType": "void",
       "params": [
         {
-          "name": "posX",
-          "type": "int"
+          "type": "int",
+          "name": "posX"
         },
         {
-          "name": "posY",
-          "type": "int"
+          "type": "int",
+          "name": "posY"
         },
         {
-          "name": "color",
-          "type": "Color"
+          "type": "Color",
+          "name": "color"
         }
       ]
     },
@@ -4392,12 +4392,12 @@
       "returnType": "void",
       "params": [
         {
-          "name": "position",
-          "type": "Vector2"
+          "type": "Vector2",
+          "name": "position"
         },
         {
-          "name": "color",
-          "type": "Color"
+          "type": "Color",
+          "name": "color"
         }
       ]
     },
@@ -4407,24 +4407,24 @@
       "returnType": "void",
       "params": [
         {
-          "name": "startPosX",
-          "type": "int"
+          "type": "int",
+          "name": "startPosX"
         },
         {
-          "name": "startPosY",
-          "type": "int"
+          "type": "int",
+          "name": "startPosY"
         },
         {
-          "name": "endPosX",
-          "type": "int"
+          "type": "int",
+          "name": "endPosX"
         },
         {
-          "name": "endPosY",
-          "type": "int"
+          "type": "int",
+          "name": "endPosY"
         },
         {
-          "name": "color",
-          "type": "Color"
+          "type": "Color",
+          "name": "color"
         }
       ]
     },
@@ -4434,16 +4434,16 @@
       "returnType": "void",
       "params": [
         {
-          "name": "startPos",
-          "type": "Vector2"
+          "type": "Vector2",
+          "name": "startPos"
         },
         {
-          "name": "endPos",
-          "type": "Vector2"
+          "type": "Vector2",
+          "name": "endPos"
         },
         {
-          "name": "color",
-          "type": "Color"
+          "type": "Color",
+          "name": "color"
         }
       ]
     },
@@ -4453,20 +4453,20 @@
       "returnType": "void",
       "params": [
         {
-          "name": "startPos",
-          "type": "Vector2"
+          "type": "Vector2",
+          "name": "startPos"
         },
         {
-          "name": "endPos",
-          "type": "Vector2"
+          "type": "Vector2",
+          "name": "endPos"
         },
         {
-          "name": "thick",
-          "type": "float"
+          "type": "float",
+          "name": "thick"
         },
         {
-          "name": "color",
-          "type": "Color"
+          "type": "Color",
+          "name": "color"
         }
       ]
     },
@@ -4476,20 +4476,20 @@
       "returnType": "void",
       "params": [
         {
-          "name": "startPos",
-          "type": "Vector2"
+          "type": "Vector2",
+          "name": "startPos"
         },
         {
-          "name": "endPos",
-          "type": "Vector2"
+          "type": "Vector2",
+          "name": "endPos"
         },
         {
-          "name": "thick",
-          "type": "float"
+          "type": "float",
+          "name": "thick"
         },
         {
-          "name": "color",
-          "type": "Color"
+          "type": "Color",
+          "name": "color"
         }
       ]
     },
@@ -4499,24 +4499,24 @@
       "returnType": "void",
       "params": [
         {
-          "name": "startPos",
-          "type": "Vector2"
+          "type": "Vector2",
+          "name": "startPos"
         },
         {
-          "name": "endPos",
-          "type": "Vector2"
+          "type": "Vector2",
+          "name": "endPos"
         },
         {
-          "name": "controlPos",
-          "type": "Vector2"
+          "type": "Vector2",
+          "name": "controlPos"
         },
         {
-          "name": "thick",
-          "type": "float"
+          "type": "float",
+          "name": "thick"
         },
         {
-          "name": "color",
-          "type": "Color"
+          "type": "Color",
+          "name": "color"
         }
       ]
     },
@@ -4526,28 +4526,28 @@
       "returnType": "void",
       "params": [
         {
-          "name": "startPos",
-          "type": "Vector2"
+          "type": "Vector2",
+          "name": "startPos"
         },
         {
-          "name": "endPos",
-          "type": "Vector2"
+          "type": "Vector2",
+          "name": "endPos"
         },
         {
-          "name": "startControlPos",
-          "type": "Vector2"
+          "type": "Vector2",
+          "name": "startControlPos"
         },
         {
-          "name": "endControlPos",
-          "type": "Vector2"
+          "type": "Vector2",
+          "name": "endControlPos"
         },
         {
-          "name": "thick",
-          "type": "float"
+          "type": "float",
+          "name": "thick"
         },
         {
-          "name": "color",
-          "type": "Color"
+          "type": "Color",
+          "name": "color"
         }
       ]
     },
@@ -4557,16 +4557,16 @@
       "returnType": "void",
       "params": [
         {
-          "name": "points",
-          "type": "Vector2 *"
+          "type": "Vector2 *",
+          "name": "points"
         },
         {
-          "name": "pointCount",
-          "type": "int"
+          "type": "int",
+          "name": "pointCount"
         },
         {
-          "name": "color",
-          "type": "Color"
+          "type": "Color",
+          "name": "color"
         }
       ]
     },
@@ -4576,20 +4576,20 @@
       "returnType": "void",
       "params": [
         {
-          "name": "centerX",
-          "type": "int"
+          "type": "int",
+          "name": "centerX"
         },
         {
-          "name": "centerY",
-          "type": "int"
+          "type": "int",
+          "name": "centerY"
         },
         {
-          "name": "radius",
-          "type": "float"
+          "type": "float",
+          "name": "radius"
         },
         {
-          "name": "color",
-          "type": "Color"
+          "type": "Color",
+          "name": "color"
         }
       ]
     },
@@ -4599,28 +4599,28 @@
       "returnType": "void",
       "params": [
         {
-          "name": "center",
-          "type": "Vector2"
+          "type": "Vector2",
+          "name": "center"
         },
         {
-          "name": "radius",
-          "type": "float"
+          "type": "float",
+          "name": "radius"
         },
         {
-          "name": "startAngle",
-          "type": "float"
+          "type": "float",
+          "name": "startAngle"
         },
         {
-          "name": "endAngle",
-          "type": "float"
+          "type": "float",
+          "name": "endAngle"
         },
         {
-          "name": "segments",
-          "type": "int"
+          "type": "int",
+          "name": "segments"
         },
         {
-          "name": "color",
-          "type": "Color"
+          "type": "Color",
+          "name": "color"
         }
       ]
     },
@@ -4630,28 +4630,28 @@
       "returnType": "void",
       "params": [
         {
-          "name": "center",
-          "type": "Vector2"
+          "type": "Vector2",
+          "name": "center"
         },
         {
-          "name": "radius",
-          "type": "float"
+          "type": "float",
+          "name": "radius"
         },
         {
-          "name": "startAngle",
-          "type": "float"
+          "type": "float",
+          "name": "startAngle"
         },
         {
-          "name": "endAngle",
-          "type": "float"
+          "type": "float",
+          "name": "endAngle"
         },
         {
-          "name": "segments",
-          "type": "int"
+          "type": "int",
+          "name": "segments"
         },
         {
-          "name": "color",
-          "type": "Color"
+          "type": "Color",
+          "name": "color"
         }
       ]
     },
@@ -4661,24 +4661,24 @@
       "returnType": "void",
       "params": [
         {
-          "name": "centerX",
-          "type": "int"
+          "type": "int",
+          "name": "centerX"
         },
         {
-          "name": "centerY",
-          "type": "int"
+          "type": "int",
+          "name": "centerY"
         },
         {
-          "name": "radius",
-          "type": "float"
+          "type": "float",
+          "name": "radius"
         },
         {
-          "name": "color1",
-          "type": "Color"
+          "type": "Color",
+          "name": "color1"
         },
         {
-          "name": "color2",
-          "type": "Color"
+          "type": "Color",
+          "name": "color2"
         }
       ]
     },
@@ -4688,16 +4688,16 @@
       "returnType": "void",
       "params": [
         {
-          "name": "center",
-          "type": "Vector2"
+          "type": "Vector2",
+          "name": "center"
         },
         {
-          "name": "radius",
-          "type": "float"
+          "type": "float",
+          "name": "radius"
         },
         {
-          "name": "color",
-          "type": "Color"
+          "type": "Color",
+          "name": "color"
         }
       ]
     },
@@ -4707,20 +4707,20 @@
       "returnType": "void",
       "params": [
         {
-          "name": "centerX",
-          "type": "int"
+          "type": "int",
+          "name": "centerX"
         },
         {
-          "name": "centerY",
-          "type": "int"
+          "type": "int",
+          "name": "centerY"
         },
         {
-          "name": "radius",
-          "type": "float"
+          "type": "float",
+          "name": "radius"
         },
         {
-          "name": "color",
-          "type": "Color"
+          "type": "Color",
+          "name": "color"
         }
       ]
     },
@@ -4730,24 +4730,24 @@
       "returnType": "void",
       "params": [
         {
-          "name": "centerX",
-          "type": "int"
+          "type": "int",
+          "name": "centerX"
         },
         {
-          "name": "centerY",
-          "type": "int"
+          "type": "int",
+          "name": "centerY"
         },
         {
-          "name": "radiusH",
-          "type": "float"
+          "type": "float",
+          "name": "radiusH"
         },
         {
-          "name": "radiusV",
-          "type": "float"
+          "type": "float",
+          "name": "radiusV"
         },
         {
-          "name": "color",
-          "type": "Color"
+          "type": "Color",
+          "name": "color"
         }
       ]
     },
@@ -4757,24 +4757,24 @@
       "returnType": "void",
       "params": [
         {
-          "name": "centerX",
-          "type": "int"
+          "type": "int",
+          "name": "centerX"
         },
         {
-          "name": "centerY",
-          "type": "int"
+          "type": "int",
+          "name": "centerY"
         },
         {
-          "name": "radiusH",
-          "type": "float"
+          "type": "float",
+          "name": "radiusH"
         },
         {
-          "name": "radiusV",
-          "type": "float"
+          "type": "float",
+          "name": "radiusV"
         },
         {
-          "name": "color",
-          "type": "Color"
+          "type": "Color",
+          "name": "color"
         }
       ]
     },
@@ -4784,32 +4784,32 @@
       "returnType": "void",
       "params": [
         {
-          "name": "center",
-          "type": "Vector2"
+          "type": "Vector2",
+          "name": "center"
         },
         {
-          "name": "innerRadius",
-          "type": "float"
+          "type": "float",
+          "name": "innerRadius"
         },
         {
-          "name": "outerRadius",
-          "type": "float"
+          "type": "float",
+          "name": "outerRadius"
         },
         {
-          "name": "startAngle",
-          "type": "float"
+          "type": "float",
+          "name": "startAngle"
         },
         {
-          "name": "endAngle",
-          "type": "float"
+          "type": "float",
+          "name": "endAngle"
         },
         {
-          "name": "segments",
-          "type": "int"
+          "type": "int",
+          "name": "segments"
         },
         {
-          "name": "color",
-          "type": "Color"
+          "type": "Color",
+          "name": "color"
         }
       ]
     },
@@ -4819,32 +4819,32 @@
       "returnType": "void",
       "params": [
         {
-          "name": "center",
-          "type": "Vector2"
+          "type": "Vector2",
+          "name": "center"
         },
         {
-          "name": "innerRadius",
-          "type": "float"
+          "type": "float",
+          "name": "innerRadius"
         },
         {
-          "name": "outerRadius",
-          "type": "float"
+          "type": "float",
+          "name": "outerRadius"
         },
         {
-          "name": "startAngle",
-          "type": "float"
+          "type": "float",
+          "name": "startAngle"
         },
         {
-          "name": "endAngle",
-          "type": "float"
+          "type": "float",
+          "name": "endAngle"
         },
         {
-          "name": "segments",
-          "type": "int"
+          "type": "int",
+          "name": "segments"
         },
         {
-          "name": "color",
-          "type": "Color"
+          "type": "Color",
+          "name": "color"
         }
       ]
     },
@@ -4854,24 +4854,24 @@
       "returnType": "void",
       "params": [
         {
-          "name": "posX",
-          "type": "int"
+          "type": "int",
+          "name": "posX"
         },
         {
-          "name": "posY",
-          "type": "int"
+          "type": "int",
+          "name": "posY"
         },
         {
-          "name": "width",
-          "type": "int"
+          "type": "int",
+          "name": "width"
         },
         {
-          "name": "height",
-          "type": "int"
+          "type": "int",
+          "name": "height"
         },
         {
-          "name": "color",
-          "type": "Color"
+          "type": "Color",
+          "name": "color"
         }
       ]
     },
@@ -4881,16 +4881,16 @@
       "returnType": "void",
       "params": [
         {
-          "name": "position",
-          "type": "Vector2"
+          "type": "Vector2",
+          "name": "position"
         },
         {
-          "name": "size",
-          "type": "Vector2"
+          "type": "Vector2",
+          "name": "size"
         },
         {
-          "name": "color",
-          "type": "Color"
+          "type": "Color",
+          "name": "color"
         }
       ]
     },
@@ -4900,12 +4900,12 @@
       "returnType": "void",
       "params": [
         {
-          "name": "rec",
-          "type": "Rectangle"
+          "type": "Rectangle",
+          "name": "rec"
         },
         {
-          "name": "color",
-          "type": "Color"
+          "type": "Color",
+          "name": "color"
         }
       ]
     },
@@ -4915,20 +4915,20 @@
       "returnType": "void",
       "params": [
         {
-          "name": "rec",
-          "type": "Rectangle"
+          "type": "Rectangle",
+          "name": "rec"
         },
         {
-          "name": "origin",
-          "type": "Vector2"
+          "type": "Vector2",
+          "name": "origin"
         },
         {
-          "name": "rotation",
-          "type": "float"
+          "type": "float",
+          "name": "rotation"
         },
         {
-          "name": "color",
-          "type": "Color"
+          "type": "Color",
+          "name": "color"
         }
       ]
     },
@@ -4938,28 +4938,28 @@
       "returnType": "void",
       "params": [
         {
-          "name": "posX",
-          "type": "int"
+          "type": "int",
+          "name": "posX"
         },
         {
-          "name": "posY",
-          "type": "int"
+          "type": "int",
+          "name": "posY"
         },
         {
-          "name": "width",
-          "type": "int"
+          "type": "int",
+          "name": "width"
         },
         {
-          "name": "height",
-          "type": "int"
+          "type": "int",
+          "name": "height"
         },
         {
-          "name": "color1",
-          "type": "Color"
+          "type": "Color",
+          "name": "color1"
         },
         {
-          "name": "color2",
-          "type": "Color"
+          "type": "Color",
+          "name": "color2"
         }
       ]
     },
@@ -4969,28 +4969,28 @@
       "returnType": "void",
       "params": [
         {
-          "name": "posX",
-          "type": "int"
+          "type": "int",
+          "name": "posX"
         },
         {
-          "name": "posY",
-          "type": "int"
+          "type": "int",
+          "name": "posY"
         },
         {
-          "name": "width",
-          "type": "int"
+          "type": "int",
+          "name": "width"
         },
         {
-          "name": "height",
-          "type": "int"
+          "type": "int",
+          "name": "height"
         },
         {
-          "name": "color1",
-          "type": "Color"
+          "type": "Color",
+          "name": "color1"
         },
         {
-          "name": "color2",
-          "type": "Color"
+          "type": "Color",
+          "name": "color2"
         }
       ]
     },
@@ -5000,24 +5000,24 @@
       "returnType": "void",
       "params": [
         {
-          "name": "rec",
-          "type": "Rectangle"
+          "type": "Rectangle",
+          "name": "rec"
         },
         {
-          "name": "col1",
-          "type": "Color"
+          "type": "Color",
+          "name": "col1"
         },
         {
-          "name": "col2",
-          "type": "Color"
+          "type": "Color",
+          "name": "col2"
         },
         {
-          "name": "col3",
-          "type": "Color"
+          "type": "Color",
+          "name": "col3"
         },
         {
-          "name": "col4",
-          "type": "Color"
+          "type": "Color",
+          "name": "col4"
         }
       ]
     },
@@ -5027,24 +5027,24 @@
       "returnType": "void",
       "params": [
         {
-          "name": "posX",
-          "type": "int"
+          "type": "int",
+          "name": "posX"
         },
         {
-          "name": "posY",
-          "type": "int"
+          "type": "int",
+          "name": "posY"
         },
         {
-          "name": "width",
-          "type": "int"
+          "type": "int",
+          "name": "width"
         },
         {
-          "name": "height",
-          "type": "int"
+          "type": "int",
+          "name": "height"
         },
         {
-          "name": "color",
-          "type": "Color"
+          "type": "Color",
+          "name": "color"
         }
       ]
     },
@@ -5054,16 +5054,16 @@
       "returnType": "void",
       "params": [
         {
-          "name": "rec",
-          "type": "Rectangle"
+          "type": "Rectangle",
+          "name": "rec"
         },
         {
-          "name": "lineThick",
-          "type": "float"
+          "type": "float",
+          "name": "lineThick"
         },
         {
-          "name": "color",
-          "type": "Color"
+          "type": "Color",
+          "name": "color"
         }
       ]
     },
@@ -5073,20 +5073,20 @@
       "returnType": "void",
       "params": [
         {
-          "name": "rec",
-          "type": "Rectangle"
+          "type": "Rectangle",
+          "name": "rec"
         },
         {
-          "name": "roundness",
-          "type": "float"
+          "type": "float",
+          "name": "roundness"
         },
         {
-          "name": "segments",
-          "type": "int"
+          "type": "int",
+          "name": "segments"
         },
         {
-          "name": "color",
-          "type": "Color"
+          "type": "Color",
+          "name": "color"
         }
       ]
     },
@@ -5096,24 +5096,24 @@
       "returnType": "void",
       "params": [
         {
-          "name": "rec",
-          "type": "Rectangle"
+          "type": "Rectangle",
+          "name": "rec"
         },
         {
-          "name": "roundness",
-          "type": "float"
+          "type": "float",
+          "name": "roundness"
         },
         {
-          "name": "segments",
-          "type": "int"
+          "type": "int",
+          "name": "segments"
         },
         {
-          "name": "lineThick",
-          "type": "float"
+          "type": "float",
+          "name": "lineThick"
         },
         {
-          "name": "color",
-          "type": "Color"
+          "type": "Color",
+          "name": "color"
         }
       ]
     },
@@ -5123,20 +5123,20 @@
       "returnType": "void",
       "params": [
         {
-          "name": "v1",
-          "type": "Vector2"
+          "type": "Vector2",
+          "name": "v1"
         },
         {
-          "name": "v2",
-          "type": "Vector2"
+          "type": "Vector2",
+          "name": "v2"
         },
         {
-          "name": "v3",
-          "type": "Vector2"
+          "type": "Vector2",
+          "name": "v3"
         },
         {
-          "name": "color",
-          "type": "Color"
+          "type": "Color",
+          "name": "color"
         }
       ]
     },
@@ -5146,20 +5146,20 @@
       "returnType": "void",
       "params": [
         {
-          "name": "v1",
-          "type": "Vector2"
+          "type": "Vector2",
+          "name": "v1"
         },
         {
-          "name": "v2",
-          "type": "Vector2"
+          "type": "Vector2",
+          "name": "v2"
         },
         {
-          "name": "v3",
-          "type": "Vector2"
+          "type": "Vector2",
+          "name": "v3"
         },
         {
-          "name": "color",
-          "type": "Color"
+          "type": "Color",
+          "name": "color"
         }
       ]
     },
@@ -5169,16 +5169,16 @@
       "returnType": "void",
       "params": [
         {
-          "name": "points",
-          "type": "Vector2 *"
+          "type": "Vector2 *",
+          "name": "points"
         },
         {
-          "name": "pointCount",
-          "type": "int"
+          "type": "int",
+          "name": "pointCount"
         },
         {
-          "name": "color",
-          "type": "Color"
+          "type": "Color",
+          "name": "color"
         }
       ]
     },
@@ -5188,16 +5188,16 @@
       "returnType": "void",
       "params": [
         {
-          "name": "points",
-          "type": "Vector2 *"
+          "type": "Vector2 *",
+          "name": "points"
         },
         {
-          "name": "pointCount",
-          "type": "int"
+          "type": "int",
+          "name": "pointCount"
         },
         {
-          "name": "color",
-          "type": "Color"
+          "type": "Color",
+          "name": "color"
         }
       ]
     },
@@ -5207,24 +5207,24 @@
       "returnType": "void",
       "params": [
         {
-          "name": "center",
-          "type": "Vector2"
+          "type": "Vector2",
+          "name": "center"
         },
         {
-          "name": "sides",
-          "type": "int"
+          "type": "int",
+          "name": "sides"
         },
         {
-          "name": "radius",
-          "type": "float"
+          "type": "float",
+          "name": "radius"
         },
         {
-          "name": "rotation",
-          "type": "float"
+          "type": "float",
+          "name": "rotation"
         },
         {
-          "name": "color",
-          "type": "Color"
+          "type": "Color",
+          "name": "color"
         }
       ]
     },
@@ -5234,24 +5234,24 @@
       "returnType": "void",
       "params": [
         {
-          "name": "center",
-          "type": "Vector2"
+          "type": "Vector2",
+          "name": "center"
         },
         {
-          "name": "sides",
-          "type": "int"
+          "type": "int",
+          "name": "sides"
         },
         {
-          "name": "radius",
-          "type": "float"
+          "type": "float",
+          "name": "radius"
         },
         {
-          "name": "rotation",
-          "type": "float"
+          "type": "float",
+          "name": "rotation"
         },
         {
-          "name": "color",
-          "type": "Color"
+          "type": "Color",
+          "name": "color"
         }
       ]
     },
@@ -5261,28 +5261,28 @@
       "returnType": "void",
       "params": [
         {
-          "name": "center",
-          "type": "Vector2"
+          "type": "Vector2",
+          "name": "center"
         },
         {
-          "name": "sides",
-          "type": "int"
+          "type": "int",
+          "name": "sides"
         },
         {
-          "name": "radius",
-          "type": "float"
+          "type": "float",
+          "name": "radius"
         },
         {
-          "name": "rotation",
-          "type": "float"
+          "type": "float",
+          "name": "rotation"
         },
         {
-          "name": "lineThick",
-          "type": "float"
+          "type": "float",
+          "name": "lineThick"
         },
         {
-          "name": "color",
-          "type": "Color"
+          "type": "Color",
+          "name": "color"
         }
       ]
     },
@@ -5292,12 +5292,12 @@
       "returnType": "bool",
       "params": [
         {
-          "name": "rec1",
-          "type": "Rectangle"
+          "type": "Rectangle",
+          "name": "rec1"
         },
         {
-          "name": "rec2",
-          "type": "Rectangle"
+          "type": "Rectangle",
+          "name": "rec2"
         }
       ]
     },
@@ -5307,20 +5307,20 @@
       "returnType": "bool",
       "params": [
         {
-          "name": "center1",
-          "type": "Vector2"
+          "type": "Vector2",
+          "name": "center1"
         },
         {
-          "name": "radius1",
-          "type": "float"
+          "type": "float",
+          "name": "radius1"
         },
         {
-          "name": "center2",
-          "type": "Vector2"
+          "type": "Vector2",
+          "name": "center2"
         },
         {
-          "name": "radius2",
-          "type": "float"
+          "type": "float",
+          "name": "radius2"
         }
       ]
     },
@@ -5330,16 +5330,16 @@
       "returnType": "bool",
       "params": [
         {
-          "name": "center",
-          "type": "Vector2"
+          "type": "Vector2",
+          "name": "center"
         },
         {
-          "name": "radius",
-          "type": "float"
+          "type": "float",
+          "name": "radius"
         },
         {
-          "name": "rec",
-          "type": "Rectangle"
+          "type": "Rectangle",
+          "name": "rec"
         }
       ]
     },
@@ -5349,12 +5349,12 @@
       "returnType": "bool",
       "params": [
         {
-          "name": "point",
-          "type": "Vector2"
+          "type": "Vector2",
+          "name": "point"
         },
         {
-          "name": "rec",
-          "type": "Rectangle"
+          "type": "Rectangle",
+          "name": "rec"
         }
       ]
     },
@@ -5364,16 +5364,16 @@
       "returnType": "bool",
       "params": [
         {
-          "name": "point",
-          "type": "Vector2"
+          "type": "Vector2",
+          "name": "point"
         },
         {
-          "name": "center",
-          "type": "Vector2"
+          "type": "Vector2",
+          "name": "center"
         },
         {
-          "name": "radius",
-          "type": "float"
+          "type": "float",
+          "name": "radius"
         }
       ]
     },
@@ -5383,20 +5383,20 @@
       "returnType": "bool",
       "params": [
         {
-          "name": "point",
-          "type": "Vector2"
+          "type": "Vector2",
+          "name": "point"
         },
         {
-          "name": "p1",
-          "type": "Vector2"
+          "type": "Vector2",
+          "name": "p1"
         },
         {
-          "name": "p2",
-          "type": "Vector2"
+          "type": "Vector2",
+          "name": "p2"
         },
         {
-          "name": "p3",
-          "type": "Vector2"
+          "type": "Vector2",
+          "name": "p3"
         }
       ]
     },
@@ -5406,24 +5406,24 @@
       "returnType": "bool",
       "params": [
         {
-          "name": "startPos1",
-          "type": "Vector2"
+          "type": "Vector2",
+          "name": "startPos1"
         },
         {
-          "name": "endPos1",
-          "type": "Vector2"
+          "type": "Vector2",
+          "name": "endPos1"
         },
         {
-          "name": "startPos2",
-          "type": "Vector2"
+          "type": "Vector2",
+          "name": "startPos2"
         },
         {
-          "name": "endPos2",
-          "type": "Vector2"
+          "type": "Vector2",
+          "name": "endPos2"
         },
         {
-          "name": "collisionPoint",
-          "type": "Vector2 *"
+          "type": "Vector2 *",
+          "name": "collisionPoint"
         }
       ]
     },
@@ -5433,20 +5433,20 @@
       "returnType": "bool",
       "params": [
         {
-          "name": "point",
-          "type": "Vector2"
+          "type": "Vector2",
+          "name": "point"
         },
         {
-          "name": "p1",
-          "type": "Vector2"
+          "type": "Vector2",
+          "name": "p1"
         },
         {
-          "name": "p2",
-          "type": "Vector2"
+          "type": "Vector2",
+          "name": "p2"
         },
         {
-          "name": "threshold",
-          "type": "int"
+          "type": "int",
+          "name": "threshold"
         }
       ]
     },
@@ -5456,12 +5456,12 @@
       "returnType": "Rectangle",
       "params": [
         {
-          "name": "rec1",
-          "type": "Rectangle"
+          "type": "Rectangle",
+          "name": "rec1"
         },
         {
-          "name": "rec2",
-          "type": "Rectangle"
+          "type": "Rectangle",
+          "name": "rec2"
         }
       ]
     },
@@ -5471,8 +5471,8 @@
       "returnType": "Image",
       "params": [
         {
-          "name": "fileName",
-          "type": "const char *"
+          "type": "const char *",
+          "name": "fileName"
         }
       ]
     },
@@ -5482,24 +5482,24 @@
       "returnType": "Image",
       "params": [
         {
-          "name": "fileName",
-          "type": "const char *"
+          "type": "const char *",
+          "name": "fileName"
         },
         {
-          "name": "width",
-          "type": "int"
+          "type": "int",
+          "name": "width"
         },
         {
-          "name": "height",
-          "type": "int"
+          "type": "int",
+          "name": "height"
         },
         {
-          "name": "format",
-          "type": "int"
+          "type": "int",
+          "name": "format"
         },
         {
-          "name": "headerSize",
-          "type": "int"
+          "type": "int",
+          "name": "headerSize"
         }
       ]
     },
@@ -5509,12 +5509,12 @@
       "returnType": "Image",
       "params": [
         {
-          "name": "fileName",
-          "type": "const char *"
+          "type": "const char *",
+          "name": "fileName"
         },
         {
-          "name": "frames",
-          "type": "int *"
+          "type": "int *",
+          "name": "frames"
         }
       ]
     },
@@ -5524,16 +5524,16 @@
       "returnType": "Image",
       "params": [
         {
-          "name": "fileType",
-          "type": "const char *"
+          "type": "const char *",
+          "name": "fileType"
         },
         {
-          "name": "fileData",
-          "type": "const unsigned char *"
+          "type": "const unsigned char *",
+          "name": "fileData"
         },
         {
-          "name": "dataSize",
-          "type": "int"
+          "type": "int",
+          "name": "dataSize"
         }
       ]
     },
@@ -5543,8 +5543,8 @@
       "returnType": "Image",
       "params": [
         {
-          "name": "texture",
-          "type": "Texture2D"
+          "type": "Texture2D",
+          "name": "texture"
         }
       ]
     },
@@ -5559,8 +5559,8 @@
       "returnType": "void",
       "params": [
         {
-          "name": "image",
-          "type": "Image"
+          "type": "Image",
+          "name": "image"
         }
       ]
     },
@@ -5570,12 +5570,12 @@
       "returnType": "bool",
       "params": [
         {
-          "name": "image",
-          "type": "Image"
+          "type": "Image",
+          "name": "image"
         },
         {
-          "name": "fileName",
-          "type": "const char *"
+          "type": "const char *",
+          "name": "fileName"
         }
       ]
     },
@@ -5585,12 +5585,12 @@
       "returnType": "bool",
       "params": [
         {
-          "name": "image",
-          "type": "Image"
+          "type": "Image",
+          "name": "image"
         },
         {
-          "name": "fileName",
-          "type": "const char *"
+          "type": "const char *",
+          "name": "fileName"
         }
       ]
     },
@@ -5600,16 +5600,16 @@
       "returnType": "Image",
       "params": [
         {
-          "name": "width",
-          "type": "int"
+          "type": "int",
+          "name": "width"
         },
         {
-          "name": "height",
-          "type": "int"
+          "type": "int",
+          "name": "height"
         },
         {
-          "name": "color",
-          "type": "Color"
+          "type": "Color",
+          "name": "color"
         }
       ]
     },
@@ -5619,20 +5619,20 @@
       "returnType": "Image",
       "params": [
         {
-          "name": "width",
-          "type": "int"
+          "type": "int",
+          "name": "width"
         },
         {
-          "name": "height",
-          "type": "int"
+          "type": "int",
+          "name": "height"
         },
         {
-          "name": "top",
-          "type": "Color"
+          "type": "Color",
+          "name": "top"
         },
         {
-          "name": "bottom",
-          "type": "Color"
+          "type": "Color",
+          "name": "bottom"
         }
       ]
     },
@@ -5642,20 +5642,20 @@
       "returnType": "Image",
       "params": [
         {
-          "name": "width",
-          "type": "int"
+          "type": "int",
+          "name": "width"
         },
         {
-          "name": "height",
-          "type": "int"
+          "type": "int",
+          "name": "height"
         },
         {
-          "name": "left",
-          "type": "Color"
+          "type": "Color",
+          "name": "left"
         },
         {
-          "name": "right",
-          "type": "Color"
+          "type": "Color",
+          "name": "right"
         }
       ]
     },
@@ -5665,24 +5665,24 @@
       "returnType": "Image",
       "params": [
         {
-          "name": "width",
-          "type": "int"
+          "type": "int",
+          "name": "width"
         },
         {
-          "name": "height",
-          "type": "int"
+          "type": "int",
+          "name": "height"
         },
         {
-          "name": "density",
-          "type": "float"
+          "type": "float",
+          "name": "density"
         },
         {
-          "name": "inner",
-          "type": "Color"
+          "type": "Color",
+          "name": "inner"
         },
         {
-          "name": "outer",
-          "type": "Color"
+          "type": "Color",
+          "name": "outer"
         }
       ]
     },
@@ -5692,28 +5692,28 @@
       "returnType": "Image",
       "params": [
         {
-          "name": "width",
-          "type": "int"
+          "type": "int",
+          "name": "width"
         },
         {
-          "name": "height",
-          "type": "int"
+          "type": "int",
+          "name": "height"
         },
         {
-          "name": "checksX",
-          "type": "int"
+          "type": "int",
+          "name": "checksX"
         },
         {
-          "name": "checksY",
-          "type": "int"
+          "type": "int",
+          "name": "checksY"
         },
         {
-          "name": "col1",
-          "type": "Color"
+          "type": "Color",
+          "name": "col1"
         },
         {
-          "name": "col2",
-          "type": "Color"
+          "type": "Color",
+          "name": "col2"
         }
       ]
     },
@@ -5723,16 +5723,16 @@
       "returnType": "Image",
       "params": [
         {
-          "name": "width",
-          "type": "int"
+          "type": "int",
+          "name": "width"
         },
         {
-          "name": "height",
-          "type": "int"
+          "type": "int",
+          "name": "height"
         },
         {
-          "name": "factor",
-          "type": "float"
+          "type": "float",
+          "name": "factor"
         }
       ]
     },
@@ -5742,16 +5742,16 @@
       "returnType": "Image",
       "params": [
         {
-          "name": "width",
-          "type": "int"
+          "type": "int",
+          "name": "width"
         },
         {
-          "name": "height",
-          "type": "int"
+          "type": "int",
+          "name": "height"
         },
         {
-          "name": "tileSize",
-          "type": "int"
+          "type": "int",
+          "name": "tileSize"
         }
       ]
     },
@@ -5761,8 +5761,8 @@
       "returnType": "Image",
       "params": [
         {
-          "name": "image",
-          "type": "Image"
+          "type": "Image",
+          "name": "image"
         }
       ]
     },
@@ -5772,12 +5772,12 @@
       "returnType": "Image",
       "params": [
         {
-          "name": "image",
-          "type": "Image"
+          "type": "Image",
+          "name": "image"
         },
         {
-          "name": "rec",
-          "type": "Rectangle"
+          "type": "Rectangle",
+          "name": "rec"
         }
       ]
     },
@@ -5787,16 +5787,16 @@
       "returnType": "Image",
       "params": [
         {
-          "name": "text",
-          "type": "const char *"
+          "type": "const char *",
+          "name": "text"
         },
         {
-          "name": "fontSize",
-          "type": "int"
+          "type": "int",
+          "name": "fontSize"
         },
         {
-          "name": "color",
-          "type": "Color"
+          "type": "Color",
+          "name": "color"
         }
       ]
     },
@@ -5806,24 +5806,24 @@
       "returnType": "Image",
       "params": [
         {
-          "name": "font",
-          "type": "Font"
+          "type": "Font",
+          "name": "font"
         },
         {
-          "name": "text",
-          "type": "const char *"
+          "type": "const char *",
+          "name": "text"
         },
         {
-          "name": "fontSize",
-          "type": "float"
+          "type": "float",
+          "name": "fontSize"
         },
         {
-          "name": "spacing",
-          "type": "float"
+          "type": "float",
+          "name": "spacing"
         },
         {
-          "name": "tint",
-          "type": "Color"
+          "type": "Color",
+          "name": "tint"
         }
       ]
     },
@@ -5833,12 +5833,12 @@
       "returnType": "void",
       "params": [
         {
-          "name": "image",
-          "type": "Image *"
+          "type": "Image *",
+          "name": "image"
         },
         {
-          "name": "newFormat",
-          "type": "int"
+          "type": "int",
+          "name": "newFormat"
         }
       ]
     },
@@ -5848,12 +5848,12 @@
       "returnType": "void",
       "params": [
         {
-          "name": "image",
-          "type": "Image *"
+          "type": "Image *",
+          "name": "image"
         },
         {
-          "name": "fill",
-          "type": "Color"
+          "type": "Color",
+          "name": "fill"
         }
       ]
     },
@@ -5863,12 +5863,12 @@
       "returnType": "void",
       "params": [
         {
-          "name": "image",
-          "type": "Image *"
+          "type": "Image *",
+          "name": "image"
         },
         {
-          "name": "crop",
-          "type": "Rectangle"
+          "type": "Rectangle",
+          "name": "crop"
         }
       ]
     },
@@ -5878,12 +5878,12 @@
       "returnType": "void",
       "params": [
         {
-          "name": "image",
-          "type": "Image *"
+          "type": "Image *",
+          "name": "image"
         },
         {
-          "name": "threshold",
-          "type": "float"
+          "type": "float",
+          "name": "threshold"
         }
       ]
     },
@@ -5893,16 +5893,16 @@
       "returnType": "void",
       "params": [
         {
-          "name": "image",
-          "type": "Image *"
+          "type": "Image *",
+          "name": "image"
         },
         {
-          "name": "color",
-          "type": "Color"
+          "type": "Color",
+          "name": "color"
         },
         {
-          "name": "threshold",
-          "type": "float"
+          "type": "float",
+          "name": "threshold"
         }
       ]
     },
@@ -5912,12 +5912,12 @@
       "returnType": "void",
       "params": [
         {
-          "name": "image",
-          "type": "Image *"
+          "type": "Image *",
+          "name": "image"
         },
         {
-          "name": "alphaMask",
-          "type": "Image"
+          "type": "Image",
+          "name": "alphaMask"
         }
       ]
     },
@@ -5927,8 +5927,8 @@
       "returnType": "void",
       "params": [
         {
-          "name": "image",
-          "type": "Image *"
+          "type": "Image *",
+          "name": "image"
         }
       ]
     },
@@ -5938,16 +5938,16 @@
       "returnType": "void",
       "params": [
         {
-          "name": "image",
-          "type": "Image *"
+          "type": "Image *",
+          "name": "image"
         },
         {
-          "name": "newWidth",
-          "type": "int"
+          "type": "int",
+          "name": "newWidth"
         },
         {
-          "name": "newHeight",
-          "type": "int"
+          "type": "int",
+          "name": "newHeight"
         }
       ]
     },
@@ -5957,16 +5957,16 @@
       "returnType": "void",
       "params": [
         {
-          "name": "image",
-          "type": "Image *"
+          "type": "Image *",
+          "name": "image"
         },
         {
-          "name": "newWidth",
-          "type": "int"
+          "type": "int",
+          "name": "newWidth"
         },
         {
-          "name": "newHeight",
-          "type": "int"
+          "type": "int",
+          "name": "newHeight"
         }
       ]
     },
@@ -5976,28 +5976,28 @@
       "returnType": "void",
       "params": [
         {
-          "name": "image",
-          "type": "Image *"
+          "type": "Image *",
+          "name": "image"
         },
         {
-          "name": "newWidth",
-          "type": "int"
+          "type": "int",
+          "name": "newWidth"
         },
         {
-          "name": "newHeight",
-          "type": "int"
+          "type": "int",
+          "name": "newHeight"
         },
         {
-          "name": "offsetX",
-          "type": "int"
+          "type": "int",
+          "name": "offsetX"
         },
         {
-          "name": "offsetY",
-          "type": "int"
+          "type": "int",
+          "name": "offsetY"
         },
         {
-          "name": "fill",
-          "type": "Color"
+          "type": "Color",
+          "name": "fill"
         }
       ]
     },
@@ -6007,8 +6007,8 @@
       "returnType": "void",
       "params": [
         {
-          "name": "image",
-          "type": "Image *"
+          "type": "Image *",
+          "name": "image"
         }
       ]
     },
@@ -6018,24 +6018,24 @@
       "returnType": "void",
       "params": [
         {
-          "name": "image",
-          "type": "Image *"
+          "type": "Image *",
+          "name": "image"
         },
         {
-          "name": "rBpp",
-          "type": "int"
+          "type": "int",
+          "name": "rBpp"
         },
         {
-          "name": "gBpp",
-          "type": "int"
+          "type": "int",
+          "name": "gBpp"
         },
         {
-          "name": "bBpp",
-          "type": "int"
+          "type": "int",
+          "name": "bBpp"
         },
         {
-          "name": "aBpp",
-          "type": "int"
+          "type": "int",
+          "name": "aBpp"
         }
       ]
     },
@@ -6045,8 +6045,8 @@
       "returnType": "void",
       "params": [
         {
-          "name": "image",
-          "type": "Image *"
+          "type": "Image *",
+          "name": "image"
         }
       ]
     },
@@ -6056,8 +6056,8 @@
       "returnType": "void",
       "params": [
         {
-          "name": "image",
-          "type": "Image *"
+          "type": "Image *",
+          "name": "image"
         }
       ]
     },
@@ -6067,8 +6067,8 @@
       "returnType": "void",
       "params": [
         {
-          "name": "image",
-          "type": "Image *"
+          "type": "Image *",
+          "name": "image"
         }
       ]
     },
@@ -6078,8 +6078,8 @@
       "returnType": "void",
       "params": [
         {
-          "name": "image",
-          "type": "Image *"
+          "type": "Image *",
+          "name": "image"
         }
       ]
     },
@@ -6089,12 +6089,12 @@
       "returnType": "void",
       "params": [
         {
-          "name": "image",
-          "type": "Image *"
+          "type": "Image *",
+          "name": "image"
         },
         {
-          "name": "color",
-          "type": "Color"
+          "type": "Color",
+          "name": "color"
         }
       ]
     },
@@ -6104,8 +6104,8 @@
       "returnType": "void",
       "params": [
         {
-          "name": "image",
-          "type": "Image *"
+          "type": "Image *",
+          "name": "image"
         }
       ]
     },
@@ -6115,8 +6115,8 @@
       "returnType": "void",
       "params": [
         {
-          "name": "image",
-          "type": "Image *"
+          "type": "Image *",
+          "name": "image"
         }
       ]
     },
@@ -6126,12 +6126,12 @@
       "returnType": "void",
       "params": [
         {
-          "name": "image",
-          "type": "Image *"
+          "type": "Image *",
+          "name": "image"
         },
         {
-          "name": "contrast",
-          "type": "float"
+          "type": "float",
+          "name": "contrast"
         }
       ]
     },
@@ -6141,12 +6141,12 @@
       "returnType": "void",
       "params": [
         {
-          "name": "image",
-          "type": "Image *"
+          "type": "Image *",
+          "name": "image"
         },
         {
-          "name": "brightness",
-          "type": "int"
+          "type": "int",
+          "name": "brightness"
         }
       ]
     },
@@ -6156,16 +6156,16 @@
       "returnType": "void",
       "params": [
         {
-          "name": "image",
-          "type": "Image *"
+          "type": "Image *",
+          "name": "image"
         },
         {
-          "name": "color",
-          "type": "Color"
+          "type": "Color",
+          "name": "color"
         },
         {
-          "name": "replace",
-          "type": "Color"
+          "type": "Color",
+          "name": "replace"
         }
       ]
     },
@@ -6175,8 +6175,8 @@
       "returnType": "Color *",
       "params": [
         {
-          "name": "image",
-          "type": "Image"
+          "type": "Image",
+          "name": "image"
         }
       ]
     },
@@ -6186,16 +6186,16 @@
       "returnType": "Color *",
       "params": [
         {
-          "name": "image",
-          "type": "Image"
+          "type": "Image",
+          "name": "image"
         },
         {
-          "name": "maxPaletteSize",
-          "type": "int"
+          "type": "int",
+          "name": "maxPaletteSize"
         },
         {
-          "name": "colorCount",
-          "type": "int *"
+          "type": "int *",
+          "name": "colorCount"
         }
       ]
     },
@@ -6205,8 +6205,8 @@
       "returnType": "void",
       "params": [
         {
-          "name": "colors",
-          "type": "Color *"
+          "type": "Color *",
+          "name": "colors"
         }
       ]
     },
@@ -6216,8 +6216,8 @@
       "returnType": "void",
       "params": [
         {
-          "name": "colors",
-          "type": "Color *"
+          "type": "Color *",
+          "name": "colors"
         }
       ]
     },
@@ -6227,12 +6227,12 @@
       "returnType": "Rectangle",
       "params": [
         {
-          "name": "image",
-          "type": "Image"
+          "type": "Image",
+          "name": "image"
         },
         {
-          "name": "threshold",
-          "type": "float"
+          "type": "float",
+          "name": "threshold"
         }
       ]
     },
@@ -6242,16 +6242,16 @@
       "returnType": "Color",
       "params": [
         {
-          "name": "image",
-          "type": "Image"
+          "type": "Image",
+          "name": "image"
         },
         {
-          "name": "x",
-          "type": "int"
+          "type": "int",
+          "name": "x"
         },
         {
-          "name": "y",
-          "type": "int"
+          "type": "int",
+          "name": "y"
         }
       ]
     },
@@ -6261,12 +6261,12 @@
       "returnType": "void",
       "params": [
         {
-          "name": "dst",
-          "type": "Image *"
+          "type": "Image *",
+          "name": "dst"
         },
         {
-          "name": "color",
-          "type": "Color"
+          "type": "Color",
+          "name": "color"
         }
       ]
     },
@@ -6276,20 +6276,20 @@
       "returnType": "void",
       "params": [
         {
-          "name": "dst",
-          "type": "Image *"
+          "type": "Image *",
+          "name": "dst"
         },
         {
-          "name": "posX",
-          "type": "int"
+          "type": "int",
+          "name": "posX"
         },
         {
-          "name": "posY",
-          "type": "int"
+          "type": "int",
+          "name": "posY"
         },
         {
-          "name": "color",
-          "type": "Color"
+          "type": "Color",
+          "name": "color"
         }
       ]
     },
@@ -6299,16 +6299,16 @@
       "returnType": "void",
       "params": [
         {
-          "name": "dst",
-          "type": "Image *"
+          "type": "Image *",
+          "name": "dst"
         },
         {
-          "name": "position",
-          "type": "Vector2"
+          "type": "Vector2",
+          "name": "position"
         },
         {
-          "name": "color",
-          "type": "Color"
+          "type": "Color",
+          "name": "color"
         }
       ]
     },
@@ -6318,28 +6318,28 @@
       "returnType": "void",
       "params": [
         {
-          "name": "dst",
-          "type": "Image *"
+          "type": "Image *",
+          "name": "dst"
         },
         {
-          "name": "startPosX",
-          "type": "int"
+          "type": "int",
+          "name": "startPosX"
         },
         {
-          "name": "startPosY",
-          "type": "int"
+          "type": "int",
+          "name": "startPosY"
         },
         {
-          "name": "endPosX",
-          "type": "int"
+          "type": "int",
+          "name": "endPosX"
         },
         {
-          "name": "endPosY",
-          "type": "int"
+          "type": "int",
+          "name": "endPosY"
         },
         {
-          "name": "color",
-          "type": "Color"
+          "type": "Color",
+          "name": "color"
         }
       ]
     },
@@ -6349,20 +6349,20 @@
       "returnType": "void",
       "params": [
         {
-          "name": "dst",
-          "type": "Image *"
+          "type": "Image *",
+          "name": "dst"
         },
         {
-          "name": "start",
-          "type": "Vector2"
+          "type": "Vector2",
+          "name": "start"
         },
         {
-          "name": "end",
-          "type": "Vector2"
+          "type": "Vector2",
+          "name": "end"
         },
         {
-          "name": "color",
-          "type": "Color"
+          "type": "Color",
+          "name": "color"
         }
       ]
     },
@@ -6372,24 +6372,24 @@
       "returnType": "void",
       "params": [
         {
-          "name": "dst",
-          "type": "Image *"
+          "type": "Image *",
+          "name": "dst"
         },
         {
-          "name": "centerX",
-          "type": "int"
+          "type": "int",
+          "name": "centerX"
         },
         {
-          "name": "centerY",
-          "type": "int"
+          "type": "int",
+          "name": "centerY"
         },
         {
-          "name": "radius",
-          "type": "int"
+          "type": "int",
+          "name": "radius"
         },
         {
-          "name": "color",
-          "type": "Color"
+          "type": "Color",
+          "name": "color"
         }
       ]
     },
@@ -6399,20 +6399,20 @@
       "returnType": "void",
       "params": [
         {
-          "name": "dst",
-          "type": "Image *"
+          "type": "Image *",
+          "name": "dst"
         },
         {
-          "name": "center",
-          "type": "Vector2"
+          "type": "Vector2",
+          "name": "center"
         },
         {
-          "name": "radius",
-          "type": "int"
+          "type": "int",
+          "name": "radius"
         },
         {
-          "name": "color",
-          "type": "Color"
+          "type": "Color",
+          "name": "color"
         }
       ]
     },
@@ -6422,28 +6422,28 @@
       "returnType": "void",
       "params": [
         {
-          "name": "dst",
-          "type": "Image *"
+          "type": "Image *",
+          "name": "dst"
         },
         {
-          "name": "posX",
-          "type": "int"
+          "type": "int",
+          "name": "posX"
         },
         {
-          "name": "posY",
-          "type": "int"
+          "type": "int",
+          "name": "posY"
         },
         {
-          "name": "width",
-          "type": "int"
+          "type": "int",
+          "name": "width"
         },
         {
-          "name": "height",
-          "type": "int"
+          "type": "int",
+          "name": "height"
         },
         {
-          "name": "color",
-          "type": "Color"
+          "type": "Color",
+          "name": "color"
         }
       ]
     },
@@ -6453,20 +6453,20 @@
       "returnType": "void",
       "params": [
         {
-          "name": "dst",
-          "type": "Image *"
+          "type": "Image *",
+          "name": "dst"
         },
         {
-          "name": "position",
-          "type": "Vector2"
+          "type": "Vector2",
+          "name": "position"
         },
         {
-          "name": "size",
-          "type": "Vector2"
+          "type": "Vector2",
+          "name": "size"
         },
         {
-          "name": "color",
-          "type": "Color"
+          "type": "Color",
+          "name": "color"
         }
       ]
     },
@@ -6476,16 +6476,16 @@
       "returnType": "void",
       "params": [
         {
-          "name": "dst",
-          "type": "Image *"
+          "type": "Image *",
+          "name": "dst"
         },
         {
-          "name": "rec",
-          "type": "Rectangle"
+          "type": "Rectangle",
+          "name": "rec"
         },
         {
-          "name": "color",
-          "type": "Color"
+          "type": "Color",
+          "name": "color"
         }
       ]
     },
@@ -6495,20 +6495,20 @@
       "returnType": "void",
       "params": [
         {
-          "name": "dst",
-          "type": "Image *"
+          "type": "Image *",
+          "name": "dst"
         },
         {
-          "name": "rec",
-          "type": "Rectangle"
+          "type": "Rectangle",
+          "name": "rec"
         },
         {
-          "name": "thick",
-          "type": "int"
+          "type": "int",
+          "name": "thick"
         },
         {
-          "name": "color",
-          "type": "Color"
+          "type": "Color",
+          "name": "color"
         }
       ]
     },
@@ -6518,24 +6518,24 @@
       "returnType": "void",
       "params": [
         {
-          "name": "dst",
-          "type": "Image *"
+          "type": "Image *",
+          "name": "dst"
         },
         {
-          "name": "src",
-          "type": "Image"
+          "type": "Image",
+          "name": "src"
         },
         {
-          "name": "srcRec",
-          "type": "Rectangle"
+          "type": "Rectangle",
+          "name": "srcRec"
         },
         {
-          "name": "dstRec",
-          "type": "Rectangle"
+          "type": "Rectangle",
+          "name": "dstRec"
         },
         {
-          "name": "tint",
-          "type": "Color"
+          "type": "Color",
+          "name": "tint"
         }
       ]
     },
@@ -6545,28 +6545,28 @@
       "returnType": "void",
       "params": [
         {
-          "name": "dst",
-          "type": "Image *"
+          "type": "Image *",
+          "name": "dst"
         },
         {
-          "name": "text",
-          "type": "const char *"
+          "type": "const char *",
+          "name": "text"
         },
         {
-          "name": "posX",
-          "type": "int"
+          "type": "int",
+          "name": "posX"
         },
         {
-          "name": "posY",
-          "type": "int"
+          "type": "int",
+          "name": "posY"
         },
         {
-          "name": "fontSize",
-          "type": "int"
+          "type": "int",
+          "name": "fontSize"
         },
         {
-          "name": "color",
-          "type": "Color"
+          "type": "Color",
+          "name": "color"
         }
       ]
     },
@@ -6576,32 +6576,32 @@
       "returnType": "void",
       "params": [
         {
-          "name": "dst",
-          "type": "Image *"
+          "type": "Image *",
+          "name": "dst"
         },
         {
-          "name": "font",
-          "type": "Font"
+          "type": "Font",
+          "name": "font"
         },
         {
-          "name": "text",
-          "type": "const char *"
+          "type": "const char *",
+          "name": "text"
         },
         {
-          "name": "position",
-          "type": "Vector2"
+          "type": "Vector2",
+          "name": "position"
         },
         {
-          "name": "fontSize",
-          "type": "float"
+          "type": "float",
+          "name": "fontSize"
         },
         {
-          "name": "spacing",
-          "type": "float"
+          "type": "float",
+          "name": "spacing"
         },
         {
-          "name": "tint",
-          "type": "Color"
+          "type": "Color",
+          "name": "tint"
         }
       ]
     },
@@ -6611,8 +6611,8 @@
       "returnType": "Texture2D",
       "params": [
         {
-          "name": "fileName",
-          "type": "const char *"
+          "type": "const char *",
+          "name": "fileName"
         }
       ]
     },
@@ -6622,8 +6622,8 @@
       "returnType": "Texture2D",
       "params": [
         {
-          "name": "image",
-          "type": "Image"
+          "type": "Image",
+          "name": "image"
         }
       ]
     },
@@ -6633,12 +6633,12 @@
       "returnType": "TextureCubemap",
       "params": [
         {
-          "name": "image",
-          "type": "Image"
+          "type": "Image",
+          "name": "image"
         },
         {
-          "name": "layout",
-          "type": "int"
+          "type": "int",
+          "name": "layout"
         }
       ]
     },
@@ -6648,12 +6648,12 @@
       "returnType": "RenderTexture2D",
       "params": [
         {
-          "name": "width",
-          "type": "int"
+          "type": "int",
+          "name": "width"
         },
         {
-          "name": "height",
-          "type": "int"
+          "type": "int",
+          "name": "height"
         }
       ]
     },
@@ -6663,8 +6663,8 @@
       "returnType": "void",
       "params": [
         {
-          "name": "texture",
-          "type": "Texture2D"
+          "type": "Texture2D",
+          "name": "texture"
         }
       ]
     },
@@ -6674,8 +6674,8 @@
       "returnType": "void",
       "params": [
         {
-          "name": "target",
-          "type": "RenderTexture2D"
+          "type": "RenderTexture2D",
+          "name": "target"
         }
       ]
     },
@@ -6685,12 +6685,12 @@
       "returnType": "void",
       "params": [
         {
-          "name": "texture",
-          "type": "Texture2D"
+          "type": "Texture2D",
+          "name": "texture"
         },
         {
-          "name": "pixels",
-          "type": "const void *"
+          "type": "const void *",
+          "name": "pixels"
         }
       ]
     },
@@ -6700,16 +6700,16 @@
       "returnType": "void",
       "params": [
         {
-          "name": "texture",
-          "type": "Texture2D"
+          "type": "Texture2D",
+          "name": "texture"
         },
         {
-          "name": "rec",
-          "type": "Rectangle"
+          "type": "Rectangle",
+          "name": "rec"
         },
         {
-          "name": "pixels",
-          "type": "const void *"
+          "type": "const void *",
+          "name": "pixels"
         }
       ]
     },
@@ -6719,8 +6719,8 @@
       "returnType": "void",
       "params": [
         {
-          "name": "texture",
-          "type": "Texture2D *"
+          "type": "Texture2D *",
+          "name": "texture"
         }
       ]
     },
@@ -6730,12 +6730,12 @@
       "returnType": "void",
       "params": [
         {
-          "name": "texture",
-          "type": "Texture2D"
+          "type": "Texture2D",
+          "name": "texture"
         },
         {
-          "name": "filter",
-          "type": "int"
+          "type": "int",
+          "name": "filter"
         }
       ]
     },
@@ -6745,12 +6745,12 @@
       "returnType": "void",
       "params": [
         {
-          "name": "texture",
-          "type": "Texture2D"
+          "type": "Texture2D",
+          "name": "texture"
         },
         {
-          "name": "wrap",
-          "type": "int"
+          "type": "int",
+          "name": "wrap"
         }
       ]
     },
@@ -6760,20 +6760,20 @@
       "returnType": "void",
       "params": [
         {
-          "name": "texture",
-          "type": "Texture2D"
+          "type": "Texture2D",
+          "name": "texture"
         },
         {
-          "name": "posX",
-          "type": "int"
+          "type": "int",
+          "name": "posX"
         },
         {
-          "name": "posY",
-          "type": "int"
+          "type": "int",
+          "name": "posY"
         },
         {
-          "name": "tint",
-          "type": "Color"
+          "type": "Color",
+          "name": "tint"
         }
       ]
     },
@@ -6783,16 +6783,16 @@
       "returnType": "void",
       "params": [
         {
-          "name": "texture",
-          "type": "Texture2D"
+          "type": "Texture2D",
+          "name": "texture"
         },
         {
-          "name": "position",
-          "type": "Vector2"
+          "type": "Vector2",
+          "name": "position"
         },
         {
-          "name": "tint",
-          "type": "Color"
+          "type": "Color",
+          "name": "tint"
         }
       ]
     },
@@ -6802,24 +6802,24 @@
       "returnType": "void",
       "params": [
         {
-          "name": "texture",
-          "type": "Texture2D"
+          "type": "Texture2D",
+          "name": "texture"
         },
         {
-          "name": "position",
-          "type": "Vector2"
+          "type": "Vector2",
+          "name": "position"
         },
         {
-          "name": "rotation",
-          "type": "float"
+          "type": "float",
+          "name": "rotation"
         },
         {
-          "name": "scale",
-          "type": "float"
+          "type": "float",
+          "name": "scale"
         },
         {
-          "name": "tint",
-          "type": "Color"
+          "type": "Color",
+          "name": "tint"
         }
       ]
     },
@@ -6829,20 +6829,20 @@
       "returnType": "void",
       "params": [
         {
-          "name": "texture",
-          "type": "Texture2D"
+          "type": "Texture2D",
+          "name": "texture"
         },
         {
-          "name": "source",
-          "type": "Rectangle"
+          "type": "Rectangle",
+          "name": "source"
         },
         {
-          "name": "position",
-          "type": "Vector2"
+          "type": "Vector2",
+          "name": "position"
         },
         {
-          "name": "tint",
-          "type": "Color"
+          "type": "Color",
+          "name": "tint"
         }
       ]
     },
@@ -6852,24 +6852,24 @@
       "returnType": "void",
       "params": [
         {
-          "name": "texture",
-          "type": "Texture2D"
+          "type": "Texture2D",
+          "name": "texture"
         },
         {
-          "name": "tiling",
-          "type": "Vector2"
+          "type": "Vector2",
+          "name": "tiling"
         },
         {
-          "name": "offset",
-          "type": "Vector2"
+          "type": "Vector2",
+          "name": "offset"
         },
         {
-          "name": "quad",
-          "type": "Rectangle"
+          "type": "Rectangle",
+          "name": "quad"
         },
         {
-          "name": "tint",
-          "type": "Color"
+          "type": "Color",
+          "name": "tint"
         }
       ]
     },
@@ -6879,32 +6879,32 @@
       "returnType": "void",
       "params": [
         {
-          "name": "texture",
-          "type": "Texture2D"
+          "type": "Texture2D",
+          "name": "texture"
         },
         {
-          "name": "source",
-          "type": "Rectangle"
+          "type": "Rectangle",
+          "name": "source"
         },
         {
-          "name": "dest",
-          "type": "Rectangle"
+          "type": "Rectangle",
+          "name": "dest"
         },
         {
-          "name": "origin",
-          "type": "Vector2"
+          "type": "Vector2",
+          "name": "origin"
         },
         {
-          "name": "rotation",
-          "type": "float"
+          "type": "float",
+          "name": "rotation"
         },
         {
-          "name": "scale",
-          "type": "float"
+          "type": "float",
+          "name": "scale"
         },
         {
-          "name": "tint",
-          "type": "Color"
+          "type": "Color",
+          "name": "tint"
         }
       ]
     },
@@ -6914,28 +6914,28 @@
       "returnType": "void",
       "params": [
         {
-          "name": "texture",
-          "type": "Texture2D"
+          "type": "Texture2D",
+          "name": "texture"
         },
         {
-          "name": "source",
-          "type": "Rectangle"
+          "type": "Rectangle",
+          "name": "source"
         },
         {
-          "name": "dest",
-          "type": "Rectangle"
+          "type": "Rectangle",
+          "name": "dest"
         },
         {
-          "name": "origin",
-          "type": "Vector2"
+          "type": "Vector2",
+          "name": "origin"
         },
         {
-          "name": "rotation",
-          "type": "float"
+          "type": "float",
+          "name": "rotation"
         },
         {
-          "name": "tint",
-          "type": "Color"
+          "type": "Color",
+          "name": "tint"
         }
       ]
     },
@@ -6945,28 +6945,28 @@
       "returnType": "void",
       "params": [
         {
-          "name": "texture",
-          "type": "Texture2D"
+          "type": "Texture2D",
+          "name": "texture"
         },
         {
-          "name": "nPatchInfo",
-          "type": "NPatchInfo"
+          "type": "NPatchInfo",
+          "name": "nPatchInfo"
         },
         {
-          "name": "dest",
-          "type": "Rectangle"
+          "type": "Rectangle",
+          "name": "dest"
         },
         {
-          "name": "origin",
-          "type": "Vector2"
+          "type": "Vector2",
+          "name": "origin"
         },
         {
-          "name": "rotation",
-          "type": "float"
+          "type": "float",
+          "name": "rotation"
         },
         {
-          "name": "tint",
-          "type": "Color"
+          "type": "Color",
+          "name": "tint"
         }
       ]
     },
@@ -6976,28 +6976,28 @@
       "returnType": "void",
       "params": [
         {
-          "name": "texture",
-          "type": "Texture2D"
+          "type": "Texture2D",
+          "name": "texture"
         },
         {
-          "name": "center",
-          "type": "Vector2"
+          "type": "Vector2",
+          "name": "center"
         },
         {
-          "name": "points",
-          "type": "Vector2 *"
+          "type": "Vector2 *",
+          "name": "points"
         },
         {
-          "name": "texcoords",
-          "type": "Vector2 *"
+          "type": "Vector2 *",
+          "name": "texcoords"
         },
         {
-          "name": "pointCount",
-          "type": "int"
+          "type": "int",
+          "name": "pointCount"
         },
         {
-          "name": "tint",
-          "type": "Color"
+          "type": "Color",
+          "name": "tint"
         }
       ]
     },
@@ -7007,12 +7007,12 @@
       "returnType": "Color",
       "params": [
         {
-          "name": "color",
-          "type": "Color"
+          "type": "Color",
+          "name": "color"
         },
         {
-          "name": "alpha",
-          "type": "float"
+          "type": "float",
+          "name": "alpha"
         }
       ]
     },
@@ -7022,8 +7022,8 @@
       "returnType": "int",
       "params": [
         {
-          "name": "color",
-          "type": "Color"
+          "type": "Color",
+          "name": "color"
         }
       ]
     },
@@ -7033,8 +7033,8 @@
       "returnType": "Vector4",
       "params": [
         {
-          "name": "color",
-          "type": "Color"
+          "type": "Color",
+          "name": "color"
         }
       ]
     },
@@ -7044,8 +7044,8 @@
       "returnType": "Color",
       "params": [
         {
-          "name": "normalized",
-          "type": "Vector4"
+          "type": "Vector4",
+          "name": "normalized"
         }
       ]
     },
@@ -7055,8 +7055,8 @@
       "returnType": "Vector3",
       "params": [
         {
-          "name": "color",
-          "type": "Color"
+          "type": "Color",
+          "name": "color"
         }
       ]
     },
@@ -7066,16 +7066,16 @@
       "returnType": "Color",
       "params": [
         {
-          "name": "hue",
-          "type": "float"
+          "type": "float",
+          "name": "hue"
         },
         {
-          "name": "saturation",
-          "type": "float"
+          "type": "float",
+          "name": "saturation"
         },
         {
-          "name": "value",
-          "type": "float"
+          "type": "float",
+          "name": "value"
         }
       ]
     },
@@ -7085,12 +7085,12 @@
       "returnType": "Color",
       "params": [
         {
-          "name": "color",
-          "type": "Color"
+          "type": "Color",
+          "name": "color"
         },
         {
-          "name": "alpha",
-          "type": "float"
+          "type": "float",
+          "name": "alpha"
         }
       ]
     },
@@ -7100,16 +7100,16 @@
       "returnType": "Color",
       "params": [
         {
-          "name": "dst",
-          "type": "Color"
+          "type": "Color",
+          "name": "dst"
         },
         {
-          "name": "src",
-          "type": "Color"
+          "type": "Color",
+          "name": "src"
         },
         {
-          "name": "tint",
-          "type": "Color"
+          "type": "Color",
+          "name": "tint"
         }
       ]
     },
@@ -7119,8 +7119,8 @@
       "returnType": "Color",
       "params": [
         {
-          "name": "hexValue",
-          "type": "unsigned int"
+          "type": "unsigned int",
+          "name": "hexValue"
         }
       ]
     },
@@ -7130,12 +7130,12 @@
       "returnType": "Color",
       "params": [
         {
-          "name": "srcPtr",
-          "type": "void *"
+          "type": "void *",
+          "name": "srcPtr"
         },
         {
-          "name": "format",
-          "type": "int"
+          "type": "int",
+          "name": "format"
         }
       ]
     },
@@ -7145,16 +7145,16 @@
       "returnType": "void",
       "params": [
         {
-          "name": "dstPtr",
-          "type": "void *"
+          "type": "void *",
+          "name": "dstPtr"
         },
         {
-          "name": "color",
-          "type": "Color"
+          "type": "Color",
+          "name": "color"
         },
         {
-          "name": "format",
-          "type": "int"
+          "type": "int",
+          "name": "format"
         }
       ]
     },
@@ -7164,16 +7164,16 @@
       "returnType": "int",
       "params": [
         {
-          "name": "width",
-          "type": "int"
+          "type": "int",
+          "name": "width"
         },
         {
-          "name": "height",
-          "type": "int"
+          "type": "int",
+          "name": "height"
         },
         {
-          "name": "format",
-          "type": "int"
+          "type": "int",
+          "name": "format"
         }
       ]
     },
@@ -7188,8 +7188,8 @@
       "returnType": "Font",
       "params": [
         {
-          "name": "fileName",
-          "type": "const char *"
+          "type": "const char *",
+          "name": "fileName"
         }
       ]
     },
@@ -7199,20 +7199,20 @@
       "returnType": "Font",
       "params": [
         {
-          "name": "fileName",
-          "type": "const char *"
+          "type": "const char *",
+          "name": "fileName"
         },
         {
-          "name": "fontSize",
-          "type": "int"
+          "type": "int",
+          "name": "fontSize"
         },
         {
-          "name": "fontChars",
-          "type": "int *"
+          "type": "int *",
+          "name": "fontChars"
         },
         {
-          "name": "glyphCount",
-          "type": "int"
+          "type": "int",
+          "name": "glyphCount"
         }
       ]
     },
@@ -7222,16 +7222,16 @@
       "returnType": "Font",
       "params": [
         {
-          "name": "image",
-          "type": "Image"
+          "type": "Image",
+          "name": "image"
         },
         {
-          "name": "key",
-          "type": "Color"
+          "type": "Color",
+          "name": "key"
         },
         {
-          "name": "firstChar",
-          "type": "int"
+          "type": "int",
+          "name": "firstChar"
         }
       ]
     },
@@ -7241,28 +7241,28 @@
       "returnType": "Font",
       "params": [
         {
-          "name": "fileType",
-          "type": "const char *"
+          "type": "const char *",
+          "name": "fileType"
         },
         {
-          "name": "fileData",
-          "type": "const unsigned char *"
+          "type": "const unsigned char *",
+          "name": "fileData"
         },
         {
-          "name": "dataSize",
-          "type": "int"
+          "type": "int",
+          "name": "dataSize"
         },
         {
-          "name": "fontSize",
-          "type": "int"
+          "type": "int",
+          "name": "fontSize"
         },
         {
-          "name": "fontChars",
-          "type": "int *"
+          "type": "int *",
+          "name": "fontChars"
         },
         {
-          "name": "glyphCount",
-          "type": "int"
+          "type": "int",
+          "name": "glyphCount"
         }
       ]
     },
@@ -7272,28 +7272,28 @@
       "returnType": "GlyphInfo *",
       "params": [
         {
-          "name": "fileData",
-          "type": "const unsigned char *"
+          "type": "const unsigned char *",
+          "name": "fileData"
         },
         {
-          "name": "dataSize",
-          "type": "int"
+          "type": "int",
+          "name": "dataSize"
         },
         {
-          "name": "fontSize",
-          "type": "int"
+          "type": "int",
+          "name": "fontSize"
         },
         {
-          "name": "fontChars",
-          "type": "int *"
+          "type": "int *",
+          "name": "fontChars"
         },
         {
-          "name": "glyphCount",
-          "type": "int"
+          "type": "int",
+          "name": "glyphCount"
         },
         {
-          "name": "type",
-          "type": "int"
+          "type": "int",
+          "name": "type"
         }
       ]
     },
@@ -7303,28 +7303,28 @@
       "returnType": "Image",
       "params": [
         {
-          "name": "chars",
-          "type": "const GlyphInfo *"
+          "type": "const GlyphInfo *",
+          "name": "chars"
         },
         {
-          "name": "recs",
-          "type": "Rectangle **"
+          "type": "Rectangle **",
+          "name": "recs"
         },
         {
-          "name": "glyphCount",
-          "type": "int"
+          "type": "int",
+          "name": "glyphCount"
         },
         {
-          "name": "fontSize",
-          "type": "int"
+          "type": "int",
+          "name": "fontSize"
         },
         {
-          "name": "padding",
-          "type": "int"
+          "type": "int",
+          "name": "padding"
         },
         {
-          "name": "packMethod",
-          "type": "int"
+          "type": "int",
+          "name": "packMethod"
         }
       ]
     },
@@ -7334,12 +7334,12 @@
       "returnType": "void",
       "params": [
         {
-          "name": "chars",
-          "type": "GlyphInfo *"
+          "type": "GlyphInfo *",
+          "name": "chars"
         },
         {
-          "name": "glyphCount",
-          "type": "int"
+          "type": "int",
+          "name": "glyphCount"
         }
       ]
     },
@@ -7349,8 +7349,8 @@
       "returnType": "void",
       "params": [
         {
-          "name": "font",
-          "type": "Font"
+          "type": "Font",
+          "name": "font"
         }
       ]
     },
@@ -7360,12 +7360,12 @@
       "returnType": "bool",
       "params": [
         {
-          "name": "font",
-          "type": "Font"
+          "type": "Font",
+          "name": "font"
         },
         {
-          "name": "fileName",
-          "type": "const char *"
+          "type": "const char *",
+          "name": "fileName"
         }
       ]
     },
@@ -7375,12 +7375,12 @@
       "returnType": "void",
       "params": [
         {
-          "name": "posX",
-          "type": "int"
+          "type": "int",
+          "name": "posX"
         },
         {
-          "name": "posY",
-          "type": "int"
+          "type": "int",
+          "name": "posY"
         }
       ]
     },
@@ -7390,24 +7390,24 @@
       "returnType": "void",
       "params": [
         {
-          "name": "text",
-          "type": "const char *"
+          "type": "const char *",
+          "name": "text"
         },
         {
-          "name": "posX",
-          "type": "int"
+          "type": "int",
+          "name": "posX"
         },
         {
-          "name": "posY",
-          "type": "int"
+          "type": "int",
+          "name": "posY"
         },
         {
-          "name": "fontSize",
-          "type": "int"
+          "type": "int",
+          "name": "fontSize"
         },
         {
-          "name": "color",
-          "type": "Color"
+          "type": "Color",
+          "name": "color"
         }
       ]
     },
@@ -7417,28 +7417,28 @@
       "returnType": "void",
       "params": [
         {
-          "name": "font",
-          "type": "Font"
+          "type": "Font",
+          "name": "font"
         },
         {
-          "name": "text",
-          "type": "const char *"
+          "type": "const char *",
+          "name": "text"
         },
         {
-          "name": "position",
-          "type": "Vector2"
+          "type": "Vector2",
+          "name": "position"
         },
         {
-          "name": "fontSize",
-          "type": "float"
+          "type": "float",
+          "name": "fontSize"
         },
         {
-          "name": "spacing",
-          "type": "float"
+          "type": "float",
+          "name": "spacing"
         },
         {
-          "name": "tint",
-          "type": "Color"
+          "type": "Color",
+          "name": "tint"
         }
       ]
     },
@@ -7448,36 +7448,36 @@
       "returnType": "void",
       "params": [
         {
-          "name": "font",
-          "type": "Font"
+          "type": "Font",
+          "name": "font"
         },
         {
-          "name": "text",
-          "type": "const char *"
+          "type": "const char *",
+          "name": "text"
         },
         {
-          "name": "position",
-          "type": "Vector2"
+          "type": "Vector2",
+          "name": "position"
         },
         {
-          "name": "origin",
-          "type": "Vector2"
+          "type": "Vector2",
+          "name": "origin"
         },
         {
-          "name": "rotation",
-          "type": "float"
+          "type": "float",
+          "name": "rotation"
         },
         {
-          "name": "fontSize",
-          "type": "float"
+          "type": "float",
+          "name": "fontSize"
         },
         {
-          "name": "spacing",
-          "type": "float"
+          "type": "float",
+          "name": "spacing"
         },
         {
-          "name": "tint",
-          "type": "Color"
+          "type": "Color",
+          "name": "tint"
         }
       ]
     },
@@ -7487,24 +7487,24 @@
       "returnType": "void",
       "params": [
         {
-          "name": "font",
-          "type": "Font"
+          "type": "Font",
+          "name": "font"
         },
         {
-          "name": "codepoint",
-          "type": "int"
+          "type": "int",
+          "name": "codepoint"
         },
         {
-          "name": "position",
-          "type": "Vector2"
+          "type": "Vector2",
+          "name": "position"
         },
         {
-          "name": "fontSize",
-          "type": "float"
+          "type": "float",
+          "name": "fontSize"
         },
         {
-          "name": "tint",
-          "type": "Color"
+          "type": "Color",
+          "name": "tint"
         }
       ]
     },
@@ -7514,12 +7514,12 @@
       "returnType": "int",
       "params": [
         {
-          "name": "text",
-          "type": "const char *"
+          "type": "const char *",
+          "name": "text"
         },
         {
-          "name": "fontSize",
-          "type": "int"
+          "type": "int",
+          "name": "fontSize"
         }
       ]
     },
@@ -7529,20 +7529,20 @@
       "returnType": "Vector2",
       "params": [
         {
-          "name": "font",
-          "type": "Font"
+          "type": "Font",
+          "name": "font"
         },
         {
-          "name": "text",
-          "type": "const char *"
+          "type": "const char *",
+          "name": "text"
         },
         {
-          "name": "fontSize",
-          "type": "float"
+          "type": "float",
+          "name": "fontSize"
         },
         {
-          "name": "spacing",
-          "type": "float"
+          "type": "float",
+          "name": "spacing"
         }
       ]
     },
@@ -7552,12 +7552,12 @@
       "returnType": "int",
       "params": [
         {
-          "name": "font",
-          "type": "Font"
+          "type": "Font",
+          "name": "font"
         },
         {
-          "name": "codepoint",
-          "type": "int"
+          "type": "int",
+          "name": "codepoint"
         }
       ]
     },
@@ -7567,12 +7567,12 @@
       "returnType": "GlyphInfo",
       "params": [
         {
-          "name": "font",
-          "type": "Font"
+          "type": "Font",
+          "name": "font"
         },
         {
-          "name": "codepoint",
-          "type": "int"
+          "type": "int",
+          "name": "codepoint"
         }
       ]
     },
@@ -7582,12 +7582,12 @@
       "returnType": "Rectangle",
       "params": [
         {
-          "name": "font",
-          "type": "Font"
+          "type": "Font",
+          "name": "font"
         },
         {
-          "name": "codepoint",
-          "type": "int"
+          "type": "int",
+          "name": "codepoint"
         }
       ]
     },
@@ -7597,12 +7597,12 @@
       "returnType": "int *",
       "params": [
         {
-          "name": "text",
-          "type": "const char *"
+          "type": "const char *",
+          "name": "text"
         },
         {
-          "name": "count",
-          "type": "int *"
+          "type": "int *",
+          "name": "count"
         }
       ]
     },
@@ -7612,8 +7612,8 @@
       "returnType": "void",
       "params": [
         {
-          "name": "codepoints",
-          "type": "int *"
+          "type": "int *",
+          "name": "codepoints"
         }
       ]
     },
@@ -7623,8 +7623,8 @@
       "returnType": "int",
       "params": [
         {
-          "name": "text",
-          "type": "const char *"
+          "type": "const char *",
+          "name": "text"
         }
       ]
     },
@@ -7634,12 +7634,12 @@
       "returnType": "int",
       "params": [
         {
-          "name": "text",
-          "type": "const char *"
+          "type": "const char *",
+          "name": "text"
         },
         {
-          "name": "bytesProcessed",
-          "type": "int *"
+          "type": "int *",
+          "name": "bytesProcessed"
         }
       ]
     },
@@ -7649,12 +7649,12 @@
       "returnType": "const char *",
       "params": [
         {
-          "name": "codepoint",
-          "type": "int"
+          "type": "int",
+          "name": "codepoint"
         },
         {
-          "name": "byteSize",
-          "type": "int *"
+          "type": "int *",
+          "name": "byteSize"
         }
       ]
     },
@@ -7664,12 +7664,12 @@
       "returnType": "char *",
       "params": [
         {
-          "name": "codepoints",
-          "type": "int *"
+          "type": "int *",
+          "name": "codepoints"
         },
         {
-          "name": "length",
-          "type": "int"
+          "type": "int",
+          "name": "length"
         }
       ]
     },
@@ -7679,12 +7679,12 @@
       "returnType": "int",
       "params": [
         {
-          "name": "dst",
-          "type": "char *"
+          "type": "char *",
+          "name": "dst"
         },
         {
-          "name": "src",
-          "type": "const char *"
+          "type": "const char *",
+          "name": "src"
         }
       ]
     },
@@ -7694,12 +7694,12 @@
       "returnType": "bool",
       "params": [
         {
-          "name": "text1",
-          "type": "const char *"
+          "type": "const char *",
+          "name": "text1"
         },
         {
-          "name": "text2",
-          "type": "const char *"
+          "type": "const char *",
+          "name": "text2"
         }
       ]
     },
@@ -7709,8 +7709,8 @@
       "returnType": "unsigned int",
       "params": [
         {
-          "name": "text",
-          "type": "const char *"
+          "type": "const char *",
+          "name": "text"
         }
       ]
     },
@@ -7720,12 +7720,12 @@
       "returnType": "const char *",
       "params": [
         {
-          "name": "text",
-          "type": "const char *"
+          "type": "const char *",
+          "name": "text"
         },
         {
-          "name": "",
-          "type": ""
+          "type": "",
+          "name": ""
         }
       ]
     },
@@ -7735,16 +7735,16 @@
       "returnType": "const char *",
       "params": [
         {
-          "name": "text",
-          "type": "const char *"
+          "type": "const char *",
+          "name": "text"
         },
         {
-          "name": "position",
-          "type": "int"
+          "type": "int",
+          "name": "position"
         },
         {
-          "name": "length",
-          "type": "int"
+          "type": "int",
+          "name": "length"
         }
       ]
     },
@@ -7754,16 +7754,16 @@
       "returnType": "char *",
       "params": [
         {
-          "name": "text",
-          "type": "char *"
+          "type": "char *",
+          "name": "text"
         },
         {
-          "name": "replace",
-          "type": "const char *"
+          "type": "const char *",
+          "name": "replace"
         },
         {
-          "name": "by",
-          "type": "const char *"
+          "type": "const char *",
+          "name": "by"
         }
       ]
     },
@@ -7773,16 +7773,16 @@
       "returnType": "char *",
       "params": [
         {
-          "name": "text",
-          "type": "const char *"
+          "type": "const char *",
+          "name": "text"
         },
         {
-          "name": "insert",
-          "type": "const char *"
+          "type": "const char *",
+          "name": "insert"
         },
         {
-          "name": "position",
-          "type": "int"
+          "type": "int",
+          "name": "position"
         }
       ]
     },
@@ -7792,16 +7792,16 @@
       "returnType": "const char *",
       "params": [
         {
-          "name": "textList",
-          "type": "const char **"
+          "type": "const char **",
+          "name": "textList"
         },
         {
-          "name": "count",
-          "type": "int"
+          "type": "int",
+          "name": "count"
         },
         {
-          "name": "delimiter",
-          "type": "const char *"
+          "type": "const char *",
+          "name": "delimiter"
         }
       ]
     },
@@ -7811,16 +7811,16 @@
       "returnType": "const char **",
       "params": [
         {
-          "name": "text",
-          "type": "const char *"
+          "type": "const char *",
+          "name": "text"
         },
         {
-          "name": "delimiter",
-          "type": "char"
+          "type": "char",
+          "name": "delimiter"
         },
         {
-          "name": "count",
-          "type": "int *"
+          "type": "int *",
+          "name": "count"
         }
       ]
     },
@@ -7830,16 +7830,16 @@
       "returnType": "void",
       "params": [
         {
-          "name": "text",
-          "type": "char *"
+          "type": "char *",
+          "name": "text"
         },
         {
-          "name": "append",
-          "type": "const char *"
+          "type": "const char *",
+          "name": "append"
         },
         {
-          "name": "position",
-          "type": "int *"
+          "type": "int *",
+          "name": "position"
         }
       ]
     },
@@ -7849,12 +7849,12 @@
       "returnType": "int",
       "params": [
         {
-          "name": "text",
-          "type": "const char *"
+          "type": "const char *",
+          "name": "text"
         },
         {
-          "name": "find",
-          "type": "const char *"
+          "type": "const char *",
+          "name": "find"
         }
       ]
     },
@@ -7864,8 +7864,8 @@
       "returnType": "const char *",
       "params": [
         {
-          "name": "text",
-          "type": "const char *"
+          "type": "const char *",
+          "name": "text"
         }
       ]
     },
@@ -7875,8 +7875,8 @@
       "returnType": "const char *",
       "params": [
         {
-          "name": "text",
-          "type": "const char *"
+          "type": "const char *",
+          "name": "text"
         }
       ]
     },
@@ -7886,8 +7886,8 @@
       "returnType": "const char *",
       "params": [
         {
-          "name": "text",
-          "type": "const char *"
+          "type": "const char *",
+          "name": "text"
         }
       ]
     },
@@ -7897,8 +7897,8 @@
       "returnType": "int",
       "params": [
         {
-          "name": "text",
-          "type": "const char *"
+          "type": "const char *",
+          "name": "text"
         }
       ]
     },
@@ -7908,16 +7908,16 @@
       "returnType": "void",
       "params": [
         {
-          "name": "startPos",
-          "type": "Vector3"
+          "type": "Vector3",
+          "name": "startPos"
         },
         {
-          "name": "endPos",
-          "type": "Vector3"
+          "type": "Vector3",
+          "name": "endPos"
         },
         {
-          "name": "color",
-          "type": "Color"
+          "type": "Color",
+          "name": "color"
         }
       ]
     },
@@ -7927,12 +7927,12 @@
       "returnType": "void",
       "params": [
         {
-          "name": "position",
-          "type": "Vector3"
+          "type": "Vector3",
+          "name": "position"
         },
         {
-          "name": "color",
-          "type": "Color"
+          "type": "Color",
+          "name": "color"
         }
       ]
     },
@@ -7942,24 +7942,24 @@
       "returnType": "void",
       "params": [
         {
-          "name": "center",
-          "type": "Vector3"
+          "type": "Vector3",
+          "name": "center"
         },
         {
-          "name": "radius",
-          "type": "float"
+          "type": "float",
+          "name": "radius"
         },
         {
-          "name": "rotationAxis",
-          "type": "Vector3"
+          "type": "Vector3",
+          "name": "rotationAxis"
         },
         {
-          "name": "rotationAngle",
-          "type": "float"
+          "type": "float",
+          "name": "rotationAngle"
         },
         {
-          "name": "color",
-          "type": "Color"
+          "type": "Color",
+          "name": "color"
         }
       ]
     },
@@ -7969,20 +7969,20 @@
       "returnType": "void",
       "params": [
         {
-          "name": "v1",
-          "type": "Vector3"
+          "type": "Vector3",
+          "name": "v1"
         },
         {
-          "name": "v2",
-          "type": "Vector3"
+          "type": "Vector3",
+          "name": "v2"
         },
         {
-          "name": "v3",
-          "type": "Vector3"
+          "type": "Vector3",
+          "name": "v3"
         },
         {
-          "name": "color",
-          "type": "Color"
+          "type": "Color",
+          "name": "color"
         }
       ]
     },
@@ -7992,16 +7992,16 @@
       "returnType": "void",
       "params": [
         {
-          "name": "points",
-          "type": "Vector3 *"
+          "type": "Vector3 *",
+          "name": "points"
         },
         {
-          "name": "pointCount",
-          "type": "int"
+          "type": "int",
+          "name": "pointCount"
         },
         {
-          "name": "color",
-          "type": "Color"
+          "type": "Color",
+          "name": "color"
         }
       ]
     },
@@ -8011,24 +8011,24 @@
       "returnType": "void",
       "params": [
         {
-          "name": "position",
-          "type": "Vector3"
+          "type": "Vector3",
+          "name": "position"
         },
         {
-          "name": "width",
-          "type": "float"
+          "type": "float",
+          "name": "width"
         },
         {
-          "name": "height",
-          "type": "float"
+          "type": "float",
+          "name": "height"
         },
         {
-          "name": "length",
-          "type": "float"
+          "type": "float",
+          "name": "length"
         },
         {
-          "name": "color",
-          "type": "Color"
+          "type": "Color",
+          "name": "color"
         }
       ]
     },
@@ -8038,16 +8038,16 @@
       "returnType": "void",
       "params": [
         {
-          "name": "position",
-          "type": "Vector3"
+          "type": "Vector3",
+          "name": "position"
         },
         {
-          "name": "size",
-          "type": "Vector3"
+          "type": "Vector3",
+          "name": "size"
         },
         {
-          "name": "color",
-          "type": "Color"
+          "type": "Color",
+          "name": "color"
         }
       ]
     },
@@ -8057,24 +8057,24 @@
       "returnType": "void",
       "params": [
         {
-          "name": "position",
-          "type": "Vector3"
+          "type": "Vector3",
+          "name": "position"
         },
         {
-          "name": "width",
-          "type": "float"
+          "type": "float",
+          "name": "width"
         },
         {
-          "name": "height",
-          "type": "float"
+          "type": "float",
+          "name": "height"
         },
         {
-          "name": "length",
-          "type": "float"
+          "type": "float",
+          "name": "length"
         },
         {
-          "name": "color",
-          "type": "Color"
+          "type": "Color",
+          "name": "color"
         }
       ]
     },
@@ -8084,16 +8084,16 @@
       "returnType": "void",
       "params": [
         {
-          "name": "position",
-          "type": "Vector3"
+          "type": "Vector3",
+          "name": "position"
         },
         {
-          "name": "size",
-          "type": "Vector3"
+          "type": "Vector3",
+          "name": "size"
         },
         {
-          "name": "color",
-          "type": "Color"
+          "type": "Color",
+          "name": "color"
         }
       ]
     },
@@ -8103,28 +8103,28 @@
       "returnType": "void",
       "params": [
         {
-          "name": "texture",
-          "type": "Texture2D"
+          "type": "Texture2D",
+          "name": "texture"
         },
         {
-          "name": "position",
-          "type": "Vector3"
+          "type": "Vector3",
+          "name": "position"
         },
         {
-          "name": "width",
-          "type": "float"
+          "type": "float",
+          "name": "width"
         },
         {
-          "name": "height",
-          "type": "float"
+          "type": "float",
+          "name": "height"
         },
         {
-          "name": "length",
-          "type": "float"
+          "type": "float",
+          "name": "length"
         },
         {
-          "name": "color",
-          "type": "Color"
+          "type": "Color",
+          "name": "color"
         }
       ]
     },
@@ -8134,32 +8134,32 @@
       "returnType": "void",
       "params": [
         {
-          "name": "texture",
-          "type": "Texture2D"
+          "type": "Texture2D",
+          "name": "texture"
         },
         {
-          "name": "source",
-          "type": "Rectangle"
+          "type": "Rectangle",
+          "name": "source"
         },
         {
-          "name": "position",
-          "type": "Vector3"
+          "type": "Vector3",
+          "name": "position"
         },
         {
-          "name": "width",
-          "type": "float"
+          "type": "float",
+          "name": "width"
         },
         {
-          "name": "height",
-          "type": "float"
+          "type": "float",
+          "name": "height"
         },
         {
-          "name": "length",
-          "type": "float"
+          "type": "float",
+          "name": "length"
         },
         {
-          "name": "color",
-          "type": "Color"
+          "type": "Color",
+          "name": "color"
         }
       ]
     },
@@ -8169,16 +8169,16 @@
       "returnType": "void",
       "params": [
         {
-          "name": "centerPos",
-          "type": "Vector3"
+          "type": "Vector3",
+          "name": "centerPos"
         },
         {
-          "name": "radius",
-          "type": "float"
+          "type": "float",
+          "name": "radius"
         },
         {
-          "name": "color",
-          "type": "Color"
+          "type": "Color",
+          "name": "color"
         }
       ]
     },
@@ -8188,24 +8188,24 @@
       "returnType": "void",
       "params": [
         {
-          "name": "centerPos",
-          "type": "Vector3"
+          "type": "Vector3",
+          "name": "centerPos"
         },
         {
-          "name": "radius",
-          "type": "float"
+          "type": "float",
+          "name": "radius"
         },
         {
-          "name": "rings",
-          "type": "int"
+          "type": "int",
+          "name": "rings"
         },
         {
-          "name": "slices",
-          "type": "int"
+          "type": "int",
+          "name": "slices"
         },
         {
-          "name": "color",
-          "type": "Color"
+          "type": "Color",
+          "name": "color"
         }
       ]
     },
@@ -8215,24 +8215,24 @@
       "returnType": "void",
       "params": [
         {
-          "name": "centerPos",
-          "type": "Vector3"
+          "type": "Vector3",
+          "name": "centerPos"
         },
         {
-          "name": "radius",
-          "type": "float"
+          "type": "float",
+          "name": "radius"
         },
         {
-          "name": "rings",
-          "type": "int"
+          "type": "int",
+          "name": "rings"
         },
         {
-          "name": "slices",
-          "type": "int"
+          "type": "int",
+          "name": "slices"
         },
         {
-          "name": "color",
-          "type": "Color"
+          "type": "Color",
+          "name": "color"
         }
       ]
     },
@@ -8242,28 +8242,28 @@
       "returnType": "void",
       "params": [
         {
-          "name": "position",
-          "type": "Vector3"
+          "type": "Vector3",
+          "name": "position"
         },
         {
-          "name": "radiusTop",
-          "type": "float"
+          "type": "float",
+          "name": "radiusTop"
         },
         {
-          "name": "radiusBottom",
-          "type": "float"
+          "type": "float",
+          "name": "radiusBottom"
         },
         {
-          "name": "height",
-          "type": "float"
+          "type": "float",
+          "name": "height"
         },
         {
-          "name": "slices",
-          "type": "int"
+          "type": "int",
+          "name": "slices"
         },
         {
-          "name": "color",
-          "type": "Color"
+          "type": "Color",
+          "name": "color"
         }
       ]
     },
@@ -8273,28 +8273,28 @@
       "returnType": "void",
       "params": [
         {
-          "name": "startPos",
-          "type": "Vector3"
+          "type": "Vector3",
+          "name": "startPos"
         },
         {
-          "name": "endPos",
-          "type": "Vector3"
+          "type": "Vector3",
+          "name": "endPos"
         },
         {
-          "name": "startRadius",
-          "type": "float"
+          "type": "float",
+          "name": "startRadius"
         },
         {
-          "name": "endRadius",
-          "type": "float"
+          "type": "float",
+          "name": "endRadius"
         },
         {
-          "name": "sides",
-          "type": "int"
+          "type": "int",
+          "name": "sides"
         },
         {
-          "name": "color",
-          "type": "Color"
+          "type": "Color",
+          "name": "color"
         }
       ]
     },
@@ -8304,28 +8304,28 @@
       "returnType": "void",
       "params": [
         {
-          "name": "position",
-          "type": "Vector3"
+          "type": "Vector3",
+          "name": "position"
         },
         {
-          "name": "radiusTop",
-          "type": "float"
+          "type": "float",
+          "name": "radiusTop"
         },
         {
-          "name": "radiusBottom",
-          "type": "float"
+          "type": "float",
+          "name": "radiusBottom"
         },
         {
-          "name": "height",
-          "type": "float"
+          "type": "float",
+          "name": "height"
         },
         {
-          "name": "slices",
-          "type": "int"
+          "type": "int",
+          "name": "slices"
         },
         {
-          "name": "color",
-          "type": "Color"
+          "type": "Color",
+          "name": "color"
         }
       ]
     },
@@ -8335,28 +8335,28 @@
       "returnType": "void",
       "params": [
         {
-          "name": "startPos",
-          "type": "Vector3"
+          "type": "Vector3",
+          "name": "startPos"
         },
         {
-          "name": "endPos",
-          "type": "Vector3"
+          "type": "Vector3",
+          "name": "endPos"
         },
         {
-          "name": "startRadius",
-          "type": "float"
+          "type": "float",
+          "name": "startRadius"
         },
         {
-          "name": "endRadius",
-          "type": "float"
+          "type": "float",
+          "name": "endRadius"
         },
         {
-          "name": "sides",
-          "type": "int"
+          "type": "int",
+          "name": "sides"
         },
         {
-          "name": "color",
-          "type": "Color"
+          "type": "Color",
+          "name": "color"
         }
       ]
     },
@@ -8366,16 +8366,16 @@
       "returnType": "void",
       "params": [
         {
-          "name": "centerPos",
-          "type": "Vector3"
+          "type": "Vector3",
+          "name": "centerPos"
         },
         {
-          "name": "size",
-          "type": "Vector2"
+          "type": "Vector2",
+          "name": "size"
         },
         {
-          "name": "color",
-          "type": "Color"
+          "type": "Color",
+          "name": "color"
         }
       ]
     },
@@ -8385,12 +8385,12 @@
       "returnType": "void",
       "params": [
         {
-          "name": "ray",
-          "type": "Ray"
+          "type": "Ray",
+          "name": "ray"
         },
         {
-          "name": "color",
-          "type": "Color"
+          "type": "Color",
+          "name": "color"
         }
       ]
     },
@@ -8400,12 +8400,12 @@
       "returnType": "void",
       "params": [
         {
-          "name": "slices",
-          "type": "int"
+          "type": "int",
+          "name": "slices"
         },
         {
-          "name": "spacing",
-          "type": "float"
+          "type": "float",
+          "name": "spacing"
         }
       ]
     },
@@ -8415,8 +8415,8 @@
       "returnType": "Model",
       "params": [
         {
-          "name": "fileName",
-          "type": "const char *"
+          "type": "const char *",
+          "name": "fileName"
         }
       ]
     },
@@ -8426,8 +8426,8 @@
       "returnType": "Model",
       "params": [
         {
-          "name": "mesh",
-          "type": "Mesh"
+          "type": "Mesh",
+          "name": "mesh"
         }
       ]
     },
@@ -8437,8 +8437,8 @@
       "returnType": "void",
       "params": [
         {
-          "name": "model",
-          "type": "Model"
+          "type": "Model",
+          "name": "model"
         }
       ]
     },
@@ -8448,8 +8448,8 @@
       "returnType": "void",
       "params": [
         {
-          "name": "model",
-          "type": "Model"
+          "type": "Model",
+          "name": "model"
         }
       ]
     },
@@ -8459,8 +8459,8 @@
       "returnType": "BoundingBox",
       "params": [
         {
-          "name": "model",
-          "type": "Model"
+          "type": "Model",
+          "name": "model"
         }
       ]
     },
@@ -8470,20 +8470,20 @@
       "returnType": "void",
       "params": [
         {
-          "name": "model",
-          "type": "Model"
+          "type": "Model",
+          "name": "model"
         },
         {
-          "name": "position",
-          "type": "Vector3"
+          "type": "Vector3",
+          "name": "position"
         },
         {
-          "name": "scale",
-          "type": "float"
+          "type": "float",
+          "name": "scale"
         },
         {
-          "name": "tint",
-          "type": "Color"
+          "type": "Color",
+          "name": "tint"
         }
       ]
     },
@@ -8493,28 +8493,28 @@
       "returnType": "void",
       "params": [
         {
-          "name": "model",
-          "type": "Model"
+          "type": "Model",
+          "name": "model"
         },
         {
-          "name": "position",
-          "type": "Vector3"
+          "type": "Vector3",
+          "name": "position"
         },
         {
-          "name": "rotationAxis",
-          "type": "Vector3"
+          "type": "Vector3",
+          "name": "rotationAxis"
         },
         {
-          "name": "rotationAngle",
-          "type": "float"
+          "type": "float",
+          "name": "rotationAngle"
         },
         {
-          "name": "scale",
-          "type": "Vector3"
+          "type": "Vector3",
+          "name": "scale"
         },
         {
-          "name": "tint",
-          "type": "Color"
+          "type": "Color",
+          "name": "tint"
         }
       ]
     },
@@ -8524,20 +8524,20 @@
       "returnType": "void",
       "params": [
         {
-          "name": "model",
-          "type": "Model"
+          "type": "Model",
+          "name": "model"
         },
         {
-          "name": "position",
-          "type": "Vector3"
+          "type": "Vector3",
+          "name": "position"
         },
         {
-          "name": "scale",
-          "type": "float"
+          "type": "float",
+          "name": "scale"
         },
         {
-          "name": "tint",
-          "type": "Color"
+          "type": "Color",
+          "name": "tint"
         }
       ]
     },
@@ -8547,28 +8547,28 @@
       "returnType": "void",
       "params": [
         {
-          "name": "model",
-          "type": "Model"
+          "type": "Model",
+          "name": "model"
         },
         {
-          "name": "position",
-          "type": "Vector3"
+          "type": "Vector3",
+          "name": "position"
         },
         {
-          "name": "rotationAxis",
-          "type": "Vector3"
+          "type": "Vector3",
+          "name": "rotationAxis"
         },
         {
-          "name": "rotationAngle",
-          "type": "float"
+          "type": "float",
+          "name": "rotationAngle"
         },
         {
-          "name": "scale",
-          "type": "Vector3"
+          "type": "Vector3",
+          "name": "scale"
         },
         {
-          "name": "tint",
-          "type": "Color"
+          "type": "Color",
+          "name": "tint"
         }
       ]
     },
@@ -8578,12 +8578,12 @@
       "returnType": "void",
       "params": [
         {
-          "name": "box",
-          "type": "BoundingBox"
+          "type": "BoundingBox",
+          "name": "box"
         },
         {
-          "name": "color",
-          "type": "Color"
+          "type": "Color",
+          "name": "color"
         }
       ]
     },
@@ -8593,24 +8593,24 @@
       "returnType": "void",
       "params": [
         {
-          "name": "camera",
-          "type": "Camera"
+          "type": "Camera",
+          "name": "camera"
         },
         {
-          "name": "texture",
-          "type": "Texture2D"
+          "type": "Texture2D",
+          "name": "texture"
         },
         {
-          "name": "position",
-          "type": "Vector3"
+          "type": "Vector3",
+          "name": "position"
         },
         {
-          "name": "size",
-          "type": "float"
+          "type": "float",
+          "name": "size"
         },
         {
-          "name": "tint",
-          "type": "Color"
+          "type": "Color",
+          "name": "tint"
         }
       ]
     },
@@ -8620,28 +8620,28 @@
       "returnType": "void",
       "params": [
         {
-          "name": "camera",
-          "type": "Camera"
+          "type": "Camera",
+          "name": "camera"
         },
         {
-          "name": "texture",
-          "type": "Texture2D"
+          "type": "Texture2D",
+          "name": "texture"
         },
         {
-          "name": "source",
-          "type": "Rectangle"
+          "type": "Rectangle",
+          "name": "source"
         },
         {
-          "name": "position",
-          "type": "Vector3"
+          "type": "Vector3",
+          "name": "position"
         },
         {
-          "name": "size",
-          "type": "Vector2"
+          "type": "Vector2",
+          "name": "size"
         },
         {
-          "name": "tint",
-          "type": "Color"
+          "type": "Color",
+          "name": "tint"
         }
       ]
     },
@@ -8651,40 +8651,40 @@
       "returnType": "void",
       "params": [
         {
-          "name": "camera",
-          "type": "Camera"
+          "type": "Camera",
+          "name": "camera"
         },
         {
-          "name": "texture",
-          "type": "Texture2D"
+          "type": "Texture2D",
+          "name": "texture"
         },
         {
-          "name": "source",
-          "type": "Rectangle"
+          "type": "Rectangle",
+          "name": "source"
         },
         {
-          "name": "position",
-          "type": "Vector3"
+          "type": "Vector3",
+          "name": "position"
         },
         {
-          "name": "up",
-          "type": "Vector3"
+          "type": "Vector3",
+          "name": "up"
         },
         {
-          "name": "size",
-          "type": "Vector2"
+          "type": "Vector2",
+          "name": "size"
         },
         {
-          "name": "origin",
-          "type": "Vector2"
+          "type": "Vector2",
+          "name": "origin"
         },
         {
-          "name": "rotation",
-          "type": "float"
+          "type": "float",
+          "name": "rotation"
         },
         {
-          "name": "tint",
-          "type": "Color"
+          "type": "Color",
+          "name": "tint"
         }
       ]
     },
@@ -8694,12 +8694,12 @@
       "returnType": "void",
       "params": [
         {
-          "name": "mesh",
-          "type": "Mesh *"
+          "type": "Mesh *",
+          "name": "mesh"
         },
         {
-          "name": "dynamic",
-          "type": "bool"
+          "type": "bool",
+          "name": "dynamic"
         }
       ]
     },
@@ -8709,24 +8709,24 @@
       "returnType": "void",
       "params": [
         {
-          "name": "mesh",
-          "type": "Mesh"
+          "type": "Mesh",
+          "name": "mesh"
         },
         {
-          "name": "index",
-          "type": "int"
+          "type": "int",
+          "name": "index"
         },
         {
-          "name": "data",
-          "type": "void *"
+          "type": "void *",
+          "name": "data"
         },
         {
-          "name": "dataSize",
-          "type": "int"
+          "type": "int",
+          "name": "dataSize"
         },
         {
-          "name": "offset",
-          "type": "int"
+          "type": "int",
+          "name": "offset"
         }
       ]
     },
@@ -8736,8 +8736,8 @@
       "returnType": "void",
       "params": [
         {
-          "name": "mesh",
-          "type": "Mesh"
+          "type": "Mesh",
+          "name": "mesh"
         }
       ]
     },
@@ -8747,16 +8747,16 @@
       "returnType": "void",
       "params": [
         {
-          "name": "mesh",
-          "type": "Mesh"
+          "type": "Mesh",
+          "name": "mesh"
         },
         {
-          "name": "material",
-          "type": "Material"
+          "type": "Material",
+          "name": "material"
         },
         {
-          "name": "transform",
-          "type": "Matrix"
+          "type": "Matrix",
+          "name": "transform"
         }
       ]
     },
@@ -8766,20 +8766,20 @@
       "returnType": "void",
       "params": [
         {
-          "name": "mesh",
-          "type": "Mesh"
+          "type": "Mesh",
+          "name": "mesh"
         },
         {
-          "name": "material",
-          "type": "Material"
+          "type": "Material",
+          "name": "material"
         },
         {
-          "name": "transforms",
-          "type": "Matrix *"
+          "type": "Matrix *",
+          "name": "transforms"
         },
         {
-          "name": "instances",
-          "type": "int"
+          "type": "int",
+          "name": "instances"
         }
       ]
     },
@@ -8789,12 +8789,12 @@
       "returnType": "bool",
       "params": [
         {
-          "name": "mesh",
-          "type": "Mesh"
+          "type": "Mesh",
+          "name": "mesh"
         },
         {
-          "name": "fileName",
-          "type": "const char *"
+          "type": "const char *",
+          "name": "fileName"
         }
       ]
     },
@@ -8804,8 +8804,8 @@
       "returnType": "BoundingBox",
       "params": [
         {
-          "name": "mesh",
-          "type": "Mesh"
+          "type": "Mesh",
+          "name": "mesh"
         }
       ]
     },
@@ -8815,8 +8815,8 @@
       "returnType": "void",
       "params": [
         {
-          "name": "mesh",
-          "type": "Mesh *"
+          "type": "Mesh *",
+          "name": "mesh"
         }
       ]
     },
@@ -8826,8 +8826,8 @@
       "returnType": "void",
       "params": [
         {
-          "name": "mesh",
-          "type": "Mesh *"
+          "type": "Mesh *",
+          "name": "mesh"
         }
       ]
     },
@@ -8837,12 +8837,12 @@
       "returnType": "Mesh",
       "params": [
         {
-          "name": "sides",
-          "type": "int"
+          "type": "int",
+          "name": "sides"
         },
         {
-          "name": "radius",
-          "type": "float"
+          "type": "float",
+          "name": "radius"
         }
       ]
     },
@@ -8852,20 +8852,20 @@
       "returnType": "Mesh",
       "params": [
         {
-          "name": "width",
-          "type": "float"
+          "type": "float",
+          "name": "width"
         },
         {
-          "name": "length",
-          "type": "float"
+          "type": "float",
+          "name": "length"
         },
         {
-          "name": "resX",
-          "type": "int"
+          "type": "int",
+          "name": "resX"
         },
         {
-          "name": "resZ",
-          "type": "int"
+          "type": "int",
+          "name": "resZ"
         }
       ]
     },
@@ -8875,16 +8875,16 @@
       "returnType": "Mesh",
       "params": [
         {
-          "name": "width",
-          "type": "float"
+          "type": "float",
+          "name": "width"
         },
         {
-          "name": "height",
-          "type": "float"
+          "type": "float",
+          "name": "height"
         },
         {
-          "name": "length",
-          "type": "float"
+          "type": "float",
+          "name": "length"
         }
       ]
     },
@@ -8894,16 +8894,16 @@
       "returnType": "Mesh",
       "params": [
         {
-          "name": "radius",
-          "type": "float"
+          "type": "float",
+          "name": "radius"
         },
         {
-          "name": "rings",
-          "type": "int"
+          "type": "int",
+          "name": "rings"
         },
         {
-          "name": "slices",
-          "type": "int"
+          "type": "int",
+          "name": "slices"
         }
       ]
     },
@@ -8913,16 +8913,16 @@
       "returnType": "Mesh",
       "params": [
         {
-          "name": "radius",
-          "type": "float"
+          "type": "float",
+          "name": "radius"
         },
         {
-          "name": "rings",
-          "type": "int"
+          "type": "int",
+          "name": "rings"
         },
         {
-          "name": "slices",
-          "type": "int"
+          "type": "int",
+          "name": "slices"
         }
       ]
     },
@@ -8932,16 +8932,16 @@
       "returnType": "Mesh",
       "params": [
         {
-          "name": "radius",
-          "type": "float"
+          "type": "float",
+          "name": "radius"
         },
         {
-          "name": "height",
-          "type": "float"
+          "type": "float",
+          "name": "height"
         },
         {
-          "name": "slices",
-          "type": "int"
+          "type": "int",
+          "name": "slices"
         }
       ]
     },
@@ -8951,16 +8951,16 @@
       "returnType": "Mesh",
       "params": [
         {
-          "name": "radius",
-          "type": "float"
+          "type": "float",
+          "name": "radius"
         },
         {
-          "name": "height",
-          "type": "float"
+          "type": "float",
+          "name": "height"
         },
         {
-          "name": "slices",
-          "type": "int"
+          "type": "int",
+          "name": "slices"
         }
       ]
     },
@@ -8970,20 +8970,20 @@
       "returnType": "Mesh",
       "params": [
         {
-          "name": "radius",
-          "type": "float"
+          "type": "float",
+          "name": "radius"
         },
         {
-          "name": "size",
-          "type": "float"
+          "type": "float",
+          "name": "size"
         },
         {
-          "name": "radSeg",
-          "type": "int"
+          "type": "int",
+          "name": "radSeg"
         },
         {
-          "name": "sides",
-          "type": "int"
+          "type": "int",
+          "name": "sides"
         }
       ]
     },
@@ -8993,20 +8993,20 @@
       "returnType": "Mesh",
       "params": [
         {
-          "name": "radius",
-          "type": "float"
+          "type": "float",
+          "name": "radius"
         },
         {
-          "name": "size",
-          "type": "float"
+          "type": "float",
+          "name": "size"
         },
         {
-          "name": "radSeg",
-          "type": "int"
+          "type": "int",
+          "name": "radSeg"
         },
         {
-          "name": "sides",
-          "type": "int"
+          "type": "int",
+          "name": "sides"
         }
       ]
     },
@@ -9016,12 +9016,12 @@
       "returnType": "Mesh",
       "params": [
         {
-          "name": "heightmap",
-          "type": "Image"
+          "type": "Image",
+          "name": "heightmap"
         },
         {
-          "name": "size",
-          "type": "Vector3"
+          "type": "Vector3",
+          "name": "size"
         }
       ]
     },
@@ -9031,12 +9031,12 @@
       "returnType": "Mesh",
       "params": [
         {
-          "name": "cubicmap",
-          "type": "Image"
+          "type": "Image",
+          "name": "cubicmap"
         },
         {
-          "name": "cubeSize",
-          "type": "Vector3"
+          "type": "Vector3",
+          "name": "cubeSize"
         }
       ]
     },
@@ -9046,12 +9046,12 @@
       "returnType": "Material *",
       "params": [
         {
-          "name": "fileName",
-          "type": "const char *"
+          "type": "const char *",
+          "name": "fileName"
         },
         {
-          "name": "materialCount",
-          "type": "int *"
+          "type": "int *",
+          "name": "materialCount"
         }
       ]
     },
@@ -9066,8 +9066,8 @@
       "returnType": "void",
       "params": [
         {
-          "name": "material",
-          "type": "Material"
+          "type": "Material",
+          "name": "material"
         }
       ]
     },
@@ -9077,16 +9077,16 @@
       "returnType": "void",
       "params": [
         {
-          "name": "material",
-          "type": "Material *"
+          "type": "Material *",
+          "name": "material"
         },
         {
-          "name": "mapType",
-          "type": "int"
+          "type": "int",
+          "name": "mapType"
         },
         {
-          "name": "texture",
-          "type": "Texture2D"
+          "type": "Texture2D",
+          "name": "texture"
         }
       ]
     },
@@ -9096,16 +9096,16 @@
       "returnType": "void",
       "params": [
         {
-          "name": "model",
-          "type": "Model *"
+          "type": "Model *",
+          "name": "model"
         },
         {
-          "name": "meshId",
-          "type": "int"
+          "type": "int",
+          "name": "meshId"
         },
         {
-          "name": "materialId",
-          "type": "int"
+          "type": "int",
+          "name": "materialId"
         }
       ]
     },
@@ -9115,12 +9115,12 @@
       "returnType": "ModelAnimation *",
       "params": [
         {
-          "name": "fileName",
-          "type": "const char *"
+          "type": "const char *",
+          "name": "fileName"
         },
         {
-          "name": "animCount",
-          "type": "unsigned int *"
+          "type": "unsigned int *",
+          "name": "animCount"
         }
       ]
     },
@@ -9130,16 +9130,16 @@
       "returnType": "void",
       "params": [
         {
-          "name": "model",
-          "type": "Model"
+          "type": "Model",
+          "name": "model"
         },
         {
-          "name": "anim",
-          "type": "ModelAnimation"
+          "type": "ModelAnimation",
+          "name": "anim"
         },
         {
-          "name": "frame",
-          "type": "int"
+          "type": "int",
+          "name": "frame"
         }
       ]
     },
@@ -9149,8 +9149,8 @@
       "returnType": "void",
       "params": [
         {
-          "name": "anim",
-          "type": "ModelAnimation"
+          "type": "ModelAnimation",
+          "name": "anim"
         }
       ]
     },
@@ -9160,12 +9160,12 @@
       "returnType": "void",
       "params": [
         {
-          "name": "animations",
-          "type": "ModelAnimation*"
+          "type": "ModelAnimation*",
+          "name": "animations"
         },
         {
-          "name": "count",
-          "type": "unsigned int"
+          "type": "unsigned int",
+          "name": "count"
         }
       ]
     },
@@ -9175,12 +9175,12 @@
       "returnType": "bool",
       "params": [
         {
-          "name": "model",
-          "type": "Model"
+          "type": "Model",
+          "name": "model"
         },
         {
-          "name": "anim",
-          "type": "ModelAnimation"
+          "type": "ModelAnimation",
+          "name": "anim"
         }
       ]
     },
@@ -9190,20 +9190,20 @@
       "returnType": "bool",
       "params": [
         {
-          "name": "center1",
-          "type": "Vector3"
+          "type": "Vector3",
+          "name": "center1"
         },
         {
-          "name": "radius1",
-          "type": "float"
+          "type": "float",
+          "name": "radius1"
         },
         {
-          "name": "center2",
-          "type": "Vector3"
+          "type": "Vector3",
+          "name": "center2"
         },
         {
-          "name": "radius2",
-          "type": "float"
+          "type": "float",
+          "name": "radius2"
         }
       ]
     },
@@ -9213,12 +9213,12 @@
       "returnType": "bool",
       "params": [
         {
-          "name": "box1",
-          "type": "BoundingBox"
+          "type": "BoundingBox",
+          "name": "box1"
         },
         {
-          "name": "box2",
-          "type": "BoundingBox"
+          "type": "BoundingBox",
+          "name": "box2"
         }
       ]
     },
@@ -9228,16 +9228,16 @@
       "returnType": "bool",
       "params": [
         {
-          "name": "box",
-          "type": "BoundingBox"
+          "type": "BoundingBox",
+          "name": "box"
         },
         {
-          "name": "center",
-          "type": "Vector3"
+          "type": "Vector3",
+          "name": "center"
         },
         {
-          "name": "radius",
-          "type": "float"
+          "type": "float",
+          "name": "radius"
         }
       ]
     },
@@ -9247,16 +9247,16 @@
       "returnType": "RayCollision",
       "params": [
         {
-          "name": "ray",
-          "type": "Ray"
+          "type": "Ray",
+          "name": "ray"
         },
         {
-          "name": "center",
-          "type": "Vector3"
+          "type": "Vector3",
+          "name": "center"
         },
         {
-          "name": "radius",
-          "type": "float"
+          "type": "float",
+          "name": "radius"
         }
       ]
     },
@@ -9266,12 +9266,12 @@
       "returnType": "RayCollision",
       "params": [
         {
-          "name": "ray",
-          "type": "Ray"
+          "type": "Ray",
+          "name": "ray"
         },
         {
-          "name": "box",
-          "type": "BoundingBox"
+          "type": "BoundingBox",
+          "name": "box"
         }
       ]
     },
@@ -9281,12 +9281,12 @@
       "returnType": "RayCollision",
       "params": [
         {
-          "name": "ray",
-          "type": "Ray"
+          "type": "Ray",
+          "name": "ray"
         },
         {
-          "name": "model",
-          "type": "Model"
+          "type": "Model",
+          "name": "model"
         }
       ]
     },
@@ -9296,16 +9296,16 @@
       "returnType": "RayCollision",
       "params": [
         {
-          "name": "ray",
-          "type": "Ray"
+          "type": "Ray",
+          "name": "ray"
         },
         {
-          "name": "mesh",
-          "type": "Mesh"
+          "type": "Mesh",
+          "name": "mesh"
         },
         {
-          "name": "transform",
-          "type": "Matrix"
+          "type": "Matrix",
+          "name": "transform"
         }
       ]
     },
@@ -9315,20 +9315,20 @@
       "returnType": "RayCollision",
       "params": [
         {
-          "name": "ray",
-          "type": "Ray"
+          "type": "Ray",
+          "name": "ray"
         },
         {
-          "name": "p1",
-          "type": "Vector3"
+          "type": "Vector3",
+          "name": "p1"
         },
         {
-          "name": "p2",
-          "type": "Vector3"
+          "type": "Vector3",
+          "name": "p2"
         },
         {
-          "name": "p3",
-          "type": "Vector3"
+          "type": "Vector3",
+          "name": "p3"
         }
       ]
     },
@@ -9338,24 +9338,24 @@
       "returnType": "RayCollision",
       "params": [
         {
-          "name": "ray",
-          "type": "Ray"
+          "type": "Ray",
+          "name": "ray"
         },
         {
-          "name": "p1",
-          "type": "Vector3"
+          "type": "Vector3",
+          "name": "p1"
         },
         {
-          "name": "p2",
-          "type": "Vector3"
+          "type": "Vector3",
+          "name": "p2"
         },
         {
-          "name": "p3",
-          "type": "Vector3"
+          "type": "Vector3",
+          "name": "p3"
         },
         {
-          "name": "p4",
-          "type": "Vector3"
+          "type": "Vector3",
+          "name": "p4"
         }
       ]
     },
@@ -9380,8 +9380,8 @@
       "returnType": "void",
       "params": [
         {
-          "name": "volume",
-          "type": "float"
+          "type": "float",
+          "name": "volume"
         }
       ]
     },
@@ -9391,8 +9391,8 @@
       "returnType": "Wave",
       "params": [
         {
-          "name": "fileName",
-          "type": "const char *"
+          "type": "const char *",
+          "name": "fileName"
         }
       ]
     },
@@ -9402,16 +9402,16 @@
       "returnType": "Wave",
       "params": [
         {
-          "name": "fileType",
-          "type": "const char *"
+          "type": "const char *",
+          "name": "fileType"
         },
         {
-          "name": "fileData",
-          "type": "const unsigned char *"
+          "type": "const unsigned char *",
+          "name": "fileData"
         },
         {
-          "name": "dataSize",
-          "type": "int"
+          "type": "int",
+          "name": "dataSize"
         }
       ]
     },
@@ -9421,8 +9421,8 @@
       "returnType": "Sound",
       "params": [
         {
-          "name": "fileName",
-          "type": "const char *"
+          "type": "const char *",
+          "name": "fileName"
         }
       ]
     },
@@ -9432,8 +9432,8 @@
       "returnType": "Sound",
       "params": [
         {
-          "name": "wave",
-          "type": "Wave"
+          "type": "Wave",
+          "name": "wave"
         }
       ]
     },
@@ -9443,16 +9443,16 @@
       "returnType": "void",
       "params": [
         {
-          "name": "sound",
-          "type": "Sound"
+          "type": "Sound",
+          "name": "sound"
         },
         {
-          "name": "data",
-          "type": "const void *"
+          "type": "const void *",
+          "name": "data"
         },
         {
-          "name": "sampleCount",
-          "type": "int"
+          "type": "int",
+          "name": "sampleCount"
         }
       ]
     },
@@ -9462,8 +9462,8 @@
       "returnType": "void",
       "params": [
         {
-          "name": "wave",
-          "type": "Wave"
+          "type": "Wave",
+          "name": "wave"
         }
       ]
     },
@@ -9473,8 +9473,8 @@
       "returnType": "void",
       "params": [
         {
-          "name": "sound",
-          "type": "Sound"
+          "type": "Sound",
+          "name": "sound"
         }
       ]
     },
@@ -9484,12 +9484,12 @@
       "returnType": "bool",
       "params": [
         {
-          "name": "wave",
-          "type": "Wave"
+          "type": "Wave",
+          "name": "wave"
         },
         {
-          "name": "fileName",
-          "type": "const char *"
+          "type": "const char *",
+          "name": "fileName"
         }
       ]
     },
@@ -9499,12 +9499,12 @@
       "returnType": "bool",
       "params": [
         {
-          "name": "wave",
-          "type": "Wave"
+          "type": "Wave",
+          "name": "wave"
         },
         {
-          "name": "fileName",
-          "type": "const char *"
+          "type": "const char *",
+          "name": "fileName"
         }
       ]
     },
@@ -9514,8 +9514,8 @@
       "returnType": "void",
       "params": [
         {
-          "name": "sound",
-          "type": "Sound"
+          "type": "Sound",
+          "name": "sound"
         }
       ]
     },
@@ -9525,8 +9525,8 @@
       "returnType": "void",
       "params": [
         {
-          "name": "sound",
-          "type": "Sound"
+          "type": "Sound",
+          "name": "sound"
         }
       ]
     },
@@ -9536,8 +9536,8 @@
       "returnType": "void",
       "params": [
         {
-          "name": "sound",
-          "type": "Sound"
+          "type": "Sound",
+          "name": "sound"
         }
       ]
     },
@@ -9547,8 +9547,8 @@
       "returnType": "void",
       "params": [
         {
-          "name": "sound",
-          "type": "Sound"
+          "type": "Sound",
+          "name": "sound"
         }
       ]
     },
@@ -9558,8 +9558,8 @@
       "returnType": "void",
       "params": [
         {
-          "name": "sound",
-          "type": "Sound"
+          "type": "Sound",
+          "name": "sound"
         }
       ]
     },
@@ -9579,8 +9579,8 @@
       "returnType": "bool",
       "params": [
         {
-          "name": "sound",
-          "type": "Sound"
+          "type": "Sound",
+          "name": "sound"
         }
       ]
     },
@@ -9590,12 +9590,12 @@
       "returnType": "void",
       "params": [
         {
-          "name": "sound",
-          "type": "Sound"
+          "type": "Sound",
+          "name": "sound"
         },
         {
-          "name": "volume",
-          "type": "float"
+          "type": "float",
+          "name": "volume"
         }
       ]
     },
@@ -9605,12 +9605,12 @@
       "returnType": "void",
       "params": [
         {
-          "name": "sound",
-          "type": "Sound"
+          "type": "Sound",
+          "name": "sound"
         },
         {
-          "name": "pitch",
-          "type": "float"
+          "type": "float",
+          "name": "pitch"
         }
       ]
     },
@@ -9620,20 +9620,20 @@
       "returnType": "void",
       "params": [
         {
-          "name": "wave",
-          "type": "Wave *"
+          "type": "Wave *",
+          "name": "wave"
         },
         {
-          "name": "sampleRate",
-          "type": "int"
+          "type": "int",
+          "name": "sampleRate"
         },
         {
-          "name": "sampleSize",
-          "type": "int"
+          "type": "int",
+          "name": "sampleSize"
         },
         {
-          "name": "channels",
-          "type": "int"
+          "type": "int",
+          "name": "channels"
         }
       ]
     },
@@ -9643,8 +9643,8 @@
       "returnType": "Wave",
       "params": [
         {
-          "name": "wave",
-          "type": "Wave"
+          "type": "Wave",
+          "name": "wave"
         }
       ]
     },
@@ -9654,16 +9654,16 @@
       "returnType": "void",
       "params": [
         {
-          "name": "wave",
-          "type": "Wave *"
+          "type": "Wave *",
+          "name": "wave"
         },
         {
-          "name": "initSample",
-          "type": "int"
+          "type": "int",
+          "name": "initSample"
         },
         {
-          "name": "finalSample",
-          "type": "int"
+          "type": "int",
+          "name": "finalSample"
         }
       ]
     },
@@ -9673,8 +9673,8 @@
       "returnType": "float *",
       "params": [
         {
-          "name": "wave",
-          "type": "Wave"
+          "type": "Wave",
+          "name": "wave"
         }
       ]
     },
@@ -9684,8 +9684,8 @@
       "returnType": "void",
       "params": [
         {
-          "name": "samples",
-          "type": "float *"
+          "type": "float *",
+          "name": "samples"
         }
       ]
     },
@@ -9695,8 +9695,8 @@
       "returnType": "Music",
       "params": [
         {
-          "name": "fileName",
-          "type": "const char *"
+          "type": "const char *",
+          "name": "fileName"
         }
       ]
     },
@@ -9706,16 +9706,16 @@
       "returnType": "Music",
       "params": [
         {
-          "name": "fileType",
-          "type": "const char *"
+          "type": "const char *",
+          "name": "fileType"
         },
         {
-          "name": "data",
-          "type": "unsigned char *"
+          "type": "unsigned char *",
+          "name": "data"
         },
         {
-          "name": "dataSize",
-          "type": "int"
+          "type": "int",
+          "name": "dataSize"
         }
       ]
     },
@@ -9725,8 +9725,8 @@
       "returnType": "void",
       "params": [
         {
-          "name": "music",
-          "type": "Music"
+          "type": "Music",
+          "name": "music"
         }
       ]
     },
@@ -9736,8 +9736,8 @@
       "returnType": "void",
       "params": [
         {
-          "name": "music",
-          "type": "Music"
+          "type": "Music",
+          "name": "music"
         }
       ]
     },
@@ -9747,8 +9747,8 @@
       "returnType": "bool",
       "params": [
         {
-          "name": "music",
-          "type": "Music"
+          "type": "Music",
+          "name": "music"
         }
       ]
     },
@@ -9758,8 +9758,8 @@
       "returnType": "void",
       "params": [
         {
-          "name": "music",
-          "type": "Music"
+          "type": "Music",
+          "name": "music"
         }
       ]
     },
@@ -9769,8 +9769,8 @@
       "returnType": "void",
       "params": [
         {
-          "name": "music",
-          "type": "Music"
+          "type": "Music",
+          "name": "music"
         }
       ]
     },
@@ -9780,8 +9780,8 @@
       "returnType": "void",
       "params": [
         {
-          "name": "music",
-          "type": "Music"
+          "type": "Music",
+          "name": "music"
         }
       ]
     },
@@ -9791,8 +9791,8 @@
       "returnType": "void",
       "params": [
         {
-          "name": "music",
-          "type": "Music"
+          "type": "Music",
+          "name": "music"
         }
       ]
     },
@@ -9802,12 +9802,12 @@
       "returnType": "void",
       "params": [
         {
-          "name": "music",
-          "type": "Music"
+          "type": "Music",
+          "name": "music"
         },
         {
-          "name": "position",
-          "type": "float"
+          "type": "float",
+          "name": "position"
         }
       ]
     },
@@ -9817,12 +9817,12 @@
       "returnType": "void",
       "params": [
         {
-          "name": "music",
-          "type": "Music"
+          "type": "Music",
+          "name": "music"
         },
         {
-          "name": "volume",
-          "type": "float"
+          "type": "float",
+          "name": "volume"
         }
       ]
     },
@@ -9832,12 +9832,12 @@
       "returnType": "void",
       "params": [
         {
-          "name": "music",
-          "type": "Music"
+          "type": "Music",
+          "name": "music"
         },
         {
-          "name": "pitch",
-          "type": "float"
+          "type": "float",
+          "name": "pitch"
         }
       ]
     },
@@ -9847,8 +9847,8 @@
       "returnType": "float",
       "params": [
         {
-          "name": "music",
-          "type": "Music"
+          "type": "Music",
+          "name": "music"
         }
       ]
     },
@@ -9858,8 +9858,8 @@
       "returnType": "float",
       "params": [
         {
-          "name": "music",
-          "type": "Music"
+          "type": "Music",
+          "name": "music"
         }
       ]
     },
@@ -9869,16 +9869,16 @@
       "returnType": "AudioStream",
       "params": [
         {
-          "name": "sampleRate",
-          "type": "unsigned int"
+          "type": "unsigned int",
+          "name": "sampleRate"
         },
         {
-          "name": "sampleSize",
-          "type": "unsigned int"
+          "type": "unsigned int",
+          "name": "sampleSize"
         },
         {
-          "name": "channels",
-          "type": "unsigned int"
+          "type": "unsigned int",
+          "name": "channels"
         }
       ]
     },
@@ -9888,8 +9888,8 @@
       "returnType": "void",
       "params": [
         {
-          "name": "stream",
-          "type": "AudioStream"
+          "type": "AudioStream",
+          "name": "stream"
         }
       ]
     },
@@ -9899,16 +9899,16 @@
       "returnType": "void",
       "params": [
         {
-          "name": "stream",
-          "type": "AudioStream"
+          "type": "AudioStream",
+          "name": "stream"
         },
         {
-          "name": "data",
-          "type": "const void *"
+          "type": "const void *",
+          "name": "data"
         },
         {
-          "name": "frameCount",
-          "type": "int"
+          "type": "int",
+          "name": "frameCount"
         }
       ]
     },
@@ -9918,8 +9918,8 @@
       "returnType": "bool",
       "params": [
         {
-          "name": "stream",
-          "type": "AudioStream"
+          "type": "AudioStream",
+          "name": "stream"
         }
       ]
     },
@@ -9929,8 +9929,8 @@
       "returnType": "void",
       "params": [
         {
-          "name": "stream",
-          "type": "AudioStream"
+          "type": "AudioStream",
+          "name": "stream"
         }
       ]
     },
@@ -9940,8 +9940,8 @@
       "returnType": "void",
       "params": [
         {
-          "name": "stream",
-          "type": "AudioStream"
+          "type": "AudioStream",
+          "name": "stream"
         }
       ]
     },
@@ -9951,8 +9951,8 @@
       "returnType": "void",
       "params": [
         {
-          "name": "stream",
-          "type": "AudioStream"
+          "type": "AudioStream",
+          "name": "stream"
         }
       ]
     },
@@ -9962,8 +9962,8 @@
       "returnType": "bool",
       "params": [
         {
-          "name": "stream",
-          "type": "AudioStream"
+          "type": "AudioStream",
+          "name": "stream"
         }
       ]
     },
@@ -9973,8 +9973,8 @@
       "returnType": "void",
       "params": [
         {
-          "name": "stream",
-          "type": "AudioStream"
+          "type": "AudioStream",
+          "name": "stream"
         }
       ]
     },
@@ -9984,12 +9984,12 @@
       "returnType": "void",
       "params": [
         {
-          "name": "stream",
-          "type": "AudioStream"
+          "type": "AudioStream",
+          "name": "stream"
         },
         {
-          "name": "volume",
-          "type": "float"
+          "type": "float",
+          "name": "volume"
         }
       ]
     },
@@ -9999,12 +9999,12 @@
       "returnType": "void",
       "params": [
         {
-          "name": "stream",
-          "type": "AudioStream"
+          "type": "AudioStream",
+          "name": "stream"
         },
         {
-          "name": "pitch",
-          "type": "float"
+          "type": "float",
+          "name": "pitch"
         }
       ]
     },
@@ -10014,8 +10014,8 @@
       "returnType": "void",
       "params": [
         {
-          "name": "size",
-          "type": "int"
+          "type": "int",
+          "name": "size"
         }
       ]
     }

--- a/parser/raylib_api.lua
+++ b/parser/raylib_api.lua
@@ -2551,7 +2551,7 @@ return {
     },
     {
       name = "SetWindowState",
-      description = "Set window configuration state using flags",
+      description = "Set window configuration state using flags (only PLATFORM_DESKTOP)",
       returnType = "void",
       params = {
         {name = "flags", type = "unsigned int"}
@@ -2634,6 +2634,14 @@ return {
       params = {
         {name = "width", type = "int"},
         {name = "height", type = "int"}
+      }
+    },
+    {
+      name = "SetWindowOpacity",
+      description = "Set window opacity [0.0f..1.0f] (only PLATFORM_DESKTOP)",
+      returnType = "void",
+      params = {
+        {name = "opacity", type = "float"}
       }
     },
     {
@@ -5264,7 +5272,7 @@ return {
     },
     {
       name = "LoadFontEx",
-      description = "Load font from file with extended parameters",
+      description = "Load font from file with extended parameters, use NULL for fontChars and 0 for glyphCount to load the default character set",
       returnType = "Font",
       params = {
         {name = "fileName", type = "const char *"},
@@ -5333,10 +5341,19 @@ return {
     },
     {
       name = "UnloadFont",
-      description = "Unload Font from GPU memory (VRAM)",
+      description = "Unload font from GPU memory (VRAM)",
       returnType = "void",
       params = {
         {name = "font", type = "Font"}
+      }
+    },
+    {
+      name = "ExportFontAsCode",
+      description = "Export font as code file, returns true on success",
+      returnType = "bool",
+      params = {
+        {name = "font", type = "Font"},
+        {name = "fileName", type = "const char *"}
       }
     },
     {

--- a/parser/raylib_api.lua
+++ b/parser/raylib_api.lua
@@ -5,13 +5,13 @@ return {
       description = "Vector2, 2 components",
       fields = {
         {
-          name = "x",
           type = "float",
+          name = "x",
           description = "Vector x component"
         },
         {
-          name = "y",
           type = "float",
+          name = "y",
           description = "Vector y component"
         }
       }
@@ -21,18 +21,18 @@ return {
       description = "Vector3, 3 components",
       fields = {
         {
-          name = "x",
           type = "float",
+          name = "x",
           description = "Vector x component"
         },
         {
-          name = "y",
           type = "float",
+          name = "y",
           description = "Vector y component"
         },
         {
-          name = "z",
           type = "float",
+          name = "z",
           description = "Vector z component"
         }
       }
@@ -42,23 +42,23 @@ return {
       description = "Vector4, 4 components",
       fields = {
         {
-          name = "x",
           type = "float",
+          name = "x",
           description = "Vector x component"
         },
         {
-          name = "y",
           type = "float",
+          name = "y",
           description = "Vector y component"
         },
         {
-          name = "z",
           type = "float",
+          name = "z",
           description = "Vector z component"
         },
         {
-          name = "w",
           type = "float",
+          name = "w",
           description = "Vector w component"
         }
       }
@@ -68,23 +68,23 @@ return {
       description = "Matrix, 4x4 components, column major, OpenGL style, right handed",
       fields = {
         {
-          name = "m0, m4, m8, m12",
           type = "float",
+          name = "m0, m4, m8, m12",
           description = "Matrix first row (4 components)"
         },
         {
-          name = "m1, m5, m9, m13",
           type = "float",
+          name = "m1, m5, m9, m13",
           description = "Matrix second row (4 components)"
         },
         {
-          name = "m2, m6, m10, m14",
           type = "float",
+          name = "m2, m6, m10, m14",
           description = "Matrix third row (4 components)"
         },
         {
-          name = "m3, m7, m11, m15",
           type = "float",
+          name = "m3, m7, m11, m15",
           description = "Matrix fourth row (4 components)"
         }
       }
@@ -94,23 +94,23 @@ return {
       description = "Color, 4 components, R8G8B8A8 (32bit)",
       fields = {
         {
-          name = "r",
           type = "unsigned char",
+          name = "r",
           description = "Color red value"
         },
         {
-          name = "g",
           type = "unsigned char",
+          name = "g",
           description = "Color green value"
         },
         {
-          name = "b",
           type = "unsigned char",
+          name = "b",
           description = "Color blue value"
         },
         {
-          name = "a",
           type = "unsigned char",
+          name = "a",
           description = "Color alpha value"
         }
       }
@@ -120,23 +120,23 @@ return {
       description = "Rectangle, 4 components",
       fields = {
         {
-          name = "x",
           type = "float",
+          name = "x",
           description = "Rectangle top-left corner position x"
         },
         {
-          name = "y",
           type = "float",
+          name = "y",
           description = "Rectangle top-left corner position y"
         },
         {
-          name = "width",
           type = "float",
+          name = "width",
           description = "Rectangle width"
         },
         {
-          name = "height",
           type = "float",
+          name = "height",
           description = "Rectangle height"
         }
       }
@@ -146,28 +146,28 @@ return {
       description = "Image, pixel data stored in CPU memory (RAM)",
       fields = {
         {
-          name = "data",
           type = "void *",
+          name = "data",
           description = "Image raw data"
         },
         {
-          name = "width",
           type = "int",
+          name = "width",
           description = "Image base width"
         },
         {
-          name = "height",
           type = "int",
+          name = "height",
           description = "Image base height"
         },
         {
-          name = "mipmaps",
           type = "int",
+          name = "mipmaps",
           description = "Mipmap levels, 1 by default"
         },
         {
-          name = "format",
           type = "int",
+          name = "format",
           description = "Data format (PixelFormat type)"
         }
       }
@@ -177,28 +177,28 @@ return {
       description = "Texture, tex data stored in GPU memory (VRAM)",
       fields = {
         {
-          name = "id",
           type = "unsigned int",
+          name = "id",
           description = "OpenGL texture id"
         },
         {
-          name = "width",
           type = "int",
+          name = "width",
           description = "Texture base width"
         },
         {
-          name = "height",
           type = "int",
+          name = "height",
           description = "Texture base height"
         },
         {
-          name = "mipmaps",
           type = "int",
+          name = "mipmaps",
           description = "Mipmap levels, 1 by default"
         },
         {
-          name = "format",
           type = "int",
+          name = "format",
           description = "Data format (PixelFormat type)"
         }
       }
@@ -208,18 +208,18 @@ return {
       description = "RenderTexture, fbo for texture rendering",
       fields = {
         {
-          name = "id",
           type = "unsigned int",
+          name = "id",
           description = "OpenGL framebuffer object id"
         },
         {
-          name = "texture",
           type = "Texture",
+          name = "texture",
           description = "Color buffer attachment texture"
         },
         {
-          name = "depth",
           type = "Texture",
+          name = "depth",
           description = "Depth buffer attachment texture"
         }
       }
@@ -229,33 +229,33 @@ return {
       description = "NPatchInfo, n-patch layout info",
       fields = {
         {
-          name = "source",
           type = "Rectangle",
+          name = "source",
           description = "Texture source rectangle"
         },
         {
-          name = "left",
           type = "int",
+          name = "left",
           description = "Left border offset"
         },
         {
-          name = "top",
           type = "int",
+          name = "top",
           description = "Top border offset"
         },
         {
-          name = "right",
           type = "int",
+          name = "right",
           description = "Right border offset"
         },
         {
-          name = "bottom",
           type = "int",
+          name = "bottom",
           description = "Bottom border offset"
         },
         {
-          name = "layout",
           type = "int",
+          name = "layout",
           description = "Layout of the n-patch: 3x3, 1x3 or 3x1"
         }
       }
@@ -265,28 +265,28 @@ return {
       description = "GlyphInfo, font characters glyphs info",
       fields = {
         {
-          name = "value",
           type = "int",
+          name = "value",
           description = "Character value (Unicode)"
         },
         {
-          name = "offsetX",
           type = "int",
+          name = "offsetX",
           description = "Character offset X when drawing"
         },
         {
-          name = "offsetY",
           type = "int",
+          name = "offsetY",
           description = "Character offset Y when drawing"
         },
         {
-          name = "advanceX",
           type = "int",
+          name = "advanceX",
           description = "Character advance position X"
         },
         {
-          name = "image",
           type = "Image",
+          name = "image",
           description = "Character image data"
         }
       }
@@ -296,33 +296,33 @@ return {
       description = "Font, font texture and GlyphInfo array data",
       fields = {
         {
-          name = "baseSize",
           type = "int",
+          name = "baseSize",
           description = "Base size (default chars height)"
         },
         {
-          name = "glyphCount",
           type = "int",
+          name = "glyphCount",
           description = "Number of glyph characters"
         },
         {
-          name = "glyphPadding",
           type = "int",
+          name = "glyphPadding",
           description = "Padding around the glyph characters"
         },
         {
-          name = "texture",
           type = "Texture2D",
+          name = "texture",
           description = "Texture atlas containing the glyphs"
         },
         {
-          name = "recs",
           type = "Rectangle *",
+          name = "recs",
           description = "Rectangles in texture for the glyphs"
         },
         {
-          name = "glyphs",
           type = "GlyphInfo *",
+          name = "glyphs",
           description = "Glyphs info data"
         }
       }
@@ -332,28 +332,28 @@ return {
       description = "Camera, defines position/orientation in 3d space",
       fields = {
         {
-          name = "position",
           type = "Vector3",
+          name = "position",
           description = "Camera position"
         },
         {
-          name = "target",
           type = "Vector3",
+          name = "target",
           description = "Camera target it looks-at"
         },
         {
-          name = "up",
           type = "Vector3",
+          name = "up",
           description = "Camera up vector (rotation over its axis)"
         },
         {
-          name = "fovy",
           type = "float",
+          name = "fovy",
           description = "Camera field-of-view apperture in Y (degrees) in perspective, used as near plane width in orthographic"
         },
         {
-          name = "projection",
           type = "int",
+          name = "projection",
           description = "Camera projection: CAMERA_PERSPECTIVE or CAMERA_ORTHOGRAPHIC"
         }
       }
@@ -363,23 +363,23 @@ return {
       description = "Camera2D, defines position/orientation in 2d space",
       fields = {
         {
-          name = "offset",
           type = "Vector2",
+          name = "offset",
           description = "Camera offset (displacement from target)"
         },
         {
-          name = "target",
           type = "Vector2",
+          name = "target",
           description = "Camera target (rotation and zoom origin)"
         },
         {
-          name = "rotation",
           type = "float",
+          name = "rotation",
           description = "Camera rotation in degrees"
         },
         {
-          name = "zoom",
           type = "float",
+          name = "zoom",
           description = "Camera zoom (scaling), should be 1.0f by default"
         }
       }
@@ -389,78 +389,78 @@ return {
       description = "Mesh, vertex data and vao/vbo",
       fields = {
         {
-          name = "vertexCount",
           type = "int",
+          name = "vertexCount",
           description = "Number of vertices stored in arrays"
         },
         {
-          name = "triangleCount",
           type = "int",
+          name = "triangleCount",
           description = "Number of triangles stored (indexed or not)"
         },
         {
-          name = "vertices",
           type = "float *",
+          name = "vertices",
           description = "Vertex position (XYZ - 3 components per vertex) (shader-location = 0)"
         },
         {
-          name = "texcoords",
           type = "float *",
+          name = "texcoords",
           description = "Vertex texture coordinates (UV - 2 components per vertex) (shader-location = 1)"
         },
         {
-          name = "texcoords2",
           type = "float *",
+          name = "texcoords2",
           description = "Vertex second texture coordinates (useful for lightmaps) (shader-location = 5)"
         },
         {
-          name = "normals",
           type = "float *",
+          name = "normals",
           description = "Vertex normals (XYZ - 3 components per vertex) (shader-location = 2)"
         },
         {
-          name = "tangents",
           type = "float *",
+          name = "tangents",
           description = "Vertex tangents (XYZW - 4 components per vertex) (shader-location = 4)"
         },
         {
-          name = "colors",
           type = "unsigned char *",
+          name = "colors",
           description = "Vertex colors (RGBA - 4 components per vertex) (shader-location = 3)"
         },
         {
-          name = "indices",
           type = "unsigned short *",
+          name = "indices",
           description = "Vertex indices (in case vertex data comes indexed)"
         },
         {
-          name = "animVertices",
           type = "float *",
+          name = "animVertices",
           description = "Animated vertex positions (after bones transformations)"
         },
         {
-          name = "animNormals",
           type = "float *",
+          name = "animNormals",
           description = "Animated normals (after bones transformations)"
         },
         {
-          name = "boneIds",
           type = "unsigned char *",
+          name = "boneIds",
           description = "Vertex bone ids, max 255 bone ids, up to 4 bones influence by vertex (skinning)"
         },
         {
-          name = "boneWeights",
           type = "float *",
+          name = "boneWeights",
           description = "Vertex bone weight, up to 4 bones influence by vertex (skinning)"
         },
         {
-          name = "vaoId",
           type = "unsigned int",
+          name = "vaoId",
           description = "OpenGL Vertex Array Object id"
         },
         {
-          name = "vboId",
           type = "unsigned int *",
+          name = "vboId",
           description = "OpenGL Vertex Buffer Objects id (default vertex data)"
         }
       }
@@ -470,13 +470,13 @@ return {
       description = "Shader",
       fields = {
         {
-          name = "id",
           type = "unsigned int",
+          name = "id",
           description = "Shader program id"
         },
         {
-          name = "locs",
           type = "int *",
+          name = "locs",
           description = "Shader locations array (RL_MAX_SHADER_LOCATIONS)"
         }
       }
@@ -486,18 +486,18 @@ return {
       description = "MaterialMap",
       fields = {
         {
-          name = "texture",
           type = "Texture2D",
+          name = "texture",
           description = "Material map texture"
         },
         {
-          name = "color",
           type = "Color",
+          name = "color",
           description = "Material map color"
         },
         {
-          name = "value",
           type = "float",
+          name = "value",
           description = "Material map value"
         }
       }
@@ -507,18 +507,18 @@ return {
       description = "Material, includes shader and maps",
       fields = {
         {
-          name = "shader",
           type = "Shader",
+          name = "shader",
           description = "Material shader"
         },
         {
-          name = "maps",
           type = "MaterialMap *",
+          name = "maps",
           description = "Material maps array (MAX_MATERIAL_MAPS)"
         },
         {
-          name = "params[4]",
           type = "float",
+          name = "params[4]",
           description = "Material generic parameters (if required)"
         }
       }
@@ -528,18 +528,18 @@ return {
       description = "Transform, vectex transformation data",
       fields = {
         {
-          name = "translation",
           type = "Vector3",
+          name = "translation",
           description = "Translation"
         },
         {
-          name = "rotation",
           type = "Quaternion",
+          name = "rotation",
           description = "Rotation"
         },
         {
-          name = "scale",
           type = "Vector3",
+          name = "scale",
           description = "Scale"
         }
       }
@@ -549,13 +549,13 @@ return {
       description = "Bone, skeletal animation bone",
       fields = {
         {
-          name = "name[32]",
           type = "char",
+          name = "name[32]",
           description = "Bone name"
         },
         {
-          name = "parent",
           type = "int",
+          name = "parent",
           description = "Bone parent"
         }
       }
@@ -565,48 +565,48 @@ return {
       description = "Model, meshes, materials and animation data",
       fields = {
         {
-          name = "transform",
           type = "Matrix",
+          name = "transform",
           description = "Local transform matrix"
         },
         {
-          name = "meshCount",
           type = "int",
+          name = "meshCount",
           description = "Number of meshes"
         },
         {
-          name = "materialCount",
           type = "int",
+          name = "materialCount",
           description = "Number of materials"
         },
         {
-          name = "meshes",
           type = "Mesh *",
+          name = "meshes",
           description = "Meshes array"
         },
         {
-          name = "materials",
           type = "Material *",
+          name = "materials",
           description = "Materials array"
         },
         {
-          name = "meshMaterial",
           type = "int *",
+          name = "meshMaterial",
           description = "Mesh material number"
         },
         {
-          name = "boneCount",
           type = "int",
+          name = "boneCount",
           description = "Number of bones"
         },
         {
-          name = "bones",
           type = "BoneInfo *",
+          name = "bones",
           description = "Bones information (skeleton)"
         },
         {
-          name = "bindPose",
           type = "Transform *",
+          name = "bindPose",
           description = "Bones base transformation (pose)"
         }
       }
@@ -616,23 +616,23 @@ return {
       description = "ModelAnimation",
       fields = {
         {
-          name = "boneCount",
           type = "int",
+          name = "boneCount",
           description = "Number of bones"
         },
         {
-          name = "frameCount",
           type = "int",
+          name = "frameCount",
           description = "Number of animation frames"
         },
         {
-          name = "bones",
           type = "BoneInfo *",
+          name = "bones",
           description = "Bones information (skeleton)"
         },
         {
-          name = "framePoses",
           type = "Transform **",
+          name = "framePoses",
           description = "Poses array by frame"
         }
       }
@@ -642,13 +642,13 @@ return {
       description = "Ray, ray for raycasting",
       fields = {
         {
-          name = "position",
           type = "Vector3",
+          name = "position",
           description = "Ray position (origin)"
         },
         {
-          name = "direction",
           type = "Vector3",
+          name = "direction",
           description = "Ray direction"
         }
       }
@@ -658,23 +658,23 @@ return {
       description = "RayCollision, ray hit information",
       fields = {
         {
-          name = "hit",
           type = "bool",
+          name = "hit",
           description = "Did the ray hit something?"
         },
         {
-          name = "distance",
           type = "float",
+          name = "distance",
           description = "Distance to nearest hit"
         },
         {
-          name = "point",
           type = "Vector3",
+          name = "point",
           description = "Point of nearest hit"
         },
         {
-          name = "normal",
           type = "Vector3",
+          name = "normal",
           description = "Surface normal of hit"
         }
       }
@@ -684,13 +684,13 @@ return {
       description = "BoundingBox",
       fields = {
         {
-          name = "min",
           type = "Vector3",
+          name = "min",
           description = "Minimum vertex box-corner"
         },
         {
-          name = "max",
           type = "Vector3",
+          name = "max",
           description = "Maximum vertex box-corner"
         }
       }
@@ -700,28 +700,28 @@ return {
       description = "Wave, audio wave data",
       fields = {
         {
-          name = "frameCount",
           type = "unsigned int",
+          name = "frameCount",
           description = "Total number of frames (considering channels)"
         },
         {
-          name = "sampleRate",
           type = "unsigned int",
+          name = "sampleRate",
           description = "Frequency (samples per second)"
         },
         {
-          name = "sampleSize",
           type = "unsigned int",
+          name = "sampleSize",
           description = "Bit depth (bits per sample): 8, 16, 32 (24 not supported)"
         },
         {
-          name = "channels",
           type = "unsigned int",
+          name = "channels",
           description = "Number of channels (1-mono, 2-stereo, ...)"
         },
         {
-          name = "data",
           type = "void *",
+          name = "data",
           description = "Buffer data pointer"
         }
       }
@@ -731,23 +731,23 @@ return {
       description = "AudioStream, custom audio stream",
       fields = {
         {
-          name = "buffer",
           type = "rAudioBuffer *",
+          name = "buffer",
           description = "Pointer to internal data used by the audio system"
         },
         {
-          name = "sampleRate",
           type = "unsigned int",
+          name = "sampleRate",
           description = "Frequency (samples per second)"
         },
         {
-          name = "sampleSize",
           type = "unsigned int",
+          name = "sampleSize",
           description = "Bit depth (bits per sample): 8, 16, 32 (24 not supported)"
         },
         {
-          name = "channels",
           type = "unsigned int",
+          name = "channels",
           description = "Number of channels (1-mono, 2-stereo, ...)"
         }
       }
@@ -757,13 +757,13 @@ return {
       description = "Sound",
       fields = {
         {
-          name = "stream",
           type = "AudioStream",
+          name = "stream",
           description = "Audio stream"
         },
         {
-          name = "frameCount",
           type = "unsigned int",
+          name = "frameCount",
           description = "Total number of frames (considering channels)"
         }
       }
@@ -773,28 +773,28 @@ return {
       description = "Music, audio stream, anything longer than ~10 seconds should be streamed",
       fields = {
         {
-          name = "stream",
           type = "AudioStream",
+          name = "stream",
           description = "Audio stream"
         },
         {
-          name = "frameCount",
           type = "unsigned int",
+          name = "frameCount",
           description = "Total number of frames (considering channels)"
         },
         {
-          name = "looping",
           type = "bool",
+          name = "looping",
           description = "Music looping enable"
         },
         {
-          name = "ctxType",
           type = "int",
+          name = "ctxType",
           description = "Type of music context (audio filetype)"
         },
         {
-          name = "ctxData",
           type = "void *",
+          name = "ctxData",
           description = "Audio context data, depends on type"
         }
       }
@@ -804,53 +804,53 @@ return {
       description = "VrDeviceInfo, Head-Mounted-Display device parameters",
       fields = {
         {
-          name = "hResolution",
           type = "int",
+          name = "hResolution",
           description = "Horizontal resolution in pixels"
         },
         {
-          name = "vResolution",
           type = "int",
+          name = "vResolution",
           description = "Vertical resolution in pixels"
         },
         {
-          name = "hScreenSize",
           type = "float",
+          name = "hScreenSize",
           description = "Horizontal size in meters"
         },
         {
-          name = "vScreenSize",
           type = "float",
+          name = "vScreenSize",
           description = "Vertical size in meters"
         },
         {
-          name = "vScreenCenter",
           type = "float",
+          name = "vScreenCenter",
           description = "Screen center in meters"
         },
         {
-          name = "eyeToScreenDistance",
           type = "float",
+          name = "eyeToScreenDistance",
           description = "Distance between eye and display in meters"
         },
         {
-          name = "lensSeparationDistance",
           type = "float",
+          name = "lensSeparationDistance",
           description = "Lens separation distance in meters"
         },
         {
-          name = "interpupillaryDistance",
           type = "float",
+          name = "interpupillaryDistance",
           description = "IPD (distance between pupils) in meters"
         },
         {
-          name = "lensDistortionValues[4]",
           type = "float",
+          name = "lensDistortionValues[4]",
           description = "Lens distortion constant parameters"
         },
         {
-          name = "chromaAbCorrection[4]",
           type = "float",
+          name = "chromaAbCorrection[4]",
           description = "Chromatic aberration correction parameters"
         }
       }
@@ -860,43 +860,43 @@ return {
       description = "VrStereoConfig, VR stereo rendering configuration for simulator",
       fields = {
         {
-          name = "projection[2]",
           type = "Matrix",
+          name = "projection[2]",
           description = "VR projection matrices (per eye)"
         },
         {
-          name = "viewOffset[2]",
           type = "Matrix",
+          name = "viewOffset[2]",
           description = "VR view offset matrices (per eye)"
         },
         {
-          name = "leftLensCenter[2]",
           type = "float",
+          name = "leftLensCenter[2]",
           description = "VR left lens center"
         },
         {
-          name = "rightLensCenter[2]",
           type = "float",
+          name = "rightLensCenter[2]",
           description = "VR right lens center"
         },
         {
-          name = "leftScreenCenter[2]",
           type = "float",
+          name = "leftScreenCenter[2]",
           description = "VR left screen center"
         },
         {
-          name = "rightScreenCenter[2]",
           type = "float",
+          name = "rightScreenCenter[2]",
           description = "VR right screen center"
         },
         {
-          name = "scale[2]",
           type = "float",
+          name = "scale[2]",
           description = "VR distortion scale"
         },
         {
-          name = "scaleIn[2]",
           type = "float",
+          name = "scaleIn[2]",
           description = "VR distortion scale in"
         }
       }
@@ -2491,9 +2491,9 @@ return {
       description = "Initialize window and OpenGL context",
       returnType = "void",
       params = {
-        {name = "width", type = "int"},
-        {name = "height", type = "int"},
-        {name = "title", type = "const char *"}
+        {type = "int", name = "width"},
+        {type = "int", name = "height"},
+        {type = "const char *", name = "title"}
       }
     },
     {
@@ -2546,7 +2546,7 @@ return {
       description = "Check if one specific window flag is enabled",
       returnType = "bool",
       params = {
-        {name = "flag", type = "unsigned int"}
+        {type = "unsigned int", name = "flag"}
       }
     },
     {
@@ -2554,7 +2554,7 @@ return {
       description = "Set window configuration state using flags (only PLATFORM_DESKTOP)",
       returnType = "void",
       params = {
-        {name = "flags", type = "unsigned int"}
+        {type = "unsigned int", name = "flags"}
       }
     },
     {
@@ -2562,7 +2562,7 @@ return {
       description = "Clear window configuration state flags",
       returnType = "void",
       params = {
-        {name = "flags", type = "unsigned int"}
+        {type = "unsigned int", name = "flags"}
       }
     },
     {
@@ -2590,7 +2590,7 @@ return {
       description = "Set icon for window (only PLATFORM_DESKTOP)",
       returnType = "void",
       params = {
-        {name = "image", type = "Image"}
+        {type = "Image", name = "image"}
       }
     },
     {
@@ -2598,7 +2598,7 @@ return {
       description = "Set title for window (only PLATFORM_DESKTOP)",
       returnType = "void",
       params = {
-        {name = "title", type = "const char *"}
+        {type = "const char *", name = "title"}
       }
     },
     {
@@ -2606,8 +2606,8 @@ return {
       description = "Set window position on screen (only PLATFORM_DESKTOP)",
       returnType = "void",
       params = {
-        {name = "x", type = "int"},
-        {name = "y", type = "int"}
+        {type = "int", name = "x"},
+        {type = "int", name = "y"}
       }
     },
     {
@@ -2615,7 +2615,7 @@ return {
       description = "Set monitor for the current window (fullscreen mode)",
       returnType = "void",
       params = {
-        {name = "monitor", type = "int"}
+        {type = "int", name = "monitor"}
       }
     },
     {
@@ -2623,8 +2623,8 @@ return {
       description = "Set window minimum dimensions (for FLAG_WINDOW_RESIZABLE)",
       returnType = "void",
       params = {
-        {name = "width", type = "int"},
-        {name = "height", type = "int"}
+        {type = "int", name = "width"},
+        {type = "int", name = "height"}
       }
     },
     {
@@ -2632,8 +2632,8 @@ return {
       description = "Set window dimensions",
       returnType = "void",
       params = {
-        {name = "width", type = "int"},
-        {name = "height", type = "int"}
+        {type = "int", name = "width"},
+        {type = "int", name = "height"}
       }
     },
     {
@@ -2641,7 +2641,7 @@ return {
       description = "Set window opacity [0.0f..1.0f] (only PLATFORM_DESKTOP)",
       returnType = "void",
       params = {
-        {name = "opacity", type = "float"}
+        {type = "float", name = "opacity"}
       }
     },
     {
@@ -2684,7 +2684,7 @@ return {
       description = "Get specified monitor position",
       returnType = "Vector2",
       params = {
-        {name = "monitor", type = "int"}
+        {type = "int", name = "monitor"}
       }
     },
     {
@@ -2692,7 +2692,7 @@ return {
       description = "Get specified monitor width (max available by monitor)",
       returnType = "int",
       params = {
-        {name = "monitor", type = "int"}
+        {type = "int", name = "monitor"}
       }
     },
     {
@@ -2700,7 +2700,7 @@ return {
       description = "Get specified monitor height (max available by monitor)",
       returnType = "int",
       params = {
-        {name = "monitor", type = "int"}
+        {type = "int", name = "monitor"}
       }
     },
     {
@@ -2708,7 +2708,7 @@ return {
       description = "Get specified monitor physical width in millimetres",
       returnType = "int",
       params = {
-        {name = "monitor", type = "int"}
+        {type = "int", name = "monitor"}
       }
     },
     {
@@ -2716,7 +2716,7 @@ return {
       description = "Get specified monitor physical height in millimetres",
       returnType = "int",
       params = {
-        {name = "monitor", type = "int"}
+        {type = "int", name = "monitor"}
       }
     },
     {
@@ -2724,7 +2724,7 @@ return {
       description = "Get specified monitor refresh rate",
       returnType = "int",
       params = {
-        {name = "monitor", type = "int"}
+        {type = "int", name = "monitor"}
       }
     },
     {
@@ -2742,7 +2742,7 @@ return {
       description = "Get the human-readable, UTF-8 encoded name of the primary monitor",
       returnType = "const char *",
       params = {
-        {name = "monitor", type = "int"}
+        {type = "int", name = "monitor"}
       }
     },
     {
@@ -2750,7 +2750,7 @@ return {
       description = "Set clipboard text content",
       returnType = "void",
       params = {
-        {name = "text", type = "const char *"}
+        {type = "const char *", name = "text"}
       }
     },
     {
@@ -2773,7 +2773,7 @@ return {
       description = "Wait for some milliseconds (halt program execution)",
       returnType = "void",
       params = {
-        {name = "ms", type = "float"}
+        {type = "float", name = "ms"}
       }
     },
     {
@@ -2811,7 +2811,7 @@ return {
       description = "Set background color (framebuffer clear color)",
       returnType = "void",
       params = {
-        {name = "color", type = "Color"}
+        {type = "Color", name = "color"}
       }
     },
     {
@@ -2829,7 +2829,7 @@ return {
       description = "Begin 2D mode with custom camera (2D)",
       returnType = "void",
       params = {
-        {name = "camera", type = "Camera2D"}
+        {type = "Camera2D", name = "camera"}
       }
     },
     {
@@ -2842,7 +2842,7 @@ return {
       description = "Begin 3D mode with custom camera (3D)",
       returnType = "void",
       params = {
-        {name = "camera", type = "Camera3D"}
+        {type = "Camera3D", name = "camera"}
       }
     },
     {
@@ -2855,7 +2855,7 @@ return {
       description = "Begin drawing to render texture",
       returnType = "void",
       params = {
-        {name = "target", type = "RenderTexture2D"}
+        {type = "RenderTexture2D", name = "target"}
       }
     },
     {
@@ -2868,7 +2868,7 @@ return {
       description = "Begin custom shader drawing",
       returnType = "void",
       params = {
-        {name = "shader", type = "Shader"}
+        {type = "Shader", name = "shader"}
       }
     },
     {
@@ -2881,7 +2881,7 @@ return {
       description = "Begin blending mode (alpha, additive, multiplied, subtract, custom)",
       returnType = "void",
       params = {
-        {name = "mode", type = "int"}
+        {type = "int", name = "mode"}
       }
     },
     {
@@ -2894,10 +2894,10 @@ return {
       description = "Begin scissor mode (define screen area for following drawing)",
       returnType = "void",
       params = {
-        {name = "x", type = "int"},
-        {name = "y", type = "int"},
-        {name = "width", type = "int"},
-        {name = "height", type = "int"}
+        {type = "int", name = "x"},
+        {type = "int", name = "y"},
+        {type = "int", name = "width"},
+        {type = "int", name = "height"}
       }
     },
     {
@@ -2910,7 +2910,7 @@ return {
       description = "Begin stereo rendering (requires VR simulator)",
       returnType = "void",
       params = {
-        {name = "config", type = "VrStereoConfig"}
+        {type = "VrStereoConfig", name = "config"}
       }
     },
     {
@@ -2923,7 +2923,7 @@ return {
       description = "Load VR stereo config for VR simulator device parameters",
       returnType = "VrStereoConfig",
       params = {
-        {name = "device", type = "VrDeviceInfo"}
+        {type = "VrDeviceInfo", name = "device"}
       }
     },
     {
@@ -2931,7 +2931,7 @@ return {
       description = "Unload VR stereo config",
       returnType = "void",
       params = {
-        {name = "config", type = "VrStereoConfig"}
+        {type = "VrStereoConfig", name = "config"}
       }
     },
     {
@@ -2939,8 +2939,8 @@ return {
       description = "Load shader from files and bind default locations",
       returnType = "Shader",
       params = {
-        {name = "vsFileName", type = "const char *"},
-        {name = "fsFileName", type = "const char *"}
+        {type = "const char *", name = "vsFileName"},
+        {type = "const char *", name = "fsFileName"}
       }
     },
     {
@@ -2948,8 +2948,8 @@ return {
       description = "Load shader from code strings and bind default locations",
       returnType = "Shader",
       params = {
-        {name = "vsCode", type = "const char *"},
-        {name = "fsCode", type = "const char *"}
+        {type = "const char *", name = "vsCode"},
+        {type = "const char *", name = "fsCode"}
       }
     },
     {
@@ -2957,8 +2957,8 @@ return {
       description = "Get shader uniform location",
       returnType = "int",
       params = {
-        {name = "shader", type = "Shader"},
-        {name = "uniformName", type = "const char *"}
+        {type = "Shader", name = "shader"},
+        {type = "const char *", name = "uniformName"}
       }
     },
     {
@@ -2966,8 +2966,8 @@ return {
       description = "Get shader attribute location",
       returnType = "int",
       params = {
-        {name = "shader", type = "Shader"},
-        {name = "attribName", type = "const char *"}
+        {type = "Shader", name = "shader"},
+        {type = "const char *", name = "attribName"}
       }
     },
     {
@@ -2975,10 +2975,10 @@ return {
       description = "Set shader uniform value",
       returnType = "void",
       params = {
-        {name = "shader", type = "Shader"},
-        {name = "locIndex", type = "int"},
-        {name = "value", type = "const void *"},
-        {name = "uniformType", type = "int"}
+        {type = "Shader", name = "shader"},
+        {type = "int", name = "locIndex"},
+        {type = "const void *", name = "value"},
+        {type = "int", name = "uniformType"}
       }
     },
     {
@@ -2986,11 +2986,11 @@ return {
       description = "Set shader uniform value vector",
       returnType = "void",
       params = {
-        {name = "shader", type = "Shader"},
-        {name = "locIndex", type = "int"},
-        {name = "value", type = "const void *"},
-        {name = "uniformType", type = "int"},
-        {name = "count", type = "int"}
+        {type = "Shader", name = "shader"},
+        {type = "int", name = "locIndex"},
+        {type = "const void *", name = "value"},
+        {type = "int", name = "uniformType"},
+        {type = "int", name = "count"}
       }
     },
     {
@@ -2998,9 +2998,9 @@ return {
       description = "Set shader uniform value (matrix 4x4)",
       returnType = "void",
       params = {
-        {name = "shader", type = "Shader"},
-        {name = "locIndex", type = "int"},
-        {name = "mat", type = "Matrix"}
+        {type = "Shader", name = "shader"},
+        {type = "int", name = "locIndex"},
+        {type = "Matrix", name = "mat"}
       }
     },
     {
@@ -3008,9 +3008,9 @@ return {
       description = "Set shader uniform value for texture (sampler2d)",
       returnType = "void",
       params = {
-        {name = "shader", type = "Shader"},
-        {name = "locIndex", type = "int"},
-        {name = "texture", type = "Texture2D"}
+        {type = "Shader", name = "shader"},
+        {type = "int", name = "locIndex"},
+        {type = "Texture2D", name = "texture"}
       }
     },
     {
@@ -3018,7 +3018,7 @@ return {
       description = "Unload shader from GPU memory (VRAM)",
       returnType = "void",
       params = {
-        {name = "shader", type = "Shader"}
+        {type = "Shader", name = "shader"}
       }
     },
     {
@@ -3026,8 +3026,8 @@ return {
       description = "Get a ray trace from mouse position",
       returnType = "Ray",
       params = {
-        {name = "mousePosition", type = "Vector2"},
-        {name = "camera", type = "Camera"}
+        {type = "Vector2", name = "mousePosition"},
+        {type = "Camera", name = "camera"}
       }
     },
     {
@@ -3035,7 +3035,7 @@ return {
       description = "Get camera transform matrix (view matrix)",
       returnType = "Matrix",
       params = {
-        {name = "camera", type = "Camera"}
+        {type = "Camera", name = "camera"}
       }
     },
     {
@@ -3043,7 +3043,7 @@ return {
       description = "Get camera 2d transform matrix",
       returnType = "Matrix",
       params = {
-        {name = "camera", type = "Camera2D"}
+        {type = "Camera2D", name = "camera"}
       }
     },
     {
@@ -3051,8 +3051,8 @@ return {
       description = "Get the screen space position for a 3d world space position",
       returnType = "Vector2",
       params = {
-        {name = "position", type = "Vector3"},
-        {name = "camera", type = "Camera"}
+        {type = "Vector3", name = "position"},
+        {type = "Camera", name = "camera"}
       }
     },
     {
@@ -3060,10 +3060,10 @@ return {
       description = "Get size position for a 3d world space position",
       returnType = "Vector2",
       params = {
-        {name = "position", type = "Vector3"},
-        {name = "camera", type = "Camera"},
-        {name = "width", type = "int"},
-        {name = "height", type = "int"}
+        {type = "Vector3", name = "position"},
+        {type = "Camera", name = "camera"},
+        {type = "int", name = "width"},
+        {type = "int", name = "height"}
       }
     },
     {
@@ -3071,8 +3071,8 @@ return {
       description = "Get the screen space position for a 2d camera world space position",
       returnType = "Vector2",
       params = {
-        {name = "position", type = "Vector2"},
-        {name = "camera", type = "Camera2D"}
+        {type = "Vector2", name = "position"},
+        {type = "Camera2D", name = "camera"}
       }
     },
     {
@@ -3080,8 +3080,8 @@ return {
       description = "Get the world space position for a 2d camera screen space position",
       returnType = "Vector2",
       params = {
-        {name = "position", type = "Vector2"},
-        {name = "camera", type = "Camera2D"}
+        {type = "Vector2", name = "position"},
+        {type = "Camera2D", name = "camera"}
       }
     },
     {
@@ -3089,7 +3089,7 @@ return {
       description = "Set target FPS (maximum)",
       returnType = "void",
       params = {
-        {name = "fps", type = "int"}
+        {type = "int", name = "fps"}
       }
     },
     {
@@ -3112,8 +3112,8 @@ return {
       description = "Get a random value between min and max (both included)",
       returnType = "int",
       params = {
-        {name = "min", type = "int"},
-        {name = "max", type = "int"}
+        {type = "int", name = "min"},
+        {type = "int", name = "max"}
       }
     },
     {
@@ -3121,7 +3121,7 @@ return {
       description = "Set the seed for the random number generator",
       returnType = "void",
       params = {
-        {name = "seed", type = "unsigned int"}
+        {type = "unsigned int", name = "seed"}
       }
     },
     {
@@ -3129,7 +3129,7 @@ return {
       description = "Takes a screenshot of current screen (filename extension defines format)",
       returnType = "void",
       params = {
-        {name = "fileName", type = "const char *"}
+        {type = "const char *", name = "fileName"}
       }
     },
     {
@@ -3137,7 +3137,7 @@ return {
       description = "Setup init configuration flags (view FLAGS)",
       returnType = "void",
       params = {
-        {name = "flags", type = "unsigned int"}
+        {type = "unsigned int", name = "flags"}
       }
     },
     {
@@ -3145,9 +3145,9 @@ return {
       description = "Show trace log messages (LOG_DEBUG, LOG_INFO, LOG_WARNING, LOG_ERROR...)",
       returnType = "void",
       params = {
-        {name = "logLevel", type = "int"},
-        {name = "text", type = "const char *"},
-        {name = "", type = ""}
+        {type = "int", name = "logLevel"},
+        {type = "const char *", name = "text"},
+        {type = "", name = ""}
       }
     },
     {
@@ -3155,7 +3155,7 @@ return {
       description = "Set the current threshold (minimum) log level",
       returnType = "void",
       params = {
-        {name = "logLevel", type = "int"}
+        {type = "int", name = "logLevel"}
       }
     },
     {
@@ -3163,7 +3163,7 @@ return {
       description = "Internal memory allocator",
       returnType = "void *",
       params = {
-        {name = "size", type = "int"}
+        {type = "int", name = "size"}
       }
     },
     {
@@ -3171,8 +3171,8 @@ return {
       description = "Internal memory reallocator",
       returnType = "void *",
       params = {
-        {name = "ptr", type = "void *"},
-        {name = "size", type = "int"}
+        {type = "void *", name = "ptr"},
+        {type = "int", name = "size"}
       }
     },
     {
@@ -3180,7 +3180,7 @@ return {
       description = "Internal memory free",
       returnType = "void",
       params = {
-        {name = "ptr", type = "void *"}
+        {type = "void *", name = "ptr"}
       }
     },
     {
@@ -3188,7 +3188,7 @@ return {
       description = "Set custom trace log",
       returnType = "void",
       params = {
-        {name = "callback", type = "TraceLogCallback"}
+        {type = "TraceLogCallback", name = "callback"}
       }
     },
     {
@@ -3196,7 +3196,7 @@ return {
       description = "Set custom file binary data loader",
       returnType = "void",
       params = {
-        {name = "callback", type = "LoadFileDataCallback"}
+        {type = "LoadFileDataCallback", name = "callback"}
       }
     },
     {
@@ -3204,7 +3204,7 @@ return {
       description = "Set custom file binary data saver",
       returnType = "void",
       params = {
-        {name = "callback", type = "SaveFileDataCallback"}
+        {type = "SaveFileDataCallback", name = "callback"}
       }
     },
     {
@@ -3212,7 +3212,7 @@ return {
       description = "Set custom file text data loader",
       returnType = "void",
       params = {
-        {name = "callback", type = "LoadFileTextCallback"}
+        {type = "LoadFileTextCallback", name = "callback"}
       }
     },
     {
@@ -3220,7 +3220,7 @@ return {
       description = "Set custom file text data saver",
       returnType = "void",
       params = {
-        {name = "callback", type = "SaveFileTextCallback"}
+        {type = "SaveFileTextCallback", name = "callback"}
       }
     },
     {
@@ -3228,8 +3228,8 @@ return {
       description = "Load file data as byte array (read)",
       returnType = "unsigned char *",
       params = {
-        {name = "fileName", type = "const char *"},
-        {name = "bytesRead", type = "unsigned int *"}
+        {type = "const char *", name = "fileName"},
+        {type = "unsigned int *", name = "bytesRead"}
       }
     },
     {
@@ -3237,7 +3237,7 @@ return {
       description = "Unload file data allocated by LoadFileData()",
       returnType = "void",
       params = {
-        {name = "data", type = "unsigned char *"}
+        {type = "unsigned char *", name = "data"}
       }
     },
     {
@@ -3245,9 +3245,9 @@ return {
       description = "Save data to file from byte array (write), returns true on success",
       returnType = "bool",
       params = {
-        {name = "fileName", type = "const char *"},
-        {name = "data", type = "void *"},
-        {name = "bytesToWrite", type = "unsigned int"}
+        {type = "const char *", name = "fileName"},
+        {type = "void *", name = "data"},
+        {type = "unsigned int", name = "bytesToWrite"}
       }
     },
     {
@@ -3255,7 +3255,7 @@ return {
       description = "Load text data from file (read), returns a '\\0' terminated string",
       returnType = "char *",
       params = {
-        {name = "fileName", type = "const char *"}
+        {type = "const char *", name = "fileName"}
       }
     },
     {
@@ -3263,7 +3263,7 @@ return {
       description = "Unload file text data allocated by LoadFileText()",
       returnType = "void",
       params = {
-        {name = "text", type = "char *"}
+        {type = "char *", name = "text"}
       }
     },
     {
@@ -3271,8 +3271,8 @@ return {
       description = "Save text data to file (write), string must be '\\0' terminated, returns true on success",
       returnType = "bool",
       params = {
-        {name = "fileName", type = "const char *"},
-        {name = "text", type = "char *"}
+        {type = "const char *", name = "fileName"},
+        {type = "char *", name = "text"}
       }
     },
     {
@@ -3280,7 +3280,7 @@ return {
       description = "Check if file exists",
       returnType = "bool",
       params = {
-        {name = "fileName", type = "const char *"}
+        {type = "const char *", name = "fileName"}
       }
     },
     {
@@ -3288,7 +3288,7 @@ return {
       description = "Check if a directory path exists",
       returnType = "bool",
       params = {
-        {name = "dirPath", type = "const char *"}
+        {type = "const char *", name = "dirPath"}
       }
     },
     {
@@ -3296,8 +3296,8 @@ return {
       description = "Check file extension (including point: .png, .wav)",
       returnType = "bool",
       params = {
-        {name = "fileName", type = "const char *"},
-        {name = "ext", type = "const char *"}
+        {type = "const char *", name = "fileName"},
+        {type = "const char *", name = "ext"}
       }
     },
     {
@@ -3305,7 +3305,7 @@ return {
       description = "Get pointer to extension for a filename string (includes dot: '.png')",
       returnType = "const char *",
       params = {
-        {name = "fileName", type = "const char *"}
+        {type = "const char *", name = "fileName"}
       }
     },
     {
@@ -3313,7 +3313,7 @@ return {
       description = "Get pointer to filename for a path string",
       returnType = "const char *",
       params = {
-        {name = "filePath", type = "const char *"}
+        {type = "const char *", name = "filePath"}
       }
     },
     {
@@ -3321,7 +3321,7 @@ return {
       description = "Get filename string without extension (uses static string)",
       returnType = "const char *",
       params = {
-        {name = "filePath", type = "const char *"}
+        {type = "const char *", name = "filePath"}
       }
     },
     {
@@ -3329,7 +3329,7 @@ return {
       description = "Get full path for a given fileName with path (uses static string)",
       returnType = "const char *",
       params = {
-        {name = "filePath", type = "const char *"}
+        {type = "const char *", name = "filePath"}
       }
     },
     {
@@ -3337,7 +3337,7 @@ return {
       description = "Get previous directory path for a given path (uses static string)",
       returnType = "const char *",
       params = {
-        {name = "dirPath", type = "const char *"}
+        {type = "const char *", name = "dirPath"}
       }
     },
     {
@@ -3350,8 +3350,8 @@ return {
       description = "Get filenames in a directory path (memory should be freed)",
       returnType = "char **",
       params = {
-        {name = "dirPath", type = "const char *"},
-        {name = "count", type = "int *"}
+        {type = "const char *", name = "dirPath"},
+        {type = "int *", name = "count"}
       }
     },
     {
@@ -3364,7 +3364,7 @@ return {
       description = "Change working directory, return true on success",
       returnType = "bool",
       params = {
-        {name = "dir", type = "const char *"}
+        {type = "const char *", name = "dir"}
       }
     },
     {
@@ -3377,7 +3377,7 @@ return {
       description = "Get dropped files names (memory should be freed)",
       returnType = "char **",
       params = {
-        {name = "count", type = "int *"}
+        {type = "int *", name = "count"}
       }
     },
     {
@@ -3390,7 +3390,7 @@ return {
       description = "Get file modification time (last write time)",
       returnType = "long",
       params = {
-        {name = "fileName", type = "const char *"}
+        {type = "const char *", name = "fileName"}
       }
     },
     {
@@ -3398,9 +3398,9 @@ return {
       description = "Compress data (DEFLATE algorithm)",
       returnType = "unsigned char *",
       params = {
-        {name = "data", type = "unsigned char *"},
-        {name = "dataLength", type = "int"},
-        {name = "compDataLength", type = "int *"}
+        {type = "unsigned char *", name = "data"},
+        {type = "int", name = "dataLength"},
+        {type = "int *", name = "compDataLength"}
       }
     },
     {
@@ -3408,9 +3408,9 @@ return {
       description = "Decompress data (DEFLATE algorithm)",
       returnType = "unsigned char *",
       params = {
-        {name = "compData", type = "unsigned char *"},
-        {name = "compDataLength", type = "int"},
-        {name = "dataLength", type = "int *"}
+        {type = "unsigned char *", name = "compData"},
+        {type = "int", name = "compDataLength"},
+        {type = "int *", name = "dataLength"}
       }
     },
     {
@@ -3418,9 +3418,9 @@ return {
       description = "Encode data to Base64 string",
       returnType = "char *",
       params = {
-        {name = "data", type = "const unsigned char *"},
-        {name = "dataLength", type = "int"},
-        {name = "outputLength", type = "int *"}
+        {type = "const unsigned char *", name = "data"},
+        {type = "int", name = "dataLength"},
+        {type = "int *", name = "outputLength"}
       }
     },
     {
@@ -3428,8 +3428,8 @@ return {
       description = "Decode Base64 string data",
       returnType = "unsigned char *",
       params = {
-        {name = "data", type = "unsigned char *"},
-        {name = "outputLength", type = "int *"}
+        {type = "unsigned char *", name = "data"},
+        {type = "int *", name = "outputLength"}
       }
     },
     {
@@ -3437,8 +3437,8 @@ return {
       description = "Save integer value to storage file (to defined position), returns true on success",
       returnType = "bool",
       params = {
-        {name = "position", type = "unsigned int"},
-        {name = "value", type = "int"}
+        {type = "unsigned int", name = "position"},
+        {type = "int", name = "value"}
       }
     },
     {
@@ -3446,7 +3446,7 @@ return {
       description = "Load integer value from storage file (from defined position)",
       returnType = "int",
       params = {
-        {name = "position", type = "unsigned int"}
+        {type = "unsigned int", name = "position"}
       }
     },
     {
@@ -3454,7 +3454,7 @@ return {
       description = "Open URL with default system browser (if available)",
       returnType = "void",
       params = {
-        {name = "url", type = "const char *"}
+        {type = "const char *", name = "url"}
       }
     },
     {
@@ -3462,7 +3462,7 @@ return {
       description = "Check if a key has been pressed once",
       returnType = "bool",
       params = {
-        {name = "key", type = "int"}
+        {type = "int", name = "key"}
       }
     },
     {
@@ -3470,7 +3470,7 @@ return {
       description = "Check if a key is being pressed",
       returnType = "bool",
       params = {
-        {name = "key", type = "int"}
+        {type = "int", name = "key"}
       }
     },
     {
@@ -3478,7 +3478,7 @@ return {
       description = "Check if a key has been released once",
       returnType = "bool",
       params = {
-        {name = "key", type = "int"}
+        {type = "int", name = "key"}
       }
     },
     {
@@ -3486,7 +3486,7 @@ return {
       description = "Check if a key is NOT being pressed",
       returnType = "bool",
       params = {
-        {name = "key", type = "int"}
+        {type = "int", name = "key"}
       }
     },
     {
@@ -3494,7 +3494,7 @@ return {
       description = "Set a custom key to exit program (default is ESC)",
       returnType = "void",
       params = {
-        {name = "key", type = "int"}
+        {type = "int", name = "key"}
       }
     },
     {
@@ -3512,7 +3512,7 @@ return {
       description = "Check if a gamepad is available",
       returnType = "bool",
       params = {
-        {name = "gamepad", type = "int"}
+        {type = "int", name = "gamepad"}
       }
     },
     {
@@ -3520,7 +3520,7 @@ return {
       description = "Get gamepad internal name id",
       returnType = "const char *",
       params = {
-        {name = "gamepad", type = "int"}
+        {type = "int", name = "gamepad"}
       }
     },
     {
@@ -3528,8 +3528,8 @@ return {
       description = "Check if a gamepad button has been pressed once",
       returnType = "bool",
       params = {
-        {name = "gamepad", type = "int"},
-        {name = "button", type = "int"}
+        {type = "int", name = "gamepad"},
+        {type = "int", name = "button"}
       }
     },
     {
@@ -3537,8 +3537,8 @@ return {
       description = "Check if a gamepad button is being pressed",
       returnType = "bool",
       params = {
-        {name = "gamepad", type = "int"},
-        {name = "button", type = "int"}
+        {type = "int", name = "gamepad"},
+        {type = "int", name = "button"}
       }
     },
     {
@@ -3546,8 +3546,8 @@ return {
       description = "Check if a gamepad button has been released once",
       returnType = "bool",
       params = {
-        {name = "gamepad", type = "int"},
-        {name = "button", type = "int"}
+        {type = "int", name = "gamepad"},
+        {type = "int", name = "button"}
       }
     },
     {
@@ -3555,8 +3555,8 @@ return {
       description = "Check if a gamepad button is NOT being pressed",
       returnType = "bool",
       params = {
-        {name = "gamepad", type = "int"},
-        {name = "button", type = "int"}
+        {type = "int", name = "gamepad"},
+        {type = "int", name = "button"}
       }
     },
     {
@@ -3569,7 +3569,7 @@ return {
       description = "Get gamepad axis count for a gamepad",
       returnType = "int",
       params = {
-        {name = "gamepad", type = "int"}
+        {type = "int", name = "gamepad"}
       }
     },
     {
@@ -3577,8 +3577,8 @@ return {
       description = "Get axis movement value for a gamepad axis",
       returnType = "float",
       params = {
-        {name = "gamepad", type = "int"},
-        {name = "axis", type = "int"}
+        {type = "int", name = "gamepad"},
+        {type = "int", name = "axis"}
       }
     },
     {
@@ -3586,7 +3586,7 @@ return {
       description = "Set internal gamepad mappings (SDL_GameControllerDB)",
       returnType = "int",
       params = {
-        {name = "mappings", type = "const char *"}
+        {type = "const char *", name = "mappings"}
       }
     },
     {
@@ -3594,7 +3594,7 @@ return {
       description = "Check if a mouse button has been pressed once",
       returnType = "bool",
       params = {
-        {name = "button", type = "int"}
+        {type = "int", name = "button"}
       }
     },
     {
@@ -3602,7 +3602,7 @@ return {
       description = "Check if a mouse button is being pressed",
       returnType = "bool",
       params = {
-        {name = "button", type = "int"}
+        {type = "int", name = "button"}
       }
     },
     {
@@ -3610,7 +3610,7 @@ return {
       description = "Check if a mouse button has been released once",
       returnType = "bool",
       params = {
-        {name = "button", type = "int"}
+        {type = "int", name = "button"}
       }
     },
     {
@@ -3618,7 +3618,7 @@ return {
       description = "Check if a mouse button is NOT being pressed",
       returnType = "bool",
       params = {
-        {name = "button", type = "int"}
+        {type = "int", name = "button"}
       }
     },
     {
@@ -3646,8 +3646,8 @@ return {
       description = "Set mouse position XY",
       returnType = "void",
       params = {
-        {name = "x", type = "int"},
-        {name = "y", type = "int"}
+        {type = "int", name = "x"},
+        {type = "int", name = "y"}
       }
     },
     {
@@ -3655,8 +3655,8 @@ return {
       description = "Set mouse offset",
       returnType = "void",
       params = {
-        {name = "offsetX", type = "int"},
-        {name = "offsetY", type = "int"}
+        {type = "int", name = "offsetX"},
+        {type = "int", name = "offsetY"}
       }
     },
     {
@@ -3664,8 +3664,8 @@ return {
       description = "Set mouse scaling",
       returnType = "void",
       params = {
-        {name = "scaleX", type = "float"},
-        {name = "scaleY", type = "float"}
+        {type = "float", name = "scaleX"},
+        {type = "float", name = "scaleY"}
       }
     },
     {
@@ -3678,7 +3678,7 @@ return {
       description = "Set mouse cursor",
       returnType = "void",
       params = {
-        {name = "cursor", type = "int"}
+        {type = "int", name = "cursor"}
       }
     },
     {
@@ -3696,7 +3696,7 @@ return {
       description = "Get touch position XY for a touch point index (relative to screen size)",
       returnType = "Vector2",
       params = {
-        {name = "index", type = "int"}
+        {type = "int", name = "index"}
       }
     },
     {
@@ -3704,7 +3704,7 @@ return {
       description = "Get touch point identifier for given index",
       returnType = "int",
       params = {
-        {name = "index", type = "int"}
+        {type = "int", name = "index"}
       }
     },
     {
@@ -3717,7 +3717,7 @@ return {
       description = "Enable a set of gestures using flags",
       returnType = "void",
       params = {
-        {name = "flags", type = "unsigned int"}
+        {type = "unsigned int", name = "flags"}
       }
     },
     {
@@ -3725,7 +3725,7 @@ return {
       description = "Check if a gesture have been detected",
       returnType = "bool",
       params = {
-        {name = "gesture", type = "int"}
+        {type = "int", name = "gesture"}
       }
     },
     {
@@ -3763,8 +3763,8 @@ return {
       description = "Set camera mode (multiple camera modes available)",
       returnType = "void",
       params = {
-        {name = "camera", type = "Camera"},
-        {name = "mode", type = "int"}
+        {type = "Camera", name = "camera"},
+        {type = "int", name = "mode"}
       }
     },
     {
@@ -3772,7 +3772,7 @@ return {
       description = "Update camera position for selected mode",
       returnType = "void",
       params = {
-        {name = "camera", type = "Camera *"}
+        {type = "Camera *", name = "camera"}
       }
     },
     {
@@ -3780,7 +3780,7 @@ return {
       description = "Set camera pan key to combine with mouse movement (free camera)",
       returnType = "void",
       params = {
-        {name = "keyPan", type = "int"}
+        {type = "int", name = "keyPan"}
       }
     },
     {
@@ -3788,7 +3788,7 @@ return {
       description = "Set camera alt key to combine with mouse movement (free camera)",
       returnType = "void",
       params = {
-        {name = "keyAlt", type = "int"}
+        {type = "int", name = "keyAlt"}
       }
     },
     {
@@ -3796,7 +3796,7 @@ return {
       description = "Set camera smooth zoom key to combine with mouse (free camera)",
       returnType = "void",
       params = {
-        {name = "keySmoothZoom", type = "int"}
+        {type = "int", name = "keySmoothZoom"}
       }
     },
     {
@@ -3804,12 +3804,12 @@ return {
       description = "Set camera move controls (1st person and 3rd person cameras)",
       returnType = "void",
       params = {
-        {name = "keyFront", type = "int"},
-        {name = "keyBack", type = "int"},
-        {name = "keyRight", type = "int"},
-        {name = "keyLeft", type = "int"},
-        {name = "keyUp", type = "int"},
-        {name = "keyDown", type = "int"}
+        {type = "int", name = "keyFront"},
+        {type = "int", name = "keyBack"},
+        {type = "int", name = "keyRight"},
+        {type = "int", name = "keyLeft"},
+        {type = "int", name = "keyUp"},
+        {type = "int", name = "keyDown"}
       }
     },
     {
@@ -3817,8 +3817,8 @@ return {
       description = "Set texture and rectangle to be used on shapes drawing",
       returnType = "void",
       params = {
-        {name = "texture", type = "Texture2D"},
-        {name = "source", type = "Rectangle"}
+        {type = "Texture2D", name = "texture"},
+        {type = "Rectangle", name = "source"}
       }
     },
     {
@@ -3826,9 +3826,9 @@ return {
       description = "Draw a pixel",
       returnType = "void",
       params = {
-        {name = "posX", type = "int"},
-        {name = "posY", type = "int"},
-        {name = "color", type = "Color"}
+        {type = "int", name = "posX"},
+        {type = "int", name = "posY"},
+        {type = "Color", name = "color"}
       }
     },
     {
@@ -3836,8 +3836,8 @@ return {
       description = "Draw a pixel (Vector version)",
       returnType = "void",
       params = {
-        {name = "position", type = "Vector2"},
-        {name = "color", type = "Color"}
+        {type = "Vector2", name = "position"},
+        {type = "Color", name = "color"}
       }
     },
     {
@@ -3845,11 +3845,11 @@ return {
       description = "Draw a line",
       returnType = "void",
       params = {
-        {name = "startPosX", type = "int"},
-        {name = "startPosY", type = "int"},
-        {name = "endPosX", type = "int"},
-        {name = "endPosY", type = "int"},
-        {name = "color", type = "Color"}
+        {type = "int", name = "startPosX"},
+        {type = "int", name = "startPosY"},
+        {type = "int", name = "endPosX"},
+        {type = "int", name = "endPosY"},
+        {type = "Color", name = "color"}
       }
     },
     {
@@ -3857,9 +3857,9 @@ return {
       description = "Draw a line (Vector version)",
       returnType = "void",
       params = {
-        {name = "startPos", type = "Vector2"},
-        {name = "endPos", type = "Vector2"},
-        {name = "color", type = "Color"}
+        {type = "Vector2", name = "startPos"},
+        {type = "Vector2", name = "endPos"},
+        {type = "Color", name = "color"}
       }
     },
     {
@@ -3867,10 +3867,10 @@ return {
       description = "Draw a line defining thickness",
       returnType = "void",
       params = {
-        {name = "startPos", type = "Vector2"},
-        {name = "endPos", type = "Vector2"},
-        {name = "thick", type = "float"},
-        {name = "color", type = "Color"}
+        {type = "Vector2", name = "startPos"},
+        {type = "Vector2", name = "endPos"},
+        {type = "float", name = "thick"},
+        {type = "Color", name = "color"}
       }
     },
     {
@@ -3878,10 +3878,10 @@ return {
       description = "Draw a line using cubic-bezier curves in-out",
       returnType = "void",
       params = {
-        {name = "startPos", type = "Vector2"},
-        {name = "endPos", type = "Vector2"},
-        {name = "thick", type = "float"},
-        {name = "color", type = "Color"}
+        {type = "Vector2", name = "startPos"},
+        {type = "Vector2", name = "endPos"},
+        {type = "float", name = "thick"},
+        {type = "Color", name = "color"}
       }
     },
     {
@@ -3889,11 +3889,11 @@ return {
       description = "Draw line using quadratic bezier curves with a control point",
       returnType = "void",
       params = {
-        {name = "startPos", type = "Vector2"},
-        {name = "endPos", type = "Vector2"},
-        {name = "controlPos", type = "Vector2"},
-        {name = "thick", type = "float"},
-        {name = "color", type = "Color"}
+        {type = "Vector2", name = "startPos"},
+        {type = "Vector2", name = "endPos"},
+        {type = "Vector2", name = "controlPos"},
+        {type = "float", name = "thick"},
+        {type = "Color", name = "color"}
       }
     },
     {
@@ -3901,12 +3901,12 @@ return {
       description = "Draw line using cubic bezier curves with 2 control points",
       returnType = "void",
       params = {
-        {name = "startPos", type = "Vector2"},
-        {name = "endPos", type = "Vector2"},
-        {name = "startControlPos", type = "Vector2"},
-        {name = "endControlPos", type = "Vector2"},
-        {name = "thick", type = "float"},
-        {name = "color", type = "Color"}
+        {type = "Vector2", name = "startPos"},
+        {type = "Vector2", name = "endPos"},
+        {type = "Vector2", name = "startControlPos"},
+        {type = "Vector2", name = "endControlPos"},
+        {type = "float", name = "thick"},
+        {type = "Color", name = "color"}
       }
     },
     {
@@ -3914,9 +3914,9 @@ return {
       description = "Draw lines sequence",
       returnType = "void",
       params = {
-        {name = "points", type = "Vector2 *"},
-        {name = "pointCount", type = "int"},
-        {name = "color", type = "Color"}
+        {type = "Vector2 *", name = "points"},
+        {type = "int", name = "pointCount"},
+        {type = "Color", name = "color"}
       }
     },
     {
@@ -3924,10 +3924,10 @@ return {
       description = "Draw a color-filled circle",
       returnType = "void",
       params = {
-        {name = "centerX", type = "int"},
-        {name = "centerY", type = "int"},
-        {name = "radius", type = "float"},
-        {name = "color", type = "Color"}
+        {type = "int", name = "centerX"},
+        {type = "int", name = "centerY"},
+        {type = "float", name = "radius"},
+        {type = "Color", name = "color"}
       }
     },
     {
@@ -3935,12 +3935,12 @@ return {
       description = "Draw a piece of a circle",
       returnType = "void",
       params = {
-        {name = "center", type = "Vector2"},
-        {name = "radius", type = "float"},
-        {name = "startAngle", type = "float"},
-        {name = "endAngle", type = "float"},
-        {name = "segments", type = "int"},
-        {name = "color", type = "Color"}
+        {type = "Vector2", name = "center"},
+        {type = "float", name = "radius"},
+        {type = "float", name = "startAngle"},
+        {type = "float", name = "endAngle"},
+        {type = "int", name = "segments"},
+        {type = "Color", name = "color"}
       }
     },
     {
@@ -3948,12 +3948,12 @@ return {
       description = "Draw circle sector outline",
       returnType = "void",
       params = {
-        {name = "center", type = "Vector2"},
-        {name = "radius", type = "float"},
-        {name = "startAngle", type = "float"},
-        {name = "endAngle", type = "float"},
-        {name = "segments", type = "int"},
-        {name = "color", type = "Color"}
+        {type = "Vector2", name = "center"},
+        {type = "float", name = "radius"},
+        {type = "float", name = "startAngle"},
+        {type = "float", name = "endAngle"},
+        {type = "int", name = "segments"},
+        {type = "Color", name = "color"}
       }
     },
     {
@@ -3961,11 +3961,11 @@ return {
       description = "Draw a gradient-filled circle",
       returnType = "void",
       params = {
-        {name = "centerX", type = "int"},
-        {name = "centerY", type = "int"},
-        {name = "radius", type = "float"},
-        {name = "color1", type = "Color"},
-        {name = "color2", type = "Color"}
+        {type = "int", name = "centerX"},
+        {type = "int", name = "centerY"},
+        {type = "float", name = "radius"},
+        {type = "Color", name = "color1"},
+        {type = "Color", name = "color2"}
       }
     },
     {
@@ -3973,9 +3973,9 @@ return {
       description = "Draw a color-filled circle (Vector version)",
       returnType = "void",
       params = {
-        {name = "center", type = "Vector2"},
-        {name = "radius", type = "float"},
-        {name = "color", type = "Color"}
+        {type = "Vector2", name = "center"},
+        {type = "float", name = "radius"},
+        {type = "Color", name = "color"}
       }
     },
     {
@@ -3983,10 +3983,10 @@ return {
       description = "Draw circle outline",
       returnType = "void",
       params = {
-        {name = "centerX", type = "int"},
-        {name = "centerY", type = "int"},
-        {name = "radius", type = "float"},
-        {name = "color", type = "Color"}
+        {type = "int", name = "centerX"},
+        {type = "int", name = "centerY"},
+        {type = "float", name = "radius"},
+        {type = "Color", name = "color"}
       }
     },
     {
@@ -3994,11 +3994,11 @@ return {
       description = "Draw ellipse",
       returnType = "void",
       params = {
-        {name = "centerX", type = "int"},
-        {name = "centerY", type = "int"},
-        {name = "radiusH", type = "float"},
-        {name = "radiusV", type = "float"},
-        {name = "color", type = "Color"}
+        {type = "int", name = "centerX"},
+        {type = "int", name = "centerY"},
+        {type = "float", name = "radiusH"},
+        {type = "float", name = "radiusV"},
+        {type = "Color", name = "color"}
       }
     },
     {
@@ -4006,11 +4006,11 @@ return {
       description = "Draw ellipse outline",
       returnType = "void",
       params = {
-        {name = "centerX", type = "int"},
-        {name = "centerY", type = "int"},
-        {name = "radiusH", type = "float"},
-        {name = "radiusV", type = "float"},
-        {name = "color", type = "Color"}
+        {type = "int", name = "centerX"},
+        {type = "int", name = "centerY"},
+        {type = "float", name = "radiusH"},
+        {type = "float", name = "radiusV"},
+        {type = "Color", name = "color"}
       }
     },
     {
@@ -4018,13 +4018,13 @@ return {
       description = "Draw ring",
       returnType = "void",
       params = {
-        {name = "center", type = "Vector2"},
-        {name = "innerRadius", type = "float"},
-        {name = "outerRadius", type = "float"},
-        {name = "startAngle", type = "float"},
-        {name = "endAngle", type = "float"},
-        {name = "segments", type = "int"},
-        {name = "color", type = "Color"}
+        {type = "Vector2", name = "center"},
+        {type = "float", name = "innerRadius"},
+        {type = "float", name = "outerRadius"},
+        {type = "float", name = "startAngle"},
+        {type = "float", name = "endAngle"},
+        {type = "int", name = "segments"},
+        {type = "Color", name = "color"}
       }
     },
     {
@@ -4032,13 +4032,13 @@ return {
       description = "Draw ring outline",
       returnType = "void",
       params = {
-        {name = "center", type = "Vector2"},
-        {name = "innerRadius", type = "float"},
-        {name = "outerRadius", type = "float"},
-        {name = "startAngle", type = "float"},
-        {name = "endAngle", type = "float"},
-        {name = "segments", type = "int"},
-        {name = "color", type = "Color"}
+        {type = "Vector2", name = "center"},
+        {type = "float", name = "innerRadius"},
+        {type = "float", name = "outerRadius"},
+        {type = "float", name = "startAngle"},
+        {type = "float", name = "endAngle"},
+        {type = "int", name = "segments"},
+        {type = "Color", name = "color"}
       }
     },
     {
@@ -4046,11 +4046,11 @@ return {
       description = "Draw a color-filled rectangle",
       returnType = "void",
       params = {
-        {name = "posX", type = "int"},
-        {name = "posY", type = "int"},
-        {name = "width", type = "int"},
-        {name = "height", type = "int"},
-        {name = "color", type = "Color"}
+        {type = "int", name = "posX"},
+        {type = "int", name = "posY"},
+        {type = "int", name = "width"},
+        {type = "int", name = "height"},
+        {type = "Color", name = "color"}
       }
     },
     {
@@ -4058,9 +4058,9 @@ return {
       description = "Draw a color-filled rectangle (Vector version)",
       returnType = "void",
       params = {
-        {name = "position", type = "Vector2"},
-        {name = "size", type = "Vector2"},
-        {name = "color", type = "Color"}
+        {type = "Vector2", name = "position"},
+        {type = "Vector2", name = "size"},
+        {type = "Color", name = "color"}
       }
     },
     {
@@ -4068,8 +4068,8 @@ return {
       description = "Draw a color-filled rectangle",
       returnType = "void",
       params = {
-        {name = "rec", type = "Rectangle"},
-        {name = "color", type = "Color"}
+        {type = "Rectangle", name = "rec"},
+        {type = "Color", name = "color"}
       }
     },
     {
@@ -4077,10 +4077,10 @@ return {
       description = "Draw a color-filled rectangle with pro parameters",
       returnType = "void",
       params = {
-        {name = "rec", type = "Rectangle"},
-        {name = "origin", type = "Vector2"},
-        {name = "rotation", type = "float"},
-        {name = "color", type = "Color"}
+        {type = "Rectangle", name = "rec"},
+        {type = "Vector2", name = "origin"},
+        {type = "float", name = "rotation"},
+        {type = "Color", name = "color"}
       }
     },
     {
@@ -4088,12 +4088,12 @@ return {
       description = "Draw a vertical-gradient-filled rectangle",
       returnType = "void",
       params = {
-        {name = "posX", type = "int"},
-        {name = "posY", type = "int"},
-        {name = "width", type = "int"},
-        {name = "height", type = "int"},
-        {name = "color1", type = "Color"},
-        {name = "color2", type = "Color"}
+        {type = "int", name = "posX"},
+        {type = "int", name = "posY"},
+        {type = "int", name = "width"},
+        {type = "int", name = "height"},
+        {type = "Color", name = "color1"},
+        {type = "Color", name = "color2"}
       }
     },
     {
@@ -4101,12 +4101,12 @@ return {
       description = "Draw a horizontal-gradient-filled rectangle",
       returnType = "void",
       params = {
-        {name = "posX", type = "int"},
-        {name = "posY", type = "int"},
-        {name = "width", type = "int"},
-        {name = "height", type = "int"},
-        {name = "color1", type = "Color"},
-        {name = "color2", type = "Color"}
+        {type = "int", name = "posX"},
+        {type = "int", name = "posY"},
+        {type = "int", name = "width"},
+        {type = "int", name = "height"},
+        {type = "Color", name = "color1"},
+        {type = "Color", name = "color2"}
       }
     },
     {
@@ -4114,11 +4114,11 @@ return {
       description = "Draw a gradient-filled rectangle with custom vertex colors",
       returnType = "void",
       params = {
-        {name = "rec", type = "Rectangle"},
-        {name = "col1", type = "Color"},
-        {name = "col2", type = "Color"},
-        {name = "col3", type = "Color"},
-        {name = "col4", type = "Color"}
+        {type = "Rectangle", name = "rec"},
+        {type = "Color", name = "col1"},
+        {type = "Color", name = "col2"},
+        {type = "Color", name = "col3"},
+        {type = "Color", name = "col4"}
       }
     },
     {
@@ -4126,11 +4126,11 @@ return {
       description = "Draw rectangle outline",
       returnType = "void",
       params = {
-        {name = "posX", type = "int"},
-        {name = "posY", type = "int"},
-        {name = "width", type = "int"},
-        {name = "height", type = "int"},
-        {name = "color", type = "Color"}
+        {type = "int", name = "posX"},
+        {type = "int", name = "posY"},
+        {type = "int", name = "width"},
+        {type = "int", name = "height"},
+        {type = "Color", name = "color"}
       }
     },
     {
@@ -4138,9 +4138,9 @@ return {
       description = "Draw rectangle outline with extended parameters",
       returnType = "void",
       params = {
-        {name = "rec", type = "Rectangle"},
-        {name = "lineThick", type = "float"},
-        {name = "color", type = "Color"}
+        {type = "Rectangle", name = "rec"},
+        {type = "float", name = "lineThick"},
+        {type = "Color", name = "color"}
       }
     },
     {
@@ -4148,10 +4148,10 @@ return {
       description = "Draw rectangle with rounded edges",
       returnType = "void",
       params = {
-        {name = "rec", type = "Rectangle"},
-        {name = "roundness", type = "float"},
-        {name = "segments", type = "int"},
-        {name = "color", type = "Color"}
+        {type = "Rectangle", name = "rec"},
+        {type = "float", name = "roundness"},
+        {type = "int", name = "segments"},
+        {type = "Color", name = "color"}
       }
     },
     {
@@ -4159,11 +4159,11 @@ return {
       description = "Draw rectangle with rounded edges outline",
       returnType = "void",
       params = {
-        {name = "rec", type = "Rectangle"},
-        {name = "roundness", type = "float"},
-        {name = "segments", type = "int"},
-        {name = "lineThick", type = "float"},
-        {name = "color", type = "Color"}
+        {type = "Rectangle", name = "rec"},
+        {type = "float", name = "roundness"},
+        {type = "int", name = "segments"},
+        {type = "float", name = "lineThick"},
+        {type = "Color", name = "color"}
       }
     },
     {
@@ -4171,10 +4171,10 @@ return {
       description = "Draw a color-filled triangle (vertex in counter-clockwise order!)",
       returnType = "void",
       params = {
-        {name = "v1", type = "Vector2"},
-        {name = "v2", type = "Vector2"},
-        {name = "v3", type = "Vector2"},
-        {name = "color", type = "Color"}
+        {type = "Vector2", name = "v1"},
+        {type = "Vector2", name = "v2"},
+        {type = "Vector2", name = "v3"},
+        {type = "Color", name = "color"}
       }
     },
     {
@@ -4182,10 +4182,10 @@ return {
       description = "Draw triangle outline (vertex in counter-clockwise order!)",
       returnType = "void",
       params = {
-        {name = "v1", type = "Vector2"},
-        {name = "v2", type = "Vector2"},
-        {name = "v3", type = "Vector2"},
-        {name = "color", type = "Color"}
+        {type = "Vector2", name = "v1"},
+        {type = "Vector2", name = "v2"},
+        {type = "Vector2", name = "v3"},
+        {type = "Color", name = "color"}
       }
     },
     {
@@ -4193,9 +4193,9 @@ return {
       description = "Draw a triangle fan defined by points (first vertex is the center)",
       returnType = "void",
       params = {
-        {name = "points", type = "Vector2 *"},
-        {name = "pointCount", type = "int"},
-        {name = "color", type = "Color"}
+        {type = "Vector2 *", name = "points"},
+        {type = "int", name = "pointCount"},
+        {type = "Color", name = "color"}
       }
     },
     {
@@ -4203,9 +4203,9 @@ return {
       description = "Draw a triangle strip defined by points",
       returnType = "void",
       params = {
-        {name = "points", type = "Vector2 *"},
-        {name = "pointCount", type = "int"},
-        {name = "color", type = "Color"}
+        {type = "Vector2 *", name = "points"},
+        {type = "int", name = "pointCount"},
+        {type = "Color", name = "color"}
       }
     },
     {
@@ -4213,11 +4213,11 @@ return {
       description = "Draw a regular polygon (Vector version)",
       returnType = "void",
       params = {
-        {name = "center", type = "Vector2"},
-        {name = "sides", type = "int"},
-        {name = "radius", type = "float"},
-        {name = "rotation", type = "float"},
-        {name = "color", type = "Color"}
+        {type = "Vector2", name = "center"},
+        {type = "int", name = "sides"},
+        {type = "float", name = "radius"},
+        {type = "float", name = "rotation"},
+        {type = "Color", name = "color"}
       }
     },
     {
@@ -4225,11 +4225,11 @@ return {
       description = "Draw a polygon outline of n sides",
       returnType = "void",
       params = {
-        {name = "center", type = "Vector2"},
-        {name = "sides", type = "int"},
-        {name = "radius", type = "float"},
-        {name = "rotation", type = "float"},
-        {name = "color", type = "Color"}
+        {type = "Vector2", name = "center"},
+        {type = "int", name = "sides"},
+        {type = "float", name = "radius"},
+        {type = "float", name = "rotation"},
+        {type = "Color", name = "color"}
       }
     },
     {
@@ -4237,12 +4237,12 @@ return {
       description = "Draw a polygon outline of n sides with extended parameters",
       returnType = "void",
       params = {
-        {name = "center", type = "Vector2"},
-        {name = "sides", type = "int"},
-        {name = "radius", type = "float"},
-        {name = "rotation", type = "float"},
-        {name = "lineThick", type = "float"},
-        {name = "color", type = "Color"}
+        {type = "Vector2", name = "center"},
+        {type = "int", name = "sides"},
+        {type = "float", name = "radius"},
+        {type = "float", name = "rotation"},
+        {type = "float", name = "lineThick"},
+        {type = "Color", name = "color"}
       }
     },
     {
@@ -4250,8 +4250,8 @@ return {
       description = "Check collision between two rectangles",
       returnType = "bool",
       params = {
-        {name = "rec1", type = "Rectangle"},
-        {name = "rec2", type = "Rectangle"}
+        {type = "Rectangle", name = "rec1"},
+        {type = "Rectangle", name = "rec2"}
       }
     },
     {
@@ -4259,10 +4259,10 @@ return {
       description = "Check collision between two circles",
       returnType = "bool",
       params = {
-        {name = "center1", type = "Vector2"},
-        {name = "radius1", type = "float"},
-        {name = "center2", type = "Vector2"},
-        {name = "radius2", type = "float"}
+        {type = "Vector2", name = "center1"},
+        {type = "float", name = "radius1"},
+        {type = "Vector2", name = "center2"},
+        {type = "float", name = "radius2"}
       }
     },
     {
@@ -4270,9 +4270,9 @@ return {
       description = "Check collision between circle and rectangle",
       returnType = "bool",
       params = {
-        {name = "center", type = "Vector2"},
-        {name = "radius", type = "float"},
-        {name = "rec", type = "Rectangle"}
+        {type = "Vector2", name = "center"},
+        {type = "float", name = "radius"},
+        {type = "Rectangle", name = "rec"}
       }
     },
     {
@@ -4280,8 +4280,8 @@ return {
       description = "Check if point is inside rectangle",
       returnType = "bool",
       params = {
-        {name = "point", type = "Vector2"},
-        {name = "rec", type = "Rectangle"}
+        {type = "Vector2", name = "point"},
+        {type = "Rectangle", name = "rec"}
       }
     },
     {
@@ -4289,9 +4289,9 @@ return {
       description = "Check if point is inside circle",
       returnType = "bool",
       params = {
-        {name = "point", type = "Vector2"},
-        {name = "center", type = "Vector2"},
-        {name = "radius", type = "float"}
+        {type = "Vector2", name = "point"},
+        {type = "Vector2", name = "center"},
+        {type = "float", name = "radius"}
       }
     },
     {
@@ -4299,10 +4299,10 @@ return {
       description = "Check if point is inside a triangle",
       returnType = "bool",
       params = {
-        {name = "point", type = "Vector2"},
-        {name = "p1", type = "Vector2"},
-        {name = "p2", type = "Vector2"},
-        {name = "p3", type = "Vector2"}
+        {type = "Vector2", name = "point"},
+        {type = "Vector2", name = "p1"},
+        {type = "Vector2", name = "p2"},
+        {type = "Vector2", name = "p3"}
       }
     },
     {
@@ -4310,11 +4310,11 @@ return {
       description = "Check the collision between two lines defined by two points each, returns collision point by reference",
       returnType = "bool",
       params = {
-        {name = "startPos1", type = "Vector2"},
-        {name = "endPos1", type = "Vector2"},
-        {name = "startPos2", type = "Vector2"},
-        {name = "endPos2", type = "Vector2"},
-        {name = "collisionPoint", type = "Vector2 *"}
+        {type = "Vector2", name = "startPos1"},
+        {type = "Vector2", name = "endPos1"},
+        {type = "Vector2", name = "startPos2"},
+        {type = "Vector2", name = "endPos2"},
+        {type = "Vector2 *", name = "collisionPoint"}
       }
     },
     {
@@ -4322,10 +4322,10 @@ return {
       description = "Check if point belongs to line created between two points [p1] and [p2] with defined margin in pixels [threshold]",
       returnType = "bool",
       params = {
-        {name = "point", type = "Vector2"},
-        {name = "p1", type = "Vector2"},
-        {name = "p2", type = "Vector2"},
-        {name = "threshold", type = "int"}
+        {type = "Vector2", name = "point"},
+        {type = "Vector2", name = "p1"},
+        {type = "Vector2", name = "p2"},
+        {type = "int", name = "threshold"}
       }
     },
     {
@@ -4333,8 +4333,8 @@ return {
       description = "Get collision rectangle for two rectangles collision",
       returnType = "Rectangle",
       params = {
-        {name = "rec1", type = "Rectangle"},
-        {name = "rec2", type = "Rectangle"}
+        {type = "Rectangle", name = "rec1"},
+        {type = "Rectangle", name = "rec2"}
       }
     },
     {
@@ -4342,7 +4342,7 @@ return {
       description = "Load image from file into CPU memory (RAM)",
       returnType = "Image",
       params = {
-        {name = "fileName", type = "const char *"}
+        {type = "const char *", name = "fileName"}
       }
     },
     {
@@ -4350,11 +4350,11 @@ return {
       description = "Load image from RAW file data",
       returnType = "Image",
       params = {
-        {name = "fileName", type = "const char *"},
-        {name = "width", type = "int"},
-        {name = "height", type = "int"},
-        {name = "format", type = "int"},
-        {name = "headerSize", type = "int"}
+        {type = "const char *", name = "fileName"},
+        {type = "int", name = "width"},
+        {type = "int", name = "height"},
+        {type = "int", name = "format"},
+        {type = "int", name = "headerSize"}
       }
     },
     {
@@ -4362,8 +4362,8 @@ return {
       description = "Load image sequence from file (frames appended to image.data)",
       returnType = "Image",
       params = {
-        {name = "fileName", type = "const char *"},
-        {name = "frames", type = "int *"}
+        {type = "const char *", name = "fileName"},
+        {type = "int *", name = "frames"}
       }
     },
     {
@@ -4371,9 +4371,9 @@ return {
       description = "Load image from memory buffer, fileType refers to extension: i.e. '.png'",
       returnType = "Image",
       params = {
-        {name = "fileType", type = "const char *"},
-        {name = "fileData", type = "const unsigned char *"},
-        {name = "dataSize", type = "int"}
+        {type = "const char *", name = "fileType"},
+        {type = "const unsigned char *", name = "fileData"},
+        {type = "int", name = "dataSize"}
       }
     },
     {
@@ -4381,7 +4381,7 @@ return {
       description = "Load image from GPU texture data",
       returnType = "Image",
       params = {
-        {name = "texture", type = "Texture2D"}
+        {type = "Texture2D", name = "texture"}
       }
     },
     {
@@ -4394,7 +4394,7 @@ return {
       description = "Unload image from CPU memory (RAM)",
       returnType = "void",
       params = {
-        {name = "image", type = "Image"}
+        {type = "Image", name = "image"}
       }
     },
     {
@@ -4402,8 +4402,8 @@ return {
       description = "Export image data to file, returns true on success",
       returnType = "bool",
       params = {
-        {name = "image", type = "Image"},
-        {name = "fileName", type = "const char *"}
+        {type = "Image", name = "image"},
+        {type = "const char *", name = "fileName"}
       }
     },
     {
@@ -4411,8 +4411,8 @@ return {
       description = "Export image as code file defining an array of bytes, returns true on success",
       returnType = "bool",
       params = {
-        {name = "image", type = "Image"},
-        {name = "fileName", type = "const char *"}
+        {type = "Image", name = "image"},
+        {type = "const char *", name = "fileName"}
       }
     },
     {
@@ -4420,9 +4420,9 @@ return {
       description = "Generate image: plain color",
       returnType = "Image",
       params = {
-        {name = "width", type = "int"},
-        {name = "height", type = "int"},
-        {name = "color", type = "Color"}
+        {type = "int", name = "width"},
+        {type = "int", name = "height"},
+        {type = "Color", name = "color"}
       }
     },
     {
@@ -4430,10 +4430,10 @@ return {
       description = "Generate image: vertical gradient",
       returnType = "Image",
       params = {
-        {name = "width", type = "int"},
-        {name = "height", type = "int"},
-        {name = "top", type = "Color"},
-        {name = "bottom", type = "Color"}
+        {type = "int", name = "width"},
+        {type = "int", name = "height"},
+        {type = "Color", name = "top"},
+        {type = "Color", name = "bottom"}
       }
     },
     {
@@ -4441,10 +4441,10 @@ return {
       description = "Generate image: horizontal gradient",
       returnType = "Image",
       params = {
-        {name = "width", type = "int"},
-        {name = "height", type = "int"},
-        {name = "left", type = "Color"},
-        {name = "right", type = "Color"}
+        {type = "int", name = "width"},
+        {type = "int", name = "height"},
+        {type = "Color", name = "left"},
+        {type = "Color", name = "right"}
       }
     },
     {
@@ -4452,11 +4452,11 @@ return {
       description = "Generate image: radial gradient",
       returnType = "Image",
       params = {
-        {name = "width", type = "int"},
-        {name = "height", type = "int"},
-        {name = "density", type = "float"},
-        {name = "inner", type = "Color"},
-        {name = "outer", type = "Color"}
+        {type = "int", name = "width"},
+        {type = "int", name = "height"},
+        {type = "float", name = "density"},
+        {type = "Color", name = "inner"},
+        {type = "Color", name = "outer"}
       }
     },
     {
@@ -4464,12 +4464,12 @@ return {
       description = "Generate image: checked",
       returnType = "Image",
       params = {
-        {name = "width", type = "int"},
-        {name = "height", type = "int"},
-        {name = "checksX", type = "int"},
-        {name = "checksY", type = "int"},
-        {name = "col1", type = "Color"},
-        {name = "col2", type = "Color"}
+        {type = "int", name = "width"},
+        {type = "int", name = "height"},
+        {type = "int", name = "checksX"},
+        {type = "int", name = "checksY"},
+        {type = "Color", name = "col1"},
+        {type = "Color", name = "col2"}
       }
     },
     {
@@ -4477,9 +4477,9 @@ return {
       description = "Generate image: white noise",
       returnType = "Image",
       params = {
-        {name = "width", type = "int"},
-        {name = "height", type = "int"},
-        {name = "factor", type = "float"}
+        {type = "int", name = "width"},
+        {type = "int", name = "height"},
+        {type = "float", name = "factor"}
       }
     },
     {
@@ -4487,9 +4487,9 @@ return {
       description = "Generate image: cellular algorithm, bigger tileSize means bigger cells",
       returnType = "Image",
       params = {
-        {name = "width", type = "int"},
-        {name = "height", type = "int"},
-        {name = "tileSize", type = "int"}
+        {type = "int", name = "width"},
+        {type = "int", name = "height"},
+        {type = "int", name = "tileSize"}
       }
     },
     {
@@ -4497,7 +4497,7 @@ return {
       description = "Create an image duplicate (useful for transformations)",
       returnType = "Image",
       params = {
-        {name = "image", type = "Image"}
+        {type = "Image", name = "image"}
       }
     },
     {
@@ -4505,8 +4505,8 @@ return {
       description = "Create an image from another image piece",
       returnType = "Image",
       params = {
-        {name = "image", type = "Image"},
-        {name = "rec", type = "Rectangle"}
+        {type = "Image", name = "image"},
+        {type = "Rectangle", name = "rec"}
       }
     },
     {
@@ -4514,9 +4514,9 @@ return {
       description = "Create an image from text (default font)",
       returnType = "Image",
       params = {
-        {name = "text", type = "const char *"},
-        {name = "fontSize", type = "int"},
-        {name = "color", type = "Color"}
+        {type = "const char *", name = "text"},
+        {type = "int", name = "fontSize"},
+        {type = "Color", name = "color"}
       }
     },
     {
@@ -4524,11 +4524,11 @@ return {
       description = "Create an image from text (custom sprite font)",
       returnType = "Image",
       params = {
-        {name = "font", type = "Font"},
-        {name = "text", type = "const char *"},
-        {name = "fontSize", type = "float"},
-        {name = "spacing", type = "float"},
-        {name = "tint", type = "Color"}
+        {type = "Font", name = "font"},
+        {type = "const char *", name = "text"},
+        {type = "float", name = "fontSize"},
+        {type = "float", name = "spacing"},
+        {type = "Color", name = "tint"}
       }
     },
     {
@@ -4536,8 +4536,8 @@ return {
       description = "Convert image data to desired format",
       returnType = "void",
       params = {
-        {name = "image", type = "Image *"},
-        {name = "newFormat", type = "int"}
+        {type = "Image *", name = "image"},
+        {type = "int", name = "newFormat"}
       }
     },
     {
@@ -4545,8 +4545,8 @@ return {
       description = "Convert image to POT (power-of-two)",
       returnType = "void",
       params = {
-        {name = "image", type = "Image *"},
-        {name = "fill", type = "Color"}
+        {type = "Image *", name = "image"},
+        {type = "Color", name = "fill"}
       }
     },
     {
@@ -4554,8 +4554,8 @@ return {
       description = "Crop an image to a defined rectangle",
       returnType = "void",
       params = {
-        {name = "image", type = "Image *"},
-        {name = "crop", type = "Rectangle"}
+        {type = "Image *", name = "image"},
+        {type = "Rectangle", name = "crop"}
       }
     },
     {
@@ -4563,8 +4563,8 @@ return {
       description = "Crop image depending on alpha value",
       returnType = "void",
       params = {
-        {name = "image", type = "Image *"},
-        {name = "threshold", type = "float"}
+        {type = "Image *", name = "image"},
+        {type = "float", name = "threshold"}
       }
     },
     {
@@ -4572,9 +4572,9 @@ return {
       description = "Clear alpha channel to desired color",
       returnType = "void",
       params = {
-        {name = "image", type = "Image *"},
-        {name = "color", type = "Color"},
-        {name = "threshold", type = "float"}
+        {type = "Image *", name = "image"},
+        {type = "Color", name = "color"},
+        {type = "float", name = "threshold"}
       }
     },
     {
@@ -4582,8 +4582,8 @@ return {
       description = "Apply alpha mask to image",
       returnType = "void",
       params = {
-        {name = "image", type = "Image *"},
-        {name = "alphaMask", type = "Image"}
+        {type = "Image *", name = "image"},
+        {type = "Image", name = "alphaMask"}
       }
     },
     {
@@ -4591,7 +4591,7 @@ return {
       description = "Premultiply alpha channel",
       returnType = "void",
       params = {
-        {name = "image", type = "Image *"}
+        {type = "Image *", name = "image"}
       }
     },
     {
@@ -4599,9 +4599,9 @@ return {
       description = "Resize image (Bicubic scaling algorithm)",
       returnType = "void",
       params = {
-        {name = "image", type = "Image *"},
-        {name = "newWidth", type = "int"},
-        {name = "newHeight", type = "int"}
+        {type = "Image *", name = "image"},
+        {type = "int", name = "newWidth"},
+        {type = "int", name = "newHeight"}
       }
     },
     {
@@ -4609,9 +4609,9 @@ return {
       description = "Resize image (Nearest-Neighbor scaling algorithm)",
       returnType = "void",
       params = {
-        {name = "image", type = "Image *"},
-        {name = "newWidth", type = "int"},
-        {name = "newHeight", type = "int"}
+        {type = "Image *", name = "image"},
+        {type = "int", name = "newWidth"},
+        {type = "int", name = "newHeight"}
       }
     },
     {
@@ -4619,12 +4619,12 @@ return {
       description = "Resize canvas and fill with color",
       returnType = "void",
       params = {
-        {name = "image", type = "Image *"},
-        {name = "newWidth", type = "int"},
-        {name = "newHeight", type = "int"},
-        {name = "offsetX", type = "int"},
-        {name = "offsetY", type = "int"},
-        {name = "fill", type = "Color"}
+        {type = "Image *", name = "image"},
+        {type = "int", name = "newWidth"},
+        {type = "int", name = "newHeight"},
+        {type = "int", name = "offsetX"},
+        {type = "int", name = "offsetY"},
+        {type = "Color", name = "fill"}
       }
     },
     {
@@ -4632,7 +4632,7 @@ return {
       description = "Compute all mipmap levels for a provided image",
       returnType = "void",
       params = {
-        {name = "image", type = "Image *"}
+        {type = "Image *", name = "image"}
       }
     },
     {
@@ -4640,11 +4640,11 @@ return {
       description = "Dither image data to 16bpp or lower (Floyd-Steinberg dithering)",
       returnType = "void",
       params = {
-        {name = "image", type = "Image *"},
-        {name = "rBpp", type = "int"},
-        {name = "gBpp", type = "int"},
-        {name = "bBpp", type = "int"},
-        {name = "aBpp", type = "int"}
+        {type = "Image *", name = "image"},
+        {type = "int", name = "rBpp"},
+        {type = "int", name = "gBpp"},
+        {type = "int", name = "bBpp"},
+        {type = "int", name = "aBpp"}
       }
     },
     {
@@ -4652,7 +4652,7 @@ return {
       description = "Flip image vertically",
       returnType = "void",
       params = {
-        {name = "image", type = "Image *"}
+        {type = "Image *", name = "image"}
       }
     },
     {
@@ -4660,7 +4660,7 @@ return {
       description = "Flip image horizontally",
       returnType = "void",
       params = {
-        {name = "image", type = "Image *"}
+        {type = "Image *", name = "image"}
       }
     },
     {
@@ -4668,7 +4668,7 @@ return {
       description = "Rotate image clockwise 90deg",
       returnType = "void",
       params = {
-        {name = "image", type = "Image *"}
+        {type = "Image *", name = "image"}
       }
     },
     {
@@ -4676,7 +4676,7 @@ return {
       description = "Rotate image counter-clockwise 90deg",
       returnType = "void",
       params = {
-        {name = "image", type = "Image *"}
+        {type = "Image *", name = "image"}
       }
     },
     {
@@ -4684,8 +4684,8 @@ return {
       description = "Modify image color: tint",
       returnType = "void",
       params = {
-        {name = "image", type = "Image *"},
-        {name = "color", type = "Color"}
+        {type = "Image *", name = "image"},
+        {type = "Color", name = "color"}
       }
     },
     {
@@ -4693,7 +4693,7 @@ return {
       description = "Modify image color: invert",
       returnType = "void",
       params = {
-        {name = "image", type = "Image *"}
+        {type = "Image *", name = "image"}
       }
     },
     {
@@ -4701,7 +4701,7 @@ return {
       description = "Modify image color: grayscale",
       returnType = "void",
       params = {
-        {name = "image", type = "Image *"}
+        {type = "Image *", name = "image"}
       }
     },
     {
@@ -4709,8 +4709,8 @@ return {
       description = "Modify image color: contrast (-100 to 100)",
       returnType = "void",
       params = {
-        {name = "image", type = "Image *"},
-        {name = "contrast", type = "float"}
+        {type = "Image *", name = "image"},
+        {type = "float", name = "contrast"}
       }
     },
     {
@@ -4718,8 +4718,8 @@ return {
       description = "Modify image color: brightness (-255 to 255)",
       returnType = "void",
       params = {
-        {name = "image", type = "Image *"},
-        {name = "brightness", type = "int"}
+        {type = "Image *", name = "image"},
+        {type = "int", name = "brightness"}
       }
     },
     {
@@ -4727,9 +4727,9 @@ return {
       description = "Modify image color: replace color",
       returnType = "void",
       params = {
-        {name = "image", type = "Image *"},
-        {name = "color", type = "Color"},
-        {name = "replace", type = "Color"}
+        {type = "Image *", name = "image"},
+        {type = "Color", name = "color"},
+        {type = "Color", name = "replace"}
       }
     },
     {
@@ -4737,7 +4737,7 @@ return {
       description = "Load color data from image as a Color array (RGBA - 32bit)",
       returnType = "Color *",
       params = {
-        {name = "image", type = "Image"}
+        {type = "Image", name = "image"}
       }
     },
     {
@@ -4745,9 +4745,9 @@ return {
       description = "Load colors palette from image as a Color array (RGBA - 32bit)",
       returnType = "Color *",
       params = {
-        {name = "image", type = "Image"},
-        {name = "maxPaletteSize", type = "int"},
-        {name = "colorCount", type = "int *"}
+        {type = "Image", name = "image"},
+        {type = "int", name = "maxPaletteSize"},
+        {type = "int *", name = "colorCount"}
       }
     },
     {
@@ -4755,7 +4755,7 @@ return {
       description = "Unload color data loaded with LoadImageColors()",
       returnType = "void",
       params = {
-        {name = "colors", type = "Color *"}
+        {type = "Color *", name = "colors"}
       }
     },
     {
@@ -4763,7 +4763,7 @@ return {
       description = "Unload colors palette loaded with LoadImagePalette()",
       returnType = "void",
       params = {
-        {name = "colors", type = "Color *"}
+        {type = "Color *", name = "colors"}
       }
     },
     {
@@ -4771,8 +4771,8 @@ return {
       description = "Get image alpha border rectangle",
       returnType = "Rectangle",
       params = {
-        {name = "image", type = "Image"},
-        {name = "threshold", type = "float"}
+        {type = "Image", name = "image"},
+        {type = "float", name = "threshold"}
       }
     },
     {
@@ -4780,9 +4780,9 @@ return {
       description = "Get image pixel color at (x, y) position",
       returnType = "Color",
       params = {
-        {name = "image", type = "Image"},
-        {name = "x", type = "int"},
-        {name = "y", type = "int"}
+        {type = "Image", name = "image"},
+        {type = "int", name = "x"},
+        {type = "int", name = "y"}
       }
     },
     {
@@ -4790,8 +4790,8 @@ return {
       description = "Clear image background with given color",
       returnType = "void",
       params = {
-        {name = "dst", type = "Image *"},
-        {name = "color", type = "Color"}
+        {type = "Image *", name = "dst"},
+        {type = "Color", name = "color"}
       }
     },
     {
@@ -4799,10 +4799,10 @@ return {
       description = "Draw pixel within an image",
       returnType = "void",
       params = {
-        {name = "dst", type = "Image *"},
-        {name = "posX", type = "int"},
-        {name = "posY", type = "int"},
-        {name = "color", type = "Color"}
+        {type = "Image *", name = "dst"},
+        {type = "int", name = "posX"},
+        {type = "int", name = "posY"},
+        {type = "Color", name = "color"}
       }
     },
     {
@@ -4810,9 +4810,9 @@ return {
       description = "Draw pixel within an image (Vector version)",
       returnType = "void",
       params = {
-        {name = "dst", type = "Image *"},
-        {name = "position", type = "Vector2"},
-        {name = "color", type = "Color"}
+        {type = "Image *", name = "dst"},
+        {type = "Vector2", name = "position"},
+        {type = "Color", name = "color"}
       }
     },
     {
@@ -4820,12 +4820,12 @@ return {
       description = "Draw line within an image",
       returnType = "void",
       params = {
-        {name = "dst", type = "Image *"},
-        {name = "startPosX", type = "int"},
-        {name = "startPosY", type = "int"},
-        {name = "endPosX", type = "int"},
-        {name = "endPosY", type = "int"},
-        {name = "color", type = "Color"}
+        {type = "Image *", name = "dst"},
+        {type = "int", name = "startPosX"},
+        {type = "int", name = "startPosY"},
+        {type = "int", name = "endPosX"},
+        {type = "int", name = "endPosY"},
+        {type = "Color", name = "color"}
       }
     },
     {
@@ -4833,10 +4833,10 @@ return {
       description = "Draw line within an image (Vector version)",
       returnType = "void",
       params = {
-        {name = "dst", type = "Image *"},
-        {name = "start", type = "Vector2"},
-        {name = "end", type = "Vector2"},
-        {name = "color", type = "Color"}
+        {type = "Image *", name = "dst"},
+        {type = "Vector2", name = "start"},
+        {type = "Vector2", name = "end"},
+        {type = "Color", name = "color"}
       }
     },
     {
@@ -4844,11 +4844,11 @@ return {
       description = "Draw circle within an image",
       returnType = "void",
       params = {
-        {name = "dst", type = "Image *"},
-        {name = "centerX", type = "int"},
-        {name = "centerY", type = "int"},
-        {name = "radius", type = "int"},
-        {name = "color", type = "Color"}
+        {type = "Image *", name = "dst"},
+        {type = "int", name = "centerX"},
+        {type = "int", name = "centerY"},
+        {type = "int", name = "radius"},
+        {type = "Color", name = "color"}
       }
     },
     {
@@ -4856,10 +4856,10 @@ return {
       description = "Draw circle within an image (Vector version)",
       returnType = "void",
       params = {
-        {name = "dst", type = "Image *"},
-        {name = "center", type = "Vector2"},
-        {name = "radius", type = "int"},
-        {name = "color", type = "Color"}
+        {type = "Image *", name = "dst"},
+        {type = "Vector2", name = "center"},
+        {type = "int", name = "radius"},
+        {type = "Color", name = "color"}
       }
     },
     {
@@ -4867,12 +4867,12 @@ return {
       description = "Draw rectangle within an image",
       returnType = "void",
       params = {
-        {name = "dst", type = "Image *"},
-        {name = "posX", type = "int"},
-        {name = "posY", type = "int"},
-        {name = "width", type = "int"},
-        {name = "height", type = "int"},
-        {name = "color", type = "Color"}
+        {type = "Image *", name = "dst"},
+        {type = "int", name = "posX"},
+        {type = "int", name = "posY"},
+        {type = "int", name = "width"},
+        {type = "int", name = "height"},
+        {type = "Color", name = "color"}
       }
     },
     {
@@ -4880,10 +4880,10 @@ return {
       description = "Draw rectangle within an image (Vector version)",
       returnType = "void",
       params = {
-        {name = "dst", type = "Image *"},
-        {name = "position", type = "Vector2"},
-        {name = "size", type = "Vector2"},
-        {name = "color", type = "Color"}
+        {type = "Image *", name = "dst"},
+        {type = "Vector2", name = "position"},
+        {type = "Vector2", name = "size"},
+        {type = "Color", name = "color"}
       }
     },
     {
@@ -4891,9 +4891,9 @@ return {
       description = "Draw rectangle within an image",
       returnType = "void",
       params = {
-        {name = "dst", type = "Image *"},
-        {name = "rec", type = "Rectangle"},
-        {name = "color", type = "Color"}
+        {type = "Image *", name = "dst"},
+        {type = "Rectangle", name = "rec"},
+        {type = "Color", name = "color"}
       }
     },
     {
@@ -4901,10 +4901,10 @@ return {
       description = "Draw rectangle lines within an image",
       returnType = "void",
       params = {
-        {name = "dst", type = "Image *"},
-        {name = "rec", type = "Rectangle"},
-        {name = "thick", type = "int"},
-        {name = "color", type = "Color"}
+        {type = "Image *", name = "dst"},
+        {type = "Rectangle", name = "rec"},
+        {type = "int", name = "thick"},
+        {type = "Color", name = "color"}
       }
     },
     {
@@ -4912,11 +4912,11 @@ return {
       description = "Draw a source image within a destination image (tint applied to source)",
       returnType = "void",
       params = {
-        {name = "dst", type = "Image *"},
-        {name = "src", type = "Image"},
-        {name = "srcRec", type = "Rectangle"},
-        {name = "dstRec", type = "Rectangle"},
-        {name = "tint", type = "Color"}
+        {type = "Image *", name = "dst"},
+        {type = "Image", name = "src"},
+        {type = "Rectangle", name = "srcRec"},
+        {type = "Rectangle", name = "dstRec"},
+        {type = "Color", name = "tint"}
       }
     },
     {
@@ -4924,12 +4924,12 @@ return {
       description = "Draw text (using default font) within an image (destination)",
       returnType = "void",
       params = {
-        {name = "dst", type = "Image *"},
-        {name = "text", type = "const char *"},
-        {name = "posX", type = "int"},
-        {name = "posY", type = "int"},
-        {name = "fontSize", type = "int"},
-        {name = "color", type = "Color"}
+        {type = "Image *", name = "dst"},
+        {type = "const char *", name = "text"},
+        {type = "int", name = "posX"},
+        {type = "int", name = "posY"},
+        {type = "int", name = "fontSize"},
+        {type = "Color", name = "color"}
       }
     },
     {
@@ -4937,13 +4937,13 @@ return {
       description = "Draw text (custom sprite font) within an image (destination)",
       returnType = "void",
       params = {
-        {name = "dst", type = "Image *"},
-        {name = "font", type = "Font"},
-        {name = "text", type = "const char *"},
-        {name = "position", type = "Vector2"},
-        {name = "fontSize", type = "float"},
-        {name = "spacing", type = "float"},
-        {name = "tint", type = "Color"}
+        {type = "Image *", name = "dst"},
+        {type = "Font", name = "font"},
+        {type = "const char *", name = "text"},
+        {type = "Vector2", name = "position"},
+        {type = "float", name = "fontSize"},
+        {type = "float", name = "spacing"},
+        {type = "Color", name = "tint"}
       }
     },
     {
@@ -4951,7 +4951,7 @@ return {
       description = "Load texture from file into GPU memory (VRAM)",
       returnType = "Texture2D",
       params = {
-        {name = "fileName", type = "const char *"}
+        {type = "const char *", name = "fileName"}
       }
     },
     {
@@ -4959,7 +4959,7 @@ return {
       description = "Load texture from image data",
       returnType = "Texture2D",
       params = {
-        {name = "image", type = "Image"}
+        {type = "Image", name = "image"}
       }
     },
     {
@@ -4967,8 +4967,8 @@ return {
       description = "Load cubemap from image, multiple image cubemap layouts supported",
       returnType = "TextureCubemap",
       params = {
-        {name = "image", type = "Image"},
-        {name = "layout", type = "int"}
+        {type = "Image", name = "image"},
+        {type = "int", name = "layout"}
       }
     },
     {
@@ -4976,8 +4976,8 @@ return {
       description = "Load texture for rendering (framebuffer)",
       returnType = "RenderTexture2D",
       params = {
-        {name = "width", type = "int"},
-        {name = "height", type = "int"}
+        {type = "int", name = "width"},
+        {type = "int", name = "height"}
       }
     },
     {
@@ -4985,7 +4985,7 @@ return {
       description = "Unload texture from GPU memory (VRAM)",
       returnType = "void",
       params = {
-        {name = "texture", type = "Texture2D"}
+        {type = "Texture2D", name = "texture"}
       }
     },
     {
@@ -4993,7 +4993,7 @@ return {
       description = "Unload render texture from GPU memory (VRAM)",
       returnType = "void",
       params = {
-        {name = "target", type = "RenderTexture2D"}
+        {type = "RenderTexture2D", name = "target"}
       }
     },
     {
@@ -5001,8 +5001,8 @@ return {
       description = "Update GPU texture with new data",
       returnType = "void",
       params = {
-        {name = "texture", type = "Texture2D"},
-        {name = "pixels", type = "const void *"}
+        {type = "Texture2D", name = "texture"},
+        {type = "const void *", name = "pixels"}
       }
     },
     {
@@ -5010,9 +5010,9 @@ return {
       description = "Update GPU texture rectangle with new data",
       returnType = "void",
       params = {
-        {name = "texture", type = "Texture2D"},
-        {name = "rec", type = "Rectangle"},
-        {name = "pixels", type = "const void *"}
+        {type = "Texture2D", name = "texture"},
+        {type = "Rectangle", name = "rec"},
+        {type = "const void *", name = "pixels"}
       }
     },
     {
@@ -5020,7 +5020,7 @@ return {
       description = "Generate GPU mipmaps for a texture",
       returnType = "void",
       params = {
-        {name = "texture", type = "Texture2D *"}
+        {type = "Texture2D *", name = "texture"}
       }
     },
     {
@@ -5028,8 +5028,8 @@ return {
       description = "Set texture scaling filter mode",
       returnType = "void",
       params = {
-        {name = "texture", type = "Texture2D"},
-        {name = "filter", type = "int"}
+        {type = "Texture2D", name = "texture"},
+        {type = "int", name = "filter"}
       }
     },
     {
@@ -5037,8 +5037,8 @@ return {
       description = "Set texture wrapping mode",
       returnType = "void",
       params = {
-        {name = "texture", type = "Texture2D"},
-        {name = "wrap", type = "int"}
+        {type = "Texture2D", name = "texture"},
+        {type = "int", name = "wrap"}
       }
     },
     {
@@ -5046,10 +5046,10 @@ return {
       description = "Draw a Texture2D",
       returnType = "void",
       params = {
-        {name = "texture", type = "Texture2D"},
-        {name = "posX", type = "int"},
-        {name = "posY", type = "int"},
-        {name = "tint", type = "Color"}
+        {type = "Texture2D", name = "texture"},
+        {type = "int", name = "posX"},
+        {type = "int", name = "posY"},
+        {type = "Color", name = "tint"}
       }
     },
     {
@@ -5057,9 +5057,9 @@ return {
       description = "Draw a Texture2D with position defined as Vector2",
       returnType = "void",
       params = {
-        {name = "texture", type = "Texture2D"},
-        {name = "position", type = "Vector2"},
-        {name = "tint", type = "Color"}
+        {type = "Texture2D", name = "texture"},
+        {type = "Vector2", name = "position"},
+        {type = "Color", name = "tint"}
       }
     },
     {
@@ -5067,11 +5067,11 @@ return {
       description = "Draw a Texture2D with extended parameters",
       returnType = "void",
       params = {
-        {name = "texture", type = "Texture2D"},
-        {name = "position", type = "Vector2"},
-        {name = "rotation", type = "float"},
-        {name = "scale", type = "float"},
-        {name = "tint", type = "Color"}
+        {type = "Texture2D", name = "texture"},
+        {type = "Vector2", name = "position"},
+        {type = "float", name = "rotation"},
+        {type = "float", name = "scale"},
+        {type = "Color", name = "tint"}
       }
     },
     {
@@ -5079,10 +5079,10 @@ return {
       description = "Draw a part of a texture defined by a rectangle",
       returnType = "void",
       params = {
-        {name = "texture", type = "Texture2D"},
-        {name = "source", type = "Rectangle"},
-        {name = "position", type = "Vector2"},
-        {name = "tint", type = "Color"}
+        {type = "Texture2D", name = "texture"},
+        {type = "Rectangle", name = "source"},
+        {type = "Vector2", name = "position"},
+        {type = "Color", name = "tint"}
       }
     },
     {
@@ -5090,11 +5090,11 @@ return {
       description = "Draw texture quad with tiling and offset parameters",
       returnType = "void",
       params = {
-        {name = "texture", type = "Texture2D"},
-        {name = "tiling", type = "Vector2"},
-        {name = "offset", type = "Vector2"},
-        {name = "quad", type = "Rectangle"},
-        {name = "tint", type = "Color"}
+        {type = "Texture2D", name = "texture"},
+        {type = "Vector2", name = "tiling"},
+        {type = "Vector2", name = "offset"},
+        {type = "Rectangle", name = "quad"},
+        {type = "Color", name = "tint"}
       }
     },
     {
@@ -5102,13 +5102,13 @@ return {
       description = "Draw part of a texture (defined by a rectangle) with rotation and scale tiled into dest.",
       returnType = "void",
       params = {
-        {name = "texture", type = "Texture2D"},
-        {name = "source", type = "Rectangle"},
-        {name = "dest", type = "Rectangle"},
-        {name = "origin", type = "Vector2"},
-        {name = "rotation", type = "float"},
-        {name = "scale", type = "float"},
-        {name = "tint", type = "Color"}
+        {type = "Texture2D", name = "texture"},
+        {type = "Rectangle", name = "source"},
+        {type = "Rectangle", name = "dest"},
+        {type = "Vector2", name = "origin"},
+        {type = "float", name = "rotation"},
+        {type = "float", name = "scale"},
+        {type = "Color", name = "tint"}
       }
     },
     {
@@ -5116,12 +5116,12 @@ return {
       description = "Draw a part of a texture defined by a rectangle with 'pro' parameters",
       returnType = "void",
       params = {
-        {name = "texture", type = "Texture2D"},
-        {name = "source", type = "Rectangle"},
-        {name = "dest", type = "Rectangle"},
-        {name = "origin", type = "Vector2"},
-        {name = "rotation", type = "float"},
-        {name = "tint", type = "Color"}
+        {type = "Texture2D", name = "texture"},
+        {type = "Rectangle", name = "source"},
+        {type = "Rectangle", name = "dest"},
+        {type = "Vector2", name = "origin"},
+        {type = "float", name = "rotation"},
+        {type = "Color", name = "tint"}
       }
     },
     {
@@ -5129,12 +5129,12 @@ return {
       description = "Draws a texture (or part of it) that stretches or shrinks nicely",
       returnType = "void",
       params = {
-        {name = "texture", type = "Texture2D"},
-        {name = "nPatchInfo", type = "NPatchInfo"},
-        {name = "dest", type = "Rectangle"},
-        {name = "origin", type = "Vector2"},
-        {name = "rotation", type = "float"},
-        {name = "tint", type = "Color"}
+        {type = "Texture2D", name = "texture"},
+        {type = "NPatchInfo", name = "nPatchInfo"},
+        {type = "Rectangle", name = "dest"},
+        {type = "Vector2", name = "origin"},
+        {type = "float", name = "rotation"},
+        {type = "Color", name = "tint"}
       }
     },
     {
@@ -5142,12 +5142,12 @@ return {
       description = "Draw a textured polygon",
       returnType = "void",
       params = {
-        {name = "texture", type = "Texture2D"},
-        {name = "center", type = "Vector2"},
-        {name = "points", type = "Vector2 *"},
-        {name = "texcoords", type = "Vector2 *"},
-        {name = "pointCount", type = "int"},
-        {name = "tint", type = "Color"}
+        {type = "Texture2D", name = "texture"},
+        {type = "Vector2", name = "center"},
+        {type = "Vector2 *", name = "points"},
+        {type = "Vector2 *", name = "texcoords"},
+        {type = "int", name = "pointCount"},
+        {type = "Color", name = "tint"}
       }
     },
     {
@@ -5155,8 +5155,8 @@ return {
       description = "Get color with alpha applied, alpha goes from 0.0f to 1.0f",
       returnType = "Color",
       params = {
-        {name = "color", type = "Color"},
-        {name = "alpha", type = "float"}
+        {type = "Color", name = "color"},
+        {type = "float", name = "alpha"}
       }
     },
     {
@@ -5164,7 +5164,7 @@ return {
       description = "Get hexadecimal value for a Color",
       returnType = "int",
       params = {
-        {name = "color", type = "Color"}
+        {type = "Color", name = "color"}
       }
     },
     {
@@ -5172,7 +5172,7 @@ return {
       description = "Get Color normalized as float [0..1]",
       returnType = "Vector4",
       params = {
-        {name = "color", type = "Color"}
+        {type = "Color", name = "color"}
       }
     },
     {
@@ -5180,7 +5180,7 @@ return {
       description = "Get Color from normalized values [0..1]",
       returnType = "Color",
       params = {
-        {name = "normalized", type = "Vector4"}
+        {type = "Vector4", name = "normalized"}
       }
     },
     {
@@ -5188,7 +5188,7 @@ return {
       description = "Get HSV values for a Color, hue [0..360], saturation/value [0..1]",
       returnType = "Vector3",
       params = {
-        {name = "color", type = "Color"}
+        {type = "Color", name = "color"}
       }
     },
     {
@@ -5196,9 +5196,9 @@ return {
       description = "Get a Color from HSV values, hue [0..360], saturation/value [0..1]",
       returnType = "Color",
       params = {
-        {name = "hue", type = "float"},
-        {name = "saturation", type = "float"},
-        {name = "value", type = "float"}
+        {type = "float", name = "hue"},
+        {type = "float", name = "saturation"},
+        {type = "float", name = "value"}
       }
     },
     {
@@ -5206,8 +5206,8 @@ return {
       description = "Get color with alpha applied, alpha goes from 0.0f to 1.0f",
       returnType = "Color",
       params = {
-        {name = "color", type = "Color"},
-        {name = "alpha", type = "float"}
+        {type = "Color", name = "color"},
+        {type = "float", name = "alpha"}
       }
     },
     {
@@ -5215,9 +5215,9 @@ return {
       description = "Get src alpha-blended into dst color with tint",
       returnType = "Color",
       params = {
-        {name = "dst", type = "Color"},
-        {name = "src", type = "Color"},
-        {name = "tint", type = "Color"}
+        {type = "Color", name = "dst"},
+        {type = "Color", name = "src"},
+        {type = "Color", name = "tint"}
       }
     },
     {
@@ -5225,7 +5225,7 @@ return {
       description = "Get Color structure from hexadecimal value",
       returnType = "Color",
       params = {
-        {name = "hexValue", type = "unsigned int"}
+        {type = "unsigned int", name = "hexValue"}
       }
     },
     {
@@ -5233,8 +5233,8 @@ return {
       description = "Get Color from a source pixel pointer of certain format",
       returnType = "Color",
       params = {
-        {name = "srcPtr", type = "void *"},
-        {name = "format", type = "int"}
+        {type = "void *", name = "srcPtr"},
+        {type = "int", name = "format"}
       }
     },
     {
@@ -5242,9 +5242,9 @@ return {
       description = "Set color formatted into destination pixel pointer",
       returnType = "void",
       params = {
-        {name = "dstPtr", type = "void *"},
-        {name = "color", type = "Color"},
-        {name = "format", type = "int"}
+        {type = "void *", name = "dstPtr"},
+        {type = "Color", name = "color"},
+        {type = "int", name = "format"}
       }
     },
     {
@@ -5252,9 +5252,9 @@ return {
       description = "Get pixel data size in bytes for certain format",
       returnType = "int",
       params = {
-        {name = "width", type = "int"},
-        {name = "height", type = "int"},
-        {name = "format", type = "int"}
+        {type = "int", name = "width"},
+        {type = "int", name = "height"},
+        {type = "int", name = "format"}
       }
     },
     {
@@ -5267,7 +5267,7 @@ return {
       description = "Load font from file into GPU memory (VRAM)",
       returnType = "Font",
       params = {
-        {name = "fileName", type = "const char *"}
+        {type = "const char *", name = "fileName"}
       }
     },
     {
@@ -5275,10 +5275,10 @@ return {
       description = "Load font from file with extended parameters, use NULL for fontChars and 0 for glyphCount to load the default character set",
       returnType = "Font",
       params = {
-        {name = "fileName", type = "const char *"},
-        {name = "fontSize", type = "int"},
-        {name = "fontChars", type = "int *"},
-        {name = "glyphCount", type = "int"}
+        {type = "const char *", name = "fileName"},
+        {type = "int", name = "fontSize"},
+        {type = "int *", name = "fontChars"},
+        {type = "int", name = "glyphCount"}
       }
     },
     {
@@ -5286,9 +5286,9 @@ return {
       description = "Load font from Image (XNA style)",
       returnType = "Font",
       params = {
-        {name = "image", type = "Image"},
-        {name = "key", type = "Color"},
-        {name = "firstChar", type = "int"}
+        {type = "Image", name = "image"},
+        {type = "Color", name = "key"},
+        {type = "int", name = "firstChar"}
       }
     },
     {
@@ -5296,12 +5296,12 @@ return {
       description = "Load font from memory buffer, fileType refers to extension: i.e. '.ttf'",
       returnType = "Font",
       params = {
-        {name = "fileType", type = "const char *"},
-        {name = "fileData", type = "const unsigned char *"},
-        {name = "dataSize", type = "int"},
-        {name = "fontSize", type = "int"},
-        {name = "fontChars", type = "int *"},
-        {name = "glyphCount", type = "int"}
+        {type = "const char *", name = "fileType"},
+        {type = "const unsigned char *", name = "fileData"},
+        {type = "int", name = "dataSize"},
+        {type = "int", name = "fontSize"},
+        {type = "int *", name = "fontChars"},
+        {type = "int", name = "glyphCount"}
       }
     },
     {
@@ -5309,12 +5309,12 @@ return {
       description = "Load font data for further use",
       returnType = "GlyphInfo *",
       params = {
-        {name = "fileData", type = "const unsigned char *"},
-        {name = "dataSize", type = "int"},
-        {name = "fontSize", type = "int"},
-        {name = "fontChars", type = "int *"},
-        {name = "glyphCount", type = "int"},
-        {name = "type", type = "int"}
+        {type = "const unsigned char *", name = "fileData"},
+        {type = "int", name = "dataSize"},
+        {type = "int", name = "fontSize"},
+        {type = "int *", name = "fontChars"},
+        {type = "int", name = "glyphCount"},
+        {type = "int", name = "type"}
       }
     },
     {
@@ -5322,12 +5322,12 @@ return {
       description = "Generate image font atlas using chars info",
       returnType = "Image",
       params = {
-        {name = "chars", type = "const GlyphInfo *"},
-        {name = "recs", type = "Rectangle **"},
-        {name = "glyphCount", type = "int"},
-        {name = "fontSize", type = "int"},
-        {name = "padding", type = "int"},
-        {name = "packMethod", type = "int"}
+        {type = "const GlyphInfo *", name = "chars"},
+        {type = "Rectangle **", name = "recs"},
+        {type = "int", name = "glyphCount"},
+        {type = "int", name = "fontSize"},
+        {type = "int", name = "padding"},
+        {type = "int", name = "packMethod"}
       }
     },
     {
@@ -5335,8 +5335,8 @@ return {
       description = "Unload font chars info data (RAM)",
       returnType = "void",
       params = {
-        {name = "chars", type = "GlyphInfo *"},
-        {name = "glyphCount", type = "int"}
+        {type = "GlyphInfo *", name = "chars"},
+        {type = "int", name = "glyphCount"}
       }
     },
     {
@@ -5344,7 +5344,7 @@ return {
       description = "Unload font from GPU memory (VRAM)",
       returnType = "void",
       params = {
-        {name = "font", type = "Font"}
+        {type = "Font", name = "font"}
       }
     },
     {
@@ -5352,8 +5352,8 @@ return {
       description = "Export font as code file, returns true on success",
       returnType = "bool",
       params = {
-        {name = "font", type = "Font"},
-        {name = "fileName", type = "const char *"}
+        {type = "Font", name = "font"},
+        {type = "const char *", name = "fileName"}
       }
     },
     {
@@ -5361,8 +5361,8 @@ return {
       description = "Draw current FPS",
       returnType = "void",
       params = {
-        {name = "posX", type = "int"},
-        {name = "posY", type = "int"}
+        {type = "int", name = "posX"},
+        {type = "int", name = "posY"}
       }
     },
     {
@@ -5370,11 +5370,11 @@ return {
       description = "Draw text (using default font)",
       returnType = "void",
       params = {
-        {name = "text", type = "const char *"},
-        {name = "posX", type = "int"},
-        {name = "posY", type = "int"},
-        {name = "fontSize", type = "int"},
-        {name = "color", type = "Color"}
+        {type = "const char *", name = "text"},
+        {type = "int", name = "posX"},
+        {type = "int", name = "posY"},
+        {type = "int", name = "fontSize"},
+        {type = "Color", name = "color"}
       }
     },
     {
@@ -5382,12 +5382,12 @@ return {
       description = "Draw text using font and additional parameters",
       returnType = "void",
       params = {
-        {name = "font", type = "Font"},
-        {name = "text", type = "const char *"},
-        {name = "position", type = "Vector2"},
-        {name = "fontSize", type = "float"},
-        {name = "spacing", type = "float"},
-        {name = "tint", type = "Color"}
+        {type = "Font", name = "font"},
+        {type = "const char *", name = "text"},
+        {type = "Vector2", name = "position"},
+        {type = "float", name = "fontSize"},
+        {type = "float", name = "spacing"},
+        {type = "Color", name = "tint"}
       }
     },
     {
@@ -5395,14 +5395,14 @@ return {
       description = "Draw text using Font and pro parameters (rotation)",
       returnType = "void",
       params = {
-        {name = "font", type = "Font"},
-        {name = "text", type = "const char *"},
-        {name = "position", type = "Vector2"},
-        {name = "origin", type = "Vector2"},
-        {name = "rotation", type = "float"},
-        {name = "fontSize", type = "float"},
-        {name = "spacing", type = "float"},
-        {name = "tint", type = "Color"}
+        {type = "Font", name = "font"},
+        {type = "const char *", name = "text"},
+        {type = "Vector2", name = "position"},
+        {type = "Vector2", name = "origin"},
+        {type = "float", name = "rotation"},
+        {type = "float", name = "fontSize"},
+        {type = "float", name = "spacing"},
+        {type = "Color", name = "tint"}
       }
     },
     {
@@ -5410,11 +5410,11 @@ return {
       description = "Draw one character (codepoint)",
       returnType = "void",
       params = {
-        {name = "font", type = "Font"},
-        {name = "codepoint", type = "int"},
-        {name = "position", type = "Vector2"},
-        {name = "fontSize", type = "float"},
-        {name = "tint", type = "Color"}
+        {type = "Font", name = "font"},
+        {type = "int", name = "codepoint"},
+        {type = "Vector2", name = "position"},
+        {type = "float", name = "fontSize"},
+        {type = "Color", name = "tint"}
       }
     },
     {
@@ -5422,8 +5422,8 @@ return {
       description = "Measure string width for default font",
       returnType = "int",
       params = {
-        {name = "text", type = "const char *"},
-        {name = "fontSize", type = "int"}
+        {type = "const char *", name = "text"},
+        {type = "int", name = "fontSize"}
       }
     },
     {
@@ -5431,10 +5431,10 @@ return {
       description = "Measure string size for Font",
       returnType = "Vector2",
       params = {
-        {name = "font", type = "Font"},
-        {name = "text", type = "const char *"},
-        {name = "fontSize", type = "float"},
-        {name = "spacing", type = "float"}
+        {type = "Font", name = "font"},
+        {type = "const char *", name = "text"},
+        {type = "float", name = "fontSize"},
+        {type = "float", name = "spacing"}
       }
     },
     {
@@ -5442,8 +5442,8 @@ return {
       description = "Get glyph index position in font for a codepoint (unicode character), fallback to '?' if not found",
       returnType = "int",
       params = {
-        {name = "font", type = "Font"},
-        {name = "codepoint", type = "int"}
+        {type = "Font", name = "font"},
+        {type = "int", name = "codepoint"}
       }
     },
     {
@@ -5451,8 +5451,8 @@ return {
       description = "Get glyph font info data for a codepoint (unicode character), fallback to '?' if not found",
       returnType = "GlyphInfo",
       params = {
-        {name = "font", type = "Font"},
-        {name = "codepoint", type = "int"}
+        {type = "Font", name = "font"},
+        {type = "int", name = "codepoint"}
       }
     },
     {
@@ -5460,8 +5460,8 @@ return {
       description = "Get glyph rectangle in font atlas for a codepoint (unicode character), fallback to '?' if not found",
       returnType = "Rectangle",
       params = {
-        {name = "font", type = "Font"},
-        {name = "codepoint", type = "int"}
+        {type = "Font", name = "font"},
+        {type = "int", name = "codepoint"}
       }
     },
     {
@@ -5469,8 +5469,8 @@ return {
       description = "Load all codepoints from a UTF-8 text string, codepoints count returned by parameter",
       returnType = "int *",
       params = {
-        {name = "text", type = "const char *"},
-        {name = "count", type = "int *"}
+        {type = "const char *", name = "text"},
+        {type = "int *", name = "count"}
       }
     },
     {
@@ -5478,7 +5478,7 @@ return {
       description = "Unload codepoints data from memory",
       returnType = "void",
       params = {
-        {name = "codepoints", type = "int *"}
+        {type = "int *", name = "codepoints"}
       }
     },
     {
@@ -5486,7 +5486,7 @@ return {
       description = "Get total number of codepoints in a UTF-8 encoded string",
       returnType = "int",
       params = {
-        {name = "text", type = "const char *"}
+        {type = "const char *", name = "text"}
       }
     },
     {
@@ -5494,8 +5494,8 @@ return {
       description = "Get next codepoint in a UTF-8 encoded string, 0x3f('?') is returned on failure",
       returnType = "int",
       params = {
-        {name = "text", type = "const char *"},
-        {name = "bytesProcessed", type = "int *"}
+        {type = "const char *", name = "text"},
+        {type = "int *", name = "bytesProcessed"}
       }
     },
     {
@@ -5503,8 +5503,8 @@ return {
       description = "Encode one codepoint into UTF-8 byte array (array length returned as parameter)",
       returnType = "const char *",
       params = {
-        {name = "codepoint", type = "int"},
-        {name = "byteSize", type = "int *"}
+        {type = "int", name = "codepoint"},
+        {type = "int *", name = "byteSize"}
       }
     },
     {
@@ -5512,8 +5512,8 @@ return {
       description = "Encode text as codepoints array into UTF-8 text string (WARNING: memory must be freed!)",
       returnType = "char *",
       params = {
-        {name = "codepoints", type = "int *"},
-        {name = "length", type = "int"}
+        {type = "int *", name = "codepoints"},
+        {type = "int", name = "length"}
       }
     },
     {
@@ -5521,8 +5521,8 @@ return {
       description = "Copy one string to another, returns bytes copied",
       returnType = "int",
       params = {
-        {name = "dst", type = "char *"},
-        {name = "src", type = "const char *"}
+        {type = "char *", name = "dst"},
+        {type = "const char *", name = "src"}
       }
     },
     {
@@ -5530,8 +5530,8 @@ return {
       description = "Check if two text string are equal",
       returnType = "bool",
       params = {
-        {name = "text1", type = "const char *"},
-        {name = "text2", type = "const char *"}
+        {type = "const char *", name = "text1"},
+        {type = "const char *", name = "text2"}
       }
     },
     {
@@ -5539,7 +5539,7 @@ return {
       description = "Get text length, checks for '\\0' ending",
       returnType = "unsigned int",
       params = {
-        {name = "text", type = "const char *"}
+        {type = "const char *", name = "text"}
       }
     },
     {
@@ -5547,8 +5547,8 @@ return {
       description = "Text formatting with variables (sprintf() style)",
       returnType = "const char *",
       params = {
-        {name = "text", type = "const char *"},
-        {name = "", type = ""}
+        {type = "const char *", name = "text"},
+        {type = "", name = ""}
       }
     },
     {
@@ -5556,9 +5556,9 @@ return {
       description = "Get a piece of a text string",
       returnType = "const char *",
       params = {
-        {name = "text", type = "const char *"},
-        {name = "position", type = "int"},
-        {name = "length", type = "int"}
+        {type = "const char *", name = "text"},
+        {type = "int", name = "position"},
+        {type = "int", name = "length"}
       }
     },
     {
@@ -5566,9 +5566,9 @@ return {
       description = "Replace text string (WARNING: memory must be freed!)",
       returnType = "char *",
       params = {
-        {name = "text", type = "char *"},
-        {name = "replace", type = "const char *"},
-        {name = "by", type = "const char *"}
+        {type = "char *", name = "text"},
+        {type = "const char *", name = "replace"},
+        {type = "const char *", name = "by"}
       }
     },
     {
@@ -5576,9 +5576,9 @@ return {
       description = "Insert text in a position (WARNING: memory must be freed!)",
       returnType = "char *",
       params = {
-        {name = "text", type = "const char *"},
-        {name = "insert", type = "const char *"},
-        {name = "position", type = "int"}
+        {type = "const char *", name = "text"},
+        {type = "const char *", name = "insert"},
+        {type = "int", name = "position"}
       }
     },
     {
@@ -5586,9 +5586,9 @@ return {
       description = "Join text strings with delimiter",
       returnType = "const char *",
       params = {
-        {name = "textList", type = "const char **"},
-        {name = "count", type = "int"},
-        {name = "delimiter", type = "const char *"}
+        {type = "const char **", name = "textList"},
+        {type = "int", name = "count"},
+        {type = "const char *", name = "delimiter"}
       }
     },
     {
@@ -5596,9 +5596,9 @@ return {
       description = "Split text into multiple strings",
       returnType = "const char **",
       params = {
-        {name = "text", type = "const char *"},
-        {name = "delimiter", type = "char"},
-        {name = "count", type = "int *"}
+        {type = "const char *", name = "text"},
+        {type = "char", name = "delimiter"},
+        {type = "int *", name = "count"}
       }
     },
     {
@@ -5606,9 +5606,9 @@ return {
       description = "Append text at specific position and move cursor!",
       returnType = "void",
       params = {
-        {name = "text", type = "char *"},
-        {name = "append", type = "const char *"},
-        {name = "position", type = "int *"}
+        {type = "char *", name = "text"},
+        {type = "const char *", name = "append"},
+        {type = "int *", name = "position"}
       }
     },
     {
@@ -5616,8 +5616,8 @@ return {
       description = "Find first text occurrence within a string",
       returnType = "int",
       params = {
-        {name = "text", type = "const char *"},
-        {name = "find", type = "const char *"}
+        {type = "const char *", name = "text"},
+        {type = "const char *", name = "find"}
       }
     },
     {
@@ -5625,7 +5625,7 @@ return {
       description = "Get upper case version of provided string",
       returnType = "const char *",
       params = {
-        {name = "text", type = "const char *"}
+        {type = "const char *", name = "text"}
       }
     },
     {
@@ -5633,7 +5633,7 @@ return {
       description = "Get lower case version of provided string",
       returnType = "const char *",
       params = {
-        {name = "text", type = "const char *"}
+        {type = "const char *", name = "text"}
       }
     },
     {
@@ -5641,7 +5641,7 @@ return {
       description = "Get Pascal case notation version of provided string",
       returnType = "const char *",
       params = {
-        {name = "text", type = "const char *"}
+        {type = "const char *", name = "text"}
       }
     },
     {
@@ -5649,7 +5649,7 @@ return {
       description = "Get integer value from text (negative values not supported)",
       returnType = "int",
       params = {
-        {name = "text", type = "const char *"}
+        {type = "const char *", name = "text"}
       }
     },
     {
@@ -5657,9 +5657,9 @@ return {
       description = "Draw a line in 3D world space",
       returnType = "void",
       params = {
-        {name = "startPos", type = "Vector3"},
-        {name = "endPos", type = "Vector3"},
-        {name = "color", type = "Color"}
+        {type = "Vector3", name = "startPos"},
+        {type = "Vector3", name = "endPos"},
+        {type = "Color", name = "color"}
       }
     },
     {
@@ -5667,8 +5667,8 @@ return {
       description = "Draw a point in 3D space, actually a small line",
       returnType = "void",
       params = {
-        {name = "position", type = "Vector3"},
-        {name = "color", type = "Color"}
+        {type = "Vector3", name = "position"},
+        {type = "Color", name = "color"}
       }
     },
     {
@@ -5676,11 +5676,11 @@ return {
       description = "Draw a circle in 3D world space",
       returnType = "void",
       params = {
-        {name = "center", type = "Vector3"},
-        {name = "radius", type = "float"},
-        {name = "rotationAxis", type = "Vector3"},
-        {name = "rotationAngle", type = "float"},
-        {name = "color", type = "Color"}
+        {type = "Vector3", name = "center"},
+        {type = "float", name = "radius"},
+        {type = "Vector3", name = "rotationAxis"},
+        {type = "float", name = "rotationAngle"},
+        {type = "Color", name = "color"}
       }
     },
     {
@@ -5688,10 +5688,10 @@ return {
       description = "Draw a color-filled triangle (vertex in counter-clockwise order!)",
       returnType = "void",
       params = {
-        {name = "v1", type = "Vector3"},
-        {name = "v2", type = "Vector3"},
-        {name = "v3", type = "Vector3"},
-        {name = "color", type = "Color"}
+        {type = "Vector3", name = "v1"},
+        {type = "Vector3", name = "v2"},
+        {type = "Vector3", name = "v3"},
+        {type = "Color", name = "color"}
       }
     },
     {
@@ -5699,9 +5699,9 @@ return {
       description = "Draw a triangle strip defined by points",
       returnType = "void",
       params = {
-        {name = "points", type = "Vector3 *"},
-        {name = "pointCount", type = "int"},
-        {name = "color", type = "Color"}
+        {type = "Vector3 *", name = "points"},
+        {type = "int", name = "pointCount"},
+        {type = "Color", name = "color"}
       }
     },
     {
@@ -5709,11 +5709,11 @@ return {
       description = "Draw cube",
       returnType = "void",
       params = {
-        {name = "position", type = "Vector3"},
-        {name = "width", type = "float"},
-        {name = "height", type = "float"},
-        {name = "length", type = "float"},
-        {name = "color", type = "Color"}
+        {type = "Vector3", name = "position"},
+        {type = "float", name = "width"},
+        {type = "float", name = "height"},
+        {type = "float", name = "length"},
+        {type = "Color", name = "color"}
       }
     },
     {
@@ -5721,9 +5721,9 @@ return {
       description = "Draw cube (Vector version)",
       returnType = "void",
       params = {
-        {name = "position", type = "Vector3"},
-        {name = "size", type = "Vector3"},
-        {name = "color", type = "Color"}
+        {type = "Vector3", name = "position"},
+        {type = "Vector3", name = "size"},
+        {type = "Color", name = "color"}
       }
     },
     {
@@ -5731,11 +5731,11 @@ return {
       description = "Draw cube wires",
       returnType = "void",
       params = {
-        {name = "position", type = "Vector3"},
-        {name = "width", type = "float"},
-        {name = "height", type = "float"},
-        {name = "length", type = "float"},
-        {name = "color", type = "Color"}
+        {type = "Vector3", name = "position"},
+        {type = "float", name = "width"},
+        {type = "float", name = "height"},
+        {type = "float", name = "length"},
+        {type = "Color", name = "color"}
       }
     },
     {
@@ -5743,9 +5743,9 @@ return {
       description = "Draw cube wires (Vector version)",
       returnType = "void",
       params = {
-        {name = "position", type = "Vector3"},
-        {name = "size", type = "Vector3"},
-        {name = "color", type = "Color"}
+        {type = "Vector3", name = "position"},
+        {type = "Vector3", name = "size"},
+        {type = "Color", name = "color"}
       }
     },
     {
@@ -5753,12 +5753,12 @@ return {
       description = "Draw cube textured",
       returnType = "void",
       params = {
-        {name = "texture", type = "Texture2D"},
-        {name = "position", type = "Vector3"},
-        {name = "width", type = "float"},
-        {name = "height", type = "float"},
-        {name = "length", type = "float"},
-        {name = "color", type = "Color"}
+        {type = "Texture2D", name = "texture"},
+        {type = "Vector3", name = "position"},
+        {type = "float", name = "width"},
+        {type = "float", name = "height"},
+        {type = "float", name = "length"},
+        {type = "Color", name = "color"}
       }
     },
     {
@@ -5766,13 +5766,13 @@ return {
       description = "Draw cube with a region of a texture",
       returnType = "void",
       params = {
-        {name = "texture", type = "Texture2D"},
-        {name = "source", type = "Rectangle"},
-        {name = "position", type = "Vector3"},
-        {name = "width", type = "float"},
-        {name = "height", type = "float"},
-        {name = "length", type = "float"},
-        {name = "color", type = "Color"}
+        {type = "Texture2D", name = "texture"},
+        {type = "Rectangle", name = "source"},
+        {type = "Vector3", name = "position"},
+        {type = "float", name = "width"},
+        {type = "float", name = "height"},
+        {type = "float", name = "length"},
+        {type = "Color", name = "color"}
       }
     },
     {
@@ -5780,9 +5780,9 @@ return {
       description = "Draw sphere",
       returnType = "void",
       params = {
-        {name = "centerPos", type = "Vector3"},
-        {name = "radius", type = "float"},
-        {name = "color", type = "Color"}
+        {type = "Vector3", name = "centerPos"},
+        {type = "float", name = "radius"},
+        {type = "Color", name = "color"}
       }
     },
     {
@@ -5790,11 +5790,11 @@ return {
       description = "Draw sphere with extended parameters",
       returnType = "void",
       params = {
-        {name = "centerPos", type = "Vector3"},
-        {name = "radius", type = "float"},
-        {name = "rings", type = "int"},
-        {name = "slices", type = "int"},
-        {name = "color", type = "Color"}
+        {type = "Vector3", name = "centerPos"},
+        {type = "float", name = "radius"},
+        {type = "int", name = "rings"},
+        {type = "int", name = "slices"},
+        {type = "Color", name = "color"}
       }
     },
     {
@@ -5802,11 +5802,11 @@ return {
       description = "Draw sphere wires",
       returnType = "void",
       params = {
-        {name = "centerPos", type = "Vector3"},
-        {name = "radius", type = "float"},
-        {name = "rings", type = "int"},
-        {name = "slices", type = "int"},
-        {name = "color", type = "Color"}
+        {type = "Vector3", name = "centerPos"},
+        {type = "float", name = "radius"},
+        {type = "int", name = "rings"},
+        {type = "int", name = "slices"},
+        {type = "Color", name = "color"}
       }
     },
     {
@@ -5814,12 +5814,12 @@ return {
       description = "Draw a cylinder/cone",
       returnType = "void",
       params = {
-        {name = "position", type = "Vector3"},
-        {name = "radiusTop", type = "float"},
-        {name = "radiusBottom", type = "float"},
-        {name = "height", type = "float"},
-        {name = "slices", type = "int"},
-        {name = "color", type = "Color"}
+        {type = "Vector3", name = "position"},
+        {type = "float", name = "radiusTop"},
+        {type = "float", name = "radiusBottom"},
+        {type = "float", name = "height"},
+        {type = "int", name = "slices"},
+        {type = "Color", name = "color"}
       }
     },
     {
@@ -5827,12 +5827,12 @@ return {
       description = "Draw a cylinder with base at startPos and top at endPos",
       returnType = "void",
       params = {
-        {name = "startPos", type = "Vector3"},
-        {name = "endPos", type = "Vector3"},
-        {name = "startRadius", type = "float"},
-        {name = "endRadius", type = "float"},
-        {name = "sides", type = "int"},
-        {name = "color", type = "Color"}
+        {type = "Vector3", name = "startPos"},
+        {type = "Vector3", name = "endPos"},
+        {type = "float", name = "startRadius"},
+        {type = "float", name = "endRadius"},
+        {type = "int", name = "sides"},
+        {type = "Color", name = "color"}
       }
     },
     {
@@ -5840,12 +5840,12 @@ return {
       description = "Draw a cylinder/cone wires",
       returnType = "void",
       params = {
-        {name = "position", type = "Vector3"},
-        {name = "radiusTop", type = "float"},
-        {name = "radiusBottom", type = "float"},
-        {name = "height", type = "float"},
-        {name = "slices", type = "int"},
-        {name = "color", type = "Color"}
+        {type = "Vector3", name = "position"},
+        {type = "float", name = "radiusTop"},
+        {type = "float", name = "radiusBottom"},
+        {type = "float", name = "height"},
+        {type = "int", name = "slices"},
+        {type = "Color", name = "color"}
       }
     },
     {
@@ -5853,12 +5853,12 @@ return {
       description = "Draw a cylinder wires with base at startPos and top at endPos",
       returnType = "void",
       params = {
-        {name = "startPos", type = "Vector3"},
-        {name = "endPos", type = "Vector3"},
-        {name = "startRadius", type = "float"},
-        {name = "endRadius", type = "float"},
-        {name = "sides", type = "int"},
-        {name = "color", type = "Color"}
+        {type = "Vector3", name = "startPos"},
+        {type = "Vector3", name = "endPos"},
+        {type = "float", name = "startRadius"},
+        {type = "float", name = "endRadius"},
+        {type = "int", name = "sides"},
+        {type = "Color", name = "color"}
       }
     },
     {
@@ -5866,9 +5866,9 @@ return {
       description = "Draw a plane XZ",
       returnType = "void",
       params = {
-        {name = "centerPos", type = "Vector3"},
-        {name = "size", type = "Vector2"},
-        {name = "color", type = "Color"}
+        {type = "Vector3", name = "centerPos"},
+        {type = "Vector2", name = "size"},
+        {type = "Color", name = "color"}
       }
     },
     {
@@ -5876,8 +5876,8 @@ return {
       description = "Draw a ray line",
       returnType = "void",
       params = {
-        {name = "ray", type = "Ray"},
-        {name = "color", type = "Color"}
+        {type = "Ray", name = "ray"},
+        {type = "Color", name = "color"}
       }
     },
     {
@@ -5885,8 +5885,8 @@ return {
       description = "Draw a grid (centered at (0, 0, 0))",
       returnType = "void",
       params = {
-        {name = "slices", type = "int"},
-        {name = "spacing", type = "float"}
+        {type = "int", name = "slices"},
+        {type = "float", name = "spacing"}
       }
     },
     {
@@ -5894,7 +5894,7 @@ return {
       description = "Load model from files (meshes and materials)",
       returnType = "Model",
       params = {
-        {name = "fileName", type = "const char *"}
+        {type = "const char *", name = "fileName"}
       }
     },
     {
@@ -5902,7 +5902,7 @@ return {
       description = "Load model from generated mesh (default material)",
       returnType = "Model",
       params = {
-        {name = "mesh", type = "Mesh"}
+        {type = "Mesh", name = "mesh"}
       }
     },
     {
@@ -5910,7 +5910,7 @@ return {
       description = "Unload model (including meshes) from memory (RAM and/or VRAM)",
       returnType = "void",
       params = {
-        {name = "model", type = "Model"}
+        {type = "Model", name = "model"}
       }
     },
     {
@@ -5918,7 +5918,7 @@ return {
       description = "Unload model (but not meshes) from memory (RAM and/or VRAM)",
       returnType = "void",
       params = {
-        {name = "model", type = "Model"}
+        {type = "Model", name = "model"}
       }
     },
     {
@@ -5926,7 +5926,7 @@ return {
       description = "Compute model bounding box limits (considers all meshes)",
       returnType = "BoundingBox",
       params = {
-        {name = "model", type = "Model"}
+        {type = "Model", name = "model"}
       }
     },
     {
@@ -5934,10 +5934,10 @@ return {
       description = "Draw a model (with texture if set)",
       returnType = "void",
       params = {
-        {name = "model", type = "Model"},
-        {name = "position", type = "Vector3"},
-        {name = "scale", type = "float"},
-        {name = "tint", type = "Color"}
+        {type = "Model", name = "model"},
+        {type = "Vector3", name = "position"},
+        {type = "float", name = "scale"},
+        {type = "Color", name = "tint"}
       }
     },
     {
@@ -5945,12 +5945,12 @@ return {
       description = "Draw a model with extended parameters",
       returnType = "void",
       params = {
-        {name = "model", type = "Model"},
-        {name = "position", type = "Vector3"},
-        {name = "rotationAxis", type = "Vector3"},
-        {name = "rotationAngle", type = "float"},
-        {name = "scale", type = "Vector3"},
-        {name = "tint", type = "Color"}
+        {type = "Model", name = "model"},
+        {type = "Vector3", name = "position"},
+        {type = "Vector3", name = "rotationAxis"},
+        {type = "float", name = "rotationAngle"},
+        {type = "Vector3", name = "scale"},
+        {type = "Color", name = "tint"}
       }
     },
     {
@@ -5958,10 +5958,10 @@ return {
       description = "Draw a model wires (with texture if set)",
       returnType = "void",
       params = {
-        {name = "model", type = "Model"},
-        {name = "position", type = "Vector3"},
-        {name = "scale", type = "float"},
-        {name = "tint", type = "Color"}
+        {type = "Model", name = "model"},
+        {type = "Vector3", name = "position"},
+        {type = "float", name = "scale"},
+        {type = "Color", name = "tint"}
       }
     },
     {
@@ -5969,12 +5969,12 @@ return {
       description = "Draw a model wires (with texture if set) with extended parameters",
       returnType = "void",
       params = {
-        {name = "model", type = "Model"},
-        {name = "position", type = "Vector3"},
-        {name = "rotationAxis", type = "Vector3"},
-        {name = "rotationAngle", type = "float"},
-        {name = "scale", type = "Vector3"},
-        {name = "tint", type = "Color"}
+        {type = "Model", name = "model"},
+        {type = "Vector3", name = "position"},
+        {type = "Vector3", name = "rotationAxis"},
+        {type = "float", name = "rotationAngle"},
+        {type = "Vector3", name = "scale"},
+        {type = "Color", name = "tint"}
       }
     },
     {
@@ -5982,8 +5982,8 @@ return {
       description = "Draw bounding box (wires)",
       returnType = "void",
       params = {
-        {name = "box", type = "BoundingBox"},
-        {name = "color", type = "Color"}
+        {type = "BoundingBox", name = "box"},
+        {type = "Color", name = "color"}
       }
     },
     {
@@ -5991,11 +5991,11 @@ return {
       description = "Draw a billboard texture",
       returnType = "void",
       params = {
-        {name = "camera", type = "Camera"},
-        {name = "texture", type = "Texture2D"},
-        {name = "position", type = "Vector3"},
-        {name = "size", type = "float"},
-        {name = "tint", type = "Color"}
+        {type = "Camera", name = "camera"},
+        {type = "Texture2D", name = "texture"},
+        {type = "Vector3", name = "position"},
+        {type = "float", name = "size"},
+        {type = "Color", name = "tint"}
       }
     },
     {
@@ -6003,12 +6003,12 @@ return {
       description = "Draw a billboard texture defined by source",
       returnType = "void",
       params = {
-        {name = "camera", type = "Camera"},
-        {name = "texture", type = "Texture2D"},
-        {name = "source", type = "Rectangle"},
-        {name = "position", type = "Vector3"},
-        {name = "size", type = "Vector2"},
-        {name = "tint", type = "Color"}
+        {type = "Camera", name = "camera"},
+        {type = "Texture2D", name = "texture"},
+        {type = "Rectangle", name = "source"},
+        {type = "Vector3", name = "position"},
+        {type = "Vector2", name = "size"},
+        {type = "Color", name = "tint"}
       }
     },
     {
@@ -6016,15 +6016,15 @@ return {
       description = "Draw a billboard texture defined by source and rotation",
       returnType = "void",
       params = {
-        {name = "camera", type = "Camera"},
-        {name = "texture", type = "Texture2D"},
-        {name = "source", type = "Rectangle"},
-        {name = "position", type = "Vector3"},
-        {name = "up", type = "Vector3"},
-        {name = "size", type = "Vector2"},
-        {name = "origin", type = "Vector2"},
-        {name = "rotation", type = "float"},
-        {name = "tint", type = "Color"}
+        {type = "Camera", name = "camera"},
+        {type = "Texture2D", name = "texture"},
+        {type = "Rectangle", name = "source"},
+        {type = "Vector3", name = "position"},
+        {type = "Vector3", name = "up"},
+        {type = "Vector2", name = "size"},
+        {type = "Vector2", name = "origin"},
+        {type = "float", name = "rotation"},
+        {type = "Color", name = "tint"}
       }
     },
     {
@@ -6032,8 +6032,8 @@ return {
       description = "Upload mesh vertex data in GPU and provide VAO/VBO ids",
       returnType = "void",
       params = {
-        {name = "mesh", type = "Mesh *"},
-        {name = "dynamic", type = "bool"}
+        {type = "Mesh *", name = "mesh"},
+        {type = "bool", name = "dynamic"}
       }
     },
     {
@@ -6041,11 +6041,11 @@ return {
       description = "Update mesh vertex data in GPU for a specific buffer index",
       returnType = "void",
       params = {
-        {name = "mesh", type = "Mesh"},
-        {name = "index", type = "int"},
-        {name = "data", type = "void *"},
-        {name = "dataSize", type = "int"},
-        {name = "offset", type = "int"}
+        {type = "Mesh", name = "mesh"},
+        {type = "int", name = "index"},
+        {type = "void *", name = "data"},
+        {type = "int", name = "dataSize"},
+        {type = "int", name = "offset"}
       }
     },
     {
@@ -6053,7 +6053,7 @@ return {
       description = "Unload mesh data from CPU and GPU",
       returnType = "void",
       params = {
-        {name = "mesh", type = "Mesh"}
+        {type = "Mesh", name = "mesh"}
       }
     },
     {
@@ -6061,9 +6061,9 @@ return {
       description = "Draw a 3d mesh with material and transform",
       returnType = "void",
       params = {
-        {name = "mesh", type = "Mesh"},
-        {name = "material", type = "Material"},
-        {name = "transform", type = "Matrix"}
+        {type = "Mesh", name = "mesh"},
+        {type = "Material", name = "material"},
+        {type = "Matrix", name = "transform"}
       }
     },
     {
@@ -6071,10 +6071,10 @@ return {
       description = "Draw multiple mesh instances with material and different transforms",
       returnType = "void",
       params = {
-        {name = "mesh", type = "Mesh"},
-        {name = "material", type = "Material"},
-        {name = "transforms", type = "Matrix *"},
-        {name = "instances", type = "int"}
+        {type = "Mesh", name = "mesh"},
+        {type = "Material", name = "material"},
+        {type = "Matrix *", name = "transforms"},
+        {type = "int", name = "instances"}
       }
     },
     {
@@ -6082,8 +6082,8 @@ return {
       description = "Export mesh data to file, returns true on success",
       returnType = "bool",
       params = {
-        {name = "mesh", type = "Mesh"},
-        {name = "fileName", type = "const char *"}
+        {type = "Mesh", name = "mesh"},
+        {type = "const char *", name = "fileName"}
       }
     },
     {
@@ -6091,7 +6091,7 @@ return {
       description = "Compute mesh bounding box limits",
       returnType = "BoundingBox",
       params = {
-        {name = "mesh", type = "Mesh"}
+        {type = "Mesh", name = "mesh"}
       }
     },
     {
@@ -6099,7 +6099,7 @@ return {
       description = "Compute mesh tangents",
       returnType = "void",
       params = {
-        {name = "mesh", type = "Mesh *"}
+        {type = "Mesh *", name = "mesh"}
       }
     },
     {
@@ -6107,7 +6107,7 @@ return {
       description = "Compute mesh binormals",
       returnType = "void",
       params = {
-        {name = "mesh", type = "Mesh *"}
+        {type = "Mesh *", name = "mesh"}
       }
     },
     {
@@ -6115,8 +6115,8 @@ return {
       description = "Generate polygonal mesh",
       returnType = "Mesh",
       params = {
-        {name = "sides", type = "int"},
-        {name = "radius", type = "float"}
+        {type = "int", name = "sides"},
+        {type = "float", name = "radius"}
       }
     },
     {
@@ -6124,10 +6124,10 @@ return {
       description = "Generate plane mesh (with subdivisions)",
       returnType = "Mesh",
       params = {
-        {name = "width", type = "float"},
-        {name = "length", type = "float"},
-        {name = "resX", type = "int"},
-        {name = "resZ", type = "int"}
+        {type = "float", name = "width"},
+        {type = "float", name = "length"},
+        {type = "int", name = "resX"},
+        {type = "int", name = "resZ"}
       }
     },
     {
@@ -6135,9 +6135,9 @@ return {
       description = "Generate cuboid mesh",
       returnType = "Mesh",
       params = {
-        {name = "width", type = "float"},
-        {name = "height", type = "float"},
-        {name = "length", type = "float"}
+        {type = "float", name = "width"},
+        {type = "float", name = "height"},
+        {type = "float", name = "length"}
       }
     },
     {
@@ -6145,9 +6145,9 @@ return {
       description = "Generate sphere mesh (standard sphere)",
       returnType = "Mesh",
       params = {
-        {name = "radius", type = "float"},
-        {name = "rings", type = "int"},
-        {name = "slices", type = "int"}
+        {type = "float", name = "radius"},
+        {type = "int", name = "rings"},
+        {type = "int", name = "slices"}
       }
     },
     {
@@ -6155,9 +6155,9 @@ return {
       description = "Generate half-sphere mesh (no bottom cap)",
       returnType = "Mesh",
       params = {
-        {name = "radius", type = "float"},
-        {name = "rings", type = "int"},
-        {name = "slices", type = "int"}
+        {type = "float", name = "radius"},
+        {type = "int", name = "rings"},
+        {type = "int", name = "slices"}
       }
     },
     {
@@ -6165,9 +6165,9 @@ return {
       description = "Generate cylinder mesh",
       returnType = "Mesh",
       params = {
-        {name = "radius", type = "float"},
-        {name = "height", type = "float"},
-        {name = "slices", type = "int"}
+        {type = "float", name = "radius"},
+        {type = "float", name = "height"},
+        {type = "int", name = "slices"}
       }
     },
     {
@@ -6175,9 +6175,9 @@ return {
       description = "Generate cone/pyramid mesh",
       returnType = "Mesh",
       params = {
-        {name = "radius", type = "float"},
-        {name = "height", type = "float"},
-        {name = "slices", type = "int"}
+        {type = "float", name = "radius"},
+        {type = "float", name = "height"},
+        {type = "int", name = "slices"}
       }
     },
     {
@@ -6185,10 +6185,10 @@ return {
       description = "Generate torus mesh",
       returnType = "Mesh",
       params = {
-        {name = "radius", type = "float"},
-        {name = "size", type = "float"},
-        {name = "radSeg", type = "int"},
-        {name = "sides", type = "int"}
+        {type = "float", name = "radius"},
+        {type = "float", name = "size"},
+        {type = "int", name = "radSeg"},
+        {type = "int", name = "sides"}
       }
     },
     {
@@ -6196,10 +6196,10 @@ return {
       description = "Generate trefoil knot mesh",
       returnType = "Mesh",
       params = {
-        {name = "radius", type = "float"},
-        {name = "size", type = "float"},
-        {name = "radSeg", type = "int"},
-        {name = "sides", type = "int"}
+        {type = "float", name = "radius"},
+        {type = "float", name = "size"},
+        {type = "int", name = "radSeg"},
+        {type = "int", name = "sides"}
       }
     },
     {
@@ -6207,8 +6207,8 @@ return {
       description = "Generate heightmap mesh from image data",
       returnType = "Mesh",
       params = {
-        {name = "heightmap", type = "Image"},
-        {name = "size", type = "Vector3"}
+        {type = "Image", name = "heightmap"},
+        {type = "Vector3", name = "size"}
       }
     },
     {
@@ -6216,8 +6216,8 @@ return {
       description = "Generate cubes-based map mesh from image data",
       returnType = "Mesh",
       params = {
-        {name = "cubicmap", type = "Image"},
-        {name = "cubeSize", type = "Vector3"}
+        {type = "Image", name = "cubicmap"},
+        {type = "Vector3", name = "cubeSize"}
       }
     },
     {
@@ -6225,8 +6225,8 @@ return {
       description = "Load materials from model file",
       returnType = "Material *",
       params = {
-        {name = "fileName", type = "const char *"},
-        {name = "materialCount", type = "int *"}
+        {type = "const char *", name = "fileName"},
+        {type = "int *", name = "materialCount"}
       }
     },
     {
@@ -6239,7 +6239,7 @@ return {
       description = "Unload material from GPU memory (VRAM)",
       returnType = "void",
       params = {
-        {name = "material", type = "Material"}
+        {type = "Material", name = "material"}
       }
     },
     {
@@ -6247,9 +6247,9 @@ return {
       description = "Set texture for a material map type (MATERIAL_MAP_DIFFUSE, MATERIAL_MAP_SPECULAR...)",
       returnType = "void",
       params = {
-        {name = "material", type = "Material *"},
-        {name = "mapType", type = "int"},
-        {name = "texture", type = "Texture2D"}
+        {type = "Material *", name = "material"},
+        {type = "int", name = "mapType"},
+        {type = "Texture2D", name = "texture"}
       }
     },
     {
@@ -6257,9 +6257,9 @@ return {
       description = "Set material for a mesh",
       returnType = "void",
       params = {
-        {name = "model", type = "Model *"},
-        {name = "meshId", type = "int"},
-        {name = "materialId", type = "int"}
+        {type = "Model *", name = "model"},
+        {type = "int", name = "meshId"},
+        {type = "int", name = "materialId"}
       }
     },
     {
@@ -6267,8 +6267,8 @@ return {
       description = "Load model animations from file",
       returnType = "ModelAnimation *",
       params = {
-        {name = "fileName", type = "const char *"},
-        {name = "animCount", type = "unsigned int *"}
+        {type = "const char *", name = "fileName"},
+        {type = "unsigned int *", name = "animCount"}
       }
     },
     {
@@ -6276,9 +6276,9 @@ return {
       description = "Update model animation pose",
       returnType = "void",
       params = {
-        {name = "model", type = "Model"},
-        {name = "anim", type = "ModelAnimation"},
-        {name = "frame", type = "int"}
+        {type = "Model", name = "model"},
+        {type = "ModelAnimation", name = "anim"},
+        {type = "int", name = "frame"}
       }
     },
     {
@@ -6286,7 +6286,7 @@ return {
       description = "Unload animation data",
       returnType = "void",
       params = {
-        {name = "anim", type = "ModelAnimation"}
+        {type = "ModelAnimation", name = "anim"}
       }
     },
     {
@@ -6294,8 +6294,8 @@ return {
       description = "Unload animation array data",
       returnType = "void",
       params = {
-        {name = "animations", type = "ModelAnimation*"},
-        {name = "count", type = "unsigned int"}
+        {type = "ModelAnimation*", name = "animations"},
+        {type = "unsigned int", name = "count"}
       }
     },
     {
@@ -6303,8 +6303,8 @@ return {
       description = "Check model animation skeleton match",
       returnType = "bool",
       params = {
-        {name = "model", type = "Model"},
-        {name = "anim", type = "ModelAnimation"}
+        {type = "Model", name = "model"},
+        {type = "ModelAnimation", name = "anim"}
       }
     },
     {
@@ -6312,10 +6312,10 @@ return {
       description = "Check collision between two spheres",
       returnType = "bool",
       params = {
-        {name = "center1", type = "Vector3"},
-        {name = "radius1", type = "float"},
-        {name = "center2", type = "Vector3"},
-        {name = "radius2", type = "float"}
+        {type = "Vector3", name = "center1"},
+        {type = "float", name = "radius1"},
+        {type = "Vector3", name = "center2"},
+        {type = "float", name = "radius2"}
       }
     },
     {
@@ -6323,8 +6323,8 @@ return {
       description = "Check collision between two bounding boxes",
       returnType = "bool",
       params = {
-        {name = "box1", type = "BoundingBox"},
-        {name = "box2", type = "BoundingBox"}
+        {type = "BoundingBox", name = "box1"},
+        {type = "BoundingBox", name = "box2"}
       }
     },
     {
@@ -6332,9 +6332,9 @@ return {
       description = "Check collision between box and sphere",
       returnType = "bool",
       params = {
-        {name = "box", type = "BoundingBox"},
-        {name = "center", type = "Vector3"},
-        {name = "radius", type = "float"}
+        {type = "BoundingBox", name = "box"},
+        {type = "Vector3", name = "center"},
+        {type = "float", name = "radius"}
       }
     },
     {
@@ -6342,9 +6342,9 @@ return {
       description = "Get collision info between ray and sphere",
       returnType = "RayCollision",
       params = {
-        {name = "ray", type = "Ray"},
-        {name = "center", type = "Vector3"},
-        {name = "radius", type = "float"}
+        {type = "Ray", name = "ray"},
+        {type = "Vector3", name = "center"},
+        {type = "float", name = "radius"}
       }
     },
     {
@@ -6352,8 +6352,8 @@ return {
       description = "Get collision info between ray and box",
       returnType = "RayCollision",
       params = {
-        {name = "ray", type = "Ray"},
-        {name = "box", type = "BoundingBox"}
+        {type = "Ray", name = "ray"},
+        {type = "BoundingBox", name = "box"}
       }
     },
     {
@@ -6361,8 +6361,8 @@ return {
       description = "Get collision info between ray and model",
       returnType = "RayCollision",
       params = {
-        {name = "ray", type = "Ray"},
-        {name = "model", type = "Model"}
+        {type = "Ray", name = "ray"},
+        {type = "Model", name = "model"}
       }
     },
     {
@@ -6370,9 +6370,9 @@ return {
       description = "Get collision info between ray and mesh",
       returnType = "RayCollision",
       params = {
-        {name = "ray", type = "Ray"},
-        {name = "mesh", type = "Mesh"},
-        {name = "transform", type = "Matrix"}
+        {type = "Ray", name = "ray"},
+        {type = "Mesh", name = "mesh"},
+        {type = "Matrix", name = "transform"}
       }
     },
     {
@@ -6380,10 +6380,10 @@ return {
       description = "Get collision info between ray and triangle",
       returnType = "RayCollision",
       params = {
-        {name = "ray", type = "Ray"},
-        {name = "p1", type = "Vector3"},
-        {name = "p2", type = "Vector3"},
-        {name = "p3", type = "Vector3"}
+        {type = "Ray", name = "ray"},
+        {type = "Vector3", name = "p1"},
+        {type = "Vector3", name = "p2"},
+        {type = "Vector3", name = "p3"}
       }
     },
     {
@@ -6391,11 +6391,11 @@ return {
       description = "Get collision info between ray and quad",
       returnType = "RayCollision",
       params = {
-        {name = "ray", type = "Ray"},
-        {name = "p1", type = "Vector3"},
-        {name = "p2", type = "Vector3"},
-        {name = "p3", type = "Vector3"},
-        {name = "p4", type = "Vector3"}
+        {type = "Ray", name = "ray"},
+        {type = "Vector3", name = "p1"},
+        {type = "Vector3", name = "p2"},
+        {type = "Vector3", name = "p3"},
+        {type = "Vector3", name = "p4"}
       }
     },
     {
@@ -6418,7 +6418,7 @@ return {
       description = "Set master volume (listener)",
       returnType = "void",
       params = {
-        {name = "volume", type = "float"}
+        {type = "float", name = "volume"}
       }
     },
     {
@@ -6426,7 +6426,7 @@ return {
       description = "Load wave data from file",
       returnType = "Wave",
       params = {
-        {name = "fileName", type = "const char *"}
+        {type = "const char *", name = "fileName"}
       }
     },
     {
@@ -6434,9 +6434,9 @@ return {
       description = "Load wave from memory buffer, fileType refers to extension: i.e. '.wav'",
       returnType = "Wave",
       params = {
-        {name = "fileType", type = "const char *"},
-        {name = "fileData", type = "const unsigned char *"},
-        {name = "dataSize", type = "int"}
+        {type = "const char *", name = "fileType"},
+        {type = "const unsigned char *", name = "fileData"},
+        {type = "int", name = "dataSize"}
       }
     },
     {
@@ -6444,7 +6444,7 @@ return {
       description = "Load sound from file",
       returnType = "Sound",
       params = {
-        {name = "fileName", type = "const char *"}
+        {type = "const char *", name = "fileName"}
       }
     },
     {
@@ -6452,7 +6452,7 @@ return {
       description = "Load sound from wave data",
       returnType = "Sound",
       params = {
-        {name = "wave", type = "Wave"}
+        {type = "Wave", name = "wave"}
       }
     },
     {
@@ -6460,9 +6460,9 @@ return {
       description = "Update sound buffer with new data",
       returnType = "void",
       params = {
-        {name = "sound", type = "Sound"},
-        {name = "data", type = "const void *"},
-        {name = "sampleCount", type = "int"}
+        {type = "Sound", name = "sound"},
+        {type = "const void *", name = "data"},
+        {type = "int", name = "sampleCount"}
       }
     },
     {
@@ -6470,7 +6470,7 @@ return {
       description = "Unload wave data",
       returnType = "void",
       params = {
-        {name = "wave", type = "Wave"}
+        {type = "Wave", name = "wave"}
       }
     },
     {
@@ -6478,7 +6478,7 @@ return {
       description = "Unload sound",
       returnType = "void",
       params = {
-        {name = "sound", type = "Sound"}
+        {type = "Sound", name = "sound"}
       }
     },
     {
@@ -6486,8 +6486,8 @@ return {
       description = "Export wave data to file, returns true on success",
       returnType = "bool",
       params = {
-        {name = "wave", type = "Wave"},
-        {name = "fileName", type = "const char *"}
+        {type = "Wave", name = "wave"},
+        {type = "const char *", name = "fileName"}
       }
     },
     {
@@ -6495,8 +6495,8 @@ return {
       description = "Export wave sample data to code (.h), returns true on success",
       returnType = "bool",
       params = {
-        {name = "wave", type = "Wave"},
-        {name = "fileName", type = "const char *"}
+        {type = "Wave", name = "wave"},
+        {type = "const char *", name = "fileName"}
       }
     },
     {
@@ -6504,7 +6504,7 @@ return {
       description = "Play a sound",
       returnType = "void",
       params = {
-        {name = "sound", type = "Sound"}
+        {type = "Sound", name = "sound"}
       }
     },
     {
@@ -6512,7 +6512,7 @@ return {
       description = "Stop playing a sound",
       returnType = "void",
       params = {
-        {name = "sound", type = "Sound"}
+        {type = "Sound", name = "sound"}
       }
     },
     {
@@ -6520,7 +6520,7 @@ return {
       description = "Pause a sound",
       returnType = "void",
       params = {
-        {name = "sound", type = "Sound"}
+        {type = "Sound", name = "sound"}
       }
     },
     {
@@ -6528,7 +6528,7 @@ return {
       description = "Resume a paused sound",
       returnType = "void",
       params = {
-        {name = "sound", type = "Sound"}
+        {type = "Sound", name = "sound"}
       }
     },
     {
@@ -6536,7 +6536,7 @@ return {
       description = "Play a sound (using multichannel buffer pool)",
       returnType = "void",
       params = {
-        {name = "sound", type = "Sound"}
+        {type = "Sound", name = "sound"}
       }
     },
     {
@@ -6554,7 +6554,7 @@ return {
       description = "Check if a sound is currently playing",
       returnType = "bool",
       params = {
-        {name = "sound", type = "Sound"}
+        {type = "Sound", name = "sound"}
       }
     },
     {
@@ -6562,8 +6562,8 @@ return {
       description = "Set volume for a sound (1.0 is max level)",
       returnType = "void",
       params = {
-        {name = "sound", type = "Sound"},
-        {name = "volume", type = "float"}
+        {type = "Sound", name = "sound"},
+        {type = "float", name = "volume"}
       }
     },
     {
@@ -6571,8 +6571,8 @@ return {
       description = "Set pitch for a sound (1.0 is base level)",
       returnType = "void",
       params = {
-        {name = "sound", type = "Sound"},
-        {name = "pitch", type = "float"}
+        {type = "Sound", name = "sound"},
+        {type = "float", name = "pitch"}
       }
     },
     {
@@ -6580,10 +6580,10 @@ return {
       description = "Convert wave data to desired format",
       returnType = "void",
       params = {
-        {name = "wave", type = "Wave *"},
-        {name = "sampleRate", type = "int"},
-        {name = "sampleSize", type = "int"},
-        {name = "channels", type = "int"}
+        {type = "Wave *", name = "wave"},
+        {type = "int", name = "sampleRate"},
+        {type = "int", name = "sampleSize"},
+        {type = "int", name = "channels"}
       }
     },
     {
@@ -6591,7 +6591,7 @@ return {
       description = "Copy a wave to a new wave",
       returnType = "Wave",
       params = {
-        {name = "wave", type = "Wave"}
+        {type = "Wave", name = "wave"}
       }
     },
     {
@@ -6599,9 +6599,9 @@ return {
       description = "Crop a wave to defined samples range",
       returnType = "void",
       params = {
-        {name = "wave", type = "Wave *"},
-        {name = "initSample", type = "int"},
-        {name = "finalSample", type = "int"}
+        {type = "Wave *", name = "wave"},
+        {type = "int", name = "initSample"},
+        {type = "int", name = "finalSample"}
       }
     },
     {
@@ -6609,7 +6609,7 @@ return {
       description = "Load samples data from wave as a floats array",
       returnType = "float *",
       params = {
-        {name = "wave", type = "Wave"}
+        {type = "Wave", name = "wave"}
       }
     },
     {
@@ -6617,7 +6617,7 @@ return {
       description = "Unload samples data loaded with LoadWaveSamples()",
       returnType = "void",
       params = {
-        {name = "samples", type = "float *"}
+        {type = "float *", name = "samples"}
       }
     },
     {
@@ -6625,7 +6625,7 @@ return {
       description = "Load music stream from file",
       returnType = "Music",
       params = {
-        {name = "fileName", type = "const char *"}
+        {type = "const char *", name = "fileName"}
       }
     },
     {
@@ -6633,9 +6633,9 @@ return {
       description = "Load music stream from data",
       returnType = "Music",
       params = {
-        {name = "fileType", type = "const char *"},
-        {name = "data", type = "unsigned char *"},
-        {name = "dataSize", type = "int"}
+        {type = "const char *", name = "fileType"},
+        {type = "unsigned char *", name = "data"},
+        {type = "int", name = "dataSize"}
       }
     },
     {
@@ -6643,7 +6643,7 @@ return {
       description = "Unload music stream",
       returnType = "void",
       params = {
-        {name = "music", type = "Music"}
+        {type = "Music", name = "music"}
       }
     },
     {
@@ -6651,7 +6651,7 @@ return {
       description = "Start music playing",
       returnType = "void",
       params = {
-        {name = "music", type = "Music"}
+        {type = "Music", name = "music"}
       }
     },
     {
@@ -6659,7 +6659,7 @@ return {
       description = "Check if music is playing",
       returnType = "bool",
       params = {
-        {name = "music", type = "Music"}
+        {type = "Music", name = "music"}
       }
     },
     {
@@ -6667,7 +6667,7 @@ return {
       description = "Updates buffers for music streaming",
       returnType = "void",
       params = {
-        {name = "music", type = "Music"}
+        {type = "Music", name = "music"}
       }
     },
     {
@@ -6675,7 +6675,7 @@ return {
       description = "Stop music playing",
       returnType = "void",
       params = {
-        {name = "music", type = "Music"}
+        {type = "Music", name = "music"}
       }
     },
     {
@@ -6683,7 +6683,7 @@ return {
       description = "Pause music playing",
       returnType = "void",
       params = {
-        {name = "music", type = "Music"}
+        {type = "Music", name = "music"}
       }
     },
     {
@@ -6691,7 +6691,7 @@ return {
       description = "Resume playing paused music",
       returnType = "void",
       params = {
-        {name = "music", type = "Music"}
+        {type = "Music", name = "music"}
       }
     },
     {
@@ -6699,8 +6699,8 @@ return {
       description = "Seek music to a position (in seconds)",
       returnType = "void",
       params = {
-        {name = "music", type = "Music"},
-        {name = "position", type = "float"}
+        {type = "Music", name = "music"},
+        {type = "float", name = "position"}
       }
     },
     {
@@ -6708,8 +6708,8 @@ return {
       description = "Set volume for music (1.0 is max level)",
       returnType = "void",
       params = {
-        {name = "music", type = "Music"},
-        {name = "volume", type = "float"}
+        {type = "Music", name = "music"},
+        {type = "float", name = "volume"}
       }
     },
     {
@@ -6717,8 +6717,8 @@ return {
       description = "Set pitch for a music (1.0 is base level)",
       returnType = "void",
       params = {
-        {name = "music", type = "Music"},
-        {name = "pitch", type = "float"}
+        {type = "Music", name = "music"},
+        {type = "float", name = "pitch"}
       }
     },
     {
@@ -6726,7 +6726,7 @@ return {
       description = "Get music time length (in seconds)",
       returnType = "float",
       params = {
-        {name = "music", type = "Music"}
+        {type = "Music", name = "music"}
       }
     },
     {
@@ -6734,7 +6734,7 @@ return {
       description = "Get current music time played (in seconds)",
       returnType = "float",
       params = {
-        {name = "music", type = "Music"}
+        {type = "Music", name = "music"}
       }
     },
     {
@@ -6742,9 +6742,9 @@ return {
       description = "Load audio stream (to stream raw audio pcm data)",
       returnType = "AudioStream",
       params = {
-        {name = "sampleRate", type = "unsigned int"},
-        {name = "sampleSize", type = "unsigned int"},
-        {name = "channels", type = "unsigned int"}
+        {type = "unsigned int", name = "sampleRate"},
+        {type = "unsigned int", name = "sampleSize"},
+        {type = "unsigned int", name = "channels"}
       }
     },
     {
@@ -6752,7 +6752,7 @@ return {
       description = "Unload audio stream and free memory",
       returnType = "void",
       params = {
-        {name = "stream", type = "AudioStream"}
+        {type = "AudioStream", name = "stream"}
       }
     },
     {
@@ -6760,9 +6760,9 @@ return {
       description = "Update audio stream buffers with data",
       returnType = "void",
       params = {
-        {name = "stream", type = "AudioStream"},
-        {name = "data", type = "const void *"},
-        {name = "frameCount", type = "int"}
+        {type = "AudioStream", name = "stream"},
+        {type = "const void *", name = "data"},
+        {type = "int", name = "frameCount"}
       }
     },
     {
@@ -6770,7 +6770,7 @@ return {
       description = "Check if any audio stream buffers requires refill",
       returnType = "bool",
       params = {
-        {name = "stream", type = "AudioStream"}
+        {type = "AudioStream", name = "stream"}
       }
     },
     {
@@ -6778,7 +6778,7 @@ return {
       description = "Play audio stream",
       returnType = "void",
       params = {
-        {name = "stream", type = "AudioStream"}
+        {type = "AudioStream", name = "stream"}
       }
     },
     {
@@ -6786,7 +6786,7 @@ return {
       description = "Pause audio stream",
       returnType = "void",
       params = {
-        {name = "stream", type = "AudioStream"}
+        {type = "AudioStream", name = "stream"}
       }
     },
     {
@@ -6794,7 +6794,7 @@ return {
       description = "Resume audio stream",
       returnType = "void",
       params = {
-        {name = "stream", type = "AudioStream"}
+        {type = "AudioStream", name = "stream"}
       }
     },
     {
@@ -6802,7 +6802,7 @@ return {
       description = "Check if audio stream is playing",
       returnType = "bool",
       params = {
-        {name = "stream", type = "AudioStream"}
+        {type = "AudioStream", name = "stream"}
       }
     },
     {
@@ -6810,7 +6810,7 @@ return {
       description = "Stop audio stream",
       returnType = "void",
       params = {
-        {name = "stream", type = "AudioStream"}
+        {type = "AudioStream", name = "stream"}
       }
     },
     {
@@ -6818,8 +6818,8 @@ return {
       description = "Set volume for audio stream (1.0 is max level)",
       returnType = "void",
       params = {
-        {name = "stream", type = "AudioStream"},
-        {name = "volume", type = "float"}
+        {type = "AudioStream", name = "stream"},
+        {type = "float", name = "volume"}
       }
     },
     {
@@ -6827,8 +6827,8 @@ return {
       description = "Set pitch for audio stream (1.0 is base level)",
       returnType = "void",
       params = {
-        {name = "stream", type = "AudioStream"},
-        {name = "pitch", type = "float"}
+        {type = "AudioStream", name = "stream"},
+        {type = "float", name = "pitch"}
       }
     },
     {
@@ -6836,7 +6836,7 @@ return {
       description = "Default size for new audio streams",
       returnType = "void",
       params = {
-        {name = "size", type = "int"}
+        {type = "int", name = "size"}
       }
     }
   }

--- a/parser/raylib_api.txt
+++ b/parser/raylib_api.txt
@@ -595,7 +595,7 @@ Enum 21: NPatchLayout (3 values)
   Value[NPATCH_THREE_PATCH_VERTICAL]: 1
   Value[NPATCH_THREE_PATCH_HORIZONTAL]: 2
 
-Functions found: 489
+Functions found: 491
 
 Function 001: InitWindow() (3 input parameters)
   Name: InitWindow
@@ -657,7 +657,7 @@ Function 011: IsWindowState() (1 input parameters)
 Function 012: SetWindowState() (1 input parameters)
   Name: SetWindowState
   Return type: void
-  Description: Set window configuration state using flags
+  Description: Set window configuration state using flags (only PLATFORM_DESKTOP)
   Param[1]: flags (type: unsigned int)
 Function 013: ClearWindowState() (1 input parameters)
   Name: ClearWindowState
@@ -717,207 +717,212 @@ Function 023: SetWindowSize() (2 input parameters)
   Description: Set window dimensions
   Param[1]: width (type: int)
   Param[2]: height (type: int)
-Function 024: GetWindowHandle() (0 input parameters)
+Function 024: SetWindowOpacity() (1 input parameters)
+  Name: SetWindowOpacity
+  Return type: void
+  Description: Set window opacity [0.0f..1.0f] (only PLATFORM_DESKTOP)
+  Param[1]: opacity (type: float)
+Function 025: GetWindowHandle() (0 input parameters)
   Name: GetWindowHandle
   Return type: void *
   Description: Get native window handle
   No input parameters
-Function 025: GetScreenWidth() (0 input parameters)
+Function 026: GetScreenWidth() (0 input parameters)
   Name: GetScreenWidth
   Return type: int
   Description: Get current screen width
   No input parameters
-Function 026: GetScreenHeight() (0 input parameters)
+Function 027: GetScreenHeight() (0 input parameters)
   Name: GetScreenHeight
   Return type: int
   Description: Get current screen height
   No input parameters
-Function 027: GetRenderWidth() (0 input parameters)
+Function 028: GetRenderWidth() (0 input parameters)
   Name: GetRenderWidth
   Return type: int
   Description: Get current render width (it considers HiDPI)
   No input parameters
-Function 028: GetRenderHeight() (0 input parameters)
+Function 029: GetRenderHeight() (0 input parameters)
   Name: GetRenderHeight
   Return type: int
   Description: Get current render height (it considers HiDPI)
   No input parameters
-Function 029: GetMonitorCount() (0 input parameters)
+Function 030: GetMonitorCount() (0 input parameters)
   Name: GetMonitorCount
   Return type: int
   Description: Get number of connected monitors
   No input parameters
-Function 030: GetCurrentMonitor() (0 input parameters)
+Function 031: GetCurrentMonitor() (0 input parameters)
   Name: GetCurrentMonitor
   Return type: int
   Description: Get current connected monitor
   No input parameters
-Function 031: GetMonitorPosition() (1 input parameters)
+Function 032: GetMonitorPosition() (1 input parameters)
   Name: GetMonitorPosition
   Return type: Vector2
   Description: Get specified monitor position
   Param[1]: monitor (type: int)
-Function 032: GetMonitorWidth() (1 input parameters)
+Function 033: GetMonitorWidth() (1 input parameters)
   Name: GetMonitorWidth
   Return type: int
   Description: Get specified monitor width (max available by monitor)
   Param[1]: monitor (type: int)
-Function 033: GetMonitorHeight() (1 input parameters)
+Function 034: GetMonitorHeight() (1 input parameters)
   Name: GetMonitorHeight
   Return type: int
   Description: Get specified monitor height (max available by monitor)
   Param[1]: monitor (type: int)
-Function 034: GetMonitorPhysicalWidth() (1 input parameters)
+Function 035: GetMonitorPhysicalWidth() (1 input parameters)
   Name: GetMonitorPhysicalWidth
   Return type: int
   Description: Get specified monitor physical width in millimetres
   Param[1]: monitor (type: int)
-Function 035: GetMonitorPhysicalHeight() (1 input parameters)
+Function 036: GetMonitorPhysicalHeight() (1 input parameters)
   Name: GetMonitorPhysicalHeight
   Return type: int
   Description: Get specified monitor physical height in millimetres
   Param[1]: monitor (type: int)
-Function 036: GetMonitorRefreshRate() (1 input parameters)
+Function 037: GetMonitorRefreshRate() (1 input parameters)
   Name: GetMonitorRefreshRate
   Return type: int
   Description: Get specified monitor refresh rate
   Param[1]: monitor (type: int)
-Function 037: GetWindowPosition() (0 input parameters)
+Function 038: GetWindowPosition() (0 input parameters)
   Name: GetWindowPosition
   Return type: Vector2
   Description: Get window position XY on monitor
   No input parameters
-Function 038: GetWindowScaleDPI() (0 input parameters)
+Function 039: GetWindowScaleDPI() (0 input parameters)
   Name: GetWindowScaleDPI
   Return type: Vector2
   Description: Get window scale DPI factor
   No input parameters
-Function 039: GetMonitorName() (1 input parameters)
+Function 040: GetMonitorName() (1 input parameters)
   Name: GetMonitorName
   Return type: const char *
   Description: Get the human-readable, UTF-8 encoded name of the primary monitor
   Param[1]: monitor (type: int)
-Function 040: SetClipboardText() (1 input parameters)
+Function 041: SetClipboardText() (1 input parameters)
   Name: SetClipboardText
   Return type: void
   Description: Set clipboard text content
   Param[1]: text (type: const char *)
-Function 041: GetClipboardText() (0 input parameters)
+Function 042: GetClipboardText() (0 input parameters)
   Name: GetClipboardText
   Return type: const char *
   Description: Get clipboard text content
   No input parameters
-Function 042: SwapScreenBuffer() (0 input parameters)
+Function 043: SwapScreenBuffer() (0 input parameters)
   Name: SwapScreenBuffer
   Return type: void
   Description: Swap back buffer with front buffer (screen drawing)
   No input parameters
-Function 043: PollInputEvents() (0 input parameters)
+Function 044: PollInputEvents() (0 input parameters)
   Name: PollInputEvents
   Return type: void
   Description: Register all input events
   No input parameters
-Function 044: WaitTime() (1 input parameters)
+Function 045: WaitTime() (1 input parameters)
   Name: WaitTime
   Return type: void
   Description: Wait for some milliseconds (halt program execution)
   Param[1]: ms (type: float)
-Function 045: ShowCursor() (0 input parameters)
+Function 046: ShowCursor() (0 input parameters)
   Name: ShowCursor
   Return type: void
   Description: Shows cursor
   No input parameters
-Function 046: HideCursor() (0 input parameters)
+Function 047: HideCursor() (0 input parameters)
   Name: HideCursor
   Return type: void
   Description: Hides cursor
   No input parameters
-Function 047: IsCursorHidden() (0 input parameters)
+Function 048: IsCursorHidden() (0 input parameters)
   Name: IsCursorHidden
   Return type: bool
   Description: Check if cursor is not visible
   No input parameters
-Function 048: EnableCursor() (0 input parameters)
+Function 049: EnableCursor() (0 input parameters)
   Name: EnableCursor
   Return type: void
   Description: Enables cursor (unlock cursor)
   No input parameters
-Function 049: DisableCursor() (0 input parameters)
+Function 050: DisableCursor() (0 input parameters)
   Name: DisableCursor
   Return type: void
   Description: Disables cursor (lock cursor)
   No input parameters
-Function 050: IsCursorOnScreen() (0 input parameters)
+Function 051: IsCursorOnScreen() (0 input parameters)
   Name: IsCursorOnScreen
   Return type: bool
   Description: Check if cursor is on the screen
   No input parameters
-Function 051: ClearBackground() (1 input parameters)
+Function 052: ClearBackground() (1 input parameters)
   Name: ClearBackground
   Return type: void
   Description: Set background color (framebuffer clear color)
   Param[1]: color (type: Color)
-Function 052: BeginDrawing() (0 input parameters)
+Function 053: BeginDrawing() (0 input parameters)
   Name: BeginDrawing
   Return type: void
   Description: Setup canvas (framebuffer) to start drawing
   No input parameters
-Function 053: EndDrawing() (0 input parameters)
+Function 054: EndDrawing() (0 input parameters)
   Name: EndDrawing
   Return type: void
   Description: End canvas drawing and swap buffers (double buffering)
   No input parameters
-Function 054: BeginMode2D() (1 input parameters)
+Function 055: BeginMode2D() (1 input parameters)
   Name: BeginMode2D
   Return type: void
   Description: Begin 2D mode with custom camera (2D)
   Param[1]: camera (type: Camera2D)
-Function 055: EndMode2D() (0 input parameters)
+Function 056: EndMode2D() (0 input parameters)
   Name: EndMode2D
   Return type: void
   Description: Ends 2D mode with custom camera
   No input parameters
-Function 056: BeginMode3D() (1 input parameters)
+Function 057: BeginMode3D() (1 input parameters)
   Name: BeginMode3D
   Return type: void
   Description: Begin 3D mode with custom camera (3D)
   Param[1]: camera (type: Camera3D)
-Function 057: EndMode3D() (0 input parameters)
+Function 058: EndMode3D() (0 input parameters)
   Name: EndMode3D
   Return type: void
   Description: Ends 3D mode and returns to default 2D orthographic mode
   No input parameters
-Function 058: BeginTextureMode() (1 input parameters)
+Function 059: BeginTextureMode() (1 input parameters)
   Name: BeginTextureMode
   Return type: void
   Description: Begin drawing to render texture
   Param[1]: target (type: RenderTexture2D)
-Function 059: EndTextureMode() (0 input parameters)
+Function 060: EndTextureMode() (0 input parameters)
   Name: EndTextureMode
   Return type: void
   Description: Ends drawing to render texture
   No input parameters
-Function 060: BeginShaderMode() (1 input parameters)
+Function 061: BeginShaderMode() (1 input parameters)
   Name: BeginShaderMode
   Return type: void
   Description: Begin custom shader drawing
   Param[1]: shader (type: Shader)
-Function 061: EndShaderMode() (0 input parameters)
+Function 062: EndShaderMode() (0 input parameters)
   Name: EndShaderMode
   Return type: void
   Description: End custom shader drawing (use default shader)
   No input parameters
-Function 062: BeginBlendMode() (1 input parameters)
+Function 063: BeginBlendMode() (1 input parameters)
   Name: BeginBlendMode
   Return type: void
   Description: Begin blending mode (alpha, additive, multiplied, subtract, custom)
   Param[1]: mode (type: int)
-Function 063: EndBlendMode() (0 input parameters)
+Function 064: EndBlendMode() (0 input parameters)
   Name: EndBlendMode
   Return type: void
   Description: End blending mode (reset to default: alpha blending)
   No input parameters
-Function 064: BeginScissorMode() (4 input parameters)
+Function 065: BeginScissorMode() (4 input parameters)
   Name: BeginScissorMode
   Return type: void
   Description: Begin scissor mode (define screen area for following drawing)
@@ -925,56 +930,56 @@ Function 064: BeginScissorMode() (4 input parameters)
   Param[2]: y (type: int)
   Param[3]: width (type: int)
   Param[4]: height (type: int)
-Function 065: EndScissorMode() (0 input parameters)
+Function 066: EndScissorMode() (0 input parameters)
   Name: EndScissorMode
   Return type: void
   Description: End scissor mode
   No input parameters
-Function 066: BeginVrStereoMode() (1 input parameters)
+Function 067: BeginVrStereoMode() (1 input parameters)
   Name: BeginVrStereoMode
   Return type: void
   Description: Begin stereo rendering (requires VR simulator)
   Param[1]: config (type: VrStereoConfig)
-Function 067: EndVrStereoMode() (0 input parameters)
+Function 068: EndVrStereoMode() (0 input parameters)
   Name: EndVrStereoMode
   Return type: void
   Description: End stereo rendering (requires VR simulator)
   No input parameters
-Function 068: LoadVrStereoConfig() (1 input parameters)
+Function 069: LoadVrStereoConfig() (1 input parameters)
   Name: LoadVrStereoConfig
   Return type: VrStereoConfig
   Description: Load VR stereo config for VR simulator device parameters
   Param[1]: device (type: VrDeviceInfo)
-Function 069: UnloadVrStereoConfig() (1 input parameters)
+Function 070: UnloadVrStereoConfig() (1 input parameters)
   Name: UnloadVrStereoConfig
   Return type: void
   Description: Unload VR stereo config
   Param[1]: config (type: VrStereoConfig)
-Function 070: LoadShader() (2 input parameters)
+Function 071: LoadShader() (2 input parameters)
   Name: LoadShader
   Return type: Shader
   Description: Load shader from files and bind default locations
   Param[1]: vsFileName (type: const char *)
   Param[2]: fsFileName (type: const char *)
-Function 071: LoadShaderFromMemory() (2 input parameters)
+Function 072: LoadShaderFromMemory() (2 input parameters)
   Name: LoadShaderFromMemory
   Return type: Shader
   Description: Load shader from code strings and bind default locations
   Param[1]: vsCode (type: const char *)
   Param[2]: fsCode (type: const char *)
-Function 072: GetShaderLocation() (2 input parameters)
+Function 073: GetShaderLocation() (2 input parameters)
   Name: GetShaderLocation
   Return type: int
   Description: Get shader uniform location
   Param[1]: shader (type: Shader)
   Param[2]: uniformName (type: const char *)
-Function 073: GetShaderLocationAttrib() (2 input parameters)
+Function 074: GetShaderLocationAttrib() (2 input parameters)
   Name: GetShaderLocationAttrib
   Return type: int
   Description: Get shader attribute location
   Param[1]: shader (type: Shader)
   Param[2]: attribName (type: const char *)
-Function 074: SetShaderValue() (4 input parameters)
+Function 075: SetShaderValue() (4 input parameters)
   Name: SetShaderValue
   Return type: void
   Description: Set shader uniform value
@@ -982,7 +987,7 @@ Function 074: SetShaderValue() (4 input parameters)
   Param[2]: locIndex (type: int)
   Param[3]: value (type: const void *)
   Param[4]: uniformType (type: int)
-Function 075: SetShaderValueV() (5 input parameters)
+Function 076: SetShaderValueV() (5 input parameters)
   Name: SetShaderValueV
   Return type: void
   Description: Set shader uniform value vector
@@ -991,48 +996,48 @@ Function 075: SetShaderValueV() (5 input parameters)
   Param[3]: value (type: const void *)
   Param[4]: uniformType (type: int)
   Param[5]: count (type: int)
-Function 076: SetShaderValueMatrix() (3 input parameters)
+Function 077: SetShaderValueMatrix() (3 input parameters)
   Name: SetShaderValueMatrix
   Return type: void
   Description: Set shader uniform value (matrix 4x4)
   Param[1]: shader (type: Shader)
   Param[2]: locIndex (type: int)
   Param[3]: mat (type: Matrix)
-Function 077: SetShaderValueTexture() (3 input parameters)
+Function 078: SetShaderValueTexture() (3 input parameters)
   Name: SetShaderValueTexture
   Return type: void
   Description: Set shader uniform value for texture (sampler2d)
   Param[1]: shader (type: Shader)
   Param[2]: locIndex (type: int)
   Param[3]: texture (type: Texture2D)
-Function 078: UnloadShader() (1 input parameters)
+Function 079: UnloadShader() (1 input parameters)
   Name: UnloadShader
   Return type: void
   Description: Unload shader from GPU memory (VRAM)
   Param[1]: shader (type: Shader)
-Function 079: GetMouseRay() (2 input parameters)
+Function 080: GetMouseRay() (2 input parameters)
   Name: GetMouseRay
   Return type: Ray
   Description: Get a ray trace from mouse position
   Param[1]: mousePosition (type: Vector2)
   Param[2]: camera (type: Camera)
-Function 080: GetCameraMatrix() (1 input parameters)
+Function 081: GetCameraMatrix() (1 input parameters)
   Name: GetCameraMatrix
   Return type: Matrix
   Description: Get camera transform matrix (view matrix)
   Param[1]: camera (type: Camera)
-Function 081: GetCameraMatrix2D() (1 input parameters)
+Function 082: GetCameraMatrix2D() (1 input parameters)
   Name: GetCameraMatrix2D
   Return type: Matrix
   Description: Get camera 2d transform matrix
   Param[1]: camera (type: Camera2D)
-Function 082: GetWorldToScreen() (2 input parameters)
+Function 083: GetWorldToScreen() (2 input parameters)
   Name: GetWorldToScreen
   Return type: Vector2
   Description: Get the screen space position for a 3d world space position
   Param[1]: position (type: Vector3)
   Param[2]: camera (type: Camera)
-Function 083: GetWorldToScreenEx() (4 input parameters)
+Function 084: GetWorldToScreenEx() (4 input parameters)
   Name: GetWorldToScreenEx
   Return type: Vector2
   Description: Get size position for a 3d world space position
@@ -1040,521 +1045,521 @@ Function 083: GetWorldToScreenEx() (4 input parameters)
   Param[2]: camera (type: Camera)
   Param[3]: width (type: int)
   Param[4]: height (type: int)
-Function 084: GetWorldToScreen2D() (2 input parameters)
+Function 085: GetWorldToScreen2D() (2 input parameters)
   Name: GetWorldToScreen2D
   Return type: Vector2
   Description: Get the screen space position for a 2d camera world space position
   Param[1]: position (type: Vector2)
   Param[2]: camera (type: Camera2D)
-Function 085: GetScreenToWorld2D() (2 input parameters)
+Function 086: GetScreenToWorld2D() (2 input parameters)
   Name: GetScreenToWorld2D
   Return type: Vector2
   Description: Get the world space position for a 2d camera screen space position
   Param[1]: position (type: Vector2)
   Param[2]: camera (type: Camera2D)
-Function 086: SetTargetFPS() (1 input parameters)
+Function 087: SetTargetFPS() (1 input parameters)
   Name: SetTargetFPS
   Return type: void
   Description: Set target FPS (maximum)
   Param[1]: fps (type: int)
-Function 087: GetFPS() (0 input parameters)
+Function 088: GetFPS() (0 input parameters)
   Name: GetFPS
   Return type: int
   Description: Get current FPS
   No input parameters
-Function 088: GetFrameTime() (0 input parameters)
+Function 089: GetFrameTime() (0 input parameters)
   Name: GetFrameTime
   Return type: float
   Description: Get time in seconds for last frame drawn (delta time)
   No input parameters
-Function 089: GetTime() (0 input parameters)
+Function 090: GetTime() (0 input parameters)
   Name: GetTime
   Return type: double
   Description: Get elapsed time in seconds since InitWindow()
   No input parameters
-Function 090: GetRandomValue() (2 input parameters)
+Function 091: GetRandomValue() (2 input parameters)
   Name: GetRandomValue
   Return type: int
   Description: Get a random value between min and max (both included)
   Param[1]: min (type: int)
   Param[2]: max (type: int)
-Function 091: SetRandomSeed() (1 input parameters)
+Function 092: SetRandomSeed() (1 input parameters)
   Name: SetRandomSeed
   Return type: void
   Description: Set the seed for the random number generator
   Param[1]: seed (type: unsigned int)
-Function 092: TakeScreenshot() (1 input parameters)
+Function 093: TakeScreenshot() (1 input parameters)
   Name: TakeScreenshot
   Return type: void
   Description: Takes a screenshot of current screen (filename extension defines format)
   Param[1]: fileName (type: const char *)
-Function 093: SetConfigFlags() (1 input parameters)
+Function 094: SetConfigFlags() (1 input parameters)
   Name: SetConfigFlags
   Return type: void
   Description: Setup init configuration flags (view FLAGS)
   Param[1]: flags (type: unsigned int)
-Function 094: TraceLog() (3 input parameters)
+Function 095: TraceLog() (3 input parameters)
   Name: TraceLog
   Return type: void
   Description: Show trace log messages (LOG_DEBUG, LOG_INFO, LOG_WARNING, LOG_ERROR...)
   Param[1]: logLevel (type: int)
   Param[2]: text (type: const char *)
   Param[3]:  (type: )
-Function 095: SetTraceLogLevel() (1 input parameters)
+Function 096: SetTraceLogLevel() (1 input parameters)
   Name: SetTraceLogLevel
   Return type: void
   Description: Set the current threshold (minimum) log level
   Param[1]: logLevel (type: int)
-Function 096: MemAlloc() (1 input parameters)
+Function 097: MemAlloc() (1 input parameters)
   Name: MemAlloc
   Return type: void *
   Description: Internal memory allocator
   Param[1]: size (type: int)
-Function 097: MemRealloc() (2 input parameters)
+Function 098: MemRealloc() (2 input parameters)
   Name: MemRealloc
   Return type: void *
   Description: Internal memory reallocator
   Param[1]: ptr (type: void *)
   Param[2]: size (type: int)
-Function 098: MemFree() (1 input parameters)
+Function 099: MemFree() (1 input parameters)
   Name: MemFree
   Return type: void
   Description: Internal memory free
   Param[1]: ptr (type: void *)
-Function 099: SetTraceLogCallback() (1 input parameters)
+Function 100: SetTraceLogCallback() (1 input parameters)
   Name: SetTraceLogCallback
   Return type: void
   Description: Set custom trace log
   Param[1]: callback (type: TraceLogCallback)
-Function 100: SetLoadFileDataCallback() (1 input parameters)
+Function 101: SetLoadFileDataCallback() (1 input parameters)
   Name: SetLoadFileDataCallback
   Return type: void
   Description: Set custom file binary data loader
   Param[1]: callback (type: LoadFileDataCallback)
-Function 101: SetSaveFileDataCallback() (1 input parameters)
+Function 102: SetSaveFileDataCallback() (1 input parameters)
   Name: SetSaveFileDataCallback
   Return type: void
   Description: Set custom file binary data saver
   Param[1]: callback (type: SaveFileDataCallback)
-Function 102: SetLoadFileTextCallback() (1 input parameters)
+Function 103: SetLoadFileTextCallback() (1 input parameters)
   Name: SetLoadFileTextCallback
   Return type: void
   Description: Set custom file text data loader
   Param[1]: callback (type: LoadFileTextCallback)
-Function 103: SetSaveFileTextCallback() (1 input parameters)
+Function 104: SetSaveFileTextCallback() (1 input parameters)
   Name: SetSaveFileTextCallback
   Return type: void
   Description: Set custom file text data saver
   Param[1]: callback (type: SaveFileTextCallback)
-Function 104: LoadFileData() (2 input parameters)
+Function 105: LoadFileData() (2 input parameters)
   Name: LoadFileData
   Return type: unsigned char *
   Description: Load file data as byte array (read)
   Param[1]: fileName (type: const char *)
   Param[2]: bytesRead (type: unsigned int *)
-Function 105: UnloadFileData() (1 input parameters)
+Function 106: UnloadFileData() (1 input parameters)
   Name: UnloadFileData
   Return type: void
   Description: Unload file data allocated by LoadFileData()
   Param[1]: data (type: unsigned char *)
-Function 106: SaveFileData() (3 input parameters)
+Function 107: SaveFileData() (3 input parameters)
   Name: SaveFileData
   Return type: bool
   Description: Save data to file from byte array (write), returns true on success
   Param[1]: fileName (type: const char *)
   Param[2]: data (type: void *)
   Param[3]: bytesToWrite (type: unsigned int)
-Function 107: LoadFileText() (1 input parameters)
+Function 108: LoadFileText() (1 input parameters)
   Name: LoadFileText
   Return type: char *
   Description: Load text data from file (read), returns a '\0' terminated string
   Param[1]: fileName (type: const char *)
-Function 108: UnloadFileText() (1 input parameters)
+Function 109: UnloadFileText() (1 input parameters)
   Name: UnloadFileText
   Return type: void
   Description: Unload file text data allocated by LoadFileText()
   Param[1]: text (type: char *)
-Function 109: SaveFileText() (2 input parameters)
+Function 110: SaveFileText() (2 input parameters)
   Name: SaveFileText
   Return type: bool
   Description: Save text data to file (write), string must be '\0' terminated, returns true on success
   Param[1]: fileName (type: const char *)
   Param[2]: text (type: char *)
-Function 110: FileExists() (1 input parameters)
+Function 111: FileExists() (1 input parameters)
   Name: FileExists
   Return type: bool
   Description: Check if file exists
   Param[1]: fileName (type: const char *)
-Function 111: DirectoryExists() (1 input parameters)
+Function 112: DirectoryExists() (1 input parameters)
   Name: DirectoryExists
   Return type: bool
   Description: Check if a directory path exists
   Param[1]: dirPath (type: const char *)
-Function 112: IsFileExtension() (2 input parameters)
+Function 113: IsFileExtension() (2 input parameters)
   Name: IsFileExtension
   Return type: bool
   Description: Check file extension (including point: .png, .wav)
   Param[1]: fileName (type: const char *)
   Param[2]: ext (type: const char *)
-Function 113: GetFileExtension() (1 input parameters)
+Function 114: GetFileExtension() (1 input parameters)
   Name: GetFileExtension
   Return type: const char *
   Description: Get pointer to extension for a filename string (includes dot: '.png')
   Param[1]: fileName (type: const char *)
-Function 114: GetFileName() (1 input parameters)
+Function 115: GetFileName() (1 input parameters)
   Name: GetFileName
   Return type: const char *
   Description: Get pointer to filename for a path string
   Param[1]: filePath (type: const char *)
-Function 115: GetFileNameWithoutExt() (1 input parameters)
+Function 116: GetFileNameWithoutExt() (1 input parameters)
   Name: GetFileNameWithoutExt
   Return type: const char *
   Description: Get filename string without extension (uses static string)
   Param[1]: filePath (type: const char *)
-Function 116: GetDirectoryPath() (1 input parameters)
+Function 117: GetDirectoryPath() (1 input parameters)
   Name: GetDirectoryPath
   Return type: const char *
   Description: Get full path for a given fileName with path (uses static string)
   Param[1]: filePath (type: const char *)
-Function 117: GetPrevDirectoryPath() (1 input parameters)
+Function 118: GetPrevDirectoryPath() (1 input parameters)
   Name: GetPrevDirectoryPath
   Return type: const char *
   Description: Get previous directory path for a given path (uses static string)
   Param[1]: dirPath (type: const char *)
-Function 118: GetWorkingDirectory() (0 input parameters)
+Function 119: GetWorkingDirectory() (0 input parameters)
   Name: GetWorkingDirectory
   Return type: const char *
   Description: Get current working directory (uses static string)
   No input parameters
-Function 119: GetDirectoryFiles() (2 input parameters)
+Function 120: GetDirectoryFiles() (2 input parameters)
   Name: GetDirectoryFiles
   Return type: char **
   Description: Get filenames in a directory path (memory should be freed)
   Param[1]: dirPath (type: const char *)
   Param[2]: count (type: int *)
-Function 120: ClearDirectoryFiles() (0 input parameters)
+Function 121: ClearDirectoryFiles() (0 input parameters)
   Name: ClearDirectoryFiles
   Return type: void
   Description: Clear directory files paths buffers (free memory)
   No input parameters
-Function 121: ChangeDirectory() (1 input parameters)
+Function 122: ChangeDirectory() (1 input parameters)
   Name: ChangeDirectory
   Return type: bool
   Description: Change working directory, return true on success
   Param[1]: dir (type: const char *)
-Function 122: IsFileDropped() (0 input parameters)
+Function 123: IsFileDropped() (0 input parameters)
   Name: IsFileDropped
   Return type: bool
   Description: Check if a file has been dropped into window
   No input parameters
-Function 123: GetDroppedFiles() (1 input parameters)
+Function 124: GetDroppedFiles() (1 input parameters)
   Name: GetDroppedFiles
   Return type: char **
   Description: Get dropped files names (memory should be freed)
   Param[1]: count (type: int *)
-Function 124: ClearDroppedFiles() (0 input parameters)
+Function 125: ClearDroppedFiles() (0 input parameters)
   Name: ClearDroppedFiles
   Return type: void
   Description: Clear dropped files paths buffer (free memory)
   No input parameters
-Function 125: GetFileModTime() (1 input parameters)
+Function 126: GetFileModTime() (1 input parameters)
   Name: GetFileModTime
   Return type: long
   Description: Get file modification time (last write time)
   Param[1]: fileName (type: const char *)
-Function 126: CompressData() (3 input parameters)
+Function 127: CompressData() (3 input parameters)
   Name: CompressData
   Return type: unsigned char *
   Description: Compress data (DEFLATE algorithm)
   Param[1]: data (type: unsigned char *)
   Param[2]: dataLength (type: int)
   Param[3]: compDataLength (type: int *)
-Function 127: DecompressData() (3 input parameters)
+Function 128: DecompressData() (3 input parameters)
   Name: DecompressData
   Return type: unsigned char *
   Description: Decompress data (DEFLATE algorithm)
   Param[1]: compData (type: unsigned char *)
   Param[2]: compDataLength (type: int)
   Param[3]: dataLength (type: int *)
-Function 128: EncodeDataBase64() (3 input parameters)
+Function 129: EncodeDataBase64() (3 input parameters)
   Name: EncodeDataBase64
   Return type: char *
   Description: Encode data to Base64 string
   Param[1]: data (type: const unsigned char *)
   Param[2]: dataLength (type: int)
   Param[3]: outputLength (type: int *)
-Function 129: DecodeDataBase64() (2 input parameters)
+Function 130: DecodeDataBase64() (2 input parameters)
   Name: DecodeDataBase64
   Return type: unsigned char *
   Description: Decode Base64 string data
   Param[1]: data (type: unsigned char *)
   Param[2]: outputLength (type: int *)
-Function 130: SaveStorageValue() (2 input parameters)
+Function 131: SaveStorageValue() (2 input parameters)
   Name: SaveStorageValue
   Return type: bool
   Description: Save integer value to storage file (to defined position), returns true on success
   Param[1]: position (type: unsigned int)
   Param[2]: value (type: int)
-Function 131: LoadStorageValue() (1 input parameters)
+Function 132: LoadStorageValue() (1 input parameters)
   Name: LoadStorageValue
   Return type: int
   Description: Load integer value from storage file (from defined position)
   Param[1]: position (type: unsigned int)
-Function 132: OpenURL() (1 input parameters)
+Function 133: OpenURL() (1 input parameters)
   Name: OpenURL
   Return type: void
   Description: Open URL with default system browser (if available)
   Param[1]: url (type: const char *)
-Function 133: IsKeyPressed() (1 input parameters)
+Function 134: IsKeyPressed() (1 input parameters)
   Name: IsKeyPressed
   Return type: bool
   Description: Check if a key has been pressed once
   Param[1]: key (type: int)
-Function 134: IsKeyDown() (1 input parameters)
+Function 135: IsKeyDown() (1 input parameters)
   Name: IsKeyDown
   Return type: bool
   Description: Check if a key is being pressed
   Param[1]: key (type: int)
-Function 135: IsKeyReleased() (1 input parameters)
+Function 136: IsKeyReleased() (1 input parameters)
   Name: IsKeyReleased
   Return type: bool
   Description: Check if a key has been released once
   Param[1]: key (type: int)
-Function 136: IsKeyUp() (1 input parameters)
+Function 137: IsKeyUp() (1 input parameters)
   Name: IsKeyUp
   Return type: bool
   Description: Check if a key is NOT being pressed
   Param[1]: key (type: int)
-Function 137: SetExitKey() (1 input parameters)
+Function 138: SetExitKey() (1 input parameters)
   Name: SetExitKey
   Return type: void
   Description: Set a custom key to exit program (default is ESC)
   Param[1]: key (type: int)
-Function 138: GetKeyPressed() (0 input parameters)
+Function 139: GetKeyPressed() (0 input parameters)
   Name: GetKeyPressed
   Return type: int
   Description: Get key pressed (keycode), call it multiple times for keys queued, returns 0 when the queue is empty
   No input parameters
-Function 139: GetCharPressed() (0 input parameters)
+Function 140: GetCharPressed() (0 input parameters)
   Name: GetCharPressed
   Return type: int
   Description: Get char pressed (unicode), call it multiple times for chars queued, returns 0 when the queue is empty
   No input parameters
-Function 140: IsGamepadAvailable() (1 input parameters)
+Function 141: IsGamepadAvailable() (1 input parameters)
   Name: IsGamepadAvailable
   Return type: bool
   Description: Check if a gamepad is available
   Param[1]: gamepad (type: int)
-Function 141: GetGamepadName() (1 input parameters)
+Function 142: GetGamepadName() (1 input parameters)
   Name: GetGamepadName
   Return type: const char *
   Description: Get gamepad internal name id
   Param[1]: gamepad (type: int)
-Function 142: IsGamepadButtonPressed() (2 input parameters)
+Function 143: IsGamepadButtonPressed() (2 input parameters)
   Name: IsGamepadButtonPressed
   Return type: bool
   Description: Check if a gamepad button has been pressed once
   Param[1]: gamepad (type: int)
   Param[2]: button (type: int)
-Function 143: IsGamepadButtonDown() (2 input parameters)
+Function 144: IsGamepadButtonDown() (2 input parameters)
   Name: IsGamepadButtonDown
   Return type: bool
   Description: Check if a gamepad button is being pressed
   Param[1]: gamepad (type: int)
   Param[2]: button (type: int)
-Function 144: IsGamepadButtonReleased() (2 input parameters)
+Function 145: IsGamepadButtonReleased() (2 input parameters)
   Name: IsGamepadButtonReleased
   Return type: bool
   Description: Check if a gamepad button has been released once
   Param[1]: gamepad (type: int)
   Param[2]: button (type: int)
-Function 145: IsGamepadButtonUp() (2 input parameters)
+Function 146: IsGamepadButtonUp() (2 input parameters)
   Name: IsGamepadButtonUp
   Return type: bool
   Description: Check if a gamepad button is NOT being pressed
   Param[1]: gamepad (type: int)
   Param[2]: button (type: int)
-Function 146: GetGamepadButtonPressed() (0 input parameters)
+Function 147: GetGamepadButtonPressed() (0 input parameters)
   Name: GetGamepadButtonPressed
   Return type: int
   Description: Get the last gamepad button pressed
   No input parameters
-Function 147: GetGamepadAxisCount() (1 input parameters)
+Function 148: GetGamepadAxisCount() (1 input parameters)
   Name: GetGamepadAxisCount
   Return type: int
   Description: Get gamepad axis count for a gamepad
   Param[1]: gamepad (type: int)
-Function 148: GetGamepadAxisMovement() (2 input parameters)
+Function 149: GetGamepadAxisMovement() (2 input parameters)
   Name: GetGamepadAxisMovement
   Return type: float
   Description: Get axis movement value for a gamepad axis
   Param[1]: gamepad (type: int)
   Param[2]: axis (type: int)
-Function 149: SetGamepadMappings() (1 input parameters)
+Function 150: SetGamepadMappings() (1 input parameters)
   Name: SetGamepadMappings
   Return type: int
   Description: Set internal gamepad mappings (SDL_GameControllerDB)
   Param[1]: mappings (type: const char *)
-Function 150: IsMouseButtonPressed() (1 input parameters)
+Function 151: IsMouseButtonPressed() (1 input parameters)
   Name: IsMouseButtonPressed
   Return type: bool
   Description: Check if a mouse button has been pressed once
   Param[1]: button (type: int)
-Function 151: IsMouseButtonDown() (1 input parameters)
+Function 152: IsMouseButtonDown() (1 input parameters)
   Name: IsMouseButtonDown
   Return type: bool
   Description: Check if a mouse button is being pressed
   Param[1]: button (type: int)
-Function 152: IsMouseButtonReleased() (1 input parameters)
+Function 153: IsMouseButtonReleased() (1 input parameters)
   Name: IsMouseButtonReleased
   Return type: bool
   Description: Check if a mouse button has been released once
   Param[1]: button (type: int)
-Function 153: IsMouseButtonUp() (1 input parameters)
+Function 154: IsMouseButtonUp() (1 input parameters)
   Name: IsMouseButtonUp
   Return type: bool
   Description: Check if a mouse button is NOT being pressed
   Param[1]: button (type: int)
-Function 154: GetMouseX() (0 input parameters)
+Function 155: GetMouseX() (0 input parameters)
   Name: GetMouseX
   Return type: int
   Description: Get mouse position X
   No input parameters
-Function 155: GetMouseY() (0 input parameters)
+Function 156: GetMouseY() (0 input parameters)
   Name: GetMouseY
   Return type: int
   Description: Get mouse position Y
   No input parameters
-Function 156: GetMousePosition() (0 input parameters)
+Function 157: GetMousePosition() (0 input parameters)
   Name: GetMousePosition
   Return type: Vector2
   Description: Get mouse position XY
   No input parameters
-Function 157: GetMouseDelta() (0 input parameters)
+Function 158: GetMouseDelta() (0 input parameters)
   Name: GetMouseDelta
   Return type: Vector2
   Description: Get mouse delta between frames
   No input parameters
-Function 158: SetMousePosition() (2 input parameters)
+Function 159: SetMousePosition() (2 input parameters)
   Name: SetMousePosition
   Return type: void
   Description: Set mouse position XY
   Param[1]: x (type: int)
   Param[2]: y (type: int)
-Function 159: SetMouseOffset() (2 input parameters)
+Function 160: SetMouseOffset() (2 input parameters)
   Name: SetMouseOffset
   Return type: void
   Description: Set mouse offset
   Param[1]: offsetX (type: int)
   Param[2]: offsetY (type: int)
-Function 160: SetMouseScale() (2 input parameters)
+Function 161: SetMouseScale() (2 input parameters)
   Name: SetMouseScale
   Return type: void
   Description: Set mouse scaling
   Param[1]: scaleX (type: float)
   Param[2]: scaleY (type: float)
-Function 161: GetMouseWheelMove() (0 input parameters)
+Function 162: GetMouseWheelMove() (0 input parameters)
   Name: GetMouseWheelMove
   Return type: float
   Description: Get mouse wheel movement Y
   No input parameters
-Function 162: SetMouseCursor() (1 input parameters)
+Function 163: SetMouseCursor() (1 input parameters)
   Name: SetMouseCursor
   Return type: void
   Description: Set mouse cursor
   Param[1]: cursor (type: int)
-Function 163: GetTouchX() (0 input parameters)
+Function 164: GetTouchX() (0 input parameters)
   Name: GetTouchX
   Return type: int
   Description: Get touch position X for touch point 0 (relative to screen size)
   No input parameters
-Function 164: GetTouchY() (0 input parameters)
+Function 165: GetTouchY() (0 input parameters)
   Name: GetTouchY
   Return type: int
   Description: Get touch position Y for touch point 0 (relative to screen size)
   No input parameters
-Function 165: GetTouchPosition() (1 input parameters)
+Function 166: GetTouchPosition() (1 input parameters)
   Name: GetTouchPosition
   Return type: Vector2
   Description: Get touch position XY for a touch point index (relative to screen size)
   Param[1]: index (type: int)
-Function 166: GetTouchPointId() (1 input parameters)
+Function 167: GetTouchPointId() (1 input parameters)
   Name: GetTouchPointId
   Return type: int
   Description: Get touch point identifier for given index
   Param[1]: index (type: int)
-Function 167: GetTouchPointCount() (0 input parameters)
+Function 168: GetTouchPointCount() (0 input parameters)
   Name: GetTouchPointCount
   Return type: int
   Description: Get number of touch points
   No input parameters
-Function 168: SetGesturesEnabled() (1 input parameters)
+Function 169: SetGesturesEnabled() (1 input parameters)
   Name: SetGesturesEnabled
   Return type: void
   Description: Enable a set of gestures using flags
   Param[1]: flags (type: unsigned int)
-Function 169: IsGestureDetected() (1 input parameters)
+Function 170: IsGestureDetected() (1 input parameters)
   Name: IsGestureDetected
   Return type: bool
   Description: Check if a gesture have been detected
   Param[1]: gesture (type: int)
-Function 170: GetGestureDetected() (0 input parameters)
+Function 171: GetGestureDetected() (0 input parameters)
   Name: GetGestureDetected
   Return type: int
   Description: Get latest detected gesture
   No input parameters
-Function 171: GetGestureHoldDuration() (0 input parameters)
+Function 172: GetGestureHoldDuration() (0 input parameters)
   Name: GetGestureHoldDuration
   Return type: float
   Description: Get gesture hold time in milliseconds
   No input parameters
-Function 172: GetGestureDragVector() (0 input parameters)
+Function 173: GetGestureDragVector() (0 input parameters)
   Name: GetGestureDragVector
   Return type: Vector2
   Description: Get gesture drag vector
   No input parameters
-Function 173: GetGestureDragAngle() (0 input parameters)
+Function 174: GetGestureDragAngle() (0 input parameters)
   Name: GetGestureDragAngle
   Return type: float
   Description: Get gesture drag angle
   No input parameters
-Function 174: GetGesturePinchVector() (0 input parameters)
+Function 175: GetGesturePinchVector() (0 input parameters)
   Name: GetGesturePinchVector
   Return type: Vector2
   Description: Get gesture pinch delta
   No input parameters
-Function 175: GetGesturePinchAngle() (0 input parameters)
+Function 176: GetGesturePinchAngle() (0 input parameters)
   Name: GetGesturePinchAngle
   Return type: float
   Description: Get gesture pinch angle
   No input parameters
-Function 176: SetCameraMode() (2 input parameters)
+Function 177: SetCameraMode() (2 input parameters)
   Name: SetCameraMode
   Return type: void
   Description: Set camera mode (multiple camera modes available)
   Param[1]: camera (type: Camera)
   Param[2]: mode (type: int)
-Function 177: UpdateCamera() (1 input parameters)
+Function 178: UpdateCamera() (1 input parameters)
   Name: UpdateCamera
   Return type: void
   Description: Update camera position for selected mode
   Param[1]: camera (type: Camera *)
-Function 178: SetCameraPanControl() (1 input parameters)
+Function 179: SetCameraPanControl() (1 input parameters)
   Name: SetCameraPanControl
   Return type: void
   Description: Set camera pan key to combine with mouse movement (free camera)
   Param[1]: keyPan (type: int)
-Function 179: SetCameraAltControl() (1 input parameters)
+Function 180: SetCameraAltControl() (1 input parameters)
   Name: SetCameraAltControl
   Return type: void
   Description: Set camera alt key to combine with mouse movement (free camera)
   Param[1]: keyAlt (type: int)
-Function 180: SetCameraSmoothZoomControl() (1 input parameters)
+Function 181: SetCameraSmoothZoomControl() (1 input parameters)
   Name: SetCameraSmoothZoomControl
   Return type: void
   Description: Set camera smooth zoom key to combine with mouse (free camera)
   Param[1]: keySmoothZoom (type: int)
-Function 181: SetCameraMoveControls() (6 input parameters)
+Function 182: SetCameraMoveControls() (6 input parameters)
   Name: SetCameraMoveControls
   Return type: void
   Description: Set camera move controls (1st person and 3rd person cameras)
@@ -1564,26 +1569,26 @@ Function 181: SetCameraMoveControls() (6 input parameters)
   Param[4]: keyLeft (type: int)
   Param[5]: keyUp (type: int)
   Param[6]: keyDown (type: int)
-Function 182: SetShapesTexture() (2 input parameters)
+Function 183: SetShapesTexture() (2 input parameters)
   Name: SetShapesTexture
   Return type: void
   Description: Set texture and rectangle to be used on shapes drawing
   Param[1]: texture (type: Texture2D)
   Param[2]: source (type: Rectangle)
-Function 183: DrawPixel() (3 input parameters)
+Function 184: DrawPixel() (3 input parameters)
   Name: DrawPixel
   Return type: void
   Description: Draw a pixel
   Param[1]: posX (type: int)
   Param[2]: posY (type: int)
   Param[3]: color (type: Color)
-Function 184: DrawPixelV() (2 input parameters)
+Function 185: DrawPixelV() (2 input parameters)
   Name: DrawPixelV
   Return type: void
   Description: Draw a pixel (Vector version)
   Param[1]: position (type: Vector2)
   Param[2]: color (type: Color)
-Function 185: DrawLine() (5 input parameters)
+Function 186: DrawLine() (5 input parameters)
   Name: DrawLine
   Return type: void
   Description: Draw a line
@@ -1592,14 +1597,14 @@ Function 185: DrawLine() (5 input parameters)
   Param[3]: endPosX (type: int)
   Param[4]: endPosY (type: int)
   Param[5]: color (type: Color)
-Function 186: DrawLineV() (3 input parameters)
+Function 187: DrawLineV() (3 input parameters)
   Name: DrawLineV
   Return type: void
   Description: Draw a line (Vector version)
   Param[1]: startPos (type: Vector2)
   Param[2]: endPos (type: Vector2)
   Param[3]: color (type: Color)
-Function 187: DrawLineEx() (4 input parameters)
+Function 188: DrawLineEx() (4 input parameters)
   Name: DrawLineEx
   Return type: void
   Description: Draw a line defining thickness
@@ -1607,7 +1612,7 @@ Function 187: DrawLineEx() (4 input parameters)
   Param[2]: endPos (type: Vector2)
   Param[3]: thick (type: float)
   Param[4]: color (type: Color)
-Function 188: DrawLineBezier() (4 input parameters)
+Function 189: DrawLineBezier() (4 input parameters)
   Name: DrawLineBezier
   Return type: void
   Description: Draw a line using cubic-bezier curves in-out
@@ -1615,7 +1620,7 @@ Function 188: DrawLineBezier() (4 input parameters)
   Param[2]: endPos (type: Vector2)
   Param[3]: thick (type: float)
   Param[4]: color (type: Color)
-Function 189: DrawLineBezierQuad() (5 input parameters)
+Function 190: DrawLineBezierQuad() (5 input parameters)
   Name: DrawLineBezierQuad
   Return type: void
   Description: Draw line using quadratic bezier curves with a control point
@@ -1624,7 +1629,7 @@ Function 189: DrawLineBezierQuad() (5 input parameters)
   Param[3]: controlPos (type: Vector2)
   Param[4]: thick (type: float)
   Param[5]: color (type: Color)
-Function 190: DrawLineBezierCubic() (6 input parameters)
+Function 191: DrawLineBezierCubic() (6 input parameters)
   Name: DrawLineBezierCubic
   Return type: void
   Description: Draw line using cubic bezier curves with 2 control points
@@ -1634,14 +1639,14 @@ Function 190: DrawLineBezierCubic() (6 input parameters)
   Param[4]: endControlPos (type: Vector2)
   Param[5]: thick (type: float)
   Param[6]: color (type: Color)
-Function 191: DrawLineStrip() (3 input parameters)
+Function 192: DrawLineStrip() (3 input parameters)
   Name: DrawLineStrip
   Return type: void
   Description: Draw lines sequence
   Param[1]: points (type: Vector2 *)
   Param[2]: pointCount (type: int)
   Param[3]: color (type: Color)
-Function 192: DrawCircle() (4 input parameters)
+Function 193: DrawCircle() (4 input parameters)
   Name: DrawCircle
   Return type: void
   Description: Draw a color-filled circle
@@ -1649,7 +1654,7 @@ Function 192: DrawCircle() (4 input parameters)
   Param[2]: centerY (type: int)
   Param[3]: radius (type: float)
   Param[4]: color (type: Color)
-Function 193: DrawCircleSector() (6 input parameters)
+Function 194: DrawCircleSector() (6 input parameters)
   Name: DrawCircleSector
   Return type: void
   Description: Draw a piece of a circle
@@ -1659,7 +1664,7 @@ Function 193: DrawCircleSector() (6 input parameters)
   Param[4]: endAngle (type: float)
   Param[5]: segments (type: int)
   Param[6]: color (type: Color)
-Function 194: DrawCircleSectorLines() (6 input parameters)
+Function 195: DrawCircleSectorLines() (6 input parameters)
   Name: DrawCircleSectorLines
   Return type: void
   Description: Draw circle sector outline
@@ -1669,7 +1674,7 @@ Function 194: DrawCircleSectorLines() (6 input parameters)
   Param[4]: endAngle (type: float)
   Param[5]: segments (type: int)
   Param[6]: color (type: Color)
-Function 195: DrawCircleGradient() (5 input parameters)
+Function 196: DrawCircleGradient() (5 input parameters)
   Name: DrawCircleGradient
   Return type: void
   Description: Draw a gradient-filled circle
@@ -1678,14 +1683,14 @@ Function 195: DrawCircleGradient() (5 input parameters)
   Param[3]: radius (type: float)
   Param[4]: color1 (type: Color)
   Param[5]: color2 (type: Color)
-Function 196: DrawCircleV() (3 input parameters)
+Function 197: DrawCircleV() (3 input parameters)
   Name: DrawCircleV
   Return type: void
   Description: Draw a color-filled circle (Vector version)
   Param[1]: center (type: Vector2)
   Param[2]: radius (type: float)
   Param[3]: color (type: Color)
-Function 197: DrawCircleLines() (4 input parameters)
+Function 198: DrawCircleLines() (4 input parameters)
   Name: DrawCircleLines
   Return type: void
   Description: Draw circle outline
@@ -1693,7 +1698,7 @@ Function 197: DrawCircleLines() (4 input parameters)
   Param[2]: centerY (type: int)
   Param[3]: radius (type: float)
   Param[4]: color (type: Color)
-Function 198: DrawEllipse() (5 input parameters)
+Function 199: DrawEllipse() (5 input parameters)
   Name: DrawEllipse
   Return type: void
   Description: Draw ellipse
@@ -1702,7 +1707,7 @@ Function 198: DrawEllipse() (5 input parameters)
   Param[3]: radiusH (type: float)
   Param[4]: radiusV (type: float)
   Param[5]: color (type: Color)
-Function 199: DrawEllipseLines() (5 input parameters)
+Function 200: DrawEllipseLines() (5 input parameters)
   Name: DrawEllipseLines
   Return type: void
   Description: Draw ellipse outline
@@ -1711,7 +1716,7 @@ Function 199: DrawEllipseLines() (5 input parameters)
   Param[3]: radiusH (type: float)
   Param[4]: radiusV (type: float)
   Param[5]: color (type: Color)
-Function 200: DrawRing() (7 input parameters)
+Function 201: DrawRing() (7 input parameters)
   Name: DrawRing
   Return type: void
   Description: Draw ring
@@ -1722,7 +1727,7 @@ Function 200: DrawRing() (7 input parameters)
   Param[5]: endAngle (type: float)
   Param[6]: segments (type: int)
   Param[7]: color (type: Color)
-Function 201: DrawRingLines() (7 input parameters)
+Function 202: DrawRingLines() (7 input parameters)
   Name: DrawRingLines
   Return type: void
   Description: Draw ring outline
@@ -1733,7 +1738,7 @@ Function 201: DrawRingLines() (7 input parameters)
   Param[5]: endAngle (type: float)
   Param[6]: segments (type: int)
   Param[7]: color (type: Color)
-Function 202: DrawRectangle() (5 input parameters)
+Function 203: DrawRectangle() (5 input parameters)
   Name: DrawRectangle
   Return type: void
   Description: Draw a color-filled rectangle
@@ -1742,20 +1747,20 @@ Function 202: DrawRectangle() (5 input parameters)
   Param[3]: width (type: int)
   Param[4]: height (type: int)
   Param[5]: color (type: Color)
-Function 203: DrawRectangleV() (3 input parameters)
+Function 204: DrawRectangleV() (3 input parameters)
   Name: DrawRectangleV
   Return type: void
   Description: Draw a color-filled rectangle (Vector version)
   Param[1]: position (type: Vector2)
   Param[2]: size (type: Vector2)
   Param[3]: color (type: Color)
-Function 204: DrawRectangleRec() (2 input parameters)
+Function 205: DrawRectangleRec() (2 input parameters)
   Name: DrawRectangleRec
   Return type: void
   Description: Draw a color-filled rectangle
   Param[1]: rec (type: Rectangle)
   Param[2]: color (type: Color)
-Function 205: DrawRectanglePro() (4 input parameters)
+Function 206: DrawRectanglePro() (4 input parameters)
   Name: DrawRectanglePro
   Return type: void
   Description: Draw a color-filled rectangle with pro parameters
@@ -1763,7 +1768,7 @@ Function 205: DrawRectanglePro() (4 input parameters)
   Param[2]: origin (type: Vector2)
   Param[3]: rotation (type: float)
   Param[4]: color (type: Color)
-Function 206: DrawRectangleGradientV() (6 input parameters)
+Function 207: DrawRectangleGradientV() (6 input parameters)
   Name: DrawRectangleGradientV
   Return type: void
   Description: Draw a vertical-gradient-filled rectangle
@@ -1773,7 +1778,7 @@ Function 206: DrawRectangleGradientV() (6 input parameters)
   Param[4]: height (type: int)
   Param[5]: color1 (type: Color)
   Param[6]: color2 (type: Color)
-Function 207: DrawRectangleGradientH() (6 input parameters)
+Function 208: DrawRectangleGradientH() (6 input parameters)
   Name: DrawRectangleGradientH
   Return type: void
   Description: Draw a horizontal-gradient-filled rectangle
@@ -1783,7 +1788,7 @@ Function 207: DrawRectangleGradientH() (6 input parameters)
   Param[4]: height (type: int)
   Param[5]: color1 (type: Color)
   Param[6]: color2 (type: Color)
-Function 208: DrawRectangleGradientEx() (5 input parameters)
+Function 209: DrawRectangleGradientEx() (5 input parameters)
   Name: DrawRectangleGradientEx
   Return type: void
   Description: Draw a gradient-filled rectangle with custom vertex colors
@@ -1792,7 +1797,7 @@ Function 208: DrawRectangleGradientEx() (5 input parameters)
   Param[3]: col2 (type: Color)
   Param[4]: col3 (type: Color)
   Param[5]: col4 (type: Color)
-Function 209: DrawRectangleLines() (5 input parameters)
+Function 210: DrawRectangleLines() (5 input parameters)
   Name: DrawRectangleLines
   Return type: void
   Description: Draw rectangle outline
@@ -1801,14 +1806,14 @@ Function 209: DrawRectangleLines() (5 input parameters)
   Param[3]: width (type: int)
   Param[4]: height (type: int)
   Param[5]: color (type: Color)
-Function 210: DrawRectangleLinesEx() (3 input parameters)
+Function 211: DrawRectangleLinesEx() (3 input parameters)
   Name: DrawRectangleLinesEx
   Return type: void
   Description: Draw rectangle outline with extended parameters
   Param[1]: rec (type: Rectangle)
   Param[2]: lineThick (type: float)
   Param[3]: color (type: Color)
-Function 211: DrawRectangleRounded() (4 input parameters)
+Function 212: DrawRectangleRounded() (4 input parameters)
   Name: DrawRectangleRounded
   Return type: void
   Description: Draw rectangle with rounded edges
@@ -1816,7 +1821,7 @@ Function 211: DrawRectangleRounded() (4 input parameters)
   Param[2]: roundness (type: float)
   Param[3]: segments (type: int)
   Param[4]: color (type: Color)
-Function 212: DrawRectangleRoundedLines() (5 input parameters)
+Function 213: DrawRectangleRoundedLines() (5 input parameters)
   Name: DrawRectangleRoundedLines
   Return type: void
   Description: Draw rectangle with rounded edges outline
@@ -1825,7 +1830,7 @@ Function 212: DrawRectangleRoundedLines() (5 input parameters)
   Param[3]: segments (type: int)
   Param[4]: lineThick (type: float)
   Param[5]: color (type: Color)
-Function 213: DrawTriangle() (4 input parameters)
+Function 214: DrawTriangle() (4 input parameters)
   Name: DrawTriangle
   Return type: void
   Description: Draw a color-filled triangle (vertex in counter-clockwise order!)
@@ -1833,7 +1838,7 @@ Function 213: DrawTriangle() (4 input parameters)
   Param[2]: v2 (type: Vector2)
   Param[3]: v3 (type: Vector2)
   Param[4]: color (type: Color)
-Function 214: DrawTriangleLines() (4 input parameters)
+Function 215: DrawTriangleLines() (4 input parameters)
   Name: DrawTriangleLines
   Return type: void
   Description: Draw triangle outline (vertex in counter-clockwise order!)
@@ -1841,21 +1846,21 @@ Function 214: DrawTriangleLines() (4 input parameters)
   Param[2]: v2 (type: Vector2)
   Param[3]: v3 (type: Vector2)
   Param[4]: color (type: Color)
-Function 215: DrawTriangleFan() (3 input parameters)
+Function 216: DrawTriangleFan() (3 input parameters)
   Name: DrawTriangleFan
   Return type: void
   Description: Draw a triangle fan defined by points (first vertex is the center)
   Param[1]: points (type: Vector2 *)
   Param[2]: pointCount (type: int)
   Param[3]: color (type: Color)
-Function 216: DrawTriangleStrip() (3 input parameters)
+Function 217: DrawTriangleStrip() (3 input parameters)
   Name: DrawTriangleStrip
   Return type: void
   Description: Draw a triangle strip defined by points
   Param[1]: points (type: Vector2 *)
   Param[2]: pointCount (type: int)
   Param[3]: color (type: Color)
-Function 217: DrawPoly() (5 input parameters)
+Function 218: DrawPoly() (5 input parameters)
   Name: DrawPoly
   Return type: void
   Description: Draw a regular polygon (Vector version)
@@ -1864,7 +1869,7 @@ Function 217: DrawPoly() (5 input parameters)
   Param[3]: radius (type: float)
   Param[4]: rotation (type: float)
   Param[5]: color (type: Color)
-Function 218: DrawPolyLines() (5 input parameters)
+Function 219: DrawPolyLines() (5 input parameters)
   Name: DrawPolyLines
   Return type: void
   Description: Draw a polygon outline of n sides
@@ -1873,7 +1878,7 @@ Function 218: DrawPolyLines() (5 input parameters)
   Param[3]: radius (type: float)
   Param[4]: rotation (type: float)
   Param[5]: color (type: Color)
-Function 219: DrawPolyLinesEx() (6 input parameters)
+Function 220: DrawPolyLinesEx() (6 input parameters)
   Name: DrawPolyLinesEx
   Return type: void
   Description: Draw a polygon outline of n sides with extended parameters
@@ -1883,13 +1888,13 @@ Function 219: DrawPolyLinesEx() (6 input parameters)
   Param[4]: rotation (type: float)
   Param[5]: lineThick (type: float)
   Param[6]: color (type: Color)
-Function 220: CheckCollisionRecs() (2 input parameters)
+Function 221: CheckCollisionRecs() (2 input parameters)
   Name: CheckCollisionRecs
   Return type: bool
   Description: Check collision between two rectangles
   Param[1]: rec1 (type: Rectangle)
   Param[2]: rec2 (type: Rectangle)
-Function 221: CheckCollisionCircles() (4 input parameters)
+Function 222: CheckCollisionCircles() (4 input parameters)
   Name: CheckCollisionCircles
   Return type: bool
   Description: Check collision between two circles
@@ -1897,27 +1902,27 @@ Function 221: CheckCollisionCircles() (4 input parameters)
   Param[2]: radius1 (type: float)
   Param[3]: center2 (type: Vector2)
   Param[4]: radius2 (type: float)
-Function 222: CheckCollisionCircleRec() (3 input parameters)
+Function 223: CheckCollisionCircleRec() (3 input parameters)
   Name: CheckCollisionCircleRec
   Return type: bool
   Description: Check collision between circle and rectangle
   Param[1]: center (type: Vector2)
   Param[2]: radius (type: float)
   Param[3]: rec (type: Rectangle)
-Function 223: CheckCollisionPointRec() (2 input parameters)
+Function 224: CheckCollisionPointRec() (2 input parameters)
   Name: CheckCollisionPointRec
   Return type: bool
   Description: Check if point is inside rectangle
   Param[1]: point (type: Vector2)
   Param[2]: rec (type: Rectangle)
-Function 224: CheckCollisionPointCircle() (3 input parameters)
+Function 225: CheckCollisionPointCircle() (3 input parameters)
   Name: CheckCollisionPointCircle
   Return type: bool
   Description: Check if point is inside circle
   Param[1]: point (type: Vector2)
   Param[2]: center (type: Vector2)
   Param[3]: radius (type: float)
-Function 225: CheckCollisionPointTriangle() (4 input parameters)
+Function 226: CheckCollisionPointTriangle() (4 input parameters)
   Name: CheckCollisionPointTriangle
   Return type: bool
   Description: Check if point is inside a triangle
@@ -1925,7 +1930,7 @@ Function 225: CheckCollisionPointTriangle() (4 input parameters)
   Param[2]: p1 (type: Vector2)
   Param[3]: p2 (type: Vector2)
   Param[4]: p3 (type: Vector2)
-Function 226: CheckCollisionLines() (5 input parameters)
+Function 227: CheckCollisionLines() (5 input parameters)
   Name: CheckCollisionLines
   Return type: bool
   Description: Check the collision between two lines defined by two points each, returns collision point by reference
@@ -1934,7 +1939,7 @@ Function 226: CheckCollisionLines() (5 input parameters)
   Param[3]: startPos2 (type: Vector2)
   Param[4]: endPos2 (type: Vector2)
   Param[5]: collisionPoint (type: Vector2 *)
-Function 227: CheckCollisionPointLine() (4 input parameters)
+Function 228: CheckCollisionPointLine() (4 input parameters)
   Name: CheckCollisionPointLine
   Return type: bool
   Description: Check if point belongs to line created between two points [p1] and [p2] with defined margin in pixels [threshold]
@@ -1942,18 +1947,18 @@ Function 227: CheckCollisionPointLine() (4 input parameters)
   Param[2]: p1 (type: Vector2)
   Param[3]: p2 (type: Vector2)
   Param[4]: threshold (type: int)
-Function 228: GetCollisionRec() (2 input parameters)
+Function 229: GetCollisionRec() (2 input parameters)
   Name: GetCollisionRec
   Return type: Rectangle
   Description: Get collision rectangle for two rectangles collision
   Param[1]: rec1 (type: Rectangle)
   Param[2]: rec2 (type: Rectangle)
-Function 229: LoadImage() (1 input parameters)
+Function 230: LoadImage() (1 input parameters)
   Name: LoadImage
   Return type: Image
   Description: Load image from file into CPU memory (RAM)
   Param[1]: fileName (type: const char *)
-Function 230: LoadImageRaw() (5 input parameters)
+Function 231: LoadImageRaw() (5 input parameters)
   Name: LoadImageRaw
   Return type: Image
   Description: Load image from RAW file data
@@ -1962,54 +1967,54 @@ Function 230: LoadImageRaw() (5 input parameters)
   Param[3]: height (type: int)
   Param[4]: format (type: int)
   Param[5]: headerSize (type: int)
-Function 231: LoadImageAnim() (2 input parameters)
+Function 232: LoadImageAnim() (2 input parameters)
   Name: LoadImageAnim
   Return type: Image
   Description: Load image sequence from file (frames appended to image.data)
   Param[1]: fileName (type: const char *)
   Param[2]: frames (type: int *)
-Function 232: LoadImageFromMemory() (3 input parameters)
+Function 233: LoadImageFromMemory() (3 input parameters)
   Name: LoadImageFromMemory
   Return type: Image
   Description: Load image from memory buffer, fileType refers to extension: i.e. '.png'
   Param[1]: fileType (type: const char *)
   Param[2]: fileData (type: const unsigned char *)
   Param[3]: dataSize (type: int)
-Function 233: LoadImageFromTexture() (1 input parameters)
+Function 234: LoadImageFromTexture() (1 input parameters)
   Name: LoadImageFromTexture
   Return type: Image
   Description: Load image from GPU texture data
   Param[1]: texture (type: Texture2D)
-Function 234: LoadImageFromScreen() (0 input parameters)
+Function 235: LoadImageFromScreen() (0 input parameters)
   Name: LoadImageFromScreen
   Return type: Image
   Description: Load image from screen buffer and (screenshot)
   No input parameters
-Function 235: UnloadImage() (1 input parameters)
+Function 236: UnloadImage() (1 input parameters)
   Name: UnloadImage
   Return type: void
   Description: Unload image from CPU memory (RAM)
   Param[1]: image (type: Image)
-Function 236: ExportImage() (2 input parameters)
+Function 237: ExportImage() (2 input parameters)
   Name: ExportImage
   Return type: bool
   Description: Export image data to file, returns true on success
   Param[1]: image (type: Image)
   Param[2]: fileName (type: const char *)
-Function 237: ExportImageAsCode() (2 input parameters)
+Function 238: ExportImageAsCode() (2 input parameters)
   Name: ExportImageAsCode
   Return type: bool
   Description: Export image as code file defining an array of bytes, returns true on success
   Param[1]: image (type: Image)
   Param[2]: fileName (type: const char *)
-Function 238: GenImageColor() (3 input parameters)
+Function 239: GenImageColor() (3 input parameters)
   Name: GenImageColor
   Return type: Image
   Description: Generate image: plain color
   Param[1]: width (type: int)
   Param[2]: height (type: int)
   Param[3]: color (type: Color)
-Function 239: GenImageGradientV() (4 input parameters)
+Function 240: GenImageGradientV() (4 input parameters)
   Name: GenImageGradientV
   Return type: Image
   Description: Generate image: vertical gradient
@@ -2017,7 +2022,7 @@ Function 239: GenImageGradientV() (4 input parameters)
   Param[2]: height (type: int)
   Param[3]: top (type: Color)
   Param[4]: bottom (type: Color)
-Function 240: GenImageGradientH() (4 input parameters)
+Function 241: GenImageGradientH() (4 input parameters)
   Name: GenImageGradientH
   Return type: Image
   Description: Generate image: horizontal gradient
@@ -2025,7 +2030,7 @@ Function 240: GenImageGradientH() (4 input parameters)
   Param[2]: height (type: int)
   Param[3]: left (type: Color)
   Param[4]: right (type: Color)
-Function 241: GenImageGradientRadial() (5 input parameters)
+Function 242: GenImageGradientRadial() (5 input parameters)
   Name: GenImageGradientRadial
   Return type: Image
   Description: Generate image: radial gradient
@@ -2034,7 +2039,7 @@ Function 241: GenImageGradientRadial() (5 input parameters)
   Param[3]: density (type: float)
   Param[4]: inner (type: Color)
   Param[5]: outer (type: Color)
-Function 242: GenImageChecked() (6 input parameters)
+Function 243: GenImageChecked() (6 input parameters)
   Name: GenImageChecked
   Return type: Image
   Description: Generate image: checked
@@ -2044,39 +2049,39 @@ Function 242: GenImageChecked() (6 input parameters)
   Param[4]: checksY (type: int)
   Param[5]: col1 (type: Color)
   Param[6]: col2 (type: Color)
-Function 243: GenImageWhiteNoise() (3 input parameters)
+Function 244: GenImageWhiteNoise() (3 input parameters)
   Name: GenImageWhiteNoise
   Return type: Image
   Description: Generate image: white noise
   Param[1]: width (type: int)
   Param[2]: height (type: int)
   Param[3]: factor (type: float)
-Function 244: GenImageCellular() (3 input parameters)
+Function 245: GenImageCellular() (3 input parameters)
   Name: GenImageCellular
   Return type: Image
   Description: Generate image: cellular algorithm, bigger tileSize means bigger cells
   Param[1]: width (type: int)
   Param[2]: height (type: int)
   Param[3]: tileSize (type: int)
-Function 245: ImageCopy() (1 input parameters)
+Function 246: ImageCopy() (1 input parameters)
   Name: ImageCopy
   Return type: Image
   Description: Create an image duplicate (useful for transformations)
   Param[1]: image (type: Image)
-Function 246: ImageFromImage() (2 input parameters)
+Function 247: ImageFromImage() (2 input parameters)
   Name: ImageFromImage
   Return type: Image
   Description: Create an image from another image piece
   Param[1]: image (type: Image)
   Param[2]: rec (type: Rectangle)
-Function 247: ImageText() (3 input parameters)
+Function 248: ImageText() (3 input parameters)
   Name: ImageText
   Return type: Image
   Description: Create an image from text (default font)
   Param[1]: text (type: const char *)
   Param[2]: fontSize (type: int)
   Param[3]: color (type: Color)
-Function 248: ImageTextEx() (5 input parameters)
+Function 249: ImageTextEx() (5 input parameters)
   Name: ImageTextEx
   Return type: Image
   Description: Create an image from text (custom sprite font)
@@ -2085,63 +2090,63 @@ Function 248: ImageTextEx() (5 input parameters)
   Param[3]: fontSize (type: float)
   Param[4]: spacing (type: float)
   Param[5]: tint (type: Color)
-Function 249: ImageFormat() (2 input parameters)
+Function 250: ImageFormat() (2 input parameters)
   Name: ImageFormat
   Return type: void
   Description: Convert image data to desired format
   Param[1]: image (type: Image *)
   Param[2]: newFormat (type: int)
-Function 250: ImageToPOT() (2 input parameters)
+Function 251: ImageToPOT() (2 input parameters)
   Name: ImageToPOT
   Return type: void
   Description: Convert image to POT (power-of-two)
   Param[1]: image (type: Image *)
   Param[2]: fill (type: Color)
-Function 251: ImageCrop() (2 input parameters)
+Function 252: ImageCrop() (2 input parameters)
   Name: ImageCrop
   Return type: void
   Description: Crop an image to a defined rectangle
   Param[1]: image (type: Image *)
   Param[2]: crop (type: Rectangle)
-Function 252: ImageAlphaCrop() (2 input parameters)
+Function 253: ImageAlphaCrop() (2 input parameters)
   Name: ImageAlphaCrop
   Return type: void
   Description: Crop image depending on alpha value
   Param[1]: image (type: Image *)
   Param[2]: threshold (type: float)
-Function 253: ImageAlphaClear() (3 input parameters)
+Function 254: ImageAlphaClear() (3 input parameters)
   Name: ImageAlphaClear
   Return type: void
   Description: Clear alpha channel to desired color
   Param[1]: image (type: Image *)
   Param[2]: color (type: Color)
   Param[3]: threshold (type: float)
-Function 254: ImageAlphaMask() (2 input parameters)
+Function 255: ImageAlphaMask() (2 input parameters)
   Name: ImageAlphaMask
   Return type: void
   Description: Apply alpha mask to image
   Param[1]: image (type: Image *)
   Param[2]: alphaMask (type: Image)
-Function 255: ImageAlphaPremultiply() (1 input parameters)
+Function 256: ImageAlphaPremultiply() (1 input parameters)
   Name: ImageAlphaPremultiply
   Return type: void
   Description: Premultiply alpha channel
   Param[1]: image (type: Image *)
-Function 256: ImageResize() (3 input parameters)
+Function 257: ImageResize() (3 input parameters)
   Name: ImageResize
   Return type: void
   Description: Resize image (Bicubic scaling algorithm)
   Param[1]: image (type: Image *)
   Param[2]: newWidth (type: int)
   Param[3]: newHeight (type: int)
-Function 257: ImageResizeNN() (3 input parameters)
+Function 258: ImageResizeNN() (3 input parameters)
   Name: ImageResizeNN
   Return type: void
   Description: Resize image (Nearest-Neighbor scaling algorithm)
   Param[1]: image (type: Image *)
   Param[2]: newWidth (type: int)
   Param[3]: newHeight (type: int)
-Function 258: ImageResizeCanvas() (6 input parameters)
+Function 259: ImageResizeCanvas() (6 input parameters)
   Name: ImageResizeCanvas
   Return type: void
   Description: Resize canvas and fill with color
@@ -2151,12 +2156,12 @@ Function 258: ImageResizeCanvas() (6 input parameters)
   Param[4]: offsetX (type: int)
   Param[5]: offsetY (type: int)
   Param[6]: fill (type: Color)
-Function 259: ImageMipmaps() (1 input parameters)
+Function 260: ImageMipmaps() (1 input parameters)
   Name: ImageMipmaps
   Return type: void
   Description: Compute all mipmap levels for a provided image
   Param[1]: image (type: Image *)
-Function 260: ImageDither() (5 input parameters)
+Function 261: ImageDither() (5 input parameters)
   Name: ImageDither
   Return type: void
   Description: Dither image data to 16bpp or lower (Floyd-Steinberg dithering)
@@ -2165,103 +2170,103 @@ Function 260: ImageDither() (5 input parameters)
   Param[3]: gBpp (type: int)
   Param[4]: bBpp (type: int)
   Param[5]: aBpp (type: int)
-Function 261: ImageFlipVertical() (1 input parameters)
+Function 262: ImageFlipVertical() (1 input parameters)
   Name: ImageFlipVertical
   Return type: void
   Description: Flip image vertically
   Param[1]: image (type: Image *)
-Function 262: ImageFlipHorizontal() (1 input parameters)
+Function 263: ImageFlipHorizontal() (1 input parameters)
   Name: ImageFlipHorizontal
   Return type: void
   Description: Flip image horizontally
   Param[1]: image (type: Image *)
-Function 263: ImageRotateCW() (1 input parameters)
+Function 264: ImageRotateCW() (1 input parameters)
   Name: ImageRotateCW
   Return type: void
   Description: Rotate image clockwise 90deg
   Param[1]: image (type: Image *)
-Function 264: ImageRotateCCW() (1 input parameters)
+Function 265: ImageRotateCCW() (1 input parameters)
   Name: ImageRotateCCW
   Return type: void
   Description: Rotate image counter-clockwise 90deg
   Param[1]: image (type: Image *)
-Function 265: ImageColorTint() (2 input parameters)
+Function 266: ImageColorTint() (2 input parameters)
   Name: ImageColorTint
   Return type: void
   Description: Modify image color: tint
   Param[1]: image (type: Image *)
   Param[2]: color (type: Color)
-Function 266: ImageColorInvert() (1 input parameters)
+Function 267: ImageColorInvert() (1 input parameters)
   Name: ImageColorInvert
   Return type: void
   Description: Modify image color: invert
   Param[1]: image (type: Image *)
-Function 267: ImageColorGrayscale() (1 input parameters)
+Function 268: ImageColorGrayscale() (1 input parameters)
   Name: ImageColorGrayscale
   Return type: void
   Description: Modify image color: grayscale
   Param[1]: image (type: Image *)
-Function 268: ImageColorContrast() (2 input parameters)
+Function 269: ImageColorContrast() (2 input parameters)
   Name: ImageColorContrast
   Return type: void
   Description: Modify image color: contrast (-100 to 100)
   Param[1]: image (type: Image *)
   Param[2]: contrast (type: float)
-Function 269: ImageColorBrightness() (2 input parameters)
+Function 270: ImageColorBrightness() (2 input parameters)
   Name: ImageColorBrightness
   Return type: void
   Description: Modify image color: brightness (-255 to 255)
   Param[1]: image (type: Image *)
   Param[2]: brightness (type: int)
-Function 270: ImageColorReplace() (3 input parameters)
+Function 271: ImageColorReplace() (3 input parameters)
   Name: ImageColorReplace
   Return type: void
   Description: Modify image color: replace color
   Param[1]: image (type: Image *)
   Param[2]: color (type: Color)
   Param[3]: replace (type: Color)
-Function 271: LoadImageColors() (1 input parameters)
+Function 272: LoadImageColors() (1 input parameters)
   Name: LoadImageColors
   Return type: Color *
   Description: Load color data from image as a Color array (RGBA - 32bit)
   Param[1]: image (type: Image)
-Function 272: LoadImagePalette() (3 input parameters)
+Function 273: LoadImagePalette() (3 input parameters)
   Name: LoadImagePalette
   Return type: Color *
   Description: Load colors palette from image as a Color array (RGBA - 32bit)
   Param[1]: image (type: Image)
   Param[2]: maxPaletteSize (type: int)
   Param[3]: colorCount (type: int *)
-Function 273: UnloadImageColors() (1 input parameters)
+Function 274: UnloadImageColors() (1 input parameters)
   Name: UnloadImageColors
   Return type: void
   Description: Unload color data loaded with LoadImageColors()
   Param[1]: colors (type: Color *)
-Function 274: UnloadImagePalette() (1 input parameters)
+Function 275: UnloadImagePalette() (1 input parameters)
   Name: UnloadImagePalette
   Return type: void
   Description: Unload colors palette loaded with LoadImagePalette()
   Param[1]: colors (type: Color *)
-Function 275: GetImageAlphaBorder() (2 input parameters)
+Function 276: GetImageAlphaBorder() (2 input parameters)
   Name: GetImageAlphaBorder
   Return type: Rectangle
   Description: Get image alpha border rectangle
   Param[1]: image (type: Image)
   Param[2]: threshold (type: float)
-Function 276: GetImageColor() (3 input parameters)
+Function 277: GetImageColor() (3 input parameters)
   Name: GetImageColor
   Return type: Color
   Description: Get image pixel color at (x, y) position
   Param[1]: image (type: Image)
   Param[2]: x (type: int)
   Param[3]: y (type: int)
-Function 277: ImageClearBackground() (2 input parameters)
+Function 278: ImageClearBackground() (2 input parameters)
   Name: ImageClearBackground
   Return type: void
   Description: Clear image background with given color
   Param[1]: dst (type: Image *)
   Param[2]: color (type: Color)
-Function 278: ImageDrawPixel() (4 input parameters)
+Function 279: ImageDrawPixel() (4 input parameters)
   Name: ImageDrawPixel
   Return type: void
   Description: Draw pixel within an image
@@ -2269,14 +2274,14 @@ Function 278: ImageDrawPixel() (4 input parameters)
   Param[2]: posX (type: int)
   Param[3]: posY (type: int)
   Param[4]: color (type: Color)
-Function 279: ImageDrawPixelV() (3 input parameters)
+Function 280: ImageDrawPixelV() (3 input parameters)
   Name: ImageDrawPixelV
   Return type: void
   Description: Draw pixel within an image (Vector version)
   Param[1]: dst (type: Image *)
   Param[2]: position (type: Vector2)
   Param[3]: color (type: Color)
-Function 280: ImageDrawLine() (6 input parameters)
+Function 281: ImageDrawLine() (6 input parameters)
   Name: ImageDrawLine
   Return type: void
   Description: Draw line within an image
@@ -2286,7 +2291,7 @@ Function 280: ImageDrawLine() (6 input parameters)
   Param[4]: endPosX (type: int)
   Param[5]: endPosY (type: int)
   Param[6]: color (type: Color)
-Function 281: ImageDrawLineV() (4 input parameters)
+Function 282: ImageDrawLineV() (4 input parameters)
   Name: ImageDrawLineV
   Return type: void
   Description: Draw line within an image (Vector version)
@@ -2294,7 +2299,7 @@ Function 281: ImageDrawLineV() (4 input parameters)
   Param[2]: start (type: Vector2)
   Param[3]: end (type: Vector2)
   Param[4]: color (type: Color)
-Function 282: ImageDrawCircle() (5 input parameters)
+Function 283: ImageDrawCircle() (5 input parameters)
   Name: ImageDrawCircle
   Return type: void
   Description: Draw circle within an image
@@ -2303,7 +2308,7 @@ Function 282: ImageDrawCircle() (5 input parameters)
   Param[3]: centerY (type: int)
   Param[4]: radius (type: int)
   Param[5]: color (type: Color)
-Function 283: ImageDrawCircleV() (4 input parameters)
+Function 284: ImageDrawCircleV() (4 input parameters)
   Name: ImageDrawCircleV
   Return type: void
   Description: Draw circle within an image (Vector version)
@@ -2311,7 +2316,7 @@ Function 283: ImageDrawCircleV() (4 input parameters)
   Param[2]: center (type: Vector2)
   Param[3]: radius (type: int)
   Param[4]: color (type: Color)
-Function 284: ImageDrawRectangle() (6 input parameters)
+Function 285: ImageDrawRectangle() (6 input parameters)
   Name: ImageDrawRectangle
   Return type: void
   Description: Draw rectangle within an image
@@ -2321,7 +2326,7 @@ Function 284: ImageDrawRectangle() (6 input parameters)
   Param[4]: width (type: int)
   Param[5]: height (type: int)
   Param[6]: color (type: Color)
-Function 285: ImageDrawRectangleV() (4 input parameters)
+Function 286: ImageDrawRectangleV() (4 input parameters)
   Name: ImageDrawRectangleV
   Return type: void
   Description: Draw rectangle within an image (Vector version)
@@ -2329,14 +2334,14 @@ Function 285: ImageDrawRectangleV() (4 input parameters)
   Param[2]: position (type: Vector2)
   Param[3]: size (type: Vector2)
   Param[4]: color (type: Color)
-Function 286: ImageDrawRectangleRec() (3 input parameters)
+Function 287: ImageDrawRectangleRec() (3 input parameters)
   Name: ImageDrawRectangleRec
   Return type: void
   Description: Draw rectangle within an image
   Param[1]: dst (type: Image *)
   Param[2]: rec (type: Rectangle)
   Param[3]: color (type: Color)
-Function 287: ImageDrawRectangleLines() (4 input parameters)
+Function 288: ImageDrawRectangleLines() (4 input parameters)
   Name: ImageDrawRectangleLines
   Return type: void
   Description: Draw rectangle lines within an image
@@ -2344,7 +2349,7 @@ Function 287: ImageDrawRectangleLines() (4 input parameters)
   Param[2]: rec (type: Rectangle)
   Param[3]: thick (type: int)
   Param[4]: color (type: Color)
-Function 288: ImageDraw() (5 input parameters)
+Function 289: ImageDraw() (5 input parameters)
   Name: ImageDraw
   Return type: void
   Description: Draw a source image within a destination image (tint applied to source)
@@ -2353,7 +2358,7 @@ Function 288: ImageDraw() (5 input parameters)
   Param[3]: srcRec (type: Rectangle)
   Param[4]: dstRec (type: Rectangle)
   Param[5]: tint (type: Color)
-Function 289: ImageDrawText() (6 input parameters)
+Function 290: ImageDrawText() (6 input parameters)
   Name: ImageDrawText
   Return type: void
   Description: Draw text (using default font) within an image (destination)
@@ -2363,7 +2368,7 @@ Function 289: ImageDrawText() (6 input parameters)
   Param[4]: posY (type: int)
   Param[5]: fontSize (type: int)
   Param[6]: color (type: Color)
-Function 290: ImageDrawTextEx() (7 input parameters)
+Function 291: ImageDrawTextEx() (7 input parameters)
   Name: ImageDrawTextEx
   Return type: void
   Description: Draw text (custom sprite font) within an image (destination)
@@ -2374,69 +2379,69 @@ Function 290: ImageDrawTextEx() (7 input parameters)
   Param[5]: fontSize (type: float)
   Param[6]: spacing (type: float)
   Param[7]: tint (type: Color)
-Function 291: LoadTexture() (1 input parameters)
+Function 292: LoadTexture() (1 input parameters)
   Name: LoadTexture
   Return type: Texture2D
   Description: Load texture from file into GPU memory (VRAM)
   Param[1]: fileName (type: const char *)
-Function 292: LoadTextureFromImage() (1 input parameters)
+Function 293: LoadTextureFromImage() (1 input parameters)
   Name: LoadTextureFromImage
   Return type: Texture2D
   Description: Load texture from image data
   Param[1]: image (type: Image)
-Function 293: LoadTextureCubemap() (2 input parameters)
+Function 294: LoadTextureCubemap() (2 input parameters)
   Name: LoadTextureCubemap
   Return type: TextureCubemap
   Description: Load cubemap from image, multiple image cubemap layouts supported
   Param[1]: image (type: Image)
   Param[2]: layout (type: int)
-Function 294: LoadRenderTexture() (2 input parameters)
+Function 295: LoadRenderTexture() (2 input parameters)
   Name: LoadRenderTexture
   Return type: RenderTexture2D
   Description: Load texture for rendering (framebuffer)
   Param[1]: width (type: int)
   Param[2]: height (type: int)
-Function 295: UnloadTexture() (1 input parameters)
+Function 296: UnloadTexture() (1 input parameters)
   Name: UnloadTexture
   Return type: void
   Description: Unload texture from GPU memory (VRAM)
   Param[1]: texture (type: Texture2D)
-Function 296: UnloadRenderTexture() (1 input parameters)
+Function 297: UnloadRenderTexture() (1 input parameters)
   Name: UnloadRenderTexture
   Return type: void
   Description: Unload render texture from GPU memory (VRAM)
   Param[1]: target (type: RenderTexture2D)
-Function 297: UpdateTexture() (2 input parameters)
+Function 298: UpdateTexture() (2 input parameters)
   Name: UpdateTexture
   Return type: void
   Description: Update GPU texture with new data
   Param[1]: texture (type: Texture2D)
   Param[2]: pixels (type: const void *)
-Function 298: UpdateTextureRec() (3 input parameters)
+Function 299: UpdateTextureRec() (3 input parameters)
   Name: UpdateTextureRec
   Return type: void
   Description: Update GPU texture rectangle with new data
   Param[1]: texture (type: Texture2D)
   Param[2]: rec (type: Rectangle)
   Param[3]: pixels (type: const void *)
-Function 299: GenTextureMipmaps() (1 input parameters)
+Function 300: GenTextureMipmaps() (1 input parameters)
   Name: GenTextureMipmaps
   Return type: void
   Description: Generate GPU mipmaps for a texture
   Param[1]: texture (type: Texture2D *)
-Function 300: SetTextureFilter() (2 input parameters)
+Function 301: SetTextureFilter() (2 input parameters)
   Name: SetTextureFilter
   Return type: void
   Description: Set texture scaling filter mode
   Param[1]: texture (type: Texture2D)
   Param[2]: filter (type: int)
-Function 301: SetTextureWrap() (2 input parameters)
+Function 302: SetTextureWrap() (2 input parameters)
   Name: SetTextureWrap
   Return type: void
   Description: Set texture wrapping mode
   Param[1]: texture (type: Texture2D)
   Param[2]: wrap (type: int)
-Function 302: DrawTexture() (4 input parameters)
+Function 303: DrawTexture() (4 input parameters)
   Name: DrawTexture
   Return type: void
   Description: Draw a Texture2D
@@ -2444,14 +2449,14 @@ Function 302: DrawTexture() (4 input parameters)
   Param[2]: posX (type: int)
   Param[3]: posY (type: int)
   Param[4]: tint (type: Color)
-Function 303: DrawTextureV() (3 input parameters)
+Function 304: DrawTextureV() (3 input parameters)
   Name: DrawTextureV
   Return type: void
   Description: Draw a Texture2D with position defined as Vector2
   Param[1]: texture (type: Texture2D)
   Param[2]: position (type: Vector2)
   Param[3]: tint (type: Color)
-Function 304: DrawTextureEx() (5 input parameters)
+Function 305: DrawTextureEx() (5 input parameters)
   Name: DrawTextureEx
   Return type: void
   Description: Draw a Texture2D with extended parameters
@@ -2460,7 +2465,7 @@ Function 304: DrawTextureEx() (5 input parameters)
   Param[3]: rotation (type: float)
   Param[4]: scale (type: float)
   Param[5]: tint (type: Color)
-Function 305: DrawTextureRec() (4 input parameters)
+Function 306: DrawTextureRec() (4 input parameters)
   Name: DrawTextureRec
   Return type: void
   Description: Draw a part of a texture defined by a rectangle
@@ -2468,7 +2473,7 @@ Function 305: DrawTextureRec() (4 input parameters)
   Param[2]: source (type: Rectangle)
   Param[3]: position (type: Vector2)
   Param[4]: tint (type: Color)
-Function 306: DrawTextureQuad() (5 input parameters)
+Function 307: DrawTextureQuad() (5 input parameters)
   Name: DrawTextureQuad
   Return type: void
   Description: Draw texture quad with tiling and offset parameters
@@ -2477,7 +2482,7 @@ Function 306: DrawTextureQuad() (5 input parameters)
   Param[3]: offset (type: Vector2)
   Param[4]: quad (type: Rectangle)
   Param[5]: tint (type: Color)
-Function 307: DrawTextureTiled() (7 input parameters)
+Function 308: DrawTextureTiled() (7 input parameters)
   Name: DrawTextureTiled
   Return type: void
   Description: Draw part of a texture (defined by a rectangle) with rotation and scale tiled into dest.
@@ -2488,7 +2493,7 @@ Function 307: DrawTextureTiled() (7 input parameters)
   Param[5]: rotation (type: float)
   Param[6]: scale (type: float)
   Param[7]: tint (type: Color)
-Function 308: DrawTexturePro() (6 input parameters)
+Function 309: DrawTexturePro() (6 input parameters)
   Name: DrawTexturePro
   Return type: void
   Description: Draw a part of a texture defined by a rectangle with 'pro' parameters
@@ -2498,7 +2503,7 @@ Function 308: DrawTexturePro() (6 input parameters)
   Param[4]: origin (type: Vector2)
   Param[5]: rotation (type: float)
   Param[6]: tint (type: Color)
-Function 309: DrawTextureNPatch() (6 input parameters)
+Function 310: DrawTextureNPatch() (6 input parameters)
   Name: DrawTextureNPatch
   Return type: void
   Description: Draws a texture (or part of it) that stretches or shrinks nicely
@@ -2508,7 +2513,7 @@ Function 309: DrawTextureNPatch() (6 input parameters)
   Param[4]: origin (type: Vector2)
   Param[5]: rotation (type: float)
   Param[6]: tint (type: Color)
-Function 310: DrawTexturePoly() (6 input parameters)
+Function 311: DrawTexturePoly() (6 input parameters)
   Name: DrawTexturePoly
   Return type: void
   Description: Draw a textured polygon
@@ -2518,103 +2523,103 @@ Function 310: DrawTexturePoly() (6 input parameters)
   Param[4]: texcoords (type: Vector2 *)
   Param[5]: pointCount (type: int)
   Param[6]: tint (type: Color)
-Function 311: Fade() (2 input parameters)
+Function 312: Fade() (2 input parameters)
   Name: Fade
   Return type: Color
   Description: Get color with alpha applied, alpha goes from 0.0f to 1.0f
   Param[1]: color (type: Color)
   Param[2]: alpha (type: float)
-Function 312: ColorToInt() (1 input parameters)
+Function 313: ColorToInt() (1 input parameters)
   Name: ColorToInt
   Return type: int
   Description: Get hexadecimal value for a Color
   Param[1]: color (type: Color)
-Function 313: ColorNormalize() (1 input parameters)
+Function 314: ColorNormalize() (1 input parameters)
   Name: ColorNormalize
   Return type: Vector4
   Description: Get Color normalized as float [0..1]
   Param[1]: color (type: Color)
-Function 314: ColorFromNormalized() (1 input parameters)
+Function 315: ColorFromNormalized() (1 input parameters)
   Name: ColorFromNormalized
   Return type: Color
   Description: Get Color from normalized values [0..1]
   Param[1]: normalized (type: Vector4)
-Function 315: ColorToHSV() (1 input parameters)
+Function 316: ColorToHSV() (1 input parameters)
   Name: ColorToHSV
   Return type: Vector3
   Description: Get HSV values for a Color, hue [0..360], saturation/value [0..1]
   Param[1]: color (type: Color)
-Function 316: ColorFromHSV() (3 input parameters)
+Function 317: ColorFromHSV() (3 input parameters)
   Name: ColorFromHSV
   Return type: Color
   Description: Get a Color from HSV values, hue [0..360], saturation/value [0..1]
   Param[1]: hue (type: float)
   Param[2]: saturation (type: float)
   Param[3]: value (type: float)
-Function 317: ColorAlpha() (2 input parameters)
+Function 318: ColorAlpha() (2 input parameters)
   Name: ColorAlpha
   Return type: Color
   Description: Get color with alpha applied, alpha goes from 0.0f to 1.0f
   Param[1]: color (type: Color)
   Param[2]: alpha (type: float)
-Function 318: ColorAlphaBlend() (3 input parameters)
+Function 319: ColorAlphaBlend() (3 input parameters)
   Name: ColorAlphaBlend
   Return type: Color
   Description: Get src alpha-blended into dst color with tint
   Param[1]: dst (type: Color)
   Param[2]: src (type: Color)
   Param[3]: tint (type: Color)
-Function 319: GetColor() (1 input parameters)
+Function 320: GetColor() (1 input parameters)
   Name: GetColor
   Return type: Color
   Description: Get Color structure from hexadecimal value
   Param[1]: hexValue (type: unsigned int)
-Function 320: GetPixelColor() (2 input parameters)
+Function 321: GetPixelColor() (2 input parameters)
   Name: GetPixelColor
   Return type: Color
   Description: Get Color from a source pixel pointer of certain format
   Param[1]: srcPtr (type: void *)
   Param[2]: format (type: int)
-Function 321: SetPixelColor() (3 input parameters)
+Function 322: SetPixelColor() (3 input parameters)
   Name: SetPixelColor
   Return type: void
   Description: Set color formatted into destination pixel pointer
   Param[1]: dstPtr (type: void *)
   Param[2]: color (type: Color)
   Param[3]: format (type: int)
-Function 322: GetPixelDataSize() (3 input parameters)
+Function 323: GetPixelDataSize() (3 input parameters)
   Name: GetPixelDataSize
   Return type: int
   Description: Get pixel data size in bytes for certain format
   Param[1]: width (type: int)
   Param[2]: height (type: int)
   Param[3]: format (type: int)
-Function 323: GetFontDefault() (0 input parameters)
+Function 324: GetFontDefault() (0 input parameters)
   Name: GetFontDefault
   Return type: Font
   Description: Get the default Font
   No input parameters
-Function 324: LoadFont() (1 input parameters)
+Function 325: LoadFont() (1 input parameters)
   Name: LoadFont
   Return type: Font
   Description: Load font from file into GPU memory (VRAM)
   Param[1]: fileName (type: const char *)
-Function 325: LoadFontEx() (4 input parameters)
+Function 326: LoadFontEx() (4 input parameters)
   Name: LoadFontEx
   Return type: Font
-  Description: Load font from file with extended parameters
+  Description: Load font from file with extended parameters, use NULL for fontChars and 0 for glyphCount to load the default character set
   Param[1]: fileName (type: const char *)
   Param[2]: fontSize (type: int)
   Param[3]: fontChars (type: int *)
   Param[4]: glyphCount (type: int)
-Function 326: LoadFontFromImage() (3 input parameters)
+Function 327: LoadFontFromImage() (3 input parameters)
   Name: LoadFontFromImage
   Return type: Font
   Description: Load font from Image (XNA style)
   Param[1]: image (type: Image)
   Param[2]: key (type: Color)
   Param[3]: firstChar (type: int)
-Function 327: LoadFontFromMemory() (6 input parameters)
+Function 328: LoadFontFromMemory() (6 input parameters)
   Name: LoadFontFromMemory
   Return type: Font
   Description: Load font from memory buffer, fileType refers to extension: i.e. '.ttf'
@@ -2624,7 +2629,7 @@ Function 327: LoadFontFromMemory() (6 input parameters)
   Param[4]: fontSize (type: int)
   Param[5]: fontChars (type: int *)
   Param[6]: glyphCount (type: int)
-Function 328: LoadFontData() (6 input parameters)
+Function 329: LoadFontData() (6 input parameters)
   Name: LoadFontData
   Return type: GlyphInfo *
   Description: Load font data for further use
@@ -2634,7 +2639,7 @@ Function 328: LoadFontData() (6 input parameters)
   Param[4]: fontChars (type: int *)
   Param[5]: glyphCount (type: int)
   Param[6]: type (type: int)
-Function 329: GenImageFontAtlas() (6 input parameters)
+Function 330: GenImageFontAtlas() (6 input parameters)
   Name: GenImageFontAtlas
   Return type: Image
   Description: Generate image font atlas using chars info
@@ -2644,24 +2649,30 @@ Function 329: GenImageFontAtlas() (6 input parameters)
   Param[4]: fontSize (type: int)
   Param[5]: padding (type: int)
   Param[6]: packMethod (type: int)
-Function 330: UnloadFontData() (2 input parameters)
+Function 331: UnloadFontData() (2 input parameters)
   Name: UnloadFontData
   Return type: void
   Description: Unload font chars info data (RAM)
   Param[1]: chars (type: GlyphInfo *)
   Param[2]: glyphCount (type: int)
-Function 331: UnloadFont() (1 input parameters)
+Function 332: UnloadFont() (1 input parameters)
   Name: UnloadFont
   Return type: void
-  Description: Unload Font from GPU memory (VRAM)
+  Description: Unload font from GPU memory (VRAM)
   Param[1]: font (type: Font)
-Function 332: DrawFPS() (2 input parameters)
+Function 333: ExportFontAsCode() (2 input parameters)
+  Name: ExportFontAsCode
+  Return type: bool
+  Description: Export font as code file, returns true on success
+  Param[1]: font (type: Font)
+  Param[2]: fileName (type: const char *)
+Function 334: DrawFPS() (2 input parameters)
   Name: DrawFPS
   Return type: void
   Description: Draw current FPS
   Param[1]: posX (type: int)
   Param[2]: posY (type: int)
-Function 333: DrawText() (5 input parameters)
+Function 335: DrawText() (5 input parameters)
   Name: DrawText
   Return type: void
   Description: Draw text (using default font)
@@ -2670,7 +2681,7 @@ Function 333: DrawText() (5 input parameters)
   Param[3]: posY (type: int)
   Param[4]: fontSize (type: int)
   Param[5]: color (type: Color)
-Function 334: DrawTextEx() (6 input parameters)
+Function 336: DrawTextEx() (6 input parameters)
   Name: DrawTextEx
   Return type: void
   Description: Draw text using font and additional parameters
@@ -2680,7 +2691,7 @@ Function 334: DrawTextEx() (6 input parameters)
   Param[4]: fontSize (type: float)
   Param[5]: spacing (type: float)
   Param[6]: tint (type: Color)
-Function 335: DrawTextPro() (8 input parameters)
+Function 337: DrawTextPro() (8 input parameters)
   Name: DrawTextPro
   Return type: void
   Description: Draw text using Font and pro parameters (rotation)
@@ -2692,7 +2703,7 @@ Function 335: DrawTextPro() (8 input parameters)
   Param[6]: fontSize (type: float)
   Param[7]: spacing (type: float)
   Param[8]: tint (type: Color)
-Function 336: DrawTextCodepoint() (5 input parameters)
+Function 338: DrawTextCodepoint() (5 input parameters)
   Name: DrawTextCodepoint
   Return type: void
   Description: Draw one character (codepoint)
@@ -2701,13 +2712,13 @@ Function 336: DrawTextCodepoint() (5 input parameters)
   Param[3]: position (type: Vector2)
   Param[4]: fontSize (type: float)
   Param[5]: tint (type: Color)
-Function 337: MeasureText() (2 input parameters)
+Function 339: MeasureText() (2 input parameters)
   Name: MeasureText
   Return type: int
   Description: Measure string width for default font
   Param[1]: text (type: const char *)
   Param[2]: fontSize (type: int)
-Function 338: MeasureTextEx() (4 input parameters)
+Function 340: MeasureTextEx() (4 input parameters)
   Name: MeasureTextEx
   Return type: Vector2
   Description: Measure string size for Font
@@ -2715,163 +2726,163 @@ Function 338: MeasureTextEx() (4 input parameters)
   Param[2]: text (type: const char *)
   Param[3]: fontSize (type: float)
   Param[4]: spacing (type: float)
-Function 339: GetGlyphIndex() (2 input parameters)
+Function 341: GetGlyphIndex() (2 input parameters)
   Name: GetGlyphIndex
   Return type: int
   Description: Get glyph index position in font for a codepoint (unicode character), fallback to '?' if not found
   Param[1]: font (type: Font)
   Param[2]: codepoint (type: int)
-Function 340: GetGlyphInfo() (2 input parameters)
+Function 342: GetGlyphInfo() (2 input parameters)
   Name: GetGlyphInfo
   Return type: GlyphInfo
   Description: Get glyph font info data for a codepoint (unicode character), fallback to '?' if not found
   Param[1]: font (type: Font)
   Param[2]: codepoint (type: int)
-Function 341: GetGlyphAtlasRec() (2 input parameters)
+Function 343: GetGlyphAtlasRec() (2 input parameters)
   Name: GetGlyphAtlasRec
   Return type: Rectangle
   Description: Get glyph rectangle in font atlas for a codepoint (unicode character), fallback to '?' if not found
   Param[1]: font (type: Font)
   Param[2]: codepoint (type: int)
-Function 342: LoadCodepoints() (2 input parameters)
+Function 344: LoadCodepoints() (2 input parameters)
   Name: LoadCodepoints
   Return type: int *
   Description: Load all codepoints from a UTF-8 text string, codepoints count returned by parameter
   Param[1]: text (type: const char *)
   Param[2]: count (type: int *)
-Function 343: UnloadCodepoints() (1 input parameters)
+Function 345: UnloadCodepoints() (1 input parameters)
   Name: UnloadCodepoints
   Return type: void
   Description: Unload codepoints data from memory
   Param[1]: codepoints (type: int *)
-Function 344: GetCodepointCount() (1 input parameters)
+Function 346: GetCodepointCount() (1 input parameters)
   Name: GetCodepointCount
   Return type: int
   Description: Get total number of codepoints in a UTF-8 encoded string
   Param[1]: text (type: const char *)
-Function 345: GetCodepoint() (2 input parameters)
+Function 347: GetCodepoint() (2 input parameters)
   Name: GetCodepoint
   Return type: int
   Description: Get next codepoint in a UTF-8 encoded string, 0x3f('?') is returned on failure
   Param[1]: text (type: const char *)
   Param[2]: bytesProcessed (type: int *)
-Function 346: CodepointToUTF8() (2 input parameters)
+Function 348: CodepointToUTF8() (2 input parameters)
   Name: CodepointToUTF8
   Return type: const char *
   Description: Encode one codepoint into UTF-8 byte array (array length returned as parameter)
   Param[1]: codepoint (type: int)
   Param[2]: byteSize (type: int *)
-Function 347: TextCodepointsToUTF8() (2 input parameters)
+Function 349: TextCodepointsToUTF8() (2 input parameters)
   Name: TextCodepointsToUTF8
   Return type: char *
   Description: Encode text as codepoints array into UTF-8 text string (WARNING: memory must be freed!)
   Param[1]: codepoints (type: int *)
   Param[2]: length (type: int)
-Function 348: TextCopy() (2 input parameters)
+Function 350: TextCopy() (2 input parameters)
   Name: TextCopy
   Return type: int
   Description: Copy one string to another, returns bytes copied
   Param[1]: dst (type: char *)
   Param[2]: src (type: const char *)
-Function 349: TextIsEqual() (2 input parameters)
+Function 351: TextIsEqual() (2 input parameters)
   Name: TextIsEqual
   Return type: bool
   Description: Check if two text string are equal
   Param[1]: text1 (type: const char *)
   Param[2]: text2 (type: const char *)
-Function 350: TextLength() (1 input parameters)
+Function 352: TextLength() (1 input parameters)
   Name: TextLength
   Return type: unsigned int
   Description: Get text length, checks for '\0' ending
   Param[1]: text (type: const char *)
-Function 351: TextFormat() (2 input parameters)
+Function 353: TextFormat() (2 input parameters)
   Name: TextFormat
   Return type: const char *
   Description: Text formatting with variables (sprintf() style)
   Param[1]: text (type: const char *)
   Param[2]:  (type: )
-Function 352: TextSubtext() (3 input parameters)
+Function 354: TextSubtext() (3 input parameters)
   Name: TextSubtext
   Return type: const char *
   Description: Get a piece of a text string
   Param[1]: text (type: const char *)
   Param[2]: position (type: int)
   Param[3]: length (type: int)
-Function 353: TextReplace() (3 input parameters)
+Function 355: TextReplace() (3 input parameters)
   Name: TextReplace
   Return type: char *
   Description: Replace text string (WARNING: memory must be freed!)
   Param[1]: text (type: char *)
   Param[2]: replace (type: const char *)
   Param[3]: by (type: const char *)
-Function 354: TextInsert() (3 input parameters)
+Function 356: TextInsert() (3 input parameters)
   Name: TextInsert
   Return type: char *
   Description: Insert text in a position (WARNING: memory must be freed!)
   Param[1]: text (type: const char *)
   Param[2]: insert (type: const char *)
   Param[3]: position (type: int)
-Function 355: TextJoin() (3 input parameters)
+Function 357: TextJoin() (3 input parameters)
   Name: TextJoin
   Return type: const char *
   Description: Join text strings with delimiter
   Param[1]: textList (type: const char **)
   Param[2]: count (type: int)
   Param[3]: delimiter (type: const char *)
-Function 356: TextSplit() (3 input parameters)
+Function 358: TextSplit() (3 input parameters)
   Name: TextSplit
   Return type: const char **
   Description: Split text into multiple strings
   Param[1]: text (type: const char *)
   Param[2]: delimiter (type: char)
   Param[3]: count (type: int *)
-Function 357: TextAppend() (3 input parameters)
+Function 359: TextAppend() (3 input parameters)
   Name: TextAppend
   Return type: void
   Description: Append text at specific position and move cursor!
   Param[1]: text (type: char *)
   Param[2]: append (type: const char *)
   Param[3]: position (type: int *)
-Function 358: TextFindIndex() (2 input parameters)
+Function 360: TextFindIndex() (2 input parameters)
   Name: TextFindIndex
   Return type: int
   Description: Find first text occurrence within a string
   Param[1]: text (type: const char *)
   Param[2]: find (type: const char *)
-Function 359: TextToUpper() (1 input parameters)
+Function 361: TextToUpper() (1 input parameters)
   Name: TextToUpper
   Return type: const char *
   Description: Get upper case version of provided string
   Param[1]: text (type: const char *)
-Function 360: TextToLower() (1 input parameters)
+Function 362: TextToLower() (1 input parameters)
   Name: TextToLower
   Return type: const char *
   Description: Get lower case version of provided string
   Param[1]: text (type: const char *)
-Function 361: TextToPascal() (1 input parameters)
+Function 363: TextToPascal() (1 input parameters)
   Name: TextToPascal
   Return type: const char *
   Description: Get Pascal case notation version of provided string
   Param[1]: text (type: const char *)
-Function 362: TextToInteger() (1 input parameters)
+Function 364: TextToInteger() (1 input parameters)
   Name: TextToInteger
   Return type: int
   Description: Get integer value from text (negative values not supported)
   Param[1]: text (type: const char *)
-Function 363: DrawLine3D() (3 input parameters)
+Function 365: DrawLine3D() (3 input parameters)
   Name: DrawLine3D
   Return type: void
   Description: Draw a line in 3D world space
   Param[1]: startPos (type: Vector3)
   Param[2]: endPos (type: Vector3)
   Param[3]: color (type: Color)
-Function 364: DrawPoint3D() (2 input parameters)
+Function 366: DrawPoint3D() (2 input parameters)
   Name: DrawPoint3D
   Return type: void
   Description: Draw a point in 3D space, actually a small line
   Param[1]: position (type: Vector3)
   Param[2]: color (type: Color)
-Function 365: DrawCircle3D() (5 input parameters)
+Function 367: DrawCircle3D() (5 input parameters)
   Name: DrawCircle3D
   Return type: void
   Description: Draw a circle in 3D world space
@@ -2880,7 +2891,7 @@ Function 365: DrawCircle3D() (5 input parameters)
   Param[3]: rotationAxis (type: Vector3)
   Param[4]: rotationAngle (type: float)
   Param[5]: color (type: Color)
-Function 366: DrawTriangle3D() (4 input parameters)
+Function 368: DrawTriangle3D() (4 input parameters)
   Name: DrawTriangle3D
   Return type: void
   Description: Draw a color-filled triangle (vertex in counter-clockwise order!)
@@ -2888,14 +2899,14 @@ Function 366: DrawTriangle3D() (4 input parameters)
   Param[2]: v2 (type: Vector3)
   Param[3]: v3 (type: Vector3)
   Param[4]: color (type: Color)
-Function 367: DrawTriangleStrip3D() (3 input parameters)
+Function 369: DrawTriangleStrip3D() (3 input parameters)
   Name: DrawTriangleStrip3D
   Return type: void
   Description: Draw a triangle strip defined by points
   Param[1]: points (type: Vector3 *)
   Param[2]: pointCount (type: int)
   Param[3]: color (type: Color)
-Function 368: DrawCube() (5 input parameters)
+Function 370: DrawCube() (5 input parameters)
   Name: DrawCube
   Return type: void
   Description: Draw cube
@@ -2904,14 +2915,14 @@ Function 368: DrawCube() (5 input parameters)
   Param[3]: height (type: float)
   Param[4]: length (type: float)
   Param[5]: color (type: Color)
-Function 369: DrawCubeV() (3 input parameters)
+Function 371: DrawCubeV() (3 input parameters)
   Name: DrawCubeV
   Return type: void
   Description: Draw cube (Vector version)
   Param[1]: position (type: Vector3)
   Param[2]: size (type: Vector3)
   Param[3]: color (type: Color)
-Function 370: DrawCubeWires() (5 input parameters)
+Function 372: DrawCubeWires() (5 input parameters)
   Name: DrawCubeWires
   Return type: void
   Description: Draw cube wires
@@ -2920,14 +2931,14 @@ Function 370: DrawCubeWires() (5 input parameters)
   Param[3]: height (type: float)
   Param[4]: length (type: float)
   Param[5]: color (type: Color)
-Function 371: DrawCubeWiresV() (3 input parameters)
+Function 373: DrawCubeWiresV() (3 input parameters)
   Name: DrawCubeWiresV
   Return type: void
   Description: Draw cube wires (Vector version)
   Param[1]: position (type: Vector3)
   Param[2]: size (type: Vector3)
   Param[3]: color (type: Color)
-Function 372: DrawCubeTexture() (6 input parameters)
+Function 374: DrawCubeTexture() (6 input parameters)
   Name: DrawCubeTexture
   Return type: void
   Description: Draw cube textured
@@ -2937,7 +2948,7 @@ Function 372: DrawCubeTexture() (6 input parameters)
   Param[4]: height (type: float)
   Param[5]: length (type: float)
   Param[6]: color (type: Color)
-Function 373: DrawCubeTextureRec() (7 input parameters)
+Function 375: DrawCubeTextureRec() (7 input parameters)
   Name: DrawCubeTextureRec
   Return type: void
   Description: Draw cube with a region of a texture
@@ -2948,14 +2959,14 @@ Function 373: DrawCubeTextureRec() (7 input parameters)
   Param[5]: height (type: float)
   Param[6]: length (type: float)
   Param[7]: color (type: Color)
-Function 374: DrawSphere() (3 input parameters)
+Function 376: DrawSphere() (3 input parameters)
   Name: DrawSphere
   Return type: void
   Description: Draw sphere
   Param[1]: centerPos (type: Vector3)
   Param[2]: radius (type: float)
   Param[3]: color (type: Color)
-Function 375: DrawSphereEx() (5 input parameters)
+Function 377: DrawSphereEx() (5 input parameters)
   Name: DrawSphereEx
   Return type: void
   Description: Draw sphere with extended parameters
@@ -2964,7 +2975,7 @@ Function 375: DrawSphereEx() (5 input parameters)
   Param[3]: rings (type: int)
   Param[4]: slices (type: int)
   Param[5]: color (type: Color)
-Function 376: DrawSphereWires() (5 input parameters)
+Function 378: DrawSphereWires() (5 input parameters)
   Name: DrawSphereWires
   Return type: void
   Description: Draw sphere wires
@@ -2973,7 +2984,7 @@ Function 376: DrawSphereWires() (5 input parameters)
   Param[3]: rings (type: int)
   Param[4]: slices (type: int)
   Param[5]: color (type: Color)
-Function 377: DrawCylinder() (6 input parameters)
+Function 379: DrawCylinder() (6 input parameters)
   Name: DrawCylinder
   Return type: void
   Description: Draw a cylinder/cone
@@ -2983,7 +2994,7 @@ Function 377: DrawCylinder() (6 input parameters)
   Param[4]: height (type: float)
   Param[5]: slices (type: int)
   Param[6]: color (type: Color)
-Function 378: DrawCylinderEx() (6 input parameters)
+Function 380: DrawCylinderEx() (6 input parameters)
   Name: DrawCylinderEx
   Return type: void
   Description: Draw a cylinder with base at startPos and top at endPos
@@ -2993,7 +3004,7 @@ Function 378: DrawCylinderEx() (6 input parameters)
   Param[4]: endRadius (type: float)
   Param[5]: sides (type: int)
   Param[6]: color (type: Color)
-Function 379: DrawCylinderWires() (6 input parameters)
+Function 381: DrawCylinderWires() (6 input parameters)
   Name: DrawCylinderWires
   Return type: void
   Description: Draw a cylinder/cone wires
@@ -3003,7 +3014,7 @@ Function 379: DrawCylinderWires() (6 input parameters)
   Param[4]: height (type: float)
   Param[5]: slices (type: int)
   Param[6]: color (type: Color)
-Function 380: DrawCylinderWiresEx() (6 input parameters)
+Function 382: DrawCylinderWiresEx() (6 input parameters)
   Name: DrawCylinderWiresEx
   Return type: void
   Description: Draw a cylinder wires with base at startPos and top at endPos
@@ -3013,51 +3024,51 @@ Function 380: DrawCylinderWiresEx() (6 input parameters)
   Param[4]: endRadius (type: float)
   Param[5]: sides (type: int)
   Param[6]: color (type: Color)
-Function 381: DrawPlane() (3 input parameters)
+Function 383: DrawPlane() (3 input parameters)
   Name: DrawPlane
   Return type: void
   Description: Draw a plane XZ
   Param[1]: centerPos (type: Vector3)
   Param[2]: size (type: Vector2)
   Param[3]: color (type: Color)
-Function 382: DrawRay() (2 input parameters)
+Function 384: DrawRay() (2 input parameters)
   Name: DrawRay
   Return type: void
   Description: Draw a ray line
   Param[1]: ray (type: Ray)
   Param[2]: color (type: Color)
-Function 383: DrawGrid() (2 input parameters)
+Function 385: DrawGrid() (2 input parameters)
   Name: DrawGrid
   Return type: void
   Description: Draw a grid (centered at (0, 0, 0))
   Param[1]: slices (type: int)
   Param[2]: spacing (type: float)
-Function 384: LoadModel() (1 input parameters)
+Function 386: LoadModel() (1 input parameters)
   Name: LoadModel
   Return type: Model
   Description: Load model from files (meshes and materials)
   Param[1]: fileName (type: const char *)
-Function 385: LoadModelFromMesh() (1 input parameters)
+Function 387: LoadModelFromMesh() (1 input parameters)
   Name: LoadModelFromMesh
   Return type: Model
   Description: Load model from generated mesh (default material)
   Param[1]: mesh (type: Mesh)
-Function 386: UnloadModel() (1 input parameters)
+Function 388: UnloadModel() (1 input parameters)
   Name: UnloadModel
   Return type: void
   Description: Unload model (including meshes) from memory (RAM and/or VRAM)
   Param[1]: model (type: Model)
-Function 387: UnloadModelKeepMeshes() (1 input parameters)
+Function 389: UnloadModelKeepMeshes() (1 input parameters)
   Name: UnloadModelKeepMeshes
   Return type: void
   Description: Unload model (but not meshes) from memory (RAM and/or VRAM)
   Param[1]: model (type: Model)
-Function 388: GetModelBoundingBox() (1 input parameters)
+Function 390: GetModelBoundingBox() (1 input parameters)
   Name: GetModelBoundingBox
   Return type: BoundingBox
   Description: Compute model bounding box limits (considers all meshes)
   Param[1]: model (type: Model)
-Function 389: DrawModel() (4 input parameters)
+Function 391: DrawModel() (4 input parameters)
   Name: DrawModel
   Return type: void
   Description: Draw a model (with texture if set)
@@ -3065,7 +3076,7 @@ Function 389: DrawModel() (4 input parameters)
   Param[2]: position (type: Vector3)
   Param[3]: scale (type: float)
   Param[4]: tint (type: Color)
-Function 390: DrawModelEx() (6 input parameters)
+Function 392: DrawModelEx() (6 input parameters)
   Name: DrawModelEx
   Return type: void
   Description: Draw a model with extended parameters
@@ -3075,7 +3086,7 @@ Function 390: DrawModelEx() (6 input parameters)
   Param[4]: rotationAngle (type: float)
   Param[5]: scale (type: Vector3)
   Param[6]: tint (type: Color)
-Function 391: DrawModelWires() (4 input parameters)
+Function 393: DrawModelWires() (4 input parameters)
   Name: DrawModelWires
   Return type: void
   Description: Draw a model wires (with texture if set)
@@ -3083,7 +3094,7 @@ Function 391: DrawModelWires() (4 input parameters)
   Param[2]: position (type: Vector3)
   Param[3]: scale (type: float)
   Param[4]: tint (type: Color)
-Function 392: DrawModelWiresEx() (6 input parameters)
+Function 394: DrawModelWiresEx() (6 input parameters)
   Name: DrawModelWiresEx
   Return type: void
   Description: Draw a model wires (with texture if set) with extended parameters
@@ -3093,13 +3104,13 @@ Function 392: DrawModelWiresEx() (6 input parameters)
   Param[4]: rotationAngle (type: float)
   Param[5]: scale (type: Vector3)
   Param[6]: tint (type: Color)
-Function 393: DrawBoundingBox() (2 input parameters)
+Function 395: DrawBoundingBox() (2 input parameters)
   Name: DrawBoundingBox
   Return type: void
   Description: Draw bounding box (wires)
   Param[1]: box (type: BoundingBox)
   Param[2]: color (type: Color)
-Function 394: DrawBillboard() (5 input parameters)
+Function 396: DrawBillboard() (5 input parameters)
   Name: DrawBillboard
   Return type: void
   Description: Draw a billboard texture
@@ -3108,7 +3119,7 @@ Function 394: DrawBillboard() (5 input parameters)
   Param[3]: position (type: Vector3)
   Param[4]: size (type: float)
   Param[5]: tint (type: Color)
-Function 395: DrawBillboardRec() (6 input parameters)
+Function 397: DrawBillboardRec() (6 input parameters)
   Name: DrawBillboardRec
   Return type: void
   Description: Draw a billboard texture defined by source
@@ -3118,7 +3129,7 @@ Function 395: DrawBillboardRec() (6 input parameters)
   Param[4]: position (type: Vector3)
   Param[5]: size (type: Vector2)
   Param[6]: tint (type: Color)
-Function 396: DrawBillboardPro() (9 input parameters)
+Function 398: DrawBillboardPro() (9 input parameters)
   Name: DrawBillboardPro
   Return type: void
   Description: Draw a billboard texture defined by source and rotation
@@ -3131,13 +3142,13 @@ Function 396: DrawBillboardPro() (9 input parameters)
   Param[7]: origin (type: Vector2)
   Param[8]: rotation (type: float)
   Param[9]: tint (type: Color)
-Function 397: UploadMesh() (2 input parameters)
+Function 399: UploadMesh() (2 input parameters)
   Name: UploadMesh
   Return type: void
   Description: Upload mesh vertex data in GPU and provide VAO/VBO ids
   Param[1]: mesh (type: Mesh *)
   Param[2]: dynamic (type: bool)
-Function 398: UpdateMeshBuffer() (5 input parameters)
+Function 400: UpdateMeshBuffer() (5 input parameters)
   Name: UpdateMeshBuffer
   Return type: void
   Description: Update mesh vertex data in GPU for a specific buffer index
@@ -3146,19 +3157,19 @@ Function 398: UpdateMeshBuffer() (5 input parameters)
   Param[3]: data (type: void *)
   Param[4]: dataSize (type: int)
   Param[5]: offset (type: int)
-Function 399: UnloadMesh() (1 input parameters)
+Function 401: UnloadMesh() (1 input parameters)
   Name: UnloadMesh
   Return type: void
   Description: Unload mesh data from CPU and GPU
   Param[1]: mesh (type: Mesh)
-Function 400: DrawMesh() (3 input parameters)
+Function 402: DrawMesh() (3 input parameters)
   Name: DrawMesh
   Return type: void
   Description: Draw a 3d mesh with material and transform
   Param[1]: mesh (type: Mesh)
   Param[2]: material (type: Material)
   Param[3]: transform (type: Matrix)
-Function 401: DrawMeshInstanced() (4 input parameters)
+Function 403: DrawMeshInstanced() (4 input parameters)
   Name: DrawMeshInstanced
   Return type: void
   Description: Draw multiple mesh instances with material and different transforms
@@ -3166,34 +3177,34 @@ Function 401: DrawMeshInstanced() (4 input parameters)
   Param[2]: material (type: Material)
   Param[3]: transforms (type: Matrix *)
   Param[4]: instances (type: int)
-Function 402: ExportMesh() (2 input parameters)
+Function 404: ExportMesh() (2 input parameters)
   Name: ExportMesh
   Return type: bool
   Description: Export mesh data to file, returns true on success
   Param[1]: mesh (type: Mesh)
   Param[2]: fileName (type: const char *)
-Function 403: GetMeshBoundingBox() (1 input parameters)
+Function 405: GetMeshBoundingBox() (1 input parameters)
   Name: GetMeshBoundingBox
   Return type: BoundingBox
   Description: Compute mesh bounding box limits
   Param[1]: mesh (type: Mesh)
-Function 404: GenMeshTangents() (1 input parameters)
+Function 406: GenMeshTangents() (1 input parameters)
   Name: GenMeshTangents
   Return type: void
   Description: Compute mesh tangents
   Param[1]: mesh (type: Mesh *)
-Function 405: GenMeshBinormals() (1 input parameters)
+Function 407: GenMeshBinormals() (1 input parameters)
   Name: GenMeshBinormals
   Return type: void
   Description: Compute mesh binormals
   Param[1]: mesh (type: Mesh *)
-Function 406: GenMeshPoly() (2 input parameters)
+Function 408: GenMeshPoly() (2 input parameters)
   Name: GenMeshPoly
   Return type: Mesh
   Description: Generate polygonal mesh
   Param[1]: sides (type: int)
   Param[2]: radius (type: float)
-Function 407: GenMeshPlane() (4 input parameters)
+Function 409: GenMeshPlane() (4 input parameters)
   Name: GenMeshPlane
   Return type: Mesh
   Description: Generate plane mesh (with subdivisions)
@@ -3201,42 +3212,42 @@ Function 407: GenMeshPlane() (4 input parameters)
   Param[2]: length (type: float)
   Param[3]: resX (type: int)
   Param[4]: resZ (type: int)
-Function 408: GenMeshCube() (3 input parameters)
+Function 410: GenMeshCube() (3 input parameters)
   Name: GenMeshCube
   Return type: Mesh
   Description: Generate cuboid mesh
   Param[1]: width (type: float)
   Param[2]: height (type: float)
   Param[3]: length (type: float)
-Function 409: GenMeshSphere() (3 input parameters)
+Function 411: GenMeshSphere() (3 input parameters)
   Name: GenMeshSphere
   Return type: Mesh
   Description: Generate sphere mesh (standard sphere)
   Param[1]: radius (type: float)
   Param[2]: rings (type: int)
   Param[3]: slices (type: int)
-Function 410: GenMeshHemiSphere() (3 input parameters)
+Function 412: GenMeshHemiSphere() (3 input parameters)
   Name: GenMeshHemiSphere
   Return type: Mesh
   Description: Generate half-sphere mesh (no bottom cap)
   Param[1]: radius (type: float)
   Param[2]: rings (type: int)
   Param[3]: slices (type: int)
-Function 411: GenMeshCylinder() (3 input parameters)
+Function 413: GenMeshCylinder() (3 input parameters)
   Name: GenMeshCylinder
   Return type: Mesh
   Description: Generate cylinder mesh
   Param[1]: radius (type: float)
   Param[2]: height (type: float)
   Param[3]: slices (type: int)
-Function 412: GenMeshCone() (3 input parameters)
+Function 414: GenMeshCone() (3 input parameters)
   Name: GenMeshCone
   Return type: Mesh
   Description: Generate cone/pyramid mesh
   Param[1]: radius (type: float)
   Param[2]: height (type: float)
   Param[3]: slices (type: int)
-Function 413: GenMeshTorus() (4 input parameters)
+Function 415: GenMeshTorus() (4 input parameters)
   Name: GenMeshTorus
   Return type: Mesh
   Description: Generate torus mesh
@@ -3244,7 +3255,7 @@ Function 413: GenMeshTorus() (4 input parameters)
   Param[2]: size (type: float)
   Param[3]: radSeg (type: int)
   Param[4]: sides (type: int)
-Function 414: GenMeshKnot() (4 input parameters)
+Function 416: GenMeshKnot() (4 input parameters)
   Name: GenMeshKnot
   Return type: Mesh
   Description: Generate trefoil knot mesh
@@ -3252,79 +3263,79 @@ Function 414: GenMeshKnot() (4 input parameters)
   Param[2]: size (type: float)
   Param[3]: radSeg (type: int)
   Param[4]: sides (type: int)
-Function 415: GenMeshHeightmap() (2 input parameters)
+Function 417: GenMeshHeightmap() (2 input parameters)
   Name: GenMeshHeightmap
   Return type: Mesh
   Description: Generate heightmap mesh from image data
   Param[1]: heightmap (type: Image)
   Param[2]: size (type: Vector3)
-Function 416: GenMeshCubicmap() (2 input parameters)
+Function 418: GenMeshCubicmap() (2 input parameters)
   Name: GenMeshCubicmap
   Return type: Mesh
   Description: Generate cubes-based map mesh from image data
   Param[1]: cubicmap (type: Image)
   Param[2]: cubeSize (type: Vector3)
-Function 417: LoadMaterials() (2 input parameters)
+Function 419: LoadMaterials() (2 input parameters)
   Name: LoadMaterials
   Return type: Material *
   Description: Load materials from model file
   Param[1]: fileName (type: const char *)
   Param[2]: materialCount (type: int *)
-Function 418: LoadMaterialDefault() (0 input parameters)
+Function 420: LoadMaterialDefault() (0 input parameters)
   Name: LoadMaterialDefault
   Return type: Material
   Description: Load default material (Supports: DIFFUSE, SPECULAR, NORMAL maps)
   No input parameters
-Function 419: UnloadMaterial() (1 input parameters)
+Function 421: UnloadMaterial() (1 input parameters)
   Name: UnloadMaterial
   Return type: void
   Description: Unload material from GPU memory (VRAM)
   Param[1]: material (type: Material)
-Function 420: SetMaterialTexture() (3 input parameters)
+Function 422: SetMaterialTexture() (3 input parameters)
   Name: SetMaterialTexture
   Return type: void
   Description: Set texture for a material map type (MATERIAL_MAP_DIFFUSE, MATERIAL_MAP_SPECULAR...)
   Param[1]: material (type: Material *)
   Param[2]: mapType (type: int)
   Param[3]: texture (type: Texture2D)
-Function 421: SetModelMeshMaterial() (3 input parameters)
+Function 423: SetModelMeshMaterial() (3 input parameters)
   Name: SetModelMeshMaterial
   Return type: void
   Description: Set material for a mesh
   Param[1]: model (type: Model *)
   Param[2]: meshId (type: int)
   Param[3]: materialId (type: int)
-Function 422: LoadModelAnimations() (2 input parameters)
+Function 424: LoadModelAnimations() (2 input parameters)
   Name: LoadModelAnimations
   Return type: ModelAnimation *
   Description: Load model animations from file
   Param[1]: fileName (type: const char *)
   Param[2]: animCount (type: unsigned int *)
-Function 423: UpdateModelAnimation() (3 input parameters)
+Function 425: UpdateModelAnimation() (3 input parameters)
   Name: UpdateModelAnimation
   Return type: void
   Description: Update model animation pose
   Param[1]: model (type: Model)
   Param[2]: anim (type: ModelAnimation)
   Param[3]: frame (type: int)
-Function 424: UnloadModelAnimation() (1 input parameters)
+Function 426: UnloadModelAnimation() (1 input parameters)
   Name: UnloadModelAnimation
   Return type: void
   Description: Unload animation data
   Param[1]: anim (type: ModelAnimation)
-Function 425: UnloadModelAnimations() (2 input parameters)
+Function 427: UnloadModelAnimations() (2 input parameters)
   Name: UnloadModelAnimations
   Return type: void
   Description: Unload animation array data
   Param[1]: animations (type: ModelAnimation*)
   Param[2]: count (type: unsigned int)
-Function 426: IsModelAnimationValid() (2 input parameters)
+Function 428: IsModelAnimationValid() (2 input parameters)
   Name: IsModelAnimationValid
   Return type: bool
   Description: Check model animation skeleton match
   Param[1]: model (type: Model)
   Param[2]: anim (type: ModelAnimation)
-Function 427: CheckCollisionSpheres() (4 input parameters)
+Function 429: CheckCollisionSpheres() (4 input parameters)
   Name: CheckCollisionSpheres
   Return type: bool
   Description: Check collision between two spheres
@@ -3332,46 +3343,46 @@ Function 427: CheckCollisionSpheres() (4 input parameters)
   Param[2]: radius1 (type: float)
   Param[3]: center2 (type: Vector3)
   Param[4]: radius2 (type: float)
-Function 428: CheckCollisionBoxes() (2 input parameters)
+Function 430: CheckCollisionBoxes() (2 input parameters)
   Name: CheckCollisionBoxes
   Return type: bool
   Description: Check collision between two bounding boxes
   Param[1]: box1 (type: BoundingBox)
   Param[2]: box2 (type: BoundingBox)
-Function 429: CheckCollisionBoxSphere() (3 input parameters)
+Function 431: CheckCollisionBoxSphere() (3 input parameters)
   Name: CheckCollisionBoxSphere
   Return type: bool
   Description: Check collision between box and sphere
   Param[1]: box (type: BoundingBox)
   Param[2]: center (type: Vector3)
   Param[3]: radius (type: float)
-Function 430: GetRayCollisionSphere() (3 input parameters)
+Function 432: GetRayCollisionSphere() (3 input parameters)
   Name: GetRayCollisionSphere
   Return type: RayCollision
   Description: Get collision info between ray and sphere
   Param[1]: ray (type: Ray)
   Param[2]: center (type: Vector3)
   Param[3]: radius (type: float)
-Function 431: GetRayCollisionBox() (2 input parameters)
+Function 433: GetRayCollisionBox() (2 input parameters)
   Name: GetRayCollisionBox
   Return type: RayCollision
   Description: Get collision info between ray and box
   Param[1]: ray (type: Ray)
   Param[2]: box (type: BoundingBox)
-Function 432: GetRayCollisionModel() (2 input parameters)
+Function 434: GetRayCollisionModel() (2 input parameters)
   Name: GetRayCollisionModel
   Return type: RayCollision
   Description: Get collision info between ray and model
   Param[1]: ray (type: Ray)
   Param[2]: model (type: Model)
-Function 433: GetRayCollisionMesh() (3 input parameters)
+Function 435: GetRayCollisionMesh() (3 input parameters)
   Name: GetRayCollisionMesh
   Return type: RayCollision
   Description: Get collision info between ray and mesh
   Param[1]: ray (type: Ray)
   Param[2]: mesh (type: Mesh)
   Param[3]: transform (type: Matrix)
-Function 434: GetRayCollisionTriangle() (4 input parameters)
+Function 436: GetRayCollisionTriangle() (4 input parameters)
   Name: GetRayCollisionTriangle
   Return type: RayCollision
   Description: Get collision info between ray and triangle
@@ -3379,7 +3390,7 @@ Function 434: GetRayCollisionTriangle() (4 input parameters)
   Param[2]: p1 (type: Vector3)
   Param[3]: p2 (type: Vector3)
   Param[4]: p3 (type: Vector3)
-Function 435: GetRayCollisionQuad() (5 input parameters)
+Function 437: GetRayCollisionQuad() (5 input parameters)
   Name: GetRayCollisionQuad
   Return type: RayCollision
   Description: Get collision info between ray and quad
@@ -3388,130 +3399,130 @@ Function 435: GetRayCollisionQuad() (5 input parameters)
   Param[3]: p2 (type: Vector3)
   Param[4]: p3 (type: Vector3)
   Param[5]: p4 (type: Vector3)
-Function 436: InitAudioDevice() (0 input parameters)
+Function 438: InitAudioDevice() (0 input parameters)
   Name: InitAudioDevice
   Return type: void
   Description: Initialize audio device and context
   No input parameters
-Function 437: CloseAudioDevice() (0 input parameters)
+Function 439: CloseAudioDevice() (0 input parameters)
   Name: CloseAudioDevice
   Return type: void
   Description: Close the audio device and context
   No input parameters
-Function 438: IsAudioDeviceReady() (0 input parameters)
+Function 440: IsAudioDeviceReady() (0 input parameters)
   Name: IsAudioDeviceReady
   Return type: bool
   Description: Check if audio device has been initialized successfully
   No input parameters
-Function 439: SetMasterVolume() (1 input parameters)
+Function 441: SetMasterVolume() (1 input parameters)
   Name: SetMasterVolume
   Return type: void
   Description: Set master volume (listener)
   Param[1]: volume (type: float)
-Function 440: LoadWave() (1 input parameters)
+Function 442: LoadWave() (1 input parameters)
   Name: LoadWave
   Return type: Wave
   Description: Load wave data from file
   Param[1]: fileName (type: const char *)
-Function 441: LoadWaveFromMemory() (3 input parameters)
+Function 443: LoadWaveFromMemory() (3 input parameters)
   Name: LoadWaveFromMemory
   Return type: Wave
   Description: Load wave from memory buffer, fileType refers to extension: i.e. '.wav'
   Param[1]: fileType (type: const char *)
   Param[2]: fileData (type: const unsigned char *)
   Param[3]: dataSize (type: int)
-Function 442: LoadSound() (1 input parameters)
+Function 444: LoadSound() (1 input parameters)
   Name: LoadSound
   Return type: Sound
   Description: Load sound from file
   Param[1]: fileName (type: const char *)
-Function 443: LoadSoundFromWave() (1 input parameters)
+Function 445: LoadSoundFromWave() (1 input parameters)
   Name: LoadSoundFromWave
   Return type: Sound
   Description: Load sound from wave data
   Param[1]: wave (type: Wave)
-Function 444: UpdateSound() (3 input parameters)
+Function 446: UpdateSound() (3 input parameters)
   Name: UpdateSound
   Return type: void
   Description: Update sound buffer with new data
   Param[1]: sound (type: Sound)
   Param[2]: data (type: const void *)
   Param[3]: sampleCount (type: int)
-Function 445: UnloadWave() (1 input parameters)
+Function 447: UnloadWave() (1 input parameters)
   Name: UnloadWave
   Return type: void
   Description: Unload wave data
   Param[1]: wave (type: Wave)
-Function 446: UnloadSound() (1 input parameters)
+Function 448: UnloadSound() (1 input parameters)
   Name: UnloadSound
   Return type: void
   Description: Unload sound
   Param[1]: sound (type: Sound)
-Function 447: ExportWave() (2 input parameters)
+Function 449: ExportWave() (2 input parameters)
   Name: ExportWave
   Return type: bool
   Description: Export wave data to file, returns true on success
   Param[1]: wave (type: Wave)
   Param[2]: fileName (type: const char *)
-Function 448: ExportWaveAsCode() (2 input parameters)
+Function 450: ExportWaveAsCode() (2 input parameters)
   Name: ExportWaveAsCode
   Return type: bool
   Description: Export wave sample data to code (.h), returns true on success
   Param[1]: wave (type: Wave)
   Param[2]: fileName (type: const char *)
-Function 449: PlaySound() (1 input parameters)
+Function 451: PlaySound() (1 input parameters)
   Name: PlaySound
   Return type: void
   Description: Play a sound
   Param[1]: sound (type: Sound)
-Function 450: StopSound() (1 input parameters)
+Function 452: StopSound() (1 input parameters)
   Name: StopSound
   Return type: void
   Description: Stop playing a sound
   Param[1]: sound (type: Sound)
-Function 451: PauseSound() (1 input parameters)
+Function 453: PauseSound() (1 input parameters)
   Name: PauseSound
   Return type: void
   Description: Pause a sound
   Param[1]: sound (type: Sound)
-Function 452: ResumeSound() (1 input parameters)
+Function 454: ResumeSound() (1 input parameters)
   Name: ResumeSound
   Return type: void
   Description: Resume a paused sound
   Param[1]: sound (type: Sound)
-Function 453: PlaySoundMulti() (1 input parameters)
+Function 455: PlaySoundMulti() (1 input parameters)
   Name: PlaySoundMulti
   Return type: void
   Description: Play a sound (using multichannel buffer pool)
   Param[1]: sound (type: Sound)
-Function 454: StopSoundMulti() (0 input parameters)
+Function 456: StopSoundMulti() (0 input parameters)
   Name: StopSoundMulti
   Return type: void
   Description: Stop any sound playing (using multichannel buffer pool)
   No input parameters
-Function 455: GetSoundsPlaying() (0 input parameters)
+Function 457: GetSoundsPlaying() (0 input parameters)
   Name: GetSoundsPlaying
   Return type: int
   Description: Get number of sounds playing in the multichannel
   No input parameters
-Function 456: IsSoundPlaying() (1 input parameters)
+Function 458: IsSoundPlaying() (1 input parameters)
   Name: IsSoundPlaying
   Return type: bool
   Description: Check if a sound is currently playing
   Param[1]: sound (type: Sound)
-Function 457: SetSoundVolume() (2 input parameters)
+Function 459: SetSoundVolume() (2 input parameters)
   Name: SetSoundVolume
   Return type: void
   Description: Set volume for a sound (1.0 is max level)
   Param[1]: sound (type: Sound)
   Param[2]: volume (type: float)
-Function 458: SetSoundPitch() (2 input parameters)
+Function 460: SetSoundPitch() (2 input parameters)
   Name: SetSoundPitch
   Return type: void
   Description: Set pitch for a sound (1.0 is base level)
   Param[1]: sound (type: Sound)
   Param[2]: pitch (type: float)
-Function 459: WaveFormat() (4 input parameters)
+Function 461: WaveFormat() (4 input parameters)
   Name: WaveFormat
   Return type: void
   Description: Convert wave data to desired format
@@ -3519,165 +3530,165 @@ Function 459: WaveFormat() (4 input parameters)
   Param[2]: sampleRate (type: int)
   Param[3]: sampleSize (type: int)
   Param[4]: channels (type: int)
-Function 460: WaveCopy() (1 input parameters)
+Function 462: WaveCopy() (1 input parameters)
   Name: WaveCopy
   Return type: Wave
   Description: Copy a wave to a new wave
   Param[1]: wave (type: Wave)
-Function 461: WaveCrop() (3 input parameters)
+Function 463: WaveCrop() (3 input parameters)
   Name: WaveCrop
   Return type: void
   Description: Crop a wave to defined samples range
   Param[1]: wave (type: Wave *)
   Param[2]: initSample (type: int)
   Param[3]: finalSample (type: int)
-Function 462: LoadWaveSamples() (1 input parameters)
+Function 464: LoadWaveSamples() (1 input parameters)
   Name: LoadWaveSamples
   Return type: float *
   Description: Load samples data from wave as a floats array
   Param[1]: wave (type: Wave)
-Function 463: UnloadWaveSamples() (1 input parameters)
+Function 465: UnloadWaveSamples() (1 input parameters)
   Name: UnloadWaveSamples
   Return type: void
   Description: Unload samples data loaded with LoadWaveSamples()
   Param[1]: samples (type: float *)
-Function 464: LoadMusicStream() (1 input parameters)
+Function 466: LoadMusicStream() (1 input parameters)
   Name: LoadMusicStream
   Return type: Music
   Description: Load music stream from file
   Param[1]: fileName (type: const char *)
-Function 465: LoadMusicStreamFromMemory() (3 input parameters)
+Function 467: LoadMusicStreamFromMemory() (3 input parameters)
   Name: LoadMusicStreamFromMemory
   Return type: Music
   Description: Load music stream from data
   Param[1]: fileType (type: const char *)
   Param[2]: data (type: unsigned char *)
   Param[3]: dataSize (type: int)
-Function 466: UnloadMusicStream() (1 input parameters)
+Function 468: UnloadMusicStream() (1 input parameters)
   Name: UnloadMusicStream
   Return type: void
   Description: Unload music stream
   Param[1]: music (type: Music)
-Function 467: PlayMusicStream() (1 input parameters)
+Function 469: PlayMusicStream() (1 input parameters)
   Name: PlayMusicStream
   Return type: void
   Description: Start music playing
   Param[1]: music (type: Music)
-Function 468: IsMusicStreamPlaying() (1 input parameters)
+Function 470: IsMusicStreamPlaying() (1 input parameters)
   Name: IsMusicStreamPlaying
   Return type: bool
   Description: Check if music is playing
   Param[1]: music (type: Music)
-Function 469: UpdateMusicStream() (1 input parameters)
+Function 471: UpdateMusicStream() (1 input parameters)
   Name: UpdateMusicStream
   Return type: void
   Description: Updates buffers for music streaming
   Param[1]: music (type: Music)
-Function 470: StopMusicStream() (1 input parameters)
+Function 472: StopMusicStream() (1 input parameters)
   Name: StopMusicStream
   Return type: void
   Description: Stop music playing
   Param[1]: music (type: Music)
-Function 471: PauseMusicStream() (1 input parameters)
+Function 473: PauseMusicStream() (1 input parameters)
   Name: PauseMusicStream
   Return type: void
   Description: Pause music playing
   Param[1]: music (type: Music)
-Function 472: ResumeMusicStream() (1 input parameters)
+Function 474: ResumeMusicStream() (1 input parameters)
   Name: ResumeMusicStream
   Return type: void
   Description: Resume playing paused music
   Param[1]: music (type: Music)
-Function 473: SeekMusicStream() (2 input parameters)
+Function 475: SeekMusicStream() (2 input parameters)
   Name: SeekMusicStream
   Return type: void
   Description: Seek music to a position (in seconds)
   Param[1]: music (type: Music)
   Param[2]: position (type: float)
-Function 474: SetMusicVolume() (2 input parameters)
+Function 476: SetMusicVolume() (2 input parameters)
   Name: SetMusicVolume
   Return type: void
   Description: Set volume for music (1.0 is max level)
   Param[1]: music (type: Music)
   Param[2]: volume (type: float)
-Function 475: SetMusicPitch() (2 input parameters)
+Function 477: SetMusicPitch() (2 input parameters)
   Name: SetMusicPitch
   Return type: void
   Description: Set pitch for a music (1.0 is base level)
   Param[1]: music (type: Music)
   Param[2]: pitch (type: float)
-Function 476: GetMusicTimeLength() (1 input parameters)
+Function 478: GetMusicTimeLength() (1 input parameters)
   Name: GetMusicTimeLength
   Return type: float
   Description: Get music time length (in seconds)
   Param[1]: music (type: Music)
-Function 477: GetMusicTimePlayed() (1 input parameters)
+Function 479: GetMusicTimePlayed() (1 input parameters)
   Name: GetMusicTimePlayed
   Return type: float
   Description: Get current music time played (in seconds)
   Param[1]: music (type: Music)
-Function 478: LoadAudioStream() (3 input parameters)
+Function 480: LoadAudioStream() (3 input parameters)
   Name: LoadAudioStream
   Return type: AudioStream
   Description: Load audio stream (to stream raw audio pcm data)
   Param[1]: sampleRate (type: unsigned int)
   Param[2]: sampleSize (type: unsigned int)
   Param[3]: channels (type: unsigned int)
-Function 479: UnloadAudioStream() (1 input parameters)
+Function 481: UnloadAudioStream() (1 input parameters)
   Name: UnloadAudioStream
   Return type: void
   Description: Unload audio stream and free memory
   Param[1]: stream (type: AudioStream)
-Function 480: UpdateAudioStream() (3 input parameters)
+Function 482: UpdateAudioStream() (3 input parameters)
   Name: UpdateAudioStream
   Return type: void
   Description: Update audio stream buffers with data
   Param[1]: stream (type: AudioStream)
   Param[2]: data (type: const void *)
   Param[3]: frameCount (type: int)
-Function 481: IsAudioStreamProcessed() (1 input parameters)
+Function 483: IsAudioStreamProcessed() (1 input parameters)
   Name: IsAudioStreamProcessed
   Return type: bool
   Description: Check if any audio stream buffers requires refill
   Param[1]: stream (type: AudioStream)
-Function 482: PlayAudioStream() (1 input parameters)
+Function 484: PlayAudioStream() (1 input parameters)
   Name: PlayAudioStream
   Return type: void
   Description: Play audio stream
   Param[1]: stream (type: AudioStream)
-Function 483: PauseAudioStream() (1 input parameters)
+Function 485: PauseAudioStream() (1 input parameters)
   Name: PauseAudioStream
   Return type: void
   Description: Pause audio stream
   Param[1]: stream (type: AudioStream)
-Function 484: ResumeAudioStream() (1 input parameters)
+Function 486: ResumeAudioStream() (1 input parameters)
   Name: ResumeAudioStream
   Return type: void
   Description: Resume audio stream
   Param[1]: stream (type: AudioStream)
-Function 485: IsAudioStreamPlaying() (1 input parameters)
+Function 487: IsAudioStreamPlaying() (1 input parameters)
   Name: IsAudioStreamPlaying
   Return type: bool
   Description: Check if audio stream is playing
   Param[1]: stream (type: AudioStream)
-Function 486: StopAudioStream() (1 input parameters)
+Function 488: StopAudioStream() (1 input parameters)
   Name: StopAudioStream
   Return type: void
   Description: Stop audio stream
   Param[1]: stream (type: AudioStream)
-Function 487: SetAudioStreamVolume() (2 input parameters)
+Function 489: SetAudioStreamVolume() (2 input parameters)
   Name: SetAudioStreamVolume
   Return type: void
   Description: Set volume for audio stream (1.0 is max level)
   Param[1]: stream (type: AudioStream)
   Param[2]: volume (type: float)
-Function 488: SetAudioStreamPitch() (2 input parameters)
+Function 490: SetAudioStreamPitch() (2 input parameters)
   Name: SetAudioStreamPitch
   Return type: void
   Description: Set pitch for audio stream (1.0 is base level)
   Param[1]: stream (type: AudioStream)
   Param[2]: pitch (type: float)
-Function 489: SetAudioStreamBufferSizeDefault() (1 input parameters)
+Function 491: SetAudioStreamBufferSizeDefault() (1 input parameters)
   Name: SetAudioStreamBufferSizeDefault
   Return type: void
   Description: Default size for new audio streams

--- a/parser/raylib_api.xml
+++ b/parser/raylib_api.xml
@@ -542,7 +542,7 @@
             <Value name="NPATCH_THREE_PATCH_HORIZONTAL" integer="2" desc="Npatch layout: 3x1 tiles" />
         </Enum>
     </Enums>
-    <Functions count="489">
+    <Functions count="491">
         <Function name="InitWindow" retType="void" paramCount="3" desc="Initialize window and OpenGL context">
             <Param type="int" name="width" desc="" />
             <Param type="int" name="height" desc="" />
@@ -569,7 +569,7 @@
         <Function name="IsWindowState" retType="bool" paramCount="1" desc="Check if one specific window flag is enabled">
             <Param type="unsigned int" name="flag" desc="" />
         </Function>
-        <Function name="SetWindowState" retType="void" paramCount="1" desc="Set window configuration state using flags">
+        <Function name="SetWindowState" retType="void" paramCount="1" desc="Set window configuration state using flags (only PLATFORM_DESKTOP)">
             <Param type="unsigned int" name="flags" desc="" />
         </Function>
         <Function name="ClearWindowState" retType="void" paramCount="1" desc="Clear window configuration state flags">
@@ -603,6 +603,9 @@
         <Function name="SetWindowSize" retType="void" paramCount="2" desc="Set window dimensions">
             <Param type="int" name="width" desc="" />
             <Param type="int" name="height" desc="" />
+        </Function>
+        <Function name="SetWindowOpacity" retType="void" paramCount="1" desc="Set window opacity [0.0f..1.0f] (only PLATFORM_DESKTOP)">
+            <Param type="float" name="opacity" desc="" />
         </Function>
         <Function name="GetWindowHandle" retType="void *" paramCount="0" desc="Get native window handle">
         </Function>
@@ -1831,7 +1834,7 @@
         <Function name="LoadFont" retType="Font" paramCount="1" desc="Load font from file into GPU memory (VRAM)">
             <Param type="const char *" name="fileName" desc="" />
         </Function>
-        <Function name="LoadFontEx" retType="Font" paramCount="4" desc="Load font from file with extended parameters">
+        <Function name="LoadFontEx" retType="Font" paramCount="4" desc="Load font from file with extended parameters, use NULL for fontChars and 0 for glyphCount to load the default character set">
             <Param type="const char *" name="fileName" desc="" />
             <Param type="int" name="fontSize" desc="" />
             <Param type="int *" name="fontChars" desc="" />
@@ -1870,8 +1873,12 @@
             <Param type="GlyphInfo *" name="chars" desc="" />
             <Param type="int" name="glyphCount" desc="" />
         </Function>
-        <Function name="UnloadFont" retType="void" paramCount="1" desc="Unload Font from GPU memory (VRAM)">
+        <Function name="UnloadFont" retType="void" paramCount="1" desc="Unload font from GPU memory (VRAM)">
             <Param type="Font" name="font" desc="" />
+        </Function>
+        <Function name="ExportFontAsCode" retType="bool" paramCount="2" desc="Export font as code file, returns true on success">
+            <Param type="Font" name="font" desc="" />
+            <Param type="const char *" name="fileName" desc="" />
         </Function>
         <Function name="DrawFPS" retType="void" paramCount="2" desc="Draw current FPS">
             <Param type="int" name="posX" desc="" />

--- a/parser/raylib_parser.c
+++ b/parser/raylib_parser.c
@@ -867,8 +867,8 @@ static void ExportParsedData(const char *fileName, int format)
                 for (int f = 0; f < structs[i].fieldCount; f++)
                 {
                     fprintf(outFile, "        {\n");
-                    fprintf(outFile, "          name = \"%s\",\n", structs[i].fieldName[f]);
                     fprintf(outFile, "          type = \"%s\",\n", structs[i].fieldType[f]);
+                    fprintf(outFile, "          name = \"%s\",\n", structs[i].fieldName[f]);
                     fprintf(outFile, "          description = \"%s\"\n", EscapeBackslashes(structs[i].fieldDesc[f] + 3));
                     fprintf(outFile, "        }");
                     if (f < structs[i].fieldCount - 1) fprintf(outFile, ",\n");
@@ -921,7 +921,7 @@ static void ExportParsedData(const char *fileName, int format)
                     fprintf(outFile, ",\n      params = {\n");
                     for (int p = 0; p < funcs[i].paramCount; p++)
                     {
-                        fprintf(outFile, "        {name = \"%s\", type = \"%s\"}", funcs[i].paramName[p], funcs[i].paramType[p]);
+                        fprintf(outFile, "        {type = \"%s\", name = \"%s\"}", funcs[i].paramType[p], funcs[i].paramName[p]);
                         if (p < funcs[i].paramCount - 1) fprintf(outFile, ",\n");
                         else fprintf(outFile, "\n");
                     }
@@ -950,8 +950,8 @@ static void ExportParsedData(const char *fileName, int format)
                 for (int f = 0; f < structs[i].fieldCount; f++)
                 {
                     fprintf(outFile, "        {\n");
-                    fprintf(outFile, "          \"name\": \"%s\",\n", structs[i].fieldName[f]);
                     fprintf(outFile, "          \"type\": \"%s\",\n", structs[i].fieldType[f]);
+                    fprintf(outFile, "          \"name\": \"%s\",\n", structs[i].fieldName[f]);
                     fprintf(outFile, "          \"description\": \"%s\"\n", EscapeBackslashes(structs[i].fieldDesc[f] + 3));
                     fprintf(outFile, "        }");
                     if (f < structs[i].fieldCount - 1) fprintf(outFile, ",\n");
@@ -1005,8 +1005,8 @@ static void ExportParsedData(const char *fileName, int format)
                     for (int p = 0; p < funcs[i].paramCount; p++)
                     {
                         fprintf(outFile, "        {\n");
-                        fprintf(outFile, "          \"name\": \"%s\",\n", funcs[i].paramName[p]);
-                        fprintf(outFile, "          \"type\": \"%s\"\n", funcs[i].paramType[p]);
+                        fprintf(outFile, "          \"type\": \"%s\",\n", funcs[i].paramType[p]);
+                        fprintf(outFile, "          \"name\": \"%s\"\n", funcs[i].paramName[p]);
                         fprintf(outFile, "        }");
                         if (p < funcs[i].paramCount - 1) fprintf(outFile, ",\n");
                         else fprintf(outFile, "\n");

--- a/parser/raylib_parser.c
+++ b/parser/raylib_parser.c
@@ -1001,14 +1001,17 @@ static void ExportParsedData(const char *fileName, int format)
                 if (funcs[i].paramCount == 0) fprintf(outFile, "\n");
                 else
                 {
-                    fprintf(outFile, ",\n      \"params\": {\n");
+                    fprintf(outFile, ",\n      \"params\": [\n");
                     for (int p = 0; p < funcs[i].paramCount; p++)
                     {
-                        fprintf(outFile, "        \"%s\": \"%s\"", funcs[i].paramName[p], funcs[i].paramType[p]);
+                        fprintf(outFile, "        {\n");
+                        fprintf(outFile, "          \"name\": \"%s\",\n", funcs[i].paramName[p]);
+                        fprintf(outFile, "          \"type\": \"%s\"\n", funcs[i].paramType[p]);
+                        fprintf(outFile, "        }");
                         if (p < funcs[i].paramCount - 1) fprintf(outFile, ",\n");
                         else fprintf(outFile, "\n");
                     }
-                    fprintf(outFile, "      }\n");
+                    fprintf(outFile, "      ]\n");
                 }
                 fprintf(outFile, "    }");
 


### PR DESCRIPTION
Related issue: https://github.com/raysan5/raylib/issues/2255
Uses arrays with objects containing name and type instead of objects with name as key and type as value for function parameters in the JSON raylib parser.