### PR TITLE
Make audio examples compile with external glfw

### DIFF
--- a/cmake/LibraryConfigurations.cmake
+++ b/cmake/LibraryConfigurations.cmake
@@ -28,6 +28,10 @@ if (${PLATFORM} MATCHES "Desktop")
         endif ()
         
         set(LIBS_PRIVATE m pthread ${OPENGL_LIBRARIES} ${OSS_LIBRARY})
+
+        if (USE_AUDIO)
+            set(LIBS_PRIVATE ${LIBS_PRIVATE} dl)
+        endif ()
     endif ()
 
 elseif (${PLATFORM} MATCHES "Web")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -41,6 +41,10 @@ set(raylib_sources
 # <root>/cmake/GlfwImport.cmake handles the details around the inclusion of glfw
 include(GlfwImport)
 
+# Sets additional platform options and link libraries for each platform
+# also selects the proper graphics API and version for that platform
+# Produces a variable LIBS_PRIVATE that will be used later
+include(LibraryConfigurations)
 
 if (USE_AUDIO)
     MESSAGE(STATUS "Audio Backend: miniaudio")
@@ -49,10 +53,6 @@ else ()
     MESSAGE(STATUS "Audio Backend: None (-DUSE_AUDIO=OFF)")
 endif ()
 
-# Sets additional platform options and link libraries for each platform
-# also selects the proper graphics API and version for that platform
-# Produces a variable LIBS_PRIVATE that will be used later
-include(LibraryConfigurations)
 
 add_library(raylib ${raylib_sources} ${raylib_public_headers})
 


### PR DESCRIPTION
raudio needs `dlclose`, which is in `libdl` on Linux. Before this commit the audio examples won't compile with `USE_EXTERNAL_GLFW:STRING=ON` in CMake.