### PR TITLE
Fixed "custom frame_control" example for PLATFORM_WEB (#2380)

### DIFF
--- a/examples/core/core_custom_frame_control.c
+++ b/examples/core/core_custom_frame_control.c
@@ -54,8 +54,6 @@ int main(void)
     {
         // Update
         //----------------------------------------------------------------------------------
-        PollInputEvents();              // Poll input events (SUPPORT_CUSTOM_FRAME_CONTROL)
-        
         if (IsKeyPressed(KEY_SPACE)) pause = !pause;
         
         if (IsKeyPressed(KEY_UP)) targetFPS += 20;
@@ -113,6 +111,8 @@ int main(void)
         else deltaTime = updateDrawTime;    // Framerate could be variable
 
         previousTime = currentTime;
+
+        PollInputEvents();          // Poll input events (SUPPORT_CUSTOM_FRAME_CONTROL)
         //----------------------------------------------------------------------------------
     }
 


### PR DESCRIPTION
This PR addresses Issue https://github.com/raysan5/raylib/issues/2379.

After a lot of head-scratching I realized that `PollInputEvents` must always be called as late as possible! When `SUPPORT_CUSTOM_FRAME_CONTROL` is disabled, `EndDrawing` already calls `PollInputEvents` last.

It seems that the following pull request https://github.com/raysan5/raylib/pull/1573 was on to something.

I do not fully understand why this is a problem for `PLATFORM_WEB` and not `PLATFORM_DESKTOP`. I did spend enough time looking at `rcore.h` to conclude that this issue is a quirk of using emscripten, and not something inherently wrong with `rcore.h`'s logic. 

EDIT: I was wrong; the above mentioned pull request does not apply to this issue. 
