### PR TITLE
Fix QuaternionScale

### DIFF
--- a/src/raymath.h
+++ b/src/raymath.h
@@ -1511,12 +1511,10 @@ RMAPI Quaternion QuaternionScale(Quaternion q, float mul)
 {
     Quaternion result = { 0 };
 
-    float qax = q.x, qay = q.y, qaz = q.z, qaw = q.w;
-
-    result.x = qax*mul + qaw*mul + qay*mul - qaz*mul;
-    result.y = qay*mul + qaw*mul + qaz*mul - qax*mul;
-    result.z = qaz*mul + qaw*mul + qax*mul - qay*mul;
-    result.w = qaw*mul - qax*mul - qay*mul - qaz*mul;
+    result.x = q.x*mul;
+    result.y = q.y*mul;
+    result.z = q.z*mul;
+    result.w = q.w*mul;
 
     return result;
 }


### PR DESCRIPTION
# Description
This PR fixes calculation of `QuaternionScale` function in `raymath.h`.

# Problem
I found the previous implementation of `QuaternionScale` was calculating `(w+ix+jy+kz)(s+is+js+ks)`, rather than usual quaternion-scalar multiplication `(w+ix+jy+kz)s`.

# Solution
Changed the function to calculate `(w+ix+jy+kz)s = ws+i(xs)+j(ys)+k(zs)`.

(Sorry for hard-to-read math, because GitHub does not allow LaTeX equations)