### PR TITLE
Add support for calculated defines to parser

### DIFF
--- a/parser/raylib_api.json
+++ b/parser/raylib_api.json
@@ -26,13 +26,13 @@
     },
     {
       "name": "DEG2RAD",
-      "type": "UNKNOWN",
+      "type": "FLOAT_MATH",
       "value": "(PI/180.0f)",
       "description": ""
     },
     {
       "name": "RAD2DEG",
-      "type": "UNKNOWN",
+      "type": "FLOAT_MATH",
       "value": "(180.0f/PI)",
       "description": ""
     },

--- a/parser/raylib_api.lua
+++ b/parser/raylib_api.lua
@@ -26,13 +26,13 @@ return {
     },
     {
       name = "DEG2RAD",
-      type = "UNKNOWN",
+      type = "FLOAT_MATH",
       value = "(PI/180.0f)",
       description = ""
     },
     {
       name = "RAD2DEG",
-      type = "UNKNOWN",
+      type = "FLOAT_MATH",
       value = "(180.0f/PI)",
       description = ""
     },

--- a/parser/raylib_api.txt
+++ b/parser/raylib_api.txt
@@ -23,12 +23,12 @@ Define 004: PI
   Description: 
 Define 005: DEG2RAD
   Name: DEG2RAD
-  Type: UNKNOWN
+  Type: FLOAT_MATH
   Value: (PI/180.0f)
   Description: 
 Define 006: RAD2DEG
   Name: RAD2DEG
-  Type: UNKNOWN
+  Type: FLOAT_MATH
   Value: (180.0f/PI)
   Description: 
 Define 007: RL_MALLOC(sz)

--- a/parser/raylib_api.xml
+++ b/parser/raylib_api.xml
@@ -5,8 +5,8 @@
         <Define name="RAYLIB_VERSION" type="STRING" value="4.1-dev" desc="" />
         <Define name="RLAPI" type="UNKNOWN" value="__declspec(dllexport)" desc="We are building the library as a Win32 shared library (.dll)" />
         <Define name="PI" type="FLOAT" value="3.14159265358979323846" desc="" />
-        <Define name="DEG2RAD" type="UNKNOWN" value="(PI/180.0f)" desc="" />
-        <Define name="RAD2DEG" type="UNKNOWN" value="(180.0f/PI)" desc="" />
+        <Define name="DEG2RAD" type="FLOAT_MATH" value="(PI/180.0f)" desc="" />
+        <Define name="RAD2DEG" type="FLOAT_MATH" value="(180.0f/PI)" desc="" />
         <Define name="RL_MALLOC(sz)" type="MACRO" value="malloc(sz)" desc="" />
         <Define name="RL_CALLOC(n,sz)" type="MACRO" value="calloc(n,sz)" desc="" />
         <Define name="RL_REALLOC(ptr,sz)" type="MACRO" value="realloc(ptr,sz)" desc="" />


### PR DESCRIPTION
This small PR adds support for calculated defines to the parser. The new define types with the `_MATH` suffix mean that a define is a mathematical expression that would have the preceding type when calculated.

raylib.h examples:
```json
    {
      "name": "DEG2RAD",
      "type": "FLOAT_MATH",
      "value": "(PI/180.0f)",
      "description": ""
    },
    {
      "name": "RAD2DEG",
      "type": "FLOAT_MATH",
      "value": "(180.0f/PI)",
      "description": ""
    },
```