### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -16,8 +16,13 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   build:
+    permissions:
+      contents: write  # for actions/upload-release-asset to upload release asset
     runs-on: windows-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -23,6 +23,9 @@ env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Release
 
+permissions:
+  contents: read
+
 jobs:
   build_windows:
     name: Windows Build

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -15,8 +15,13 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   build:
+    permissions:
+      contents: write  # for actions/upload-release-asset to upload release asset
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/linux_examples.yml
+++ b/.github/workflows/linux_examples.yml
@@ -14,6 +14,9 @@ on:
       - 'examples/**'
       - '.github/workflows/linux_examples.yml'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -15,8 +15,13 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   build:
+    permissions:
+      contents: write  # for actions/upload-release-asset to upload release asset
     runs-on: macos-latest
     
     env:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -15,8 +15,13 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   build:
+    permissions:
+      contents: write  # for actions/upload-release-asset to upload release asset
     runs-on: windows-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/windows_examples.yml
+++ b/.github/workflows/windows_examples.yml
@@ -14,6 +14,9 @@ on:
       - 'examples/**'
       - '.github/workflows/windows_examples.yml'
     
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: windows-latest


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
