### PR TITLE
Simplify build.zig to not require user to specify raylib path

### DIFF
--- a/src/build.zig
+++ b/src/build.zig
@@ -1,89 +1,81 @@
 const std = @import("std");
 
-pub fn Pkg(srcdir: []const u8) type {
-    return struct {
-        pub fn addRaylib(b: *std.build.Builder, target: std.zig.CrossTarget) *std.build.LibExeObjStep {
-            // Standard release options allow the person running `zig build` to select
-            // between Debug, ReleaseSafe, ReleaseFast, and ReleaseSmall.
-            const mode = b.standardReleaseOptions();
+pub fn addRaylib(b: *std.build.Builder, target: std.zig.CrossTarget) *std.build.LibExeObjStep {
+    // Standard release options allow the person running `zig build` to select
+    // between Debug, ReleaseSafe, ReleaseFast, and ReleaseSmall.
+    const mode = b.standardReleaseOptions();
 
-            const raylib_flags = &[_][]const u8{
-                "-std=gnu99",
-                "-DPLATFORM_DESKTOP",
-                "-DGL_SILENCE_DEPRECATION=199309L",
-                "-fno-sanitize=undefined", // https://github.com/raysan5/raylib/issues/1891
-            };
-
-            const raylib = b.addStaticLibrary("raylib", srcdir ++ "/raylib.h");
-            raylib.setTarget(target);
-            raylib.setBuildMode(mode);
-            raylib.linkLibC();
-
-            raylib.addIncludeDir(srcdir ++ "/external/glfw/include");
-
-            raylib.addCSourceFiles(&.{
-                srcdir ++ "/raudio.c",
-                srcdir ++ "/rcore.c",
-                srcdir ++ "/rmodels.c",
-                srcdir ++ "/rshapes.c",
-                srcdir ++ "/rtext.c",
-                srcdir ++ "/rtextures.c",
-                srcdir ++ "/utils.c",
-            }, raylib_flags);
-
-            switch (raylib.target.toTarget().os.tag) {
-                .windows => {
-                    raylib.addCSourceFiles(&.{srcdir ++ "/rglfw.c"}, raylib_flags);
-                    raylib.linkSystemLibrary("winmm");
-                    raylib.linkSystemLibrary("gdi32");
-                    raylib.linkSystemLibrary("opengl32");
-                    raylib.addIncludeDir("external/glfw/deps/mingw");
-                },
-                .linux => {
-                    raylib.addCSourceFiles(&.{srcdir ++ "/rglfw.c"}, raylib_flags);
-                    raylib.linkSystemLibrary("GL");
-                    raylib.linkSystemLibrary("rt");
-                    raylib.linkSystemLibrary("dl");
-                    raylib.linkSystemLibrary("m");
-                    raylib.linkSystemLibrary("X11");
-                },
-                .freebsd, .openbsd, .netbsd, .dragonfly => {
-                    raylib.addCSourceFiles(&.{srcdir ++ "/rglfw.c"}, raylib_flags);
-                    raylib.linkSystemLibrary("GL");
-                    raylib.linkSystemLibrary("rt");
-                    raylib.linkSystemLibrary("dl");
-                    raylib.linkSystemLibrary("m");
-                    raylib.linkSystemLibrary("X11");
-                    raylib.linkSystemLibrary("Xrandr");
-                    raylib.linkSystemLibrary("Xinerama");
-                    raylib.linkSystemLibrary("Xi");
-                    raylib.linkSystemLibrary("Xxf86vm");
-                    raylib.linkSystemLibrary("Xcursor");
-                },
-                .macos => {
-                    // On macos rglfw.c include Objective-C files.
-                    const raylib_flags_extra_macos = &[_][]const u8{
-                        "-ObjC",
-                    };
-                    raylib.addCSourceFiles(
-                        &.{srcdir ++ "/rglfw.c"},
-                        raylib_flags ++ raylib_flags_extra_macos,
-                    );
-                    raylib.linkFramework("Foundation");
-                },
-                else => {
-                    @panic("Unsupported OS");
-                },
-            }
-
-            raylib.setOutputDir("./");
-            raylib.install();
-            return raylib;
-        }
+    const raylib_flags = &[_][]const u8{
+        "-std=gnu99",
+        "-DPLATFORM_DESKTOP",
+        "-DGL_SILENCE_DEPRECATION=199309L",
+        "-fno-sanitize=undefined", // https://github.com/raysan5/raylib/issues/1891
     };
-}
 
-const lib = Pkg(".");
+    const raylib = b.addStaticLibrary("raylib", srcdir ++ "/raylib.h");
+    raylib.setTarget(target);
+    raylib.setBuildMode(mode);
+    raylib.linkLibC();
+
+    raylib.addIncludeDir(srcdir ++ "/external/glfw/include");
+
+    raylib.addCSourceFiles(&.{
+        srcdir ++ "/raudio.c",
+        srcdir ++ "/rcore.c",
+        srcdir ++ "/rmodels.c",
+        srcdir ++ "/rshapes.c",
+        srcdir ++ "/rtext.c",
+        srcdir ++ "/rtextures.c",
+        srcdir ++ "/utils.c",
+    }, raylib_flags);
+
+    switch (raylib.target.toTarget().os.tag) {
+        .windows => {
+            raylib.addCSourceFiles(&.{srcdir ++ "/rglfw.c"}, raylib_flags);
+            raylib.linkSystemLibrary("winmm");
+            raylib.linkSystemLibrary("gdi32");
+            raylib.linkSystemLibrary("opengl32");
+            raylib.addIncludeDir("external/glfw/deps/mingw");
+        },
+        .linux => {
+            raylib.addCSourceFiles(&.{srcdir ++ "/rglfw.c"}, raylib_flags);
+            raylib.linkSystemLibrary("GL");
+            raylib.linkSystemLibrary("rt");
+            raylib.linkSystemLibrary("dl");
+            raylib.linkSystemLibrary("m");
+            raylib.linkSystemLibrary("X11");
+        },
+        .freebsd, .openbsd, .netbsd, .dragonfly => {
+            raylib.addCSourceFiles(&.{srcdir ++ "/rglfw.c"}, raylib_flags);
+            raylib.linkSystemLibrary("GL");
+            raylib.linkSystemLibrary("rt");
+            raylib.linkSystemLibrary("dl");
+            raylib.linkSystemLibrary("m");
+            raylib.linkSystemLibrary("X11");
+            raylib.linkSystemLibrary("Xrandr");
+            raylib.linkSystemLibrary("Xinerama");
+            raylib.linkSystemLibrary("Xi");
+            raylib.linkSystemLibrary("Xxf86vm");
+            raylib.linkSystemLibrary("Xcursor");
+        },
+        .macos => {
+            // On macos rglfw.c include Objective-C files.
+            const raylib_flags_extra_macos = &[_][]const u8{
+                "-ObjC",
+            };
+            raylib.addCSourceFiles(
+                &.{srcdir ++ "/rglfw.c"},
+                raylib_flags ++ raylib_flags_extra_macos,
+            );
+            raylib.linkFramework("Foundation");
+        },
+        else => {
+            @panic("Unsupported OS");
+        },
+    }
+
+    return raylib;
+}
 
 pub fn build(b: *std.build.Builder) void {
     // Standard target options allows the person running `zig build` to choose
@@ -92,5 +84,13 @@ pub fn build(b: *std.build.Builder) void {
     // for restricting supported target set are available.
     const target = b.standardTargetOptions(.{});
 
-    _ = lib.addRaylib(b, target);
+    const lib = addRaylib(b, target);
+    lib.setOutputDir(srcdir);
+    lib.install();
+}
+
+const srcdir = getSrcDir();
+
+fn getSrcDir() []const u8 {
+    return std.fs.path.dirname(@src().file) orelse ".";
 }


### PR DESCRIPTION
We can figure out the source file location based on the location of the
build.zig file. No need to require the library user to specify where
raylib is stored.

```zig
// Before
const rl = @import("raylib/src/build.zig").Pkg("raylib/src");
const exe = b.addExecutable(name, path);
exe.linkLibrary(rl.addRaylib(exe.builder, exe.target));

// After
const rl = @import("raylib/src/build.zig");
const exe = b.addExecutable(name, path);
exe.linkLibrary(rl.addRaylib(exe.builder, exe.target));
```

