### PR TITLE
Add aliases to parser

### DIFF
--- a/parser/raylib_api.json
+++ b/parser/raylib_api.json
@@ -69,22 +69,82 @@
       "fields": [
         {
           "type": "float",
-          "name": "m0, m4, m8, m12",
+          "name": "m0",
           "description": "Matrix first row (4 components)"
         },
         {
           "type": "float",
-          "name": "m1, m5, m9, m13",
+          "name": "m4",
+          "description": "Matrix first row (4 components)"
+        },
+        {
+          "type": "float",
+          "name": "m8",
+          "description": "Matrix first row (4 components)"
+        },
+        {
+          "type": "float",
+          "name": "m12",
+          "description": "Matrix first row (4 components)"
+        },
+        {
+          "type": "float",
+          "name": "m1",
           "description": "Matrix second row (4 components)"
         },
         {
           "type": "float",
-          "name": "m2, m6, m10, m14",
+          "name": "m5",
+          "description": "Matrix second row (4 components)"
+        },
+        {
+          "type": "float",
+          "name": "m9",
+          "description": "Matrix second row (4 components)"
+        },
+        {
+          "type": "float",
+          "name": "m13",
+          "description": "Matrix second row (4 components)"
+        },
+        {
+          "type": "float",
+          "name": "m2",
           "description": "Matrix third row (4 components)"
         },
         {
           "type": "float",
-          "name": "m3, m7, m11, m15",
+          "name": "m6",
+          "description": "Matrix third row (4 components)"
+        },
+        {
+          "type": "float",
+          "name": "m10",
+          "description": "Matrix third row (4 components)"
+        },
+        {
+          "type": "float",
+          "name": "m14",
+          "description": "Matrix third row (4 components)"
+        },
+        {
+          "type": "float",
+          "name": "m3",
+          "description": "Matrix fourth row (4 components)"
+        },
+        {
+          "type": "float",
+          "name": "m7",
+          "description": "Matrix fourth row (4 components)"
+        },
+        {
+          "type": "float",
+          "name": "m11",
+          "description": "Matrix fourth row (4 components)"
+        },
+        {
+          "type": "float",
+          "name": "m15",
           "description": "Matrix fourth row (4 components)"
         }
       ]

--- a/parser/raylib_api.json
+++ b/parser/raylib_api.json
@@ -907,6 +907,33 @@
       ]
     }
   ],
+  "aliases": [
+    {
+      "type": "Vector4",
+      "name": "Quaternion",
+      "description": "Quaternion, 4 components (Vector4 alias)"
+    },
+    {
+      "type": "Texture",
+      "name": "Texture2D",
+      "description": "Texture2D, same as Texture"
+    },
+    {
+      "type": "Texture",
+      "name": "TextureCubemap",
+      "description": "TextureCubemap, same as Texture"
+    },
+    {
+      "type": "RenderTexture",
+      "name": "RenderTexture2D",
+      "description": "RenderTexture2D, same as RenderTexture"
+    },
+    {
+      "type": "Camera3D",
+      "name": "Camera",
+      "description": "Camera type fallback, defaults to Camera3D"
+    }
+  ],
   "enums": [
     {
       "name": "ConfigFlags",
@@ -4101,11 +4128,11 @@
         },
         {
           "type": "int",
-          "name": "dataLength"
+          "name": "dataSize"
         },
         {
           "type": "int *",
-          "name": "compDataLength"
+          "name": "compDataSize"
         }
       ]
     },
@@ -4120,11 +4147,11 @@
         },
         {
           "type": "int",
-          "name": "compDataLength"
+          "name": "compDataSize"
         },
         {
           "type": "int *",
-          "name": "dataLength"
+          "name": "dataSize"
         }
       ]
     },
@@ -4139,11 +4166,11 @@
         },
         {
           "type": "int",
-          "name": "dataLength"
+          "name": "dataSize"
         },
         {
           "type": "int *",
-          "name": "outputLength"
+          "name": "outputSize"
         }
       ]
     },
@@ -4158,7 +4185,7 @@
         },
         {
           "type": "int *",
-          "name": "outputLength"
+          "name": "outputSize"
         }
       ]
     },

