### PR TITLE
Changed ExportFontAsCode to use given font's padding.

### DIFF
--- a/src/rtext.c
+++ b/src/rtext.c
@@ -939,7 +939,7 @@ bool ExportFontAsCode(Font font, const char *fileName)
     byteCount += sprintf(txtData + byteCount, "    Font font = { 0 };\n\n");
     byteCount += sprintf(txtData + byteCount, "    font.baseSize = %i;\n", font.baseSize);
     byteCount += sprintf(txtData + byteCount, "    font.glyphCount = %i;\n", font.glyphCount);
-    byteCount += sprintf(txtData + byteCount, "    font.glyphPadding = %i;\n\n", FONT_TTF_DEFAULT_CHARS_PADDING);
+    byteCount += sprintf(txtData + byteCount, "    font.glyphPadding = %i;\n\n", font.glyphPadding);
     byteCount += sprintf(txtData + byteCount, "    // Custom font loading\n");
 #if defined(SUPPORT_COMPRESSED_FONT_ATLAS)
     byteCount += sprintf(txtData + byteCount, "    // NOTE: Compressed font image data (DEFLATE), it requires DecompressData() function\n");


### PR DESCRIPTION
When using ExportFontAsCode(...), the exported .h file sets the font padding to the value of the constant FONT_TTF_DEFAULT_CHARS_PADDING. This results in incorrect rendering of certain AngelCode fonts, so this pull request instead uses the glyphPadding of the Font given as an argument.