### PR TITLE
Fix for vr rendering not taking render target size into account. fixes #2420

### DIFF
--- a/examples/core/core_vr_simulator.c
+++ b/examples/core/core_vr_simulator.c
@@ -78,7 +78,11 @@ int main(void)
 
     // Initialize framebuffer for stereo rendering
     // NOTE: Screen size should match HMD aspect ratio
-    RenderTexture2D target = LoadRenderTexture(GetScreenWidth(), GetScreenHeight());
+    RenderTexture2D target = LoadRenderTexture(device.hResolution, device.vResolution);
+
+    // The target's height is flipped (in the source Rectangle), due to OpenGL reasons
+    Rectangle sourceRec = { 0.0f, 0.0f, (float)target.texture.width, -(float)target.texture.height };
+    Rectangle destRec = { 0.0f, 0.0f, (float)GetScreenWidth(), (float)GetScreenHeight() };
 
     // Define the camera to look into our 3d world
     Camera camera = { 0 };
@@ -121,8 +125,7 @@ int main(void)
         BeginDrawing();
             ClearBackground(RAYWHITE);
             BeginShaderMode(distortion);
-                DrawTextureRec(target.texture, (Rectangle){ 0, 0, (float)target.texture.width,
-                              (float)-target.texture.height }, (Vector2){ 0.0f, 0.0f }, WHITE);
+                DrawTexturePro(target.texture, sourceRec, destRec, (Vector2){ 0.0f, 0.0f }, 0.0f, WHITE);
             EndShaderMode();
             DrawFPS(10, 10);
         EndDrawing();

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -2347,8 +2347,8 @@ VrStereoConfig LoadVrStereoConfig(VrDeviceInfo device)
 
         // Fovy is normally computed with: 2*atan2f(device.vScreenSize, 2*device.eyeToScreenDistance)
         // ...but with lens distortion it is increased (see Oculus SDK Documentation)
-        //float fovy = 2.0f*atan2f(device.vScreenSize*0.5f*distortionScale, device.eyeToScreenDistance);     // Really need distortionScale?
-        float fovy = 2.0f*(float)atan2f(device.vScreenSize*0.5f, device.eyeToScreenDistance);
+        float fovy = 2.0f*atan2f(device.vScreenSize*0.5f*distortionScale, device.eyeToScreenDistance);     // Really need distortionScale?
+       // float fovy = 2.0f*(float)atan2f(device.vScreenSize*0.5f, device.eyeToScreenDistance);
 
         // Compute camera projection matrices
         float projOffset = 4.0f*lensShift;      // Scaled to projection space coordinates [-1..1]


### PR DESCRIPTION
I tried to find a way to fix the issue without breaking an existing API. I think the current solution fits that criteria.

I needed to comment in the `distortionScale`, to keep the example's "vignette" effect. To my eyes the final image looks the same as the previous version.