### PR TITLE
Fix GetApplicationDirectory on macOS

### DIFF
--- a/src/rcore.c
+++ b/src/rcore.c
@@ -173,6 +173,7 @@
         #include <unistd.h>
     #elif defined(__APPLE__)
         #include <sys/syslimits.h>
+        #include <mach-o/dyld.h>
     #endif // OSs
 #endif // PLATFORM_DESKTOP
 


### PR DESCRIPTION
Previously failed to build with an implicit declaration of `_NSGetExecutablePath`.