--- a/parser/raylib_api.lua
+++ b/parser/raylib_api.lua
@@ -69,22 +69,82 @@ return {
       fields = {
         {
           type = "float",
-          name = "m0, m4, m8, m12",
+          name = "m0",
           description = "Matrix first row (4 components)"
         },
         {
           type = "float",
-          name = "m1, m5, m9, m13",
+          name = "m4",
+          description = "Matrix first row (4 components)"
+        },
+        {
+          type = "float",
+          name = "m8",
+          description = "Matrix first row (4 components)"
+        },
+        {
+          type = "float",
+          name = "m12",
+          description = "Matrix first row (4 components)"
+        },
+        {
+          type = "float",
+          name = "m1",
           description = "Matrix second row (4 components)"
         },
         {
           type = "float",
-          name = "m2, m6, m10, m14",
+          name = "m5",
+          description = "Matrix second row (4 components)"
+        },
+        {
+          type = "float",
+          name = "m9",
+          description = "Matrix second row (4 components)"
+        },
+        {
+          type = "float",
+          name = "m13",
+          description = "Matrix second row (4 components)"
+        },
+        {
+          type = "float",
+          name = "m2",
           description = "Matrix third row (4 components)"
         },
         {
           type = "float",
-          name = "m3, m7, m11, m15",
+          name = "m6",
+          description = "Matrix third row (4 components)"
+        },
+        {
+          type = "float",
+          name = "m10",
+          description = "Matrix third row (4 components)"
+        },
+        {
+          type = "float",
+          name = "m14",
+          description = "Matrix third row (4 components)"
+        },
+        {
+          type = "float",
+          name = "m3",
+          description = "Matrix fourth row (4 components)"
+        },
+        {
+          type = "float",
+          name = "m7",
+          description = "Matrix fourth row (4 components)"
+        },
+        {
+          type = "float",
+          name = "m11",
+          description = "Matrix fourth row (4 components)"
+        },
+        {
+          type = "float",
+          name = "m15",
           description = "Matrix fourth row (4 components)"
         }
       }

--- a/parser/raylib_api.lua
+++ b/parser/raylib_api.lua
@@ -907,6 +907,33 @@ return {
       }
     }
   },
