### PR TITLE
Flush stdout after trace messages

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -148,6 +148,7 @@ void TraceLog(int logType, const char *text, ...)
     strcat(buffer, text);
     strcat(buffer, "\n");
     vprintf(buffer, args);
+    fflush(stdout);
 #endif
 
     va_end(args);


### PR DESCRIPTION
This immediately shows log messages when stdout is not connected to a
tty.