### PR TITLE
[CORE] Add a matrix to GetRayCollisionModel

### DIFF
--- a/examples/models/models_mesh_picking.c
+++ b/examples/models/models_mesh_picking.c
@@ -123,7 +123,7 @@ int main(void)
 
             // Check ray collision against model
             // NOTE: It considers model.transform matrix!
-            RayCollision meshHitInfo = GetRayCollisionModel(ray, tower);
+            RayCollision meshHitInfo = GetRayCollisionModel(ray, tower, MatrixIdentity());
 
             if (meshHitInfo.hit)
             {

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1464,8 +1464,8 @@ RLAPI bool CheckCollisionBoxes(BoundingBox box1, BoundingBox box2);             
 RLAPI bool CheckCollisionBoxSphere(BoundingBox box, Vector3 center, float radius);                  // Check collision between box and sphere
 RLAPI RayCollision GetRayCollisionSphere(Ray ray, Vector3 center, float radius);                    // Get collision info between ray and sphere
 RLAPI RayCollision GetRayCollisionBox(Ray ray, BoundingBox box);                                    // Get collision info between ray and box
-RLAPI RayCollision GetRayCollisionModel(Ray ray, Model model);                                      // Get collision info between ray and model
-RLAPI RayCollision GetRayCollisionMesh(Ray ray, Mesh mesh, Matrix transform);                       // Get collision info between ray and mesh
+RLAPI RayCollision GetRayCollisionModel(Ray ray, Model model, Matrix transform);                    // Get collision info between ray and model
+RLAPI RayCollision GetRayCollisionMesh(Ray ray, Mesh mesh, Matrix transform);                      // Get collision info between ray and mesh
 RLAPI RayCollision GetRayCollisionTriangle(Ray ray, Vector3 p1, Vector3 p2, Vector3 p3);            // Get collision info between ray and triangle
 RLAPI RayCollision GetRayCollisionQuad(Ray ray, Vector3 p1, Vector3 p2, Vector3 p3, Vector3 p4);    // Get collision info between ray and quad
 

--- a/src/rmodels.c
+++ b/src/rmodels.c
@@ -3641,13 +3641,15 @@ RayCollision GetRayCollisionMesh(Ray ray, Mesh mesh, Matrix transform)
 }
 
 // Get collision info between ray and model
-RayCollision GetRayCollisionModel(Ray ray, Model model)
+RayCollision GetRayCollisionModel(Ray ray, Model model, Matrix transform)
 {
     RayCollision collision = { 0 };
 
+    Matrix mat = MatrixMultiply(model.transform, transform);
+
     for (int m = 0; m < model.meshCount; m++)
     {
-        RayCollision meshHitInfo = GetRayCollisionMesh(ray, model.meshes[m], model.transform);
+        RayCollision meshHitInfo = GetRayCollisionMesh(ray, model.meshes[m], mat);
 
         if (meshHitInfo.hit)
         {


### PR DESCRIPTION
This PR adds a matrix to GetCollisionModel so that you don't have to modify the model every time you want collisions. This allows the same unmodified model for drawing and collision.