### PR TITLE
cmake: Add Web and Docs to CMake project template

### DIFF
--- a/projects/CMake/CMakeLists.txt
+++ b/projects/CMake/CMakeLists.txt
@@ -1,38 +1,34 @@
 cmake_minimum_required(VERSION 3.11) # FetchContent is available in 3.11+
 project(example)
 
-# Set this to the minimal version you want to support
-find_package(raylib 3.0 QUIET) # Let CMake search for a raylib-config.cmake
-
-# You could change the QUIET above to REQUIRED and remove this if() clause
-# This part downloads raylib and builds it if it's not installed on your system
+# Dependencies
+find_package(raylib 4.0.0 QUIET) # QUIET or REQUIRED
 if (NOT raylib_FOUND) # If there's none, fetch and build raylib
   include(FetchContent)
-
   FetchContent_Declare(
     raylib
-    URL https://github.com/raysan5/raylib/archive/master.tar.gz
+    URL https://github.com/raysan5/raylib/archive/refs/tags/4.0.0.tar.gz
   )
-
   FetchContent_GetProperties(raylib)
   if (NOT raylib_POPULATED) # Have we downloaded raylib yet?
     set(FETCHCONTENT_QUIET NO)
     FetchContent_Populate(raylib)
-
     set(BUILD_EXAMPLES OFF CACHE BOOL "" FORCE) # don't build the supplied examples
-
-    # build raylib
     add_subdirectory(${raylib_SOURCE_DIR} ${raylib_BINARY_DIR})
-
   endif()
-
 endif()
 
-# This is the main part:
+# Our Project
 
 add_executable(${PROJECT_NAME} core_basic_window.c)
 #set(raylib_VERBOSE 1)
 target_link_libraries(${PROJECT_NAME} raylib)
+
+# Web Configurations
+if (${PLATFORM} STREQUAL "Web")
+    # Tell Emscripten to build an example.html file.
+    set_target_properties(${PROJECT_NAME} PROPERTIES SUFFIX ".html")
+endif()
 
 # Checks if OSX and links appropriate frameworks (Only required on MacOS)
 if (APPLE)
@@ -40,5 +36,3 @@ if (APPLE)
     target_link_libraries(${PROJECT_NAME} "-framework Cocoa")
     target_link_libraries(${PROJECT_NAME} "-framework OpenGL")
 endif()
-
-# That's it! You should have an example executable that you can run. Have fun!

