### PR TITLE
added: IsKeyRepeating(key) for PLATFORM_DESKTOP

### DIFF
--- a/projects/Notepad++/raylib_npp_parser/raylib_to_parse.h
+++ b/projects/Notepad++/raylib_npp_parser/raylib_to_parse.h
@@ -172,6 +172,7 @@ RLAPI void OpenURL(const char *url);                              // Open URL wi
 // Input-related functions: keyboard
 RLAPI bool IsKeyPressed(int key);                             // Check if a key has been pressed once
 RLAPI bool IsKeyDown(int key);                                // Check if a key is being pressed
+RLAPI bool IsKeyRepeating(int key);                           // Check if a key is being pressed and is currently repeating
 RLAPI bool IsKeyReleased(int key);                            // Check if a key has been released once
 RLAPI bool IsKeyUp(int key);                                  // Check if a key is NOT being pressed
 RLAPI void SetExitKey(int key);                               // Set a custom key to exit program (default is ESC)

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1082,6 +1082,7 @@ RLAPI void OpenURL(const char *url);                              // Open URL wi
 // Input-related functions: keyboard
 RLAPI bool IsKeyPressed(int key);                             // Check if a key has been pressed once
 RLAPI bool IsKeyDown(int key);                                // Check if a key is being pressed
+RLAPI bool IsKeyRepeating(int key);                           // Check if a key is being pressed and is currently repeating
 RLAPI bool IsKeyReleased(int key);                            // Check if a key has been released once
 RLAPI bool IsKeyUp(int key);                                  // Check if a key is NOT being pressed
 RLAPI void SetExitKey(int key);                               // Set a custom key to exit program (default is ESC)


### PR DESCRIPTION
Currently `GetCharPressed()` responds to os key-repeat events, making it useful for natural typing, however non-visible keys like backspace, or cursor keys etc. do not, creating an awkward inconsistency.

This adds a `IsKeyRepeating(key)` function, allowing users to query if a key is being pressed and is currently repeating (on this frame).

I've only implemented this for glfw and I've probably overlooked some things (like the `GetKeyPressed()` queue).
If we wanted the `GetKeyPressed` queue to also include key repeats, then maybe there should be a way of marking _which_ keys should repeat in this queue. Then users could do specifically mark the text control keys as repeating, when performing text editing, and turn this feature off when done. But that sounds like more of a complicated consideration.

If this is to be a thing, we'd obvs need this for other platforms too. So I guess this PR is partly just a proof-of-concept suggestion.