### PR TITLE
Improved boolean definitions

### DIFF
--- a/src/raudio.c
+++ b/src/raudio.c
@@ -247,10 +247,6 @@ typedef struct tagBITMAPINFOHEADER {
     #include "external/dr_flac.h"       // FLAC loading functions
 #endif
 
-#if defined(_MSC_VER)
-    #undef bool
-#endif
-
 //----------------------------------------------------------------------------------
 // Defines and Macros
 //----------------------------------------------------------------------------------

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -177,10 +177,10 @@
 // Structures Definition
 //----------------------------------------------------------------------------------
 // Boolean type
-#if defined(__STDC__) && __STDC_VERSION__ >= 199901L
+#if (defined(__STDC__) && __STDC_VERSION__ >= 199901L) || (defined(_MSC_VER) && _MSC_VER >= 1800)
     #include <stdbool.h>
 #elif !defined(__cplusplus) && !defined(bool)
-    typedef enum bool { false, true } bool;
+    typedef enum bool { false = 0, true = !false } bool;
     #define RL_BOOL_TYPE
 #endif
 

--- a/src/rgestures.h
+++ b/src/rgestures.h
@@ -62,10 +62,10 @@
 // NOTE: Below types are required for GESTURES_STANDALONE usage
 //----------------------------------------------------------------------------------
 // Boolean type
-#if defined(__STDC__) && __STDC_VERSION__ >= 199901L
+#if (defined(__STDC__) && __STDC_VERSION__ >= 199901L) || (defined(_MSC_VER) && _MSC_VER >= 1800)
     #include <stdbool.h>
 #elif !defined(__cplusplus) && !defined(bool) && !defined(RL_BOOL_TYPE)
-    typedef enum bool { false, true } bool;
+    typedef enum bool { false = 0, true = !false } bool;
 #endif
 
 #if !defined(RL_VECTOR2_TYPE)

--- a/src/rlgl.h
+++ b/src/rlgl.h
@@ -358,11 +358,11 @@ typedef struct rlRenderBatch {
     float currentDepth;         // Current depth value for next draw
 } rlRenderBatch;
 
-#if defined(__STDC__) && __STDC_VERSION__ >= 199901L
+#if (defined(__STDC__) && __STDC_VERSION__ >= 199901L) || (defined(_MSC_VER) && _MSC_VER >= 1800)
     #include <stdbool.h>
 #elif !defined(__cplusplus) && !defined(bool) && !defined(RL_BOOL_TYPE)
     // Boolean type
-    typedef enum bool { false, true } bool;
+typedef enum bool { false = 0, true = !false } bool;
 #endif
 
 #if !defined(RL_MATRIX_TYPE)


### PR DESCRIPTION
I've had [a bit of a trip](https://stackoverflow.com/questions/72300728/returning-a-struct-from-a-function-in-windows-corrupts-its-data/) tracking down a completely bamboozling bug, where certain member offsets in my structs were inconsistent throughout my program when compiling on Windows. It turns out this was caused by the fact that `raylib.h` defines its own `bool` data type if it deduces that `stdbool.h` cannot be used, and the size of this type is not necessarily the same as the size of `bool` as `stdbool.h` defines it. Consequently, depending on whether the compiler had seen `stdbool.h` or `raylib.h` when it came across the definition of my structs, it would generate different member layouts in different compilation units for those structs which had `bool` members. If I passed one struct from one compilation unit to another, member values would appear to be completely different.

The reason why raylib deemed `stdbool.h` unavailable was because [MSVC does not define `__STDC__` unless the /Za compiler option is provided.](https://docs.microsoft.com/en-us/cpp/preprocessor/predefined-macros?view=msvc-170#standard-predefined-macros) Even after setting an explicit C standard in my CMake project, and disabling compiler extensions, CMake still did not add this compiler option. Rather than rely on that option, and only fix this problem for myself, I thought I'd make a PR to improve the way the boolean type is defined in raylib.

This PR makes the following changes:

* The preprocessor check regarding the availability of `stdbool.h` (at least, every check that I could find) has been updated to explicitly check the MSVC version if the `__STDC__` check fails. Since Microsoft added C99 support in VS2013, the check has been augmented to check whether `_MSC_VER` is at least `1800`.
* According to best practices, the definitions of the custom `false` and `true` types have been updated to `false = 0` and `true = !false`. This ensures that `false` is always and obviously `0`, and that true is defined as whatever the compiler considers not to be false, as opposed to a numerical `1`.
* For some reason, `raudio.c` forcibly undefined the `bool` type on Windows, and this caused this file to fail compilation with the new changes. I'm not sure why that was the case, but removing this code fragment did not break compilation for me with the new changes added.