+  aliases = {
+    {
+      type = "Vector4",
+      name = "Quaternion",
+      description = "Quaternion, 4 components (Vector4 alias)"
+    },
+    {
+      type = "Texture",
+      name = "Texture2D",
+      description = "Texture2D, same as Texture"
+    },
+    {
+      type = "Texture",
+      name = "TextureCubemap",
+      description = "TextureCubemap, same as Texture"
+    },
+    {
+      type = "RenderTexture",
+      name = "RenderTexture2D",
+      description = "RenderTexture2D, same as RenderTexture"
+    },
+    {
+      type = "Camera3D",
+      name = "Camera",
+      description = "Camera type fallback, defaults to Camera3D"
+    }
+  },
   enums = {
     {
       name = "ConfigFlags",
@@ -3736,8 +3763,8 @@ return {
       returnType = "unsigned char *",
       params = {
         {type = "const unsigned char *", name = "data"},
-        {type = "int", name = "dataLength"},
-        {type = "int *", name = "compDataLength"}
+        {type = "int", name = "dataSize"},
+        {type = "int *", name = "compDataSize"}
       }
     },
     {
@@ -3746,8 +3773,8 @@ return {
       returnType = "unsigned char *",
       params = {
         {type = "const unsigned char *", name = "compData"},
-        {type = "int", name = "compDataLength"},
-        {type = "int *", name = "dataLength"}
+        {type = "int", name = "compDataSize"},
+        {type = "int *", name = "dataSize"}
       }
     },
     {
@@ -3756,8 +3783,8 @@ return {
       returnType = "char *",
       params = {
         {type = "const unsigned char *", name = "data"},
-        {type = "int", name = "dataLength"},
-        {type = "int *", name = "outputLength"}
+        {type = "int", name = "dataSize"},
+        {type = "int *", name = "outputSize"}
       }
     },
     {
@@ -3766,7 +3793,7 @@ return {
       returnType = "unsigned char *",
       params = {
         {type = "const unsigned char *", name = "data"},
-        {type = "int *", name = "outputLength"}
+        {type = "int *", name = "outputSize"}
       }
     },
     {

--- a/parser/raylib_api.txt
+++ b/parser/raylib_api.txt
@@ -239,6 +239,29 @@ Struct 31: VrStereoConfig (8 fields)
   Field[7]: float scale[2] // VR distortion scale
   Field[8]: float scaleIn[2] // VR distortion scale in
 
+Aliases found: 5
+
+Alias 001: Quaternion
+  Type: Vector4
+  Name: Quaternion
+  Description: Quaternion, 4 components (Vector4 alias)
+Alias 002: Texture2D
+  Type: Texture
+  Name: Texture2D
+  Description: Texture2D, same as Texture
+Alias 003: TextureCubemap
+  Type: Texture
+  Name: TextureCubemap
+  Description: TextureCubemap, same as Texture
+Alias 004: RenderTexture2D
+  Type: RenderTexture
+  Name: RenderTexture2D
+  Description: RenderTexture2D, same as RenderTexture
+Alias 005: Camera
+  Type: Camera3D
+  Name: Camera
+  Description: Camera type fallback, defaults to Camera3D
+
 Enums found: 21
 
 Enum 01: ConfigFlags (14 values)
@@ -1284,28 +1307,28 @@ Function 129: CompressData() (3 input parameters)
   Return type: unsigned char *
   Description: Compress data (DEFLATE algorithm)
   Param[1]: data (type: const unsigned char *)
-  Param[2]: dataLength (type: int)
-  Param[3]: compDataLength (type: int *)
+  Param[2]: dataSize (type: int)
+  Param[3]: compDataSize (type: int *)
 Function 130: DecompressData() (3 input parameters)
   Name: DecompressData
   Return type: unsigned char *
   Description: Decompress data (DEFLATE algorithm)
   Param[1]: compData (type: const unsigned char *)
-  Param[2]: compDataLength (type: int)
-  Param[3]: dataLength (type: int *)
+  Param[2]: compDataSize (type: int)
+  Param[3]: dataSize (type: int *)
 Function 131: EncodeDataBase64() (3 input parameters)
   Name: EncodeDataBase64
   Return type: char *
   Description: Encode data to Base64 string
   Param[1]: data (type: const unsigned char *)
-  Param[2]: dataLength (type: int)
-  Param[3]: outputLength (type: int *)
+  Param[2]: dataSize (type: int)
+  Param[3]: outputSize (type: int *)
 Function 132: DecodeDataBase64() (2 input parameters)
   Name: DecodeDataBase64
   Return type: unsigned char *
   Description: Decode Base64 string data
   Param[1]: data (type: const unsigned char *)
-  Param[2]: outputLength (type: int *)
+  Param[2]: outputSize (type: int *)
 Function 133: SaveStorageValue() (2 input parameters)
   Name: SaveStorageValue
   Return type: bool

--- a/parser/raylib_api.txt
+++ b/parser/raylib_api.txt
@@ -19,13 +19,25 @@ Struct 03: Vector4 (4 fields)
   Field[2]: float y // Vector y component
   Field[3]: float z // Vector z component
   Field[4]: float w // Vector w component
-Struct 04: Matrix (4 fields)
+Struct 04: Matrix (16 fields)
   Name: Matrix
   Description: Matrix, 4x4 components, column major, OpenGL style, right handed
-  Field[1]: float m0, m4, m8, m12 // Matrix first row (4 components)
-  Field[2]: float m1, m5, m9, m13 // Matrix second row (4 components)
-  Field[3]: float m2, m6, m10, m14 // Matrix third row (4 components)
-  Field[4]: float m3, m7, m11, m15 // Matrix fourth row (4 components)
+  Field[1]: float m0 // Matrix first row (4 components)
+  Field[2]: float m4 // Matrix first row (4 components)
+  Field[3]: float m8 // Matrix first row (4 components)
+  Field[4]: float m12 // Matrix first row (4 components)
+  Field[5]: float m1 // Matrix second row (4 components)
+  Field[6]: float m5 // Matrix second row (4 components)
+  Field[7]: float m9 // Matrix second row (4 components)
+  Field[8]: float m13 // Matrix second row (4 components)
+  Field[9]: float m2 // Matrix third row (4 components)
+  Field[10]: float m6 // Matrix third row (4 components)
+  Field[11]: float m10 // Matrix third row (4 components)
+  Field[12]: float m14 // Matrix third row (4 components)
+  Field[13]: float m3 // Matrix fourth row (4 components)
+  Field[14]: float m7 // Matrix fourth row (4 components)
+  Field[15]: float m11 // Matrix fourth row (4 components)
+  Field[16]: float m15 // Matrix fourth row (4 components)
 Struct 05: Color (4 fields)
   Name: Color
   Description: Color, 4 components, R8G8B8A8 (32bit)

--- a/parser/raylib_api.xml
+++ b/parser/raylib_api.xml
@@ -208,6 +208,13 @@
             <Field type="float" name="scaleIn[2]" desc="VR distortion scale in" />
         </Struct>
     </Structs>
+    <Aliases count="5">
+        <Alias type="Quaternion" name="Vector4" desc="Quaternion, 4 components (Vector4 alias)" />
+        <Alias type="Texture2D" name="Texture" desc="Texture2D, same as Texture" />
+        <Alias type="TextureCubemap" name="Texture" desc="TextureCubemap, same as Texture" />
+        <Alias type="RenderTexture2D" name="RenderTexture" desc="RenderTexture2D, same as RenderTexture" />
+        <Alias type="Camera" name="Camera3D" desc="Camera type fallback, defaults to Camera3D" />
+    </Aliases>
     <Enums count="21">
         <Enum name="ConfigFlags" valueCount="14" desc="System/Window config flags">
             <Value name="FLAG_VSYNC_HINT" integer="64" desc="Set to try enabling V-Sync on GPU" />
@@ -977,22 +984,22 @@
         </Function>
         <Function name="CompressData" retType="unsigned char *" paramCount="3" desc="Compress data (DEFLATE algorithm)">
             <Param type="const unsigned char *" name="data" desc="" />
-            <Param type="int" name="dataLength" desc="" />
-            <Param type="int *" name="compDataLength" desc="" />
+            <Param type="int" name="dataSize" desc="" />
+            <Param type="int *" name="compDataSize" desc="" />
         </Function>
         <Function name="DecompressData" retType="unsigned char *" paramCount="3" desc="Decompress data (DEFLATE algorithm)">
             <Param type="const unsigned char *" name="compData" desc="" />
-            <Param type="int" name="compDataLength" desc="" />
-            <Param type="int *" name="dataLength" desc="" />
+            <Param type="int" name="compDataSize" desc="" />
+            <Param type="int *" name="dataSize" desc="" />
         </Function>
         <Function name="EncodeDataBase64" retType="char *" paramCount="3" desc="Encode data to Base64 string">
             <Param type="const unsigned char *" name="data" desc="" />
-            <Param type="int" name="dataLength" desc="" />
-            <Param type="int *" name="outputLength" desc="" />
+            <Param type="int" name="dataSize" desc="" />
+            <Param type="int *" name="outputSize" desc="" />
         </Function>
         <Function name="DecodeDataBase64" retType="unsigned char *" paramCount="2" desc="Decode Base64 string data">
             <Param type="const unsigned char *" name="data" desc="" />
-            <Param type="int *" name="outputLength" desc="" />
+            <Param type="int *" name="outputSize" desc="" />
         </Function>
         <Function name="SaveStorageValue" retType="bool" paramCount="2" desc="Save integer value to storage file (to defined position), returns true on success">
             <Param type="unsigned int" name="position" desc="" />

--- a/parser/raylib_api.xml
+++ b/parser/raylib_api.xml
@@ -16,11 +16,23 @@
             <Field type="float" name="z" desc="Vector z component" />
             <Field type="float" name="w" desc="Vector w component" />
         </Struct>
-        <Struct name="Matrix" fieldCount="4" desc="Matrix, 4x4 components, column major, OpenGL style, right handed">
-            <Field type="float" name="m0, m4, m8, m12" desc="Matrix first row (4 components)" />
-            <Field type="float" name="m1, m5, m9, m13" desc="Matrix second row (4 components)" />
-            <Field type="float" name="m2, m6, m10, m14" desc="Matrix third row (4 components)" />
-            <Field type="float" name="m3, m7, m11, m15" desc="Matrix fourth row (4 components)" />
+        <Struct name="Matrix" fieldCount="16" desc="Matrix, 4x4 components, column major, OpenGL style, right handed">
+            <Field type="float" name="m0" desc="Matrix first row (4 components)" />
+            <Field type="float" name="m4" desc="Matrix first row (4 components)" />
+            <Field type="float" name="m8" desc="Matrix first row (4 components)" />
+            <Field type="float" name="m12" desc="Matrix first row (4 components)" />
+            <Field type="float" name="m1" desc="Matrix second row (4 components)" />
+            <Field type="float" name="m5" desc="Matrix second row (4 components)" />
+            <Field type="float" name="m9" desc="Matrix second row (4 components)" />
+            <Field type="float" name="m13" desc="Matrix second row (4 components)" />
+            <Field type="float" name="m2" desc="Matrix third row (4 components)" />
+            <Field type="float" name="m6" desc="Matrix third row (4 components)" />
+            <Field type="float" name="m10" desc="Matrix third row (4 components)" />
+            <Field type="float" name="m14" desc="Matrix third row (4 components)" />
+            <Field type="float" name="m3" desc="Matrix fourth row (4 components)" />
+            <Field type="float" name="m7" desc="Matrix fourth row (4 components)" />
+            <Field type="float" name="m11" desc="Matrix fourth row (4 components)" />
+            <Field type="float" name="m15" desc="Matrix fourth row (4 components)" />
         </Struct>
         <Struct name="Color" fieldCount="4" desc="Color, 4 components, R8G8B8A8 (32bit)">
             <Field type="unsigned char" name="r" desc="Color red value" />

--- a/parser/raylib_parser.c
+++ b/parser/raylib_parser.c
@@ -361,6 +361,42 @@ int main(int argc, char* argv[])
                     }
 
                     structs[i].fieldCount++;
+
+                    // Split field names containing multiple fields (like Matrix)
+                    int originalIndex = structs[i].fieldCount - 1;
+                    int originalLength = -1;
+                    int lastStart;
+                    for (int c = 0; c < TextLength(structs[i].fieldName[originalIndex]) + 1; c++)
+                    {
+                        char v = structs[i].fieldName[originalIndex][c];
+                        bool isEndOfString = v == '\0';
+                        if (v == ',' || isEndOfString) {
+                            if (originalLength == -1) {
+                                // Save length of original field name
+                                // Don't truncate yet, still needed for copying
+                                originalLength = c;
+                            } else {
+                                // Copy field data from original field
+                                int nameLength = c - lastStart;
+                                MemoryCopy(structs[i].fieldName[structs[i].fieldCount], &(structs[i].fieldName[originalIndex][lastStart]), nameLength);
+                                MemoryCopy(structs[i].fieldType[structs[i].fieldCount], &(structs[i].fieldType[originalIndex][0]), TextLength(structs[i].fieldType[originalIndex]));
+                                MemoryCopy(structs[i].fieldDesc[structs[i].fieldCount], &(structs[i].fieldDesc[originalIndex][0]), TextLength(structs[i].fieldDesc[originalIndex]));
+                                structs[i].fieldCount++;
+                            }
+                            if (!isEndOfString) {
+                                // Skip comma and spaces
+                                c++;
+                                while (structs[i].fieldName[originalIndex][c] == ' ') c++;
+
+                                // Save position for next field
+                                lastStart = c;
+                            }
+                        }
+                    }
+                    // Set length of original field
+                    // This has no effect on fields that are on their own line
+                    // But it truncates the first field name of fields that share a line
+                    structs[i].fieldName[originalIndex][originalLength] = '\0';
                 }
             }
 

--- a/parser/raylib_parser.c
+++ b/parser/raylib_parser.c
@@ -118,7 +118,7 @@ typedef enum { UNKNOWN = 0, MACRO, GUARD, INT, LONG, FLOAT, DOUBLE, CHAR, STRING
 typedef struct DefineInfo {
     char name[64];    // Define name
     DefineType type;  // Define type
-		char value[256];  // Define value
+    char value[256];  // Define value
     char desc[128];   // Define description
     bool isHex;       // Define is hex number (for types INT, LONG)
 } DefineInfo;
@@ -824,7 +824,7 @@ static void GetDataTypeAndName(const char *typeName, int typeNameLen, char *type
         {
             MemoryCopy(type, "...", 3);
             MemoryCopy(name, "args", 4);
-	        break;
+            break;
         }
     }
 }
@@ -1006,8 +1006,8 @@ static void ExportParsedData(const char *fileName, int format)
                 fprintf(outFile, "Define %03i: %s\n", i + 1, defines[i].name);
                 fprintf(outFile, "  Name: %s\n", defines[i].name);
                 fprintf(outFile, "  Type: %s\n", StrDefineType(defines[i].type));
-								fprintf(outFile, "  Value: %s\n", defines[i].value);
-								fprintf(outFile, "  Description: %s\n", defines[i].desc + 3);
+                fprintf(outFile, "  Value: %s\n", defines[i].value);
+                fprintf(outFile, "  Description: %s\n", defines[i].desc + 3);
             }
         } break;
         case LUA:
@@ -1076,7 +1076,7 @@ static void ExportParsedData(const char *fileName, int format)
                 } else {
                     fprintf(outFile, "      value = \"%s\",\n", defines[i].value);
                 }