--- a/projects/CMake/README.md
+++ b/projects/CMake/README.md
@@ -1,0 +1,29 @@
+# raylib CMake Project
+
+This provides a base project template which builds with [CMake](https://cmake.org).
+
+## Usage
+
+To compile the example, use one of the following dependending on your build target...
+
+### Desktop
+
+Use the following to build for desktop:
+
+``` bash
+mkdir build
+cd build
+cmake ..
+make
+```
+
+### Web
+
+Compiling for the web requires the [Emscripten SDK](https://emscripten.org/docs/getting_started/downloads.html):
+
+``` bash
+mkdir build
+cd build
+emcmake cmake .. -DPLATFORM=Web -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXE_LINKER_FLAGS="-s USE_GLFW=3" -DCMAKE_EXECUTABLE_SUFFIX=".html"
+emmake make
+```

--- a/projects/CMake/core_basic_window.c
+++ b/projects/CMake/core_basic_window.c
@@ -1,57 +1,56 @@
 /*******************************************************************************************
 *
-*   raylib [core] example - Basic window
+*   raylib [core] example - Basic window (adapted for HTML5 platform)
 *
-*   Welcome to raylib!
+*   This example is prepared to compile for PLATFORM_WEB, PLATFORM_DESKTOP and PLATFORM_RPI
+*   As you will notice, code structure is slightly diferent to the other examples...
+*   To compile it for PLATFORM_WEB just uncomment #define PLATFORM_WEB at beginning
 *
-*   To test examples, just press F6 and execute raylib_compile_execute script
-*   Note that compiled executable is placed in the same folder as .c file
-*
-*   You can find all basic examples on C:\raylib\raylib\examples folder or
-*   raylib official webpage: www.raylib.com
-*
-*   Enjoy using raylib. :)
-*
-*   This example has been created using raylib 1.0 (www.raylib.com)
+*   This example has been created using raylib 1.3 (www.raylib.com)
 *   raylib is licensed under an unmodified zlib/libpng license (View raylib.h for details)
 *
-*   Copyright (c) 2013-2016 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2015 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 
 #include "raylib.h"
 
+#if defined(PLATFORM_WEB)
+    #include <emscripten/emscripten.h>
+#endif
+
+//----------------------------------------------------------------------------------
+// Global Variables Definition
+//----------------------------------------------------------------------------------
+int screenWidth = 800;
+int screenHeight = 450;
+
+//----------------------------------------------------------------------------------
+// Module Functions Declaration
+//----------------------------------------------------------------------------------
+void UpdateDrawFrame(void);     // Update and Draw one frame
+
+//----------------------------------------------------------------------------------
+// Main Enry Point
+//----------------------------------------------------------------------------------
 int main()
 {
     // Initialization
     //--------------------------------------------------------------------------------------
-    int screenWidth = 800;
-    int screenHeight = 450;
-
     InitWindow(screenWidth, screenHeight, "raylib [core] example - basic window");
 
-    SetTargetFPS(60);
+#if defined(PLATFORM_WEB)
+    emscripten_set_main_loop(UpdateDrawFrame, 0, 1);
+#else
+    SetTargetFPS(60);   // Set our game to run at 60 frames-per-second
     //--------------------------------------------------------------------------------------
 
     // Main game loop
     while (!WindowShouldClose())    // Detect window close button or ESC key
     {
-        // Update
-        //----------------------------------------------------------------------------------
-        // TODO: Update your variables here
-        //----------------------------------------------------------------------------------
-
-        // Draw
-        //----------------------------------------------------------------------------------
-        BeginDrawing();
-
-            ClearBackground(RAYWHITE);
-
-            DrawText("Congrats! You created your first window!", 190, 200, 20, LIGHTGRAY);
-
-        EndDrawing();
-        //----------------------------------------------------------------------------------
+        UpdateDrawFrame();
     }
+#endif
 
     // De-Initialization
     //--------------------------------------------------------------------------------------
@@ -59,4 +58,26 @@ int main()
     //--------------------------------------------------------------------------------------
 
     return 0;
+}
+
+//----------------------------------------------------------------------------------
+// Module Functions Definition
+//----------------------------------------------------------------------------------
+void UpdateDrawFrame(void)
+{
+    // Update
+    //----------------------------------------------------------------------------------
+    // TODO: Update your variables here
+    //----------------------------------------------------------------------------------
+
+    // Draw
+    //----------------------------------------------------------------------------------
+    BeginDrawing();
+
+        ClearBackground(RAYWHITE);
+
+        DrawText("Congrats! You created your first window!", 190, 200, 20, LIGHTGRAY);
+
+    EndDrawing();
+    //----------------------------------------------------------------------------------
 }

--- a/projects/README.md
+++ b/projects/README.md
@@ -6,7 +6,7 @@ IDE | Platform(s) | Source | Example(s)
 ----| ------------| :-------: | :-----:
 [4coder](http://4coder.net/) | Windows | ❌ | ✔️
 [Builder](https://wiki.gnome.org/Apps/Builder) | Linux | ❌ | ✔️
-[CMake](https://cmake.org/) | Windows, Linux, macOS | ✔️ | ✔️
+[CMake](https://cmake.org/) | Windows, Linux, macOS, Web | ✔️ | ✔️
 [CodeBlocks](http://www.codeblocks.org/) | Windows, Linux, macOS | ❌ | ✔️
 [Geany](https://www.geany.org/) | Windows, Linux | ✔️ | ✔️
 [Notepad++](https://notepad-plus-plus.org/) | Windows | ✔️ | ✔️


### PR DESCRIPTION
I found the CMake documentation for building for web was lacking (as mentioned in https://github.com/raysan5/raylib/issues/2273), so I've updated the project template to help improve it. This does two things...

1. Adds a Web build to the CMake project template
2. Adds a README.md with documentation on how to use the CMake project template