### PR TITLE
fixed build for cygwin

### DIFF
--- a/src/external/stb_vorbis.h
+++ b/src/external/stb_vorbis.h
@@ -570,7 +570,7 @@ enum STBVorbisError
    #if defined(_MSC_VER) || defined(__MINGW32__)
       #include <malloc.h>
    #endif
-   #if defined(__linux__) || defined(__linux) || defined(__EMSCRIPTEN__) || defined(__APPLE__)
+   #if defined(__linux__) || defined(__linux) || defined(__EMSCRIPTEN__) || defined(__APPLE__) || defined(__CYGWIN__)
       #include <alloca.h>
    #endif
 #else // STB_VORBIS_NO_CRT

--- a/src/rglfw.c
+++ b/src/rglfw.c
@@ -37,7 +37,7 @@
 // _GLFW_OSMESA     to use the OSMesa API (headless and non-interactive)
 // _GLFW_MIR        experimental, not supported at this moment
 
-#if defined(_WIN32)
+#if defined(_WIN32) || defined(__CYGWIN__)
     #define _GLFW_WIN32
 #endif
 #if defined(__linux__)
@@ -65,7 +65,7 @@
 #include "external/glfw/src/vulkan.c"
 #include "external/glfw/src/window.c"
 
-#if defined(_WIN32)
+#if defined(_WIN32) || defined(__CYGWIN__)
     #include "external/glfw/src/win32_init.c"
     #include "external/glfw/src/win32_joystick.c"
     #include "external/glfw/src/win32_monitor.c"


### PR DESCRIPTION
I tried multiple methods to fix the build for cygwin
_WIN32 can be defined when using cygwin, this however causes other errors, because some headers are not present on cygwin and other problems.

I find this to be the cleanest solution, maybe some comments should be added for explanation?