### PR TITLE
Fix make clean target failing when shell is not cmd

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -731,6 +731,12 @@ endif
 # Clean everything
 clean:
 ifeq ($(PLATFORM_OS),WINDOWS)
+	# Make always tries to run build rules under sh.exe by default
+	# So if sh.exe is present in the PATH on windows, the del commands will fail
+	# see README.W32 of GNU Make for more details
+	# It is not specified earlier in the Makefile, because then cross-compilation
+	# will also fail.
+	SHELL = cmd
 	del *.o /s
 	cd $(RAYLIB_RELEASE_PATH)
 	del lib$(RAYLIB_LIB_NAME).a /s


### PR DESCRIPTION
GNU make on Windows first tries to find sh.exe on the path,
and will execute build rules using it if it is present.
The make clean target uses the builtin cmd.exe command del, which
won't work under sh.exe, it fails likeso:
```
del *.o /s
sh: del: not found
make: *** [Makefile:739: clean] Error 127
```

Setting the shell to cmd before attempting to run cmd builtin commands fixes the issue 

The reason this is not done for the entire Makefile is because it would
break cross-compilation of raylib.