### PR TITLE
[CORE] Bug and formating fixes for GetApplicatonDir

### DIFF
--- a/src/rcore.c
+++ b/src/rcore.c
@@ -166,29 +166,13 @@
         #ifndef MAX_PATH
             #define MAX_PATH 1025
         #endif
-        void *LoadLibraryA(void *lpLibFileName);
-        void *LoadLibraryW(void *lpLibFileName);
-
-        #ifdef UNICODE
-            #define LoadLibrary  LoadLibraryW
-        #else
-            #define LoadLibrary  LoadLibraryA
-        #endif // !UNICODE
-
-        void *GetProcAddress(void *hModule, void *lpProcName);
-
-        void *GetCurrentProcess(void);
-        bool FreeLibrary(void *hLibModule);
-
+        unsigned int GetModuleFileNameA( void* hModule, const char* lpFilename, unsigned int nSize);
+        unsigned int GetModuleFileNameW( void* hModule, const unsigned short* lpFilename, unsigned int nSize);
         int  WideCharToMultiByte(unsigned int cp, unsigned long flags, const unsigned short *widestr, int cchwide, char *str, int cbmb, const char *defchar, int *used_default);
-
-        const char pathDelim = '\\';
     #elif defined(__linux__)
         #include <unistd.h>
-        const char pathDelim = '/';
     #elif defined(__APPLE__)
         #include <sys/syslimits.h>
-        const char pathDelim = '/';
     #endif // OSs
 #endif // PLATFORM_DESKTOP
 
@@ -3007,59 +2991,31 @@ const char *GetApplicationDirectory(void)
     memset(appDir, 0, MAX_FILEPATH_LENGTH);
 
 #if defined(_WIN32)
-    typedef unsigned long(*GetModuleFileNameFunc)(void*, void*, void*, unsigned long);
-
-    GetModuleFileNameFunc getModuleFileNameExWPtr = NULL;
-    void *lib = LoadLibrary(L"psapi.dll");
-
-    if (lib == NULL)
+    int len = 0;
+#if defined (UNICODE)
+    unsigned short widePath[MAX_PATH];
+    len = GetModuleFileNameW(NULL, widePath, MAX_PATH);
+    len = WideCharToMultiByte(0, 0, widePath, len, appDir, MAX_PATH, NULL, NULL);
+#else
+    len = GetModuleFileNameA(NULL, appDir, MAX_PATH);
+#endif
+    if (len > 0)
+    {
+        for (int i = len; i >= 0; --i)
+        {
+            if (appDir[i] == '\\')
+            {
+                appDir[i + 1] = '\0';
+                i = -1;
+            }
+        }
+    }
+    else
     {
         appDir[0] = '.';
         appDir[1] = '\\';
     }
-    else
-    {
-#if defined (UNICODE)
-        getModuleFileNameExWPtr = (GetModuleFileNameFunc)GetProcAddress(lib, "GetModuleFileNameExW");
-#else
-        getModuleFileNameExWPtr = (GetModuleFileNameFunc)GetProcAddress(lib, "GetModuleFileNameExA");
-#endif
 
-        if (getModuleFileNameExWPtr == NULL)
-        {
-            appDir[0] = '.';
-            appDir[1] = '\\';
-        }
-        else
-        {
-            int len = 0;
-#if defined (UNICODE)
-            unsigned short widePath[MAX_PATH];
-            len = getModuleFileNameExWPtr(GetCurrentProcess(), NULL, widePath, MAX_PATH);
-            len = WideCharToMultiByte(0, 0, widePath, len, appDir, MAX_PATH, NULL, NULL);
-#else
-            len = getModuleFileNameExWPtr(GetCurrentProcess(), NULL, appDir, MAX_PATH);
-#endif
-            if (len > 0)
-            {
-                for (int i = len; i >= 0; --i)
-                {
-                    if (appDir[i] == '\\')
-                    {
-                        appDir[i + 1] = '\0';
-                        i = -1;
-                    }
-                }
-            }
-            else
-            {
-                appDir[0] = '.';
-                appDir[1] = '\\';
-            }
-        }
-
-        FreeLibrary(lib);
-    }
 #elif defined(__linux__)
     unsigned int size = sizeof(appDir);
     ssize_t len = readlink("/proc/self/exe", appDir, size);

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -3014,7 +3014,8 @@ const char *GetApplicationDirectory(void)
 
     if (lib == NULL)
     {
-        appDir[0] = '\\';
+        appDir[0] = '.';
+        appDir[1] = '\\';
     }
     else
     {
@@ -3026,7 +3027,8 @@ const char *GetApplicationDirectory(void)
 
         if (getModuleFileNameExWPtr == NULL)
         {
-            appDir[0] = '\\';
+            appDir[0] = '.';
+            appDir[1] = '\\';
         }
         else
         {
@@ -3049,6 +3051,11 @@ const char *GetApplicationDirectory(void)
                     }
                 }
             }
+            else
+            {
+                appDir[0] = '.';
+                appDir[1] = '\\';
+            }
         }
 
         FreeLibrary(lib);
@@ -3070,7 +3077,8 @@ const char *GetApplicationDirectory(void)
     }
     else
     {
-        appDir[0] = '/';
+        appDir[0] = '.';
+        appDir[1] = '/';
     }
 #elif defined(__APPLE__)
     uint32_t size = sizeof(appDir);
@@ -3089,7 +3097,8 @@ const char *GetApplicationDirectory(void)
     }
     else
     {
-        appDir[0] = '/';
+        appDir[0] = '.';
+        appDir[1] = '/';
     }
 #endif
 


### PR DESCRIPTION
My initial PR was not set to the correct formatting standards for raylib and there were cases that would not return a valid path. This Update fixes the formatting and should always return a valid path, even if the functions fail to find the exe dir.