### PR TITLE
Fix too many opening parens in src/rtextures.c

### DIFF
--- a/src/rtextures.c
+++ b/src/rtextures.c
@@ -306,10 +306,9 @@ Image LoadImageFromMemory(const char *fileType, const unsigned char *fileData, i
 {
     Image image = { 0 };
 
-#if defined(SUPPORT_FILEFORMAT_PNG)
-    if ((strcmp(fileType, ".png") == 0)
-#else
     if ((false)
+#if defined(SUPPORT_FILEFORMAT_PNG)
+        || (strcmp(fileType, ".png") == 0)
 #endif
 #if defined(SUPPORT_FILEFORMAT_BMP)
         || (strcmp(fileType, ".bmp") == 0)


### PR DESCRIPTION
This is a tiny change that makes code in src/rtextures.c "fold"
correctly in editors/IDE's by matching the number of opening
parenthesis to closing parenthesis.  One of those editors is Emacs ;-)