-								fprintf(outFile, "      description = \"%s\"\n", defines[i].desc + 3);
+                fprintf(outFile, "      description = \"%s\"\n", defines[i].desc + 3);
                 fprintf(outFile, "    }");
 
                 if (i < defineCount - 1) fprintf(outFile, ",\n");
@@ -1181,7 +1181,7 @@ static void ExportParsedData(const char *fileName, int format)
                 } else {
                     fprintf(outFile, "      \"value\": \"%s\",\n", defines[i].value);
                 }
-								fprintf(outFile, "      \"description\": \"%s\"\n", defines[i].desc + 3);
+                fprintf(outFile, "      \"description\": \"%s\"\n", defines[i].desc + 3);
                 fprintf(outFile, "    }");
 
                 if (i < defineCount - 1) fprintf(outFile, ",\n");

--- a/parser/raylib_parser.c
+++ b/parser/raylib_parser.c
@@ -182,7 +182,7 @@ int main(int argc, char* argv[])
     // Function lines pointers, selected from buffer "lines"
     char **funcLines = (char **)malloc(MAX_FUNCS_TO_PARSE*sizeof(char *));
 
-    // Structs data (multiple lines), selected from "buffer"
+    // Structs lines pointers, selected from buffer "lines"
     int *structLines = (int *)malloc(MAX_STRUCTS_TO_PARSE*sizeof(int));
 
     // Enums lines pointers, selected from buffer "lines"
@@ -1000,6 +1000,7 @@ static void ExportParsedData(const char *fileName, int format)
                 if (funcs[i].paramCount == 0) fprintf(outFile, "  No input parameters\n");
             }
 
+            // Print defines info
             fprintf(outFile, "\nDefines found: %i\n\n", defineCount);
             for (int i = 0; i < defineCount; i++)
             {
@@ -1229,16 +1230,19 @@ static void ExportParsedData(const char *fileName, int format)
             <raylibAPI>
                 <Structs count="">
                     <Struct name="" fieldCount="" desc="">
-                        <Field type="" name="" desc="">
-                        <Field type="" name="" desc="">
+                        <Field type="" name="" desc="" />
+                        <Field type="" name="" desc="" />
                     </Struct>
                 <Structs>
                 <Enums count="">
                     <Enum name="" valueCount="" desc="">
-                        <Value name="" integer="" desc="">
-                        <Value name="" integer="" desc="">
+                        <Value name="" integer="" desc="" />
+                        <Value name="" integer="" desc="" />
                     </Enum>
                 </Enums>
+                <Defines count="">
+                    <Define name="" type="" value="" desc="" />
+                </Defines>
                 <Functions count="">
                     <Function name="" retType="" paramCount="" desc="">
                         <Param type="" name="" desc="" />

--- a/parser/raylib_parser.c
+++ b/parser/raylib_parser.c
@@ -370,12 +370,16 @@ int main(int argc, char* argv[])
                     {
                         char v = structs[i].fieldName[originalIndex][c];
                         bool isEndOfString = v == '\0';
-                        if (v == ',' || isEndOfString) {
-                            if (originalLength == -1) {
+                        if ((v == ',') || isEndOfString)
+                        {
+                            if (originalLength == -1)
+                            {
                                 // Save length of original field name
                                 // Don't truncate yet, still needed for copying
                                 originalLength = c;
-                            } else {
+                            }
+                            else
+                            {
                                 // Copy field data from original field
                                 int nameLength = c - lastStart;
                                 MemoryCopy(structs[i].fieldName[structs[i].fieldCount], &(structs[i].fieldName[originalIndex][lastStart]), nameLength);
@@ -383,7 +387,8 @@ int main(int argc, char* argv[])
                                 MemoryCopy(structs[i].fieldDesc[structs[i].fieldCount], &(structs[i].fieldDesc[originalIndex][0]), TextLength(structs[i].fieldDesc[originalIndex]));
                                 structs[i].fieldCount++;
                             }
-                            if (!isEndOfString) {
+                            if (!isEndOfString)
+                            {
                                 // Skip comma and spaces
                                 c++;
                                 while (structs[i].fieldName[originalIndex][c] == ' ') c++;
@@ -415,7 +420,7 @@ int main(int argc, char* argv[])
         // Description from previous line
         char *previousLinePtr = lines[aliasLines[i] - 1];
         if (previousLinePtr[0] == '/') MemoryCopy(aliases[i].desc, previousLinePtr, MAX_LINE_LENGTH);
-    
+
         char *linePtr = lines[aliasLines[i]];
 
         // Skip "typedef "
@@ -437,7 +442,7 @@ int main(int argc, char* argv[])
         MemoryCopy(aliases[i].name, linePtr + nameStart, nameLen);
 
         // Description
-        while(linePtr[c] != '\0' && linePtr[c] != '/') c++;
+        while((linePtr[c] != '\0') && (linePtr[c] != '/')) c++;
         if (linePtr[c] == '/') MemoryCopy(aliases[i].desc, linePtr + c, MAX_LINE_LENGTH);
     }
     free(aliasLines);
@@ -480,7 +485,11 @@ int main(int argc, char* argv[])
                 while ((linePtr[c] != ',') &&
                        (linePtr[c] != ' ') &&
                        (linePtr[c] != '=') &&
-                       (linePtr[c] != '\0')) { enums[i].valueName[enums[i].valueCount][c] = linePtr[c]; c++; }
+                       (linePtr[c] != '\0'))
+                {
+                    enums[i].valueName[enums[i].valueCount][c] = linePtr[c];
+                    c++;
+                }
 
                 // After the name we can have:
                 //  '='  -> value is provided
@@ -497,7 +506,11 @@ int main(int argc, char* argv[])
                     bool foundValue = false;
                     while ((linePtr[c] != '\0') && (linePtr[c] != '/'))
                     {
-                        if (linePtr[c] == '=') { foundValue = true; break; }
+                        if (linePtr[c] == '=')
+                        {
+                            foundValue = true;
+                            break;
+                        }
                         c++;
                     }
 
@@ -524,7 +537,7 @@ int main(int argc, char* argv[])
                 else enums[i].valueInteger[enums[i].valueCount] = (enums[i].valueInteger[enums[i].valueCount - 1] + 1);
 
                 // Look for description or end of line
-                while ((linePtr[c] != '/') && (linePtr[c] != '\0')) { c++; }
+                while ((linePtr[c] != '/') && (linePtr[c] != '\0')) c++;
                 if (linePtr[c] == '/')
                 {
                     // Parse value description
@@ -537,7 +550,11 @@ int main(int argc, char* argv[])
             {
                 // Get enum name from typedef
                 int c = 0;
-                while (linePtr[2 + c] != ';') { enums[i].name[c] = linePtr[2 + c]; c++; }
+                while (linePtr[2 + c] != ';')
+                {
+                    enums[i].name[c] = linePtr[2 + c];
+                    c++;
+                }
 
                 break;  // Enum ended, break for() loop
             }
@@ -554,20 +571,22 @@ int main(int argc, char* argv[])
         char *linePtr = lines[defineLines[i]];
         int j = 0;
 
-        while (linePtr[j] == ' ' || linePtr[j] == '\t') j++; // Skip spaces and tabs in the begining
-        j += 8;                                              // Skip "#define "
-        while (linePtr[j] == ' ' || linePtr[j] == '\t') j++; // Skip spaces and tabs after "#define "
+        while ((linePtr[j] == ' ') || (linePtr[j] == '\t')) j++; // Skip spaces and tabs in the begining
+        j += 8;                                                  // Skip "#define "
+        while ((linePtr[j] == ' ') || (linePtr[j] == '\t')) j++; // Skip spaces and tabs after "#define "
 
         // Extract name
         int defineNameStart = j;
-        while (linePtr[j] != ' ' && linePtr[j] != '\t' && linePtr[j] != '\0') j++;
+        while ((linePtr[j] != ' ') && (linePtr[j] != '\t') && (linePtr[j] != '\0')) j++;
         int defineNameEnd = j-1;
 
         // Skip duplicates
         int nameLen = defineNameEnd - defineNameStart + 1;
         bool isDuplicate = false;
-        for (int k = 0; k < defineIndex; k++) {
-            if (nameLen == TextLength(defines[k].name) && IsTextEqual(defines[k].name, linePtr + defineNameStart, nameLen)) {
+        for (int k = 0; k < defineIndex; k++)
+        {
+            if ((nameLen == TextLength(defines[k].name)) && IsTextEqual(defines[k].name, linePtr + defineNameStart, nameLen))
+            {
                 isDuplicate = true;
                 break;
             }
@@ -579,26 +598,39 @@ int main(int argc, char* argv[])
         // Determine type
         if (linePtr[defineNameEnd] == ')') defines[defineIndex].type = MACRO;
 
-        while (linePtr[j] == ' ' || linePtr[j] == '\t') j++; // Skip spaces and tabs after name
+        while ((linePtr[j] == ' ') || (linePtr[j] == '\t')) j++; // Skip spaces and tabs after name
 
         int defineValueStart = j;
-        if (linePtr[j] == '\0' || linePtr == "/") defines[defineIndex].type = GUARD;
+        if ((linePtr[j] == '\0') || (linePtr == "/")) defines[defineIndex].type = GUARD;
         if (linePtr[j] == '"') defines[defineIndex].type = STRING;
         else if (linePtr[j] == '\'') defines[defineIndex].type = CHAR;
         else if (IsTextEqual(linePtr+j, "CLITERAL(Color)", 15)) defines[defineIndex].type = COLOR;
-        else if (isdigit(linePtr[j])) { // Parsing numbers
+        else if (isdigit(linePtr[j])) // Parsing numbers
+        {
             bool isFloat = false, isNumber = true, isHex = false;
-            while (linePtr[j] != ' ' && linePtr[j] != '\t' && linePtr[j] != '\0') {
+            while ((linePtr[j] != ' ') && (linePtr[j] != '\t') && (linePtr[j] != '\0'))
+            {
                 char ch = linePtr[j];
                 if (ch == '.') isFloat = true;
                 if (ch == 'x') isHex = true;
-                if (!(isdigit(ch)||(ch >= 'a' && ch <= 'f')||(ch >= 'A' && ch <= 'F')||ch=='x'||ch=='L'||ch=='.'||ch=='+'||ch=='-')) isNumber = false;
+                if (!(isdigit(ch) ||
+                      ((ch >= 'a') && (ch <= 'f')) ||
+                      ((ch >= 'A') && (ch <= 'F')) ||
+                      (ch == 'x') ||
+                      (ch == 'L') ||
+                      (ch == '.') ||
+                      (ch == '+') ||
+                      (ch == '-'))) isNumber = false;
                 j++;
             }
-            if (isNumber) {
-                if (isFloat) {
+            if (isNumber)
+            {
+                if (isFloat)
+                {
                     defines[defineIndex].type = linePtr[j-1] == 'f' ? FLOAT : DOUBLE;
-                } else {
+                }
+                else
+                {
                     defines[defineIndex].type = linePtr[j-1] == 'L' ? LONG : INT;
                     defines[defineIndex].isHex = isHex;
                 }
@@ -606,19 +638,20 @@ int main(int argc, char* argv[])
         }
 
         // Extracting value
-        while (linePtr[j] != '\\' && linePtr[j] != '\0' && !(linePtr[j] == '/' && linePtr[j+1] == '/')) j++;
+        while ((linePtr[j] != '\\') && (linePtr[j] != '\0') && !((linePtr[j] == '/') && (linePtr[j+1] == '/'))) j++;
         int defineValueEnd = j-1;
-        while (linePtr[defineValueEnd] == ' ' || linePtr[defineValueEnd] == '\t') defineValueEnd--; // Remove trailing spaces and tabs
-        if (defines[defineIndex].type == LONG || defines[defineIndex].type == FLOAT) defineValueEnd--; // Remove number postfix
+        while ((linePtr[defineValueEnd] == ' ') || (linePtr[defineValueEnd] == '\t')) defineValueEnd--; // Remove trailing spaces and tabs
+        if ((defines[defineIndex].type == LONG) || (defines[defineIndex].type == FLOAT)) defineValueEnd--; // Remove number postfix
         int valueLen = defineValueEnd - defineValueStart + 1;
         if (valueLen > 255) valueLen = 255;
 
         if (valueLen > 0) MemoryCopy(defines[defineIndex].value, linePtr + defineValueStart, valueLen);
 
         // Extracting description
-        if (linePtr[j] == '/') {
+        if (linePtr[j] == '/')
+        {
             int commentStart = j;
-            while (linePtr[j] != '\\' && linePtr[j] != '\0') j++;
+            while ((linePtr[j] != '\\') && (linePtr[j] != '\0')) j++;
             int commentEnd = j-1;
             int commentLen = commentEnd - commentStart + 1;
             if (commentLen > 127) commentLen = 127;
@@ -914,7 +947,7 @@ static void GetDataTypeAndName(const char *typeName, int typeNameLen, char *type
 {
     for (int k = typeNameLen; k > 0; k--)
     {
-        if (typeName[k] == ' ' && typeName[k - 1] != ',')
+        if ((typeName[k] == ' ') && (typeName[k - 1] != ','))
         {
             // Function name starts at this point (and ret type finishes at this point)
             MemoryCopy(type, typeName, k);
@@ -927,7 +960,7 @@ static void GetDataTypeAndName(const char *typeName, int typeNameLen, char *type
             MemoryCopy(name, typeName + k + 1, typeNameLen - k - 1);
             break;
         }
-        else if (typeName[k] == '.' && typeNameLen == 3) // Handle varargs ...);
+        else if ((typeName[k] == '.') && (typeNameLen == 3)) // Handle varargs ...);
         {
             MemoryCopy(type, "...", 3);
             MemoryCopy(name, "args", 4);
@@ -1204,9 +1237,16 @@ static void ExportParsedData(const char *fileName, int format)
                 fprintf(outFile, "    {\n");
                 fprintf(outFile, "      name = \"%s\",\n", defines[i].name);
                 fprintf(outFile, "      type = \"%s\",\n", StrDefineType(defines[i].type));
-                if (defines[i].type == INT || defines[i].type == LONG || defines[i].type == FLOAT || defines[i].type == DOUBLE || defines[i].type == STRING) {
+                if ((defines[i].type == INT) ||
+                    (defines[i].type == LONG) ||
+                    (defines[i].type == FLOAT) ||
+                    (defines[i].type == DOUBLE) ||
+                    (defines[i].type == STRING))
+                {
                     fprintf(outFile, "      value = %s,\n", defines[i].value);
-                } else {
+                }
+                else
+                {
                     fprintf(outFile, "      value = \"%s\",\n", defines[i].value);
                 }
                 fprintf(outFile, "      description = \"%s\"\n", defines[i].desc + 3);
@@ -1322,11 +1362,20 @@ static void ExportParsedData(const char *fileName, int format)
                 fprintf(outFile, "    {\n");
                 fprintf(outFile, "      \"name\": \"%s\",\n", defines[i].name);
                 fprintf(outFile, "      \"type\": \"%s\",\n", StrDefineType(defines[i].type));
-                if (defines[i].isHex) { // INT or LONG
+                if (defines[i].isHex) // INT or LONG
+                {
                     fprintf(outFile, "      \"value\": %ld,\n", strtol(defines[i].value, NULL, 16));
-                } else if (defines[i].type == INT || defines[i].type == LONG || defines[i].type == FLOAT || defines[i].type == DOUBLE || defines[i].type == STRING) {
+                }
+                else if ((defines[i].type == INT) ||
+                         (defines[i].type == LONG) ||
+                         (defines[i].type == FLOAT) ||
+                         (defines[i].type == DOUBLE) ||
+                         (defines[i].type == STRING))
+                {
                     fprintf(outFile, "      \"value\": %s,\n", defines[i].value);
-                } else {
+                }
+                else
+                {
                     fprintf(outFile, "      \"value\": \"%s\",\n", defines[i].value);
                 }
                 fprintf(outFile, "      \"description\": \"%s\"\n", defines[i].desc + 3);


### PR DESCRIPTION
This PR fixes some small inconsistencies in the parser and adds support for aliases.

JSON example output:
```json
  "aliases": [
    {
      "type": "Vector4",
      "name": "Quaternion",
      "description": "Quaternion, 4 components (Vector4 alias)"
    },
    {
      "type": "Texture",
      "name": "Texture2D",
      "description": "Texture2D, same as Texture"
    },
    {
      "type": "Texture",
      "name": "TextureCubemap",
      "description": "TextureCubemap, same as Texture"
    },
    {
      "type": "RenderTexture",
      "name": "RenderTexture2D",
      "description": "RenderTexture2D, same as RenderTexture"
    },
    {
      "type": "Camera3D",
      "name": "Camera",
      "description": "Camera type fallback, defaults to Camera3D"
    }
  ],
```