### PR TITLE
Parser improvements

### DIFF
--- a/parser/raylib_api.json
+++ b/parser/raylib_api.json
@@ -10556,5 +10556,101 @@
         }
       ]
     }
+  ],
+  "callbacks": [
+    {
+      "name": "TraceLogCallback",
+      "description": "Logging: Redirect trace log messages",
+      "returnType": "void",
+      "params": [
+        {
+          "type": "int",
+          "name": "logLevel"
+        },
+        {
+          "type": "const char *",
+          "name": "text"
+        },
+        {
+          "type": "va_list",
+          "name": "args"
+        }
+      ]
+    },
+    {
+      "name": "LoadFileDataCallback",
+      "description": "FileIO: Load binary data",
+      "returnType": "unsigned char *",
+      "params": [
+        {
+          "type": "const char *",
+          "name": "fileName"
+        },
+        {
+          "type": "unsigned int *",
+          "name": "bytesRead"
+        }
+      ]
+    },
+    {
+      "name": "SaveFileDataCallback",
+      "description": "FileIO: Save binary data",
+      "returnType": "bool",
+      "params": [
+        {
+          "type": "const char *",
+          "name": "fileName"
+        },
+        {
+          "type": "void *",
+          "name": "data"
+        },
+        {
+          "type": "unsigned int",
+          "name": "bytesToWrite"
+        }
+      ]
+    },
+    {
+      "name": "LoadFileTextCallback",
+      "description": "FileIO: Load text data",
+      "returnType": "char *",
+      "params": [
+        {
+          "type": "const char *",
+          "name": "fileName"
+        }
+      ]
+    },
+    {
+      "name": "SaveFileTextCallback",
+      "description": "FileIO: Save text data",
+      "returnType": "bool",
+      "params": [
+        {
+          "type": "const char *",
+          "name": "fileName"
+        },
+        {
+          "type": "char *",
+          "name": "text"
+        }
+      ]
+    },
+    {
+      "name": "AudioCallback",
+      "description": "",
+      "returnType": "void",
+      "params": [
+        {
+          "type": "void *",
+          "name": "bufferData"
+        },
+        {
+          "type": "unsigned int",
+          "name": "frames"
+        }
+      ]
+    }
   ]
 }

--- a/parser/raylib_api.json
+++ b/parser/raylib_api.json
@@ -577,8 +577,8 @@
           "description": "Material maps array (MAX_MATERIAL_MAPS)"
         },
         {
-          "type": "float",
-          "name": "params[4]",
+          "type": "float[4]",
+          "name": "params",
           "description": "Material generic parameters (if required)"
         }
       ]
@@ -609,8 +609,8 @@
       "description": "Bone, skeletal animation bone",
       "fields": [
         {
-          "type": "char",
-          "name": "name[32]",
+          "type": "char[32]",
+          "name": "name",
           "description": "Bone name"
         },
         {
@@ -909,13 +909,13 @@
           "description": "IPD (distance between pupils) in meters"
         },
         {
-          "type": "float",
-          "name": "lensDistortionValues[4]",
+          "type": "float[4]",
+          "name": "lensDistortionValues",
           "description": "Lens distortion constant parameters"
         },
         {
-          "type": "float",
-          "name": "chromaAbCorrection[4]",
+          "type": "float[4]",
+          "name": "chromaAbCorrection",
           "description": "Chromatic aberration correction parameters"
         }
       ]
@@ -925,43 +925,43 @@
       "description": "VrStereoConfig, VR stereo rendering configuration for simulator",
       "fields": [
         {
-          "type": "Matrix",
-          "name": "projection[2]",
+          "type": "Matrix[2]",
+          "name": "projection",
           "description": "VR projection matrices (per eye)"
         },
         {
-          "type": "Matrix",
-          "name": "viewOffset[2]",
+          "type": "Matrix[2]",
+          "name": "viewOffset",
           "description": "VR view offset matrices (per eye)"
         },
         {
-          "type": "float",
-          "name": "leftLensCenter[2]",
+          "type": "float[2]",
+          "name": "leftLensCenter",
           "description": "VR left lens center"
         },
         {
-          "type": "float",
-          "name": "rightLensCenter[2]",
+          "type": "float[2]",
+          "name": "rightLensCenter",
           "description": "VR right lens center"
         },
         {
-          "type": "float",
-          "name": "leftScreenCenter[2]",
+          "type": "float[2]",
+          "name": "leftScreenCenter",
           "description": "VR left screen center"
         },
         {
-          "type": "float",
-          "name": "rightScreenCenter[2]",
+          "type": "float[2]",
+          "name": "rightScreenCenter",
           "description": "VR right screen center"
         },
         {
-          "type": "float",
-          "name": "scale[2]",
+          "type": "float[2]",
+          "name": "scale",
           "description": "VR distortion scale"
         },
         {
-          "type": "float",
-          "name": "scaleIn[2]",
+          "type": "float[2]",
+          "name": "scaleIn",
           "description": "VR distortion scale in"
         }
       ]

--- a/parser/raylib_api.json
+++ b/parser/raylib_api.json
@@ -471,7 +471,7 @@
         {
           "type": "float *",
           "name": "texcoords2",
-          "description": "Vertex second texture coordinates (useful for lightmaps) (shader-location = 5)"
+          "description": "Vertex texture second coordinates (UV - 2 components per vertex) (shader-location = 5)"
         },
         {
           "type": "float *",
@@ -4116,7 +4116,7 @@
     },
     {
       "name": "GetDirectoryFiles",
-      "description": "Get filenames in a directory path (memory should be freed)",
+      "description": "Get filenames in a directory path (memory must be freed)",
       "returnType": "char **",
       "params": [
         {
@@ -4152,7 +4152,7 @@
     },
     {
       "name": "GetDroppedFiles",
-      "description": "Get dropped files names (memory should be freed)",
+      "description": "Get dropped files names (memory must be freed)",
       "returnType": "char **",
       "params": [
         {
@@ -4179,7 +4179,7 @@
     },
     {
       "name": "CompressData",
-      "description": "Compress data (DEFLATE algorithm)",
+      "description": "Compress data (DEFLATE algorithm), memory must be MemFree()",
       "returnType": "unsigned char *",
       "params": [
         {
@@ -4198,7 +4198,7 @@
     },
     {
       "name": "DecompressData",
-      "description": "Decompress data (DEFLATE algorithm)",
+      "description": "Decompress data (DEFLATE algorithm), memory must be MemFree()",
       "returnType": "unsigned char *",
       "params": [
         {
@@ -4217,7 +4217,7 @@
     },
     {
       "name": "EncodeDataBase64",
-      "description": "Encode data to Base64 string",
+      "description": "Encode data to Base64 string, memory must be MemFree()",
       "returnType": "char *",
       "params": [
         {
@@ -4236,7 +4236,7 @@
     },
     {
       "name": "DecodeDataBase64",
-      "description": "Decode Base64 string data",
+      "description": "Decode Base64 string data, memory must be MemFree()",
       "returnType": "unsigned char *",
       "params": [
         {

--- a/parser/raylib_api.lua
+++ b/parser/raylib_api.lua
@@ -577,8 +577,8 @@ return {
           description = "Material maps array (MAX_MATERIAL_MAPS)"
         },
         {
-          type = "float",
-          name = "params[4]",
+          type = "float[4]",
+          name = "params",
           description = "Material generic parameters (if required)"
         }
       }
@@ -609,8 +609,8 @@ return {
       description = "Bone, skeletal animation bone",
       fields = {
         {
-          type = "char",
-          name = "name[32]",
+          type = "char[32]",
+          name = "name",
           description = "Bone name"
         },
         {
@@ -909,13 +909,13 @@ return {
           description = "IPD (distance between pupils) in meters"
         },
         {
-          type = "float",
-          name = "lensDistortionValues[4]",
+          type = "float[4]",
+          name = "lensDistortionValues",
           description = "Lens distortion constant parameters"
         },
         {
-          type = "float",
-          name = "chromaAbCorrection[4]",
+          type = "float[4]",
+          name = "chromaAbCorrection",
           description = "Chromatic aberration correction parameters"
         }
       }
@@ -925,43 +925,43 @@ return {
       description = "VrStereoConfig, VR stereo rendering configuration for simulator",
       fields = {
         {
-          type = "Matrix",
-          name = "projection[2]",
+          type = "Matrix[2]",
+          name = "projection",
           description = "VR projection matrices (per eye)"
         },
         {
-          type = "Matrix",
-          name = "viewOffset[2]",
+          type = "Matrix[2]",
+          name = "viewOffset",
           description = "VR view offset matrices (per eye)"
         },
         {
-          type = "float",
-          name = "leftLensCenter[2]",
+          type = "float[2]",
+          name = "leftLensCenter",
           description = "VR left lens center"
         },
         {
-          type = "float",
-          name = "rightLensCenter[2]",
+          type = "float[2]",
+          name = "rightLensCenter",
           description = "VR right lens center"
         },
         {
-          type = "float",
-          name = "leftScreenCenter[2]",
+          type = "float[2]",
+          name = "leftScreenCenter",
           description = "VR left screen center"
         },
         {
-          type = "float",
-          name = "rightScreenCenter[2]",
+          type = "float[2]",
+          name = "rightScreenCenter",
           description = "VR right screen center"
         },
         {
-          type = "float",
-          name = "scale[2]",
+          type = "float[2]",
+          name = "scale",
           description = "VR distortion scale"
         },
         {
-          type = "float",
-          name = "scaleIn[2]",
+          type = "float[2]",
+          name = "scaleIn",
           description = "VR distortion scale in"
         }
       }

--- a/parser/raylib_api.lua
+++ b/parser/raylib_api.lua
@@ -7322,5 +7322,62 @@ return {
         {type = "AudioCallback", name = "processor"}
       }
     }
+  },
+  callbacks = {
+    {
+      name = "TraceLogCallback",
+      description = "Logging: Redirect trace log messages",
+      returnType = "void",
+      params = {
+        {type = "int", name = "logLevel"},
+        {type = "const char *", name = "text"},
+        {type = "va_list", name = "args"}
+      }
+    },
+    {
+      name = "LoadFileDataCallback",
+      description = "FileIO: Load binary data",
+      returnType = "unsigned char *",
+      params = {
+        {type = "const char *", name = "fileName"},
+        {type = "unsigned int *", name = "bytesRead"}
+      }
+    },
+    {
+      name = "SaveFileDataCallback",
+      description = "FileIO: Save binary data",
+      returnType = "bool",
+      params = {
+        {type = "const char *", name = "fileName"},
+        {type = "void *", name = "data"},
+        {type = "unsigned int", name = "bytesToWrite"}
+      }
+    },
+    {
+      name = "LoadFileTextCallback",
+      description = "FileIO: Load text data",
+      returnType = "char *",
+      params = {
+        {type = "const char *", name = "fileName"}
+      }
+    },
+    {
+      name = "SaveFileTextCallback",
+      description = "FileIO: Save text data",
+      returnType = "bool",
+      params = {
+        {type = "const char *", name = "fileName"},
+        {type = "char *", name = "text"}
+      }
+    },
+    {
+      name = "AudioCallback",
+      description = "",
+      returnType = "void",
+      params = {
+        {type = "void *", name = "bufferData"},
+        {type = "unsigned int", name = "frames"}
+      }
+    }
   }
 }

--- a/parser/raylib_api.lua
+++ b/parser/raylib_api.lua
@@ -471,7 +471,7 @@ return {
         {
           type = "float *",
           name = "texcoords2",
-          description = "Vertex second texture coordinates (useful for lightmaps) (shader-location = 5)"
+          description = "Vertex texture second coordinates (UV - 2 components per vertex) (shader-location = 5)"
         },
         {
           type = "float *",
@@ -3771,7 +3771,7 @@ return {
     },
     {
       name = "GetDirectoryFiles",
-      description = "Get filenames in a directory path (memory should be freed)",
+      description = "Get filenames in a directory path (memory must be freed)",
       returnType = "char **",
       params = {
         {type = "const char *", name = "dirPath"},
@@ -3798,7 +3798,7 @@ return {
     },
     {
       name = "GetDroppedFiles",
-      description = "Get dropped files names (memory should be freed)",
+      description = "Get dropped files names (memory must be freed)",
       returnType = "char **",
       params = {
         {type = "int *", name = "count"}
@@ -3819,7 +3819,7 @@ return {
     },
     {
       name = "CompressData",
-      description = "Compress data (DEFLATE algorithm)",
+      description = "Compress data (DEFLATE algorithm), memory must be MemFree()",
       returnType = "unsigned char *",
       params = {
         {type = "const unsigned char *", name = "data"},
@@ -3829,7 +3829,7 @@ return {
     },
     {
       name = "DecompressData",
-      description = "Decompress data (DEFLATE algorithm)",
+      description = "Decompress data (DEFLATE algorithm), memory must be MemFree()",
       returnType = "unsigned char *",
       params = {
         {type = "const unsigned char *", name = "compData"},
@@ -3839,7 +3839,7 @@ return {
     },
     {
       name = "EncodeDataBase64",
-      description = "Encode data to Base64 string",
+      description = "Encode data to Base64 string, memory must be MemFree()",
       returnType = "char *",
       params = {
         {type = "const unsigned char *", name = "data"},
@@ -3849,7 +3849,7 @@ return {
     },
     {
       name = "DecodeDataBase64",
-      description = "Decode Base64 string data",
+      description = "Decode Base64 string data, memory must be MemFree()",
       returnType = "unsigned char *",
       params = {
         {type = "const unsigned char *", name = "data"},

--- a/parser/raylib_api.txt
+++ b/parser/raylib_api.txt
@@ -122,7 +122,7 @@ Struct 15: Mesh (15 fields)
   Field[2]: int triangleCount // Number of triangles stored (indexed or not)
   Field[3]: float * vertices // Vertex position (XYZ - 3 components per vertex) (shader-location = 0)
   Field[4]: float * texcoords // Vertex texture coordinates (UV - 2 components per vertex) (shader-location = 1)
-  Field[5]: float * texcoords2 // Vertex second texture coordinates (useful for lightmaps) (shader-location = 5)
+  Field[5]: float * texcoords2 // Vertex texture second coordinates (UV - 2 components per vertex) (shader-location = 5)
   Field[6]: float * normals // Vertex normals (XYZ - 3 components per vertex) (shader-location = 2)
   Field[7]: float * tangents // Vertex tangents (XYZW - 4 components per vertex) (shader-location = 4)
   Field[8]: unsigned char * colors // Vertex colors (RGBA - 4 components per vertex) (shader-location = 3)
@@ -1281,7 +1281,7 @@ Function 121: GetApplicationDirectory() (0 input parameters)
 Function 122: GetDirectoryFiles() (2 input parameters)
   Name: GetDirectoryFiles
   Return type: char **
-  Description: Get filenames in a directory path (memory should be freed)
+  Description: Get filenames in a directory path (memory must be freed)
   Param[1]: dirPath (type: const char *)
   Param[2]: count (type: int *)
 Function 123: ClearDirectoryFiles() (0 input parameters)
@@ -1302,7 +1302,7 @@ Function 125: IsFileDropped() (0 input parameters)
 Function 126: GetDroppedFiles() (1 input parameters)
   Name: GetDroppedFiles
   Return type: char **
-  Description: Get dropped files names (memory should be freed)
+  Description: Get dropped files names (memory must be freed)
   Param[1]: count (type: int *)
 Function 127: ClearDroppedFiles() (0 input parameters)
   Name: ClearDroppedFiles
@@ -1317,28 +1317,28 @@ Function 128: GetFileModTime() (1 input parameters)
 Function 129: CompressData() (3 input parameters)
   Name: CompressData
   Return type: unsigned char *
-  Description: Compress data (DEFLATE algorithm)
+  Description: Compress data (DEFLATE algorithm), memory must be MemFree()
   Param[1]: data (type: const unsigned char *)
   Param[2]: dataSize (type: int)
   Param[3]: compDataSize (type: int *)
 Function 130: DecompressData() (3 input parameters)
   Name: DecompressData
   Return type: unsigned char *
-  Description: Decompress data (DEFLATE algorithm)
+  Description: Decompress data (DEFLATE algorithm), memory must be MemFree()
   Param[1]: compData (type: const unsigned char *)
   Param[2]: compDataSize (type: int)
   Param[3]: dataSize (type: int *)
 Function 131: EncodeDataBase64() (3 input parameters)
   Name: EncodeDataBase64
   Return type: char *
-  Description: Encode data to Base64 string
+  Description: Encode data to Base64 string, memory must be MemFree()
   Param[1]: data (type: const unsigned char *)
   Param[2]: dataSize (type: int)
   Param[3]: outputSize (type: int *)
 Function 132: DecodeDataBase64() (2 input parameters)
   Name: DecodeDataBase64
   Return type: unsigned char *
-  Description: Decode Base64 string data
+  Description: Decode Base64 string data, memory must be MemFree()
   Param[1]: data (type: const unsigned char *)
   Param[2]: outputSize (type: int *)
 Function 133: SaveStorageValue() (2 input parameters)

--- a/parser/raylib_api.txt
+++ b/parser/raylib_api.txt
@@ -149,7 +149,7 @@ Struct 18: Material (3 fields)
   Description: Material, includes shader and maps
   Field[1]: Shader shader // Material shader
   Field[2]: MaterialMap * maps // Material maps array (MAX_MATERIAL_MAPS)
-  Field[3]: float params[4] // Material generic parameters (if required)
+  Field[3]: float[4] params // Material generic parameters (if required)
 Struct 19: Transform (3 fields)
   Name: Transform
   Description: Transform, vectex transformation data
@@ -159,7 +159,7 @@ Struct 19: Transform (3 fields)
 Struct 20: BoneInfo (2 fields)
   Name: BoneInfo
   Description: Bone, skeletal animation bone
-  Field[1]: char name[32] // Bone name
+  Field[1]: char[32] name // Bone name
   Field[2]: int parent // Bone parent
 Struct 21: Model (9 fields)
   Name: Model
@@ -237,19 +237,19 @@ Struct 30: VrDeviceInfo (10 fields)
   Field[6]: float eyeToScreenDistance // Distance between eye and display in meters
   Field[7]: float lensSeparationDistance // Lens separation distance in meters
   Field[8]: float interpupillaryDistance // IPD (distance between pupils) in meters
-  Field[9]: float lensDistortionValues[4] // Lens distortion constant parameters
-  Field[10]: float chromaAbCorrection[4] // Chromatic aberration correction parameters
+  Field[9]: float[4] lensDistortionValues // Lens distortion constant parameters
+  Field[10]: float[4] chromaAbCorrection // Chromatic aberration correction parameters
 Struct 31: VrStereoConfig (8 fields)
   Name: VrStereoConfig
   Description: VrStereoConfig, VR stereo rendering configuration for simulator
-  Field[1]: Matrix projection[2] // VR projection matrices (per eye)
-  Field[2]: Matrix viewOffset[2] // VR view offset matrices (per eye)
-  Field[3]: float leftLensCenter[2] // VR left lens center
-  Field[4]: float rightLensCenter[2] // VR right lens center
-  Field[5]: float leftScreenCenter[2] // VR left screen center
-  Field[6]: float rightScreenCenter[2] // VR right screen center
-  Field[7]: float scale[2] // VR distortion scale
-  Field[8]: float scaleIn[2] // VR distortion scale in
+  Field[1]: Matrix[2] projection // VR projection matrices (per eye)
+  Field[2]: Matrix[2] viewOffset // VR view offset matrices (per eye)
+  Field[3]: float[2] leftLensCenter // VR left lens center
+  Field[4]: float[2] rightLensCenter // VR right lens center
+  Field[5]: float[2] leftScreenCenter // VR left screen center
+  Field[6]: float[2] rightScreenCenter // VR right screen center
+  Field[7]: float[2] scale // VR distortion scale
+  Field[8]: float[2] scaleIn // VR distortion scale in
 
 Aliases found: 5
 

--- a/parser/raylib_api.txt
+++ b/parser/raylib_api.txt
@@ -3782,6 +3782,46 @@ Function 499: DetachAudioStreamProcessor() (2 input parameters)
   Param[1]: stream (type: AudioStream)
   Param[2]: processor (type: AudioCallback)
 
+Callbacks found: 6
+
+Callback 001: TraceLogCallback() (3 input parameters)
+  Name: TraceLogCallback
+  Return type: void
+  Description: Logging: Redirect trace log messages
+  Param[1]: logLevel (type: int)
+  Param[2]: text (type: const char *)
+  Param[3]: args (type: va_list)
+Callback 002: LoadFileDataCallback() (2 input parameters)
+  Name: LoadFileDataCallback
+  Return type: unsigned char *
+  Description: FileIO: Load binary data
+  Param[1]: fileName (type: const char *)
+  Param[2]: bytesRead (type: unsigned int *)
+Callback 003: SaveFileDataCallback() (3 input parameters)
+  Name: SaveFileDataCallback
+  Return type: bool
+  Description: FileIO: Save binary data
+  Param[1]: fileName (type: const char *)
+  Param[2]: data (type: void *)
+  Param[3]: bytesToWrite (type: unsigned int)
+Callback 004: LoadFileTextCallback() (1 input parameters)
+  Name: LoadFileTextCallback
+  Return type: char *
+  Description: FileIO: Load text data
+  Param[1]: fileName (type: const char *)
+Callback 005: SaveFileTextCallback() (2 input parameters)
+  Name: SaveFileTextCallback
+  Return type: bool
+  Description: FileIO: Save text data
+  Param[1]: fileName (type: const char *)
+  Param[2]: text (type: char *)
+Callback 006: AudioCallback() (2 input parameters)
+  Name: AudioCallback
+  Return type: void
+  Description: 
+  Param[1]: bufferData (type: void *)
+  Param[2]: frames (type: unsigned int)
+
 Defines found: 52
 
 Define 001: RAYLIB_H

--- a/parser/raylib_api.xml
+++ b/parser/raylib_api.xml
@@ -2695,4 +2695,31 @@
             <Param type="AudioCallback" name="processor" desc="" />
         </Function>
     </Functions>
+    <Callbacks count="6">
+        <Callback name="TraceLogCallback" retType="void" paramCount="3" desc="Logging: Redirect trace log messages">
+            <Param type="int" name="logLevel" desc="" />
+            <Param type="const char *" name="text" desc="" />
+            <Param type="va_list" name="args" desc="" />
+        </Callback>
+        <Callback name="LoadFileDataCallback" retType="unsigned char *" paramCount="2" desc="FileIO: Load binary data">
+            <Param type="const char *" name="fileName" desc="" />
+            <Param type="unsigned int *" name="bytesRead" desc="" />
+        </Callback>
+        <Callback name="SaveFileDataCallback" retType="bool" paramCount="3" desc="FileIO: Save binary data">
+            <Param type="const char *" name="fileName" desc="" />
+            <Param type="void *" name="data" desc="" />
+            <Param type="unsigned int" name="bytesToWrite" desc="" />
+        </Callback>
+        <Callback name="LoadFileTextCallback" retType="char *" paramCount="1" desc="FileIO: Load text data">
+            <Param type="const char *" name="fileName" desc="" />
+        </Callback>
+        <Callback name="SaveFileTextCallback" retType="bool" paramCount="2" desc="FileIO: Save text data">
+            <Param type="const char *" name="fileName" desc="" />
+            <Param type="char *" name="text" desc="" />
+        </Callback>
+        <Callback name="AudioCallback" retType="void" paramCount="2" desc="">
+            <Param type="void *" name="bufferData" desc="" />
+            <Param type="unsigned int" name="frames" desc="" />
+        </Callback>
+    </Callbacks>
 </raylibAPI>

--- a/parser/raylib_api.xml
+++ b/parser/raylib_api.xml
@@ -130,7 +130,7 @@
         <Struct name="Material" fieldCount="3" desc="Material, includes shader and maps">
             <Field type="Shader" name="shader" desc="Material shader" />
             <Field type="MaterialMap *" name="maps" desc="Material maps array (MAX_MATERIAL_MAPS)" />
-            <Field type="float" name="params[4]" desc="Material generic parameters (if required)" />
+            <Field type="float[4]" name="params" desc="Material generic parameters (if required)" />
         </Struct>
         <Struct name="Transform" fieldCount="3" desc="Transform, vectex transformation data">
             <Field type="Vector3" name="translation" desc="Translation" />
@@ -138,7 +138,7 @@
             <Field type="Vector3" name="scale" desc="Scale" />
         </Struct>
         <Struct name="BoneInfo" fieldCount="2" desc="Bone, skeletal animation bone">
-            <Field type="char" name="name[32]" desc="Bone name" />
+            <Field type="char[32]" name="name" desc="Bone name" />
             <Field type="int" name="parent" desc="Bone parent" />
         </Struct>
         <Struct name="Model" fieldCount="9" desc="Model, meshes, materials and animation data">
@@ -206,18 +206,18 @@
             <Field type="float" name="eyeToScreenDistance" desc="Distance between eye and display in meters" />
             <Field type="float" name="lensSeparationDistance" desc="Lens separation distance in meters" />
             <Field type="float" name="interpupillaryDistance" desc="IPD (distance between pupils) in meters" />
-            <Field type="float" name="lensDistortionValues[4]" desc="Lens distortion constant parameters" />
-            <Field type="float" name="chromaAbCorrection[4]" desc="Chromatic aberration correction parameters" />
+            <Field type="float[4]" name="lensDistortionValues" desc="Lens distortion constant parameters" />
+            <Field type="float[4]" name="chromaAbCorrection" desc="Chromatic aberration correction parameters" />
         </Struct>
         <Struct name="VrStereoConfig" fieldCount="8" desc="VrStereoConfig, VR stereo rendering configuration for simulator">
-            <Field type="Matrix" name="projection[2]" desc="VR projection matrices (per eye)" />
-            <Field type="Matrix" name="viewOffset[2]" desc="VR view offset matrices (per eye)" />
-            <Field type="float" name="leftLensCenter[2]" desc="VR left lens center" />
-            <Field type="float" name="rightLensCenter[2]" desc="VR right lens center" />
-            <Field type="float" name="leftScreenCenter[2]" desc="VR left screen center" />
-            <Field type="float" name="rightScreenCenter[2]" desc="VR right screen center" />
-            <Field type="float" name="scale[2]" desc="VR distortion scale" />
-            <Field type="float" name="scaleIn[2]" desc="VR distortion scale in" />
+            <Field type="Matrix[2]" name="projection" desc="VR projection matrices (per eye)" />
+            <Field type="Matrix[2]" name="viewOffset" desc="VR view offset matrices (per eye)" />
+            <Field type="float[2]" name="leftLensCenter" desc="VR left lens center" />
+            <Field type="float[2]" name="rightLensCenter" desc="VR right lens center" />
+            <Field type="float[2]" name="leftScreenCenter" desc="VR left screen center" />
+            <Field type="float[2]" name="rightScreenCenter" desc="VR right screen center" />
+            <Field type="float[2]" name="scale" desc="VR distortion scale" />
+            <Field type="float[2]" name="scaleIn" desc="VR distortion scale in" />
         </Struct>
     </Structs>
     <Aliases count="5">

--- a/parser/raylib_api.xml
+++ b/parser/raylib_api.xml
@@ -106,7 +106,7 @@
             <Field type="int" name="triangleCount" desc="Number of triangles stored (indexed or not)" />
             <Field type="float *" name="vertices" desc="Vertex position (XYZ - 3 components per vertex) (shader-location = 0)" />
             <Field type="float *" name="texcoords" desc="Vertex texture coordinates (UV - 2 components per vertex) (shader-location = 1)" />
-            <Field type="float *" name="texcoords2" desc="Vertex second texture coordinates (useful for lightmaps) (shader-location = 5)" />
+            <Field type="float *" name="texcoords2" desc="Vertex texture second coordinates (UV - 2 components per vertex) (shader-location = 5)" />
             <Field type="float *" name="normals" desc="Vertex normals (XYZ - 3 components per vertex) (shader-location = 2)" />
             <Field type="float *" name="tangents" desc="Vertex tangents (XYZW - 4 components per vertex) (shader-location = 4)" />
             <Field type="unsigned char *" name="colors" desc="Vertex colors (RGBA - 4 components per vertex) (shader-location = 3)" />
@@ -975,7 +975,7 @@
         </Function>
         <Function name="GetApplicationDirectory" retType="const char *" paramCount="0" desc="Get the directory if the running application (uses static string)">
         </Function>
-        <Function name="GetDirectoryFiles" retType="char **" paramCount="2" desc="Get filenames in a directory path (memory should be freed)">
+        <Function name="GetDirectoryFiles" retType="char **" paramCount="2" desc="Get filenames in a directory path (memory must be freed)">
             <Param type="const char *" name="dirPath" desc="" />
             <Param type="int *" name="count" desc="" />
         </Function>
@@ -986,7 +986,7 @@
         </Function>
         <Function name="IsFileDropped" retType="bool" paramCount="0" desc="Check if a file has been dropped into window">
         </Function>
-        <Function name="GetDroppedFiles" retType="char **" paramCount="1" desc="Get dropped files names (memory should be freed)">
+        <Function name="GetDroppedFiles" retType="char **" paramCount="1" desc="Get dropped files names (memory must be freed)">
             <Param type="int *" name="count" desc="" />
         </Function>
         <Function name="ClearDroppedFiles" retType="void" paramCount="0" desc="Clear dropped files paths buffer (free memory)">
@@ -994,22 +994,22 @@
         <Function name="GetFileModTime" retType="long" paramCount="1" desc="Get file modification time (last write time)">
             <Param type="const char *" name="fileName" desc="" />
         </Function>
-        <Function name="CompressData" retType="unsigned char *" paramCount="3" desc="Compress data (DEFLATE algorithm)">
+        <Function name="CompressData" retType="unsigned char *" paramCount="3" desc="Compress data (DEFLATE algorithm), memory must be MemFree()">
             <Param type="const unsigned char *" name="data" desc="" />
             <Param type="int" name="dataSize" desc="" />
             <Param type="int *" name="compDataSize" desc="" />
         </Function>
-        <Function name="DecompressData" retType="unsigned char *" paramCount="3" desc="Decompress data (DEFLATE algorithm)">
+        <Function name="DecompressData" retType="unsigned char *" paramCount="3" desc="Decompress data (DEFLATE algorithm), memory must be MemFree()">
             <Param type="const unsigned char *" name="compData" desc="" />
             <Param type="int" name="compDataSize" desc="" />
             <Param type="int *" name="dataSize" desc="" />
         </Function>
-        <Function name="EncodeDataBase64" retType="char *" paramCount="3" desc="Encode data to Base64 string">
+        <Function name="EncodeDataBase64" retType="char *" paramCount="3" desc="Encode data to Base64 string, memory must be MemFree()">
             <Param type="const unsigned char *" name="data" desc="" />
             <Param type="int" name="dataSize" desc="" />
             <Param type="int *" name="outputSize" desc="" />
         </Function>
-        <Function name="DecodeDataBase64" retType="unsigned char *" paramCount="2" desc="Decode Base64 string data">
+        <Function name="DecodeDataBase64" retType="unsigned char *" paramCount="2" desc="Decode Base64 string data, memory must be MemFree()">
             <Param type="const unsigned char *" name="data" desc="" />
             <Param type="int *" name="outputSize" desc="" />
         </Function>

--- a/parser/raylib_parser.c
+++ b/parser/raylib_parser.c
@@ -177,6 +177,8 @@ static void ExportParsedData(const char *fileName, int format); // Export parsed
 
 static const char *StrDefineType(DefineType type);          // Get string of define type
 
+static void MoveArraySize(char *name, char *type);                // Move array size from name to type
+
 //------------------------------------------------------------------------------------
 // Program main entry point
 //------------------------------------------------------------------------------------
@@ -483,6 +485,11 @@ int main(int argc, char* argv[])
             l++;
         }
 
+        // Move array sizes from name to type
+        for (int j = 0; j < structs[i].fieldCount; j++)
+        {
+            MoveArraySize(structs[i].fieldName[j], structs[i].fieldType[j]);
+        }
     }
     free(structLines);
 
@@ -566,6 +573,12 @@ int main(int argc, char* argv[])
 
         // Description
         GetDescription(&linePtr[c], callbacks[i].desc);
+
+        // Move array sizes from name to type
+        for (int j = 0; j < callbacks[i].paramCount; j++)
+        {
+            MoveArraySize(callbacks[i].paramName[j], callbacks[i].paramType[j]);
+        }
     }
     free(callbackLines);
 
@@ -855,6 +868,12 @@ int main(int argc, char* argv[])
 
         // Get function description
         GetDescription(&linePtr[funcEnd], funcs[i].desc);
+
+        // Move array sizes from name to type
+        for (int j = 0; j < funcs[i].paramCount; j++)
+        {
+            MoveArraySize(funcs[i].paramName[j], funcs[i].paramType[j]);
+        }
     }
     free(funcLines);
 
@@ -1188,6 +1207,24 @@ static const char *StrDefineType(DefineType type)
         case COLOR:   return "COLOR";
     }
     return "";
+}
+
+// Move array size from name to type
+static void MoveArraySize(char *name, char *type)
+{
+    int nameLength = TextLength(name);
+    if (name[nameLength - 1] == ']')
+    {
+        for (int k = nameLength; k > 0; k--)
+        {
+            if (name[k] == '[')
+            {
+                int sizeLength = nameLength - k;
+                MemoryCopy(&type[TextLength(type)], &name[k], sizeLength);
+                name[k] = '\0';
+            }
+        }
+    }
 }
 
 /*

--- a/parser/raylib_parser.c
+++ b/parser/raylib_parser.c
@@ -410,9 +410,9 @@ int main(int argc, char* argv[])
                                 {
                                     // Copy field data from original field
                                     int nameLength = c - lastStart;
-                                    MemoryCopy(structs[i].fieldName[structs[i].fieldCount], &(structs[i].fieldName[originalIndex][lastStart]), nameLength);
-                                    MemoryCopy(structs[i].fieldType[structs[i].fieldCount], &(structs[i].fieldType[originalIndex][0]), TextLength(structs[i].fieldType[originalIndex]));
-                                    MemoryCopy(structs[i].fieldDesc[structs[i].fieldCount], &(structs[i].fieldDesc[originalIndex][0]), TextLength(structs[i].fieldDesc[originalIndex]));
+                                    MemoryCopy(structs[i].fieldName[structs[i].fieldCount], &structs[i].fieldName[originalIndex][lastStart], nameLength);
+                                    MemoryCopy(structs[i].fieldType[structs[i].fieldCount], &structs[i].fieldType[originalIndex][0], TextLength(structs[i].fieldType[originalIndex]));
+                                    MemoryCopy(structs[i].fieldDesc[structs[i].fieldCount], &structs[i].fieldDesc[originalIndex][0], TextLength(structs[i].fieldDesc[originalIndex]));
                                     structs[i].fieldCount++;
                                 }
                                 if (!isEndOfString)
@@ -440,7 +440,7 @@ int main(int argc, char* argv[])
                     if (additionalFields > 0) {
                         // Copy original name to last additional field
                         structs[i].fieldCount += additionalFields;
-                        MemoryCopy(structs[i].fieldName[originalIndex + additionalFields], &(structs[i].fieldName[originalIndex][0]), TextLength(structs[i].fieldName[originalIndex]));
+                        MemoryCopy(structs[i].fieldName[originalIndex + additionalFields], &structs[i].fieldName[originalIndex][0], TextLength(structs[i].fieldName[originalIndex]));
 
                         // Copy names from type to additional fields
                         int fieldsRemaining = additionalFields;
@@ -456,7 +456,7 @@ int main(int argc, char* argv[])
                                     if (fieldsRemaining != additionalFields)
                                     {
                                         nameStart = k + 1;
-                                        MemoryCopy(structs[i].fieldName[originalIndex + fieldsRemaining], &(structs[i].fieldType[originalIndex][nameStart]), nameEnd - nameStart + 1);
+                                        MemoryCopy(structs[i].fieldName[originalIndex + fieldsRemaining], &structs[i].fieldType[originalIndex][nameStart], nameEnd - nameStart + 1);
                                     }
                                     nameEnd = -1;
                                     fieldsRemaining--;
@@ -472,8 +472,8 @@ int main(int argc, char* argv[])
                         // Set field type and description of additional fields
                         for (int j = 1; j <= additionalFields; j++)
                         {
-                            MemoryCopy(structs[i].fieldType[originalIndex + j], &(structs[i].fieldType[originalIndex][0]), fieldTypeLength);
-                            MemoryCopy(structs[i].fieldDesc[originalIndex + j], &(structs[i].fieldDesc[originalIndex][0]), TextLength(structs[i].fieldDesc[originalIndex]));
+                            MemoryCopy(structs[i].fieldType[originalIndex + j], &structs[i].fieldType[originalIndex][0], fieldTypeLength);
+                            MemoryCopy(structs[i].fieldDesc[originalIndex + j], &structs[i].fieldDesc[originalIndex][0], TextLength(structs[i].fieldDesc[originalIndex]));
                             
                         }
                     }
@@ -503,7 +503,7 @@ int main(int argc, char* argv[])
         int typeStart = c;
         while(linePtr[c] != ' ') c++;
         int typeLen = c - typeStart;
-        MemoryCopy(aliases[i].type, linePtr + typeStart, typeLen);
+        MemoryCopy(aliases[i].type, &linePtr[typeStart], typeLen);
 
         // Skip space
         c++;
@@ -512,10 +512,10 @@ int main(int argc, char* argv[])
         int nameStart = c;
         while(linePtr[c] != ';') c++;
         int nameLen = c - nameStart;
-        MemoryCopy(aliases[i].name, linePtr + nameStart, nameLen);
+        MemoryCopy(aliases[i].name, &linePtr[nameStart], nameLen);
 
         // Description
-        GetDescription(linePtr + c, aliases[i].desc);
+        GetDescription(&linePtr[c], aliases[i].desc);
     }
     free(aliasLines);
 
@@ -526,7 +526,7 @@ int main(int argc, char* argv[])
     {
         char *linePtr = lines[callbackLines[i]];
 
-        // Skip "typedef"
+        // Skip "typedef "
         int c = 8;
 
         // Return type
@@ -565,7 +565,7 @@ int main(int argc, char* argv[])
         }
 
         // Description
-        GetDescription(linePtr + c, callbacks[i].desc);
+        GetDescription(&linePtr[c], callbacks[i].desc);
     }
     free(callbackLines);
 
@@ -709,7 +709,7 @@ int main(int argc, char* argv[])
         bool isDuplicate = false;
         for (int k = 0; k < defineIndex; k++)
         {
-            if ((nameLen == TextLength(defines[k].name)) && IsTextEqual(defines[k].name, linePtr + defineNameStart, nameLen))
+            if ((nameLen == TextLength(defines[k].name)) && IsTextEqual(defines[k].name, &linePtr[defineNameStart], nameLen))
             {
                 isDuplicate = true;
                 break;
@@ -717,7 +717,7 @@ int main(int argc, char* argv[])
         }
         if (isDuplicate) continue;
 
-        MemoryCopy(defines[defineIndex].name, linePtr + defineNameStart, nameLen);
+        MemoryCopy(defines[defineIndex].name, &linePtr[defineNameStart], nameLen);
 
         // Determine type
         if (linePtr[defineNameEnd] == ')') defines[defineIndex].type = MACRO;
@@ -769,7 +769,7 @@ int main(int argc, char* argv[])
         int valueLen = defineValueEnd - defineValueStart + 1;
         if (valueLen > 255) valueLen = 255;
 
-        if (valueLen > 0) MemoryCopy(defines[defineIndex].value, linePtr + defineValueStart, valueLen);
+        if (valueLen > 0) MemoryCopy(defines[defineIndex].value, &linePtr[defineValueStart], valueLen);
 
         // Extracting description
         if ((linePtr[j] == '/') && linePtr[j + 1] == '/')
@@ -782,7 +782,7 @@ int main(int argc, char* argv[])
             int commentLen = commentEnd - commentStart + 1;
             if (commentLen > 127) commentLen = 127;
 
-            MemoryCopy(defines[defineIndex].desc, linePtr + commentStart, commentLen);
+            MemoryCopy(defines[defineIndex].desc, &linePtr[commentStart], commentLen);
         }
 
         defineIndex++;
@@ -1109,10 +1109,7 @@ static void GetDescription(const char *line, char *description)
         }
         c++;
     }
-    if (descStart != -1)
-    {
-        MemoryCopy(description, &(line[descStart]), c - descStart);
-    }
+    if (descStart != -1) MemoryCopy(description, &line[descStart], c - descStart);
 }
 
 // Get text length in bytes, check for \0 character

--- a/parser/raylib_parser.c
+++ b/parser/raylib_parser.c
@@ -577,7 +577,14 @@ int main(int argc, char* argv[])
 
         // Extract name
         int defineNameStart = j;
-        while ((linePtr[j] != ' ') && (linePtr[j] != '\t') && (linePtr[j] != '\0')) j++;
+        int openBraces = 0;
+        while (linePtr[j] != '\0')
+        {
+            if (((linePtr[j] == ' ') || (linePtr[j] == '\t')) && (openBraces == 0)) break;
+            if (linePtr[j] == '(') openBraces++;
+            if (linePtr[j] == ')') openBraces--;
+            j++;
+        }
         int defineNameEnd = j-1;
 
         // Skip duplicates

--- a/parser/raylib_parser.c
+++ b/parser/raylib_parser.c
@@ -728,7 +728,7 @@ int main(int argc, char* argv[])
         // Get function description
         for (int c = funcEnd; c < MAX_LINE_LENGTH; c++)
         {
-            if (funcLines[i][c] == '/')
+            if ((funcLines[i][c] == '/') && (funcLines[i][c + 1] == '/'))
             {
                 MemoryCopy(funcs[i].desc, &funcLines[i][c], 127);   // WARNING: Size could be too long for funcLines[i][c]?
                 break;

--- a/parser/raylib_parser.c
+++ b/parser/raylib_parser.c
@@ -260,8 +260,8 @@ int main(int argc, char* argv[])
             {
                 char v = lines[i][c];
                 if (v == ' ') spaceCount++;
-                if (v == ';' && spaceCount == 2) validAlias = true;
-                if (v == ';' || v == '(' || v == '\0') break;
+                if ((v == ';') && (spaceCount == 2)) validAlias = true;
+                if ((v == ';') || (v == '(') || (v == '\0')) break;
             }
             if (!validAlias) continue;
             aliasLines[aliasCount] = i;
@@ -273,7 +273,7 @@ int main(int argc, char* argv[])
     for (int i = 0; i < linesCount; i++)
     {
         // Read enum line
-        if (IsTextEqual(lines[i], "typedef enum {", 14) && lines[i][TextLength(lines[i])-1] != ';') // ignore inline enums
+        if (IsTextEqual(lines[i], "typedef enum {", 14) && (lines[i][TextLength(lines[i])-1] != ';')) // ignore inline enums
         {
             // Keep the line position in the array of lines,
             // so, we can scan that position and following lines
@@ -286,7 +286,7 @@ int main(int argc, char* argv[])
     for (int i = 0; i < linesCount; i++)
     {
         int j = 0;
-        while (lines[i][j] == ' ' || lines[i][j] == '\t') j++; // skip spaces and tabs in the begining
+        while ((lines[i][j] == ' ') || (lines[i][j] == '\t')) j++; // skip spaces and tabs in the begining
         // Read define line
         if (IsTextEqual(lines[i]+j, "#define ", 8))
         {

--- a/parser/raylib_parser.c
+++ b/parser/raylib_parser.c
@@ -76,7 +76,7 @@
 #define MAX_STRUCT_LINE_LENGTH  2048    // Maximum length of one struct (multiple lines)
 
 #define MAX_FUNCTION_PARAMETERS   12    // Maximum number of function parameters
-#define MAX_STRUCT_FIELDS         32    // Maximum number of struct fields
+#define MAX_STRUCT_FIELDS         64    // Maximum number of struct fields
 #define MAX_ENUM_VALUES          512    // Maximum number of enum values
 
 //----------------------------------------------------------------------------------


### PR DESCRIPTION
- Fix parser function description detection
  - Some functions in easings.h are defined on a single line and include a division which was mistaken for the start of the description.
- Fix parser detection of macros with names that contain spaces
- Add support for self-referencing structs to parser (like MemNode)
- Fix parser code style
- Fix parser handling of multiple fields on one line
  - For types this time, pointer types are detected by the last `*` and may contain multiple fields
  - `MemNode *next, *prev` used to be parsed into one field with type `MemNode *next, *` and name `prev` 
- Increase parser MAX_STRUCT_FIELDS
  - For internal rlglData State struct (internal structs are still not supported but this makes it less wrong).
- Add description helper to parser
  - Makes sure a description is an actual comment and strips leading spaces.
- Regenerate parser output 