### PR TITLE
Fix issue #2371

### DIFF
--- a/src/rcore.c
+++ b/src/rcore.c
@@ -5409,7 +5409,7 @@ static void MouseCursorPosCallback(GLFWwindow *window, double x, double y)
 // GLFW3 Scrolling Callback, runs on mouse wheel
 static void MouseScrollCallback(GLFWwindow *window, double xoffset, double yoffset)
 {
-    if ((float)xoffset != 0.0f) CORE.Input.Mouse.currentWheelMove = (float)xoffset;
+    if (fabs(xoffset)>fabs(yoffset)) CORE.Input.Mouse.currentWheelMove = (float)xoffset;
     else CORE.Input.Mouse.currentWheelMove = (float)yoffset;
 }
 


### PR DESCRIPTION
In MouseScrollCallback priority was given to the horizontal movement, I have changed it to return the largest movement (in absolute value) between the X and Y axis.

Perhaps it would be more interesting to have different functions for the X and Y axis.