### PR TITLE
Fix Undefined Symbol `_ftelli64`

### DIFF
--- a/src/external/cgltf.h
+++ b/src/external/cgltf.h
@@ -948,7 +948,11 @@ static cgltf_result cgltf_default_file_read(const struct cgltf_memory_options* m
 		fseek(file, 0, SEEK_END);
 
 #ifdef _WIN32
-		__int64 length = _ftelli64(file);
+		#ifdef __TINYC__ 
+			__int64 length = ftell(file);
+		#else
+			__int64 length = _ftelli64(file);
+		#endif
 #else
 		long length = ftell(file);
 #endif


### PR DESCRIPTION
Fix undefined symbol `_ftelli64` when trying to compile with Raylib's Notepad++ & TCC on Windows.