### PR TITLE
Fix free camera panning in the wrong direction

### DIFF
--- a/src/rcamera.h
+++ b/src/rcamera.h
@@ -388,9 +388,9 @@ void UpdateCamera(Camera *camera)
                 else
                 {
                     // Camera panning
-                    camera->target.x += ((mousePositionDelta.x*CAMERA_FREE_MOUSE_SENSITIVITY)*cosf(CAMERA.angle.x) + (mousePositionDelta.y*CAMERA_FREE_MOUSE_SENSITIVITY)*sinf(CAMERA.angle.x)*sinf(CAMERA.angle.y))*(CAMERA.targetDistance/CAMERA_FREE_PANNING_DIVIDER);
+                    camera->target.x += ((mousePositionDelta.x*CAMERA_FREE_MOUSE_SENSITIVITY)*cosf(CAMERA.angle.x) + (mousePositionDelta.y*-CAMERA_FREE_MOUSE_SENSITIVITY)*sinf(CAMERA.angle.x)*sinf(CAMERA.angle.y))*(CAMERA.targetDistance/CAMERA_FREE_PANNING_DIVIDER);
                     camera->target.y += ((mousePositionDelta.y*CAMERA_FREE_MOUSE_SENSITIVITY)*cosf(CAMERA.angle.y))*(CAMERA.targetDistance/CAMERA_FREE_PANNING_DIVIDER);
-                    camera->target.z += ((mousePositionDelta.x*-CAMERA_FREE_MOUSE_SENSITIVITY)*sinf(CAMERA.angle.x) + (mousePositionDelta.y*CAMERA_FREE_MOUSE_SENSITIVITY)*cosf(CAMERA.angle.x)*sinf(CAMERA.angle.y))*(CAMERA.targetDistance/CAMERA_FREE_PANNING_DIVIDER);
+                    camera->target.z += ((mousePositionDelta.x*-CAMERA_FREE_MOUSE_SENSITIVITY)*sinf(CAMERA.angle.x) + (mousePositionDelta.y*-CAMERA_FREE_MOUSE_SENSITIVITY)*cosf(CAMERA.angle.x)*sinf(CAMERA.angle.y))*(CAMERA.targetDistance/CAMERA_FREE_PANNING_DIVIDER);
                 }
             }
 


### PR DESCRIPTION
I noticed the free camera acting unexpectedly and its seems some values needed to be negated. I've attached two video clips to showcasing the issue and the fix. I thought it was a platform issue but it seems the free camera example on raylib.com also has the same issue.

Only tested on arch linux.

Here you can see the panning action "zooming" in and out when panning while viewing at an angle, and the panning moving in the opposite direction when viewing straight down:

https://user-images.githubusercontent.com/30801498/154765282-c4a1dc58-3421-4511-a0de-13820e5565f9.mp4

And here it is with this PR applied, it now pans correctly:

https://user-images.githubusercontent.com/30801498/154765284-b180d8a0-3da4-4f08-9212-8c669c36b4c9.mp4

