### PR TITLE
build system: add ability to specifiy config file

### DIFF
--- a/CMakeOptions.txt
+++ b/CMakeOptions.txt
@@ -26,6 +26,7 @@ endif()
 
 option(INCLUDE_EVERYTHING "Include everything disabled by default (for CI usage" OFF)
 set(OFF ${INCLUDE_EVERYTHING} CACHE INTERNAL "Replace any OFF by default with \${OFF} to have it covered by this option")
+set(EXTERNAL_CONFIG_FILE "" CACHE STRING "Change default config.h by config file at path")
 
 # raylib modules included
 cmake_dependent_option(SUPPORT_MODULE_RSHAPES "Include module: rshapes" ON CUSTOMIZE_BUILD ON)

--- a/cmake/CompileDefinitions.cmake
+++ b/cmake/CompileDefinitions.cmake
@@ -9,6 +9,11 @@ function(define_if target variable)
     endif ()
 endfunction()
 
+if (NOT ${EXTERNAL_CONFIG_FILE} STREQUAL "")
+    message(STATUS "Config file: ${EXTERNAL_CONFIG_FILE}")
+    target_compile_definitions("raylib" PUBLIC EXTERNAL_CONFIG_FILE=<${EXTERNAL_CONFIG_FILE}>)
+endif ()
+
 if (${CUSTOMIZE_BUILD})
     target_compile_definitions("raylib" PUBLIC EXTERNAL_CONFIG_FLAGS)
     define_if("raylib" USE_AUDIO)

--- a/src/Makefile
+++ b/src/Makefile
@@ -72,6 +72,10 @@ RAYLIB_RES_FILE      ?= ./raylib.dll.rc.data
 # if NONE, default config.h flags are used
 RAYLIB_CONFIG_FLAGS  ?= NONE
 
+# Define external config file
+# NOTE: Will load supplied fine instead of default ./config.h
+RAYLIB_CONFIG_FILE  ?= NONE
+
 # To define additional cflags: Use make CUSTOM_CFLAGS=""
 
 # Include raylib modules on compilation
@@ -311,17 +315,22 @@ endif
 #  -fno-strict-aliasing     jar_xm.h does shady stuff (breaks strict aliasing)
 CFLAGS = -Wall -D_DEFAULT_SOURCE -D$(PLATFORM) -D$(GRAPHICS) -Wno-missing-braces -Werror=pointer-arith -fno-strict-aliasing $(CUSTOM_CFLAGS)
 
-ifneq ($(RAYLIB_CONFIG_FLAGS), NONE)
-    CFLAGS += -DEXTERNAL_CONFIG_FLAGS $(RAYLIB_CONFIG_FLAGS)
+ifneq ($(RAYLIB_CONFIG_FLAGS),NONE)
+    CFLAGS += -DEXTERNAL_CONFIG_FLAGS=$(RAYLIB_CONFIG_FLAGS)
 endif
 
-ifeq ($(PLATFORM), PLATFORM_WEB)
+ifneq ($(RAYLIB_CONFIG_FILE),NONE)
+    $(warning $(RAYLIB_CONFIG_FILE))
+    CFLAGS += -DEXTERNAL_CONFIG_FILE="<$(RAYLIB_CONFIG_FILE)>"
+endif
+
+ifeq ($(PLATFORM),PLATFORM_WEB)
     CFLAGS += -std=gnu99
 else
     CFLAGS += -std=c99
 endif
 
-ifeq ($(PLATFORM_OS), LINUX)
+ifeq ($(PLATFORM_OS),LINUX)
     CFLAGS += -fPIC
 endif
 

--- a/src/raudio.c
+++ b/src/raudio.c
@@ -71,14 +71,16 @@
 
 #if defined(RAUDIO_STANDALONE)
     #include "raudio.h"
-    #include <stdarg.h>         // Required for: va_list, va_start(), vfprintf(), va_end()
+    #include <stdarg.h>                 // Required for: va_list, va_start(), vfprintf(), va_end()
 #else
-    #include "raylib.h"         // Declares module functions
+    #include "raylib.h"                 // Declares module functions
     // Check if config flags have been externally provided on compilation line
-    #if !defined(EXTERNAL_CONFIG_FLAGS)
-        #include "config.h"     // Defines module configuration flags
+    #if !defined(EXTERNAL_CONFIG_FLAGS) && !defined(EXTERNAL_CONFIG_FILE)
+        #include "config.h"             // Defines module configuration flags
+    #elif defined(EXTERNAL_CONFIG_FILE)
+        #include EXTERNAL_CONFIG_FILE   // Defines module configuration flags in macro specified path
     #endif
-    #include "utils.h"          // Required for: fopen() Android mapping
+    #include "utils.h"                  // Required for: fopen() Android mapping
 #endif
 
 #if defined(SUPPORT_MODULE_RAUDIO)

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -115,8 +115,10 @@
 #include "raylib.h"                 // Declares module functions
 
 // Check if config flags have been externally provided on compilation line
-#if !defined(EXTERNAL_CONFIG_FLAGS)
+#if !defined(EXTERNAL_CONFIG_FLAGS) && !defined(EXTERNAL_CONFIG_FILE)
     #include "config.h"             // Defines module configuration flags
+#elif defined(EXTERNAL_CONFIG_FILE)
+    #include EXTERNAL_CONFIG_FILE   // Defines module configuration flags in macro specified path
 #endif
 
 #include "utils.h"                  // Required for: TRACELOG() macros

--- a/src/rmodels.c
+++ b/src/rmodels.c
@@ -40,11 +40,13 @@
 *
 **********************************************************************************************/
 
-#include "raylib.h"         // Declares module functions
+#include "raylib.h"                 // Declares module functions
 
 // Check if config flags have been externally provided on compilation line
-#if !defined(EXTERNAL_CONFIG_FLAGS)
-    #include "config.h"     // Defines module configuration flags
+#if !defined(EXTERNAL_CONFIG_FLAGS) && !defined(EXTERNAL_CONFIG_FILE)
+    #include "config.h"             // Defines module configuration flags
+#elif defined(EXTERNAL_CONFIG_FILE)
+    #include EXTERNAL_CONFIG_FILE   // Defines module configuration flags in macro specified path
 #endif
 
 #if defined(SUPPORT_MODULE_RMODELS)

--- a/src/rshapes.c
+++ b/src/rshapes.c
@@ -45,11 +45,13 @@
 *
 **********************************************************************************************/
 
-#include "raylib.h"     // Declares module functions
+#include "raylib.h"                 // Declares module functions
 
 // Check if config flags have been externally provided on compilation line
-#if !defined(EXTERNAL_CONFIG_FLAGS)
-    #include "config.h"         // Defines module configuration flags
+#if !defined(EXTERNAL_CONFIG_FLAGS) && !defined(EXTERNAL_CONFIG_FILE)
+    #include "config.h"             // Defines module configuration flags
+#elif defined(EXTERNAL_CONFIG_FILE)
+    #include EXTERNAL_CONFIG_FILE   // Defines module configuration flags in macro specified path
 #endif
 
 #if defined(SUPPORT_MODULE_RSHAPES)

--- a/src/rtext.c
+++ b/src/rtext.c
@@ -49,11 +49,13 @@
 *
 **********************************************************************************************/
 
-#include "raylib.h"         // Declares module functions
+#include "raylib.h"                 // Declares module functions
 
 // Check if config flags have been externally provided on compilation line
-#if !defined(EXTERNAL_CONFIG_FLAGS)
-    #include "config.h"     // Defines module configuration flags
+#if !defined(EXTERNAL_CONFIG_FLAGS) && !defined(EXTERNAL_CONFIG_FILE)
+    #include "config.h"             // Defines module configuration flags
+#elif defined(EXTERNAL_CONFIG_FILE)
+    #include EXTERNAL_CONFIG_FILE   // Defines module configuration flags in macro specified path
 #endif
 
 #if defined(SUPPORT_MODULE_RTEXT)

--- a/src/rtextures.c
+++ b/src/rtextures.c
@@ -64,8 +64,10 @@
 #include "raylib.h"             // Declares module functions
 
 // Check if config flags have been externally provided on compilation line
-#if !defined(EXTERNAL_CONFIG_FLAGS)
-    #include "config.h"         // Defines module configuration flags
+#if !defined(EXTERNAL_CONFIG_FLAGS) && !defined(EXTERNAL_CONFIG_FILE)
+    #include "config.h"             // Defines module configuration flags
+#elif defined(EXTERNAL_CONFIG_FILE)
+    #include EXTERNAL_CONFIG_FILE   // Defines module configuration flags in macro specified path
 #endif
 
 #if defined(SUPPORT_MODULE_RTEXTURES)

--- a/src/utils.c
+++ b/src/utils.c
@@ -33,8 +33,10 @@
 #include "raylib.h"                     // WARNING: Required for: LogType enum
 
 // Check if config flags have been externally provided on compilation line
-#if !defined(EXTERNAL_CONFIG_FLAGS)
+#if !defined(EXTERNAL_CONFIG_FLAGS) && !defined(EXTERNAL_CONFIG_FILE)
     #include "config.h"                 // Defines module configuration flags
+#elif defined(EXTERNAL_CONFIG_FILE)
+    #include EXTERNAL_CONFIG_FILE       // Defines module configuration flags in macro specified path
 #endif
 
 #include "utils.h"


### PR DESCRIPTION
This PR adds the ability for user to specify EXTERNAL_CONFIG_FILE option in CMake and Makefile solutions.

This, in my opinion, is better than the current way of specifying redefined options via command line arguments. It also provides a more portable way of doing configs, as C headers are treated about the same in all compilers, while macro specification is compiler dependent (-D, /D flags and such)

It also allows for more flexibility when targeting different platforms in the same project, with very specific options in mind for each, as you could create config.h style file for each of them.

Shouldn't break compat with anything already existing, but more thought and consideration is probably needed towards this implementation.