### PR TITLE
Add function to read both X and Y mouse scrolling from a trackpad

### DIFF
--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1114,7 +1114,8 @@ RLAPI Vector2 GetMouseDelta(void);                            // Get mouse delta
 RLAPI void SetMousePosition(int x, int y);                    // Set mouse position XY
 RLAPI void SetMouseOffset(int offsetX, int offsetY);          // Set mouse offset
 RLAPI void SetMouseScale(float scaleX, float scaleY);         // Set mouse scaling
-RLAPI float GetMouseWheelMove(void);                          // Get mouse wheel movement Y
+RLAPI float GetMouseWheelMove(void);                          // Get mouse wheel movement for X or Y, whichever is larger
+RLAPI Vector2 GetMouseWheelMoveV(void);                       // Get mouse wheel movement for both X and Y
 RLAPI void SetMouseCursor(int cursor);                        // Set mouse cursor
 
 // Input-related functions: touch


### PR DESCRIPTION
This substitutes the internal representation of the single scroll value with a `Vector2`. When the original `GetMouseScrollWheel` function is called, it performs the same task that was previously done for the x/y callback function (take the component with the largest magnitude). Callbacks that just provide one value are put into the Y component.

~~I also modified the scroll wheel example as appropriate, but I can modify it to get the original functionality back if needed.~~ EDIT: reverted back to the original.

BIG NOTE: this is only tested on MacOS by me (and only with a modified scroll wheel example), I don't have experience building any of the other platforms (Android, web, etc).

I tried to update what I think is some playback system, but I'm not sure if I did that right, please pay close attention! I did not test that functionality.

I'm also unfamiliar with the requirements for coding style, etc. Please let me know what I might need to change!

Should close #2480.