### PR TITLE
Support continue drawing while windows is being resized

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -392,6 +392,8 @@ CORE = \
     core/core_loading_thread \
     core/core_quat_conversion \
     core/core_window_flags \
+    core/core_resize_drawing \
+    core/core_resize_placeholder \
     core/core_split_screen \
     core/core_smooth_pixelperfect \
     core/core_custom_frame_control

--- a/examples/core/core_resize_drawing.c
+++ b/examples/core/core_resize_drawing.c
@@ -1,0 +1,40 @@
+/*******************************************************************************************
+*
+*   raylib [core] example - window redraws while resizing
+*
+*   This example has been created using raylib 4.0 (www.raylib.com)
+*   raylib is licensed under an unmodified zlib/libpng license (View raylib.h for details)
+*
+*   Example contributed by Efejjota (@efejjota) and reviewed by Ramon Santamaria (@raysan5)
+*
+*   Copyright (c) 2022 Efejjota (@efejjota) and Ramon Santamaria (@raysan5)
+*
+********************************************************************************************/
+
+#include "raylib.h"
+
+void draw()
+{
+    BeginDrawing();
+        ClearBackground(RAYWHITE);
+        DrawText("Congrats! Your window redraws while resizing!",  GetScreenWidth()/2.5-150, GetScreenHeight()/2, 20, LIGHTGRAY);
+    EndDrawing();
+}
+
+int main(void)
+{
+    const int screenWidth = 800;
+    const int screenHeight = 450;
+
+    SetConfigFlags(FLAG_WINDOW_RESIZABLE); // Allow resizing the windows
+    SetResizeCallback(draw);               // Set the function to call while resizing
+    InitWindow(screenWidth, screenHeight, "raylib [core] example - basic window");
+    SetTargetFPS(60);
+
+    while (!WindowShouldClose())
+    {
+        draw(); // Write drawing code in a function so we can use as callback while resizing
+    }
+    CloseWindow();
+    return 0;
+}

--- a/examples/core/core_resize_placeholder.c
+++ b/examples/core/core_resize_placeholder.c
@@ -1,0 +1,43 @@
+/*******************************************************************************************
+*
+*   raylib [core] example - window shows placeholder while resizing
+*
+*   This example has been created using raylib 4.0 (www.raylib.com)
+*   raylib is licensed under an unmodified zlib/libpng license (View raylib.h for details)
+*
+*   Example contributed by Efejjota (@efejjota) and reviewed by Ramon Santamaria (@raysan5)
+*
+*   Copyright (c) 2022 Efejjota (@efejjota) and Ramon Santamaria (@raysan5)
+*
+********************************************************************************************/
+
+#include "raylib.h"
+
+void draw()
+{
+    BeginDrawing();
+        ClearBackground(RAYWHITE);
+        DrawText("Resizing",  GetScreenWidth()/2.5, GetScreenHeight()/2.5, 30, LIGHTGRAY);
+    EndDrawing();
+}
+
+int main(void)
+{
+    const int screenWidth = 800;
+    const int screenHeight = 450;
+
+    SetConfigFlags(FLAG_WINDOW_RESIZABLE); // Allow resizing the windows
+    SetResizeCallback(draw);               // Set the function to call while resizing
+    InitWindow(screenWidth, screenHeight, "raylib [core] example - basic window");
+    SetTargetFPS(60);
+
+    while (!WindowShouldClose())
+    {
+        BeginDrawing();
+            ClearBackground(RAYWHITE);
+            DrawText("Congrats! You created your first window!",  GetScreenWidth()/2.5-100, GetScreenHeight()/2, 20, LIGHTGRAY);
+        EndDrawing();
+    }
+    CloseWindow();
+    return 0;
+}

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1016,6 +1016,7 @@ RLAPI int GetRandomValue(int min, int max);                       // Get a rando
 RLAPI void SetRandomSeed(unsigned int seed);                      // Set the seed for the random number generator
 RLAPI void TakeScreenshot(const char *fileName);                  // Takes a screenshot of current screen (filename extension defines format)
 RLAPI void SetConfigFlags(unsigned int flags);                    // Setup init configuration flags (view FLAGS)
+RLAPI void SetResizeCallback(void (*resizeCallback)());           // Set a function to call during resizing
 
 RLAPI void TraceLog(int logLevel, const char *text, ...);         // Show trace log messages (LOG_DEBUG, LOG_INFO, LOG_WARNING, LOG_ERROR...)
 RLAPI void SetTraceLogLevel(int logLevel);                        // Set the current threshold (minimum) log level

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -392,6 +392,7 @@ typedef struct CoreData {
         bool fullscreen;                    // Check if fullscreen mode is enabled
         bool shouldClose;                   // Check if window set for closing
         bool resizedLastFrame;              // Check if window has been resized last frame
+        void (*resizeCallback)(void);       // Pointer to a function to call during resizing
 
         Point position;                     // Window position on screen (required on fullscreen toggle)
         Size display;                       // Display width and height (monitor, device-screen, LCD, ...)
@@ -4618,6 +4619,10 @@ static bool InitGraphicsDevice(int width, int height)
     return true;
 }
 
+void SetResizeCallback(void (*resizeCallback)(void)) {
+    CORE.Window.resizeCallback = resizeCallback;
+}
+
 // Set viewport for a provided width and height
 static void SetupViewport(int width, int height)
 {
@@ -4644,6 +4649,9 @@ static void SetupViewport(int width, int height)
 
     rlMatrixMode(RL_MODELVIEW);         // Switch back to modelview matrix
     rlLoadIdentity();                   // Reset current matrix (modelview)
+    if (CORE.Window.resizeCallback != NULL && CORE.Window.ready) {
+        CORE.Window.resizeCallback();
+    }
 }
 
 // Compute framebuffer size relative to screen size and display size


### PR DESCRIPTION
Solves #1680

The strategy is fully opt-in and fully backward compatible with any existing code without modifications.

The implementation allows calling any custom code while resizing.
However, the most useful things to run while resizing are:

- Running the exact same code used for drawing each frame
- Running some custom code which draws some placeholder screen

I have included two examples showing these two usecases.
Tested on: Windows 10 64bit