### PR TITLE
Minor README edit. Starting text is under raylib image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 <img align="left" src="https://github.com/raysan5/raylib/blob/master/logo/raylib_logo_animation.gif" width="288px">
 
+<br clear="left"/>
+
 **raylib is a simple and easy-to-use library to enjoy videogames programming.**
 
 raylib is highly inspired by Borland BGI graphics lib and by XNA framework and it's specially well suited for prototyping, tooling, graphical applications, embedded systems and education.


### PR DESCRIPTION
The initial text on the README file looks awkward when aligned to the right side of the raylib image. The text is too close to the image and makes it seems like some of the text is cut off. This PR makes it so the text starts below the image.

![image](https://user-images.githubusercontent.com/30286973/172874158-f4268b17-6e5e-4c8e-ab89-ea0cabd3e16e.png)
