### PR TITLE
Review code conventions for specific defines

### DIFF
--- a/src/rcore.c
+++ b/src/rcore.c
@@ -166,9 +166,9 @@
         #ifndef MAX_PATH
             #define MAX_PATH 1025
         #endif
-    __declspec(dllimport) unsigned long __stdcall GetModuleFileNameA(void* hModule, void* lpFilename, unsigned long nSize);
-    __declspec(dllimport) unsigned long __stdcall GetModuleFileNameW(void* hModule, void* lpFilename, unsigned long nSize);
-    __declspec(dllimport) int __stdcall WideCharToMultiByte(unsigned int cp, unsigned long flags, void* widestr, int cchwide, void* str, int cbmb, void* defchar, int* used_default);
+    __declspec(dllimport) unsigned long __stdcall GetModuleFileNameA(void *hModule, void *lpFilename, unsigned long nSize);
+    __declspec(dllimport) unsigned long __stdcall GetModuleFileNameW(void *hModule, void *lpFilename, unsigned long nSize);
+    __declspec(dllimport) int __stdcall WideCharToMultiByte(unsigned int cp, unsigned long flags, void *widestr, int cchwide, void *str, int cbmb, void *defchar, int *used_default);
     #elif defined(__linux__)
         #include <unistd.h>
     #elif defined(__APPLE__)


### PR DESCRIPTION
Unless these imports require to have this format, the code has been adjusted to the conventions