### PR TITLE
[README] Rephrase fix from issue #2553

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,4 +143,4 @@ license
 
 raylib is licensed under an unmodified zlib/libpng license, which is an OSI-certified, BSD-like license that allows static linking with closed source software. Check [LICENSE](LICENSE) for further details.
 
-raylib uses libraries to manage window, graphics and inputs.The libraries are embedded in the [src/external](https://github.com/raysan5/raylib/tree/master/src/external) directory to support loading different file formats. Check [raylib dependencies LICENSES](https://github.com/raysan5/raylib/wiki/raylib-dependencies) on raylib Wiki for details.
+raylib uses a library to manage window, graphics and inputs.The libraries are compiled with raylib and avaible in the [src/external](https://github.com/raysan5/raylib/tree/master/src/external) directory to support loading different file formats. Check [raylib dependencies LICENSES](https://github.com/raysan5/raylib/wiki/raylib-dependencies) on raylib Wiki for details.

--- a/README.md
+++ b/README.md
@@ -143,4 +143,4 @@ license
 
 raylib is licensed under an unmodified zlib/libpng license, which is an OSI-certified, BSD-like license that allows static linking with closed source software. Check [LICENSE](LICENSE) for further details.
 
-raylib uses internally some libraries for window/graphics/inputs management and also to support different fileformats loading, all those libraries are embedded with and are available in [src/external](https://github.com/raysan5/raylib/tree/master/src/external) directory. Check [raylib dependencies LICENSES](https://github.com/raysan5/raylib/wiki/raylib-dependencies) on raylib Wiki for details.
+raylib uses libraries to manage window, graphics and inputs.The libraries are embedded in the [src/external](https://github.com/raysan5/raylib/tree/master/src/external) directory to support loading different file formats. Check [raylib dependencies LICENSES](https://github.com/raysan5/raylib/wiki/raylib-dependencies) on raylib Wiki for details.


### PR DESCRIPTION
From the feedback given I've tried correcting the rephrasing. I hope it is correct this time? From the original sentence, it said raylib uses some libraries for managing window/graphics/inputs,  so I had understood that as more than one library was used. Other than the incorrect phrasing, I do believe that my other changes improves the clarity and readability of that sentence.