### PR TITLE
[README] Improve clarity/readability last sentence

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,4 +143,4 @@ license
 
 raylib is licensed under an unmodified zlib/libpng license, which is an OSI-certified, BSD-like license that allows static linking with closed source software. Check [LICENSE](LICENSE) for further details.
 
-raylib uses internally some libraries for window/graphics/inputs management and also to support different fileformats loading, all those libraries are embedded with and are available in [src/external](https://github.com/raysan5/raylib/tree/master/src/external) directory. Check [raylib dependencies LICENSES](https://github.com/raysan5/raylib/wiki/raylib-dependencies) on raylib Wiki for details.
+raylib uses libraries to manage window, graphics and inputs.The libraries are embedded in the [src/external](https://github.com/raysan5/raylib/tree/master/src/external) directory to support loading different file formats. Check [raylib dependencies LICENSES](https://github.com/raysan5/raylib/wiki/raylib-dependencies) on raylib Wiki for details.


### PR DESCRIPTION
Reasons for changed sentence:
- "internally some" removed because  even without those words, the sentence conveys the same thing. 
- "loading" was moved to before "different file formats" for a better sentence flow.  
- Sentence was split because the first and second half are talking about different things. I.e., the first half is talking about libraries being used for management, while the second half is about how the libraries are embedded to support different file formats. Splitting the sentence increases readability.
- "and are available in" was removed because it is wordy and since it says libraries are embedded, it is implied that they are available in that directory.
- "to support loading different file formats" was moved to the second half of its sentence because it is more natural and common to place a to-infinitive clause at the end of the sentence.