### PR TITLE
Fix regression that was causing video stuttering

### DIFF
--- a/src/rcore.c
+++ b/src/rcore.c
@@ -4834,6 +4834,7 @@ void WaitTime(float ms)
     while ((currentTime - previousTime) < ms/1000.0f) currentTime = GetTime();
 #else
     #if defined(SUPPORT_PARTIALBUSY_WAIT_LOOP)
+        double destTime = GetTime() + ms/1000.0f;
         double busyWait = ms*0.05;     // NOTE: We are using a busy wait of 5% of the time
         ms -= (float)busyWait;
     #endif
@@ -4857,11 +4858,7 @@ void WaitTime(float ms)
     #endif
 
     #if defined(SUPPORT_PARTIALBUSY_WAIT_LOOP)
-        double previousTime = GetTime();
-        double currentTime = 0.0;
-
-        // Partial busy wait loop (only a fraction of the total wait time)
-        while ((currentTime - previousTime) < (busyWait/1000.0f)) currentTime = GetTime();
+        while (GetTime() < destTime) { }
     #endif
 #endif
 }


### PR DESCRIPTION
Hello,

This PR fixes the regression described in this issue (https://github.com/raysan5/raylib/issues/2434), in which video stuttering or high amount of tearing was found when running Raylib programs compiled with SUPPORT_PARTIALBUSY_WAIT_LOOP.

The regression was introduced in commit 4e9afac2a55cd3d7b347d9e3706e0dd370386ff7 (https://github.com/raysan5/raylib/commit/4e9afac2a55cd3d7b347d9e3706e0dd370386ff7), and is caused by the way the the busy wait time limit is checked before returning. In the previous version, a target time was calculated by adding the desired time to wait to the current time, and, after sleeping, the remaining busy waiting was done by continously checking the current time until it passed the target time. The stated commit changed this behavior, making it calculate the desired duration of the busy wait, sleeping, and then making the busy wait continously check the difference between the current time and the time the busy wait started, until that difference was higher than the desired duration of the busy wait. I suppose that this second way of checking was less accurate because it does not account for possible imprecision of the actual time spent sleeping.

This PR restores the old partial busy waiting end checking behavior while keeping the busy wait time to 5% of the requested wait time. I've tested it using the method described in the issue linked above and got results similar to the ones I had for version 3.7, while keeping the CPU utilization similar to the one of the current 4.1-dev version.

Please let me know if you're OK with this small change or if you'd like me to change something.

I've also made some optimizations to WaitTime to avoid unnecessary type conversions and divisions but did not include them on this PR to keep the scope on resolving the regression. If you merge this PR I'd like to open a new one with these optimizations.

Thanks a lot, and as always thanks for Raylib.