### PR TITLE
Fix make clean failing when make finds sh.exe in the PATH on windows

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -113,6 +113,12 @@ ifeq ($(PLATFORM),PLATFORM_DESKTOP)
     # ifeq ($(UNAME),Msys) -> Windows
     ifeq ($(OS),Windows_NT)
         PLATFORM_OS = WINDOWS
+        # Make always tries to run build rules under sh.exe by default
+        # so targets like "make clean" will fail if sh.exe is present in PATH
+        # this ensures under Windows, build rules are executed using cmd.exe
+        # see README.W32 of GNU Make for more details
+        # WARNING: -e flag of make will override this
+        SHELL = cmd
     else
         UNAMEOS = $(shell uname)
         ifeq ($(UNAMEOS),Linux)


### PR DESCRIPTION
Raylib's Makefile uses the cmd.exe builtin command del to delete
files for the make clean target, while make tries to use sh.exe if it is found in the PATH.
Since sh.exe obviously doesn't have the same builtin command, this target will fail because
of the bad assumption that the shell used to execute build rules is always cmd.exe
```
del *.o /s
sh: del: not found
make: *** [Makefile:739: clean] Error 127
```