### PR TITLE
add: cmake config include guard

### DIFF
--- a/cmake/raylib-config.cmake
+++ b/cmake/raylib-config.cmake
@@ -11,67 +11,69 @@
 #   raylib_LDFLAGS - The linker flags needed with raylib
 #   raylib_DEFINITIONS - Compiler switches required for using raylib
 
-set(XPREFIX PC_RAYLIB)
+if (NOT TARGET raylib)
+    set(XPREFIX PC_RAYLIB)
 
-find_package(PkgConfig QUIET)
-pkg_check_modules(${XPREFIX} QUIET raylib)
+    find_package(PkgConfig QUIET)
+    pkg_check_modules(${XPREFIX} QUIET raylib)
 
-if (raylib_USE_STATIC_LIBS)
-    set(XPREFIX ${XPREFIX}_STATIC)
-endif()
+    if (raylib_USE_STATIC_LIBS)
+        set(XPREFIX ${XPREFIX}_STATIC)
+    endif()
 
-set(raylib_DEFINITIONS ${${XPREFIX}_CFLAGS})
+    set(raylib_DEFINITIONS ${${XPREFIX}_CFLAGS})
 
-find_path(raylib_INCLUDE_DIR
-    NAMES raylib.h
-    HINTS ${${XPREFIX}_INCLUDE_DIRS}
-)
+    find_path(raylib_INCLUDE_DIR
+        NAMES raylib.h
+        HINTS ${${XPREFIX}_INCLUDE_DIRS}
+    )
 
-set(RAYLIB_NAMES raylib)
+    set(RAYLIB_NAMES raylib)
 
-if (raylib_USE_STATIC_LIBS)
-    set(RAYLIB_NAMES libraylib.a raylib.lib ${RAYLIB_NAMES})
-endif()
+    if (raylib_USE_STATIC_LIBS)
+        set(RAYLIB_NAMES libraylib.a raylib.lib ${RAYLIB_NAMES})
+    endif()
 
-find_library(raylib_LIBRARY
-    NAMES ${RAYLIB_NAMES}
-    HINTS ${${XPREFIX}_LIBRARY_DIRS}
-)
+    find_library(raylib_LIBRARY
+        NAMES ${RAYLIB_NAMES}
+        HINTS ${${XPREFIX}_LIBRARY_DIRS}
+    )
 
-set(raylib_LIBRARIES    ${raylib_LIBRARY})
-set(raylib_LIBRARY_DIRS ${${XPREFIX}_LIBRARY_DIRS})
-set(raylib_LIBRARY_DIR  ${raylib_LIBRARY_DIRS})
-set(raylib_INCLUDE_DIRS ${raylib_INCLUDE_DIR})
-set(raylib_LDFLAGS      ${${XPREFIX}_LDFLAGS})
+    set(raylib_LIBRARIES    ${raylib_LIBRARY})
+    set(raylib_LIBRARY_DIRS ${${XPREFIX}_LIBRARY_DIRS})
+    set(raylib_LIBRARY_DIR  ${raylib_LIBRARY_DIRS})
+    set(raylib_INCLUDE_DIRS ${raylib_INCLUDE_DIR})
+    set(raylib_LDFLAGS      ${${XPREFIX}_LDFLAGS})
 
-include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(raylib DEFAULT_MSG
-    raylib_LIBRARY
-    raylib_INCLUDE_DIR
-)
+    include(FindPackageHandleStandardArgs)
+    find_package_handle_standard_args(raylib DEFAULT_MSG
+        raylib_LIBRARY
+        raylib_INCLUDE_DIR
+    )
 
-mark_as_advanced(raylib_LIBRARY raylib_INCLUDE_DIR)
+    mark_as_advanced(raylib_LIBRARY raylib_INCLUDE_DIR)
 
-if (raylib_USE_STATIC_LIBS)
-  add_library(raylib STATIC IMPORTED GLOBAL)
-else()
-  add_library(raylib SHARED IMPORTED GLOBAL)
-endif()
-string (REPLACE ";" " " raylib_LDFLAGS "${raylib_LDFLAGS}")
+    if (raylib_USE_STATIC_LIBS)
+      add_library(raylib STATIC IMPORTED GLOBAL)
+    else()
+      add_library(raylib SHARED IMPORTED GLOBAL)
+    endif()
+    string (REPLACE ";" " " raylib_LDFLAGS "${raylib_LDFLAGS}")
 
-set_target_properties(raylib
-  PROPERTIES
-  IMPORTED_LOCATION             "${raylib_LIBRARIES}"
-  IMPORTED_IMPLIB               "${raylib_LIBRARIES}"
-  INTERFACE_INCLUDE_DIRECTORIES "${raylib_INCLUDE_DIRS}"
-  INTERFACE_LINK_LIBRARIES      "${raylib_LDFLAGS}"
-  INTERFACE_COMPILE_OPTIONS     "${raylib_DEFINITIONS}"
-)
+    set_target_properties(raylib
+      PROPERTIES
+      IMPORTED_LOCATION             "${raylib_LIBRARIES}"
+      IMPORTED_IMPLIB               "${raylib_LIBRARIES}"
+      INTERFACE_INCLUDE_DIRECTORIES "${raylib_INCLUDE_DIRS}"
+      INTERFACE_LINK_LIBRARIES      "${raylib_LDFLAGS}"
+      INTERFACE_COMPILE_OPTIONS     "${raylib_DEFINITIONS}"
+    )
 
-if (raylib_VERBOSE)
-  message(STATUS "raylib_FOUND: ${raylib_FOUND}")
-  message(STATUS "raylib_INCLUDE_DIRS: ${raylib_INCLUDE_DIRS}")
-  message(STATUS "raylib_LIBRARIES: ${raylib_LIBRARIES}")
-  message(STATUS "raylib_LDFLAGS: ${raylib_LDFLAGS}")
-  message(STATUS "raylib_DEFINITIONS: ${raylib_DEFINITIONS}")
+    if (raylib_VERBOSE)
+      message(STATUS "raylib_FOUND: ${raylib_FOUND}")
+      message(STATUS "raylib_INCLUDE_DIRS: ${raylib_INCLUDE_DIRS}")
+      message(STATUS "raylib_LIBRARIES: ${raylib_LIBRARIES}")
+      message(STATUS "raylib_LDFLAGS: ${raylib_LDFLAGS}")
+      message(STATUS "raylib_DEFINITIONS: ${raylib_DEFINITIONS}")
+    endif()
 endif()


### PR DESCRIPTION
raylib does not currently guard against multiple inclusion in cmake projects.

This causes issues when you want to first check for existence of a raylib install and actually add it later.

For example, in my case, I first check for a local install of all my dependencies using find_package('dependency here' QUIET). If not found, I then use FetchContent to automatically grab the missing dependency. Works fine when I DON'T have a local install of raylib. But this causes issues when a local install exists and I attempt the find_package(raylib REQUIRED) call because raylib's config will attempt to add an already existing library ("raylib") when calling find_package on it multiple times.

This change will only run the cmake configuration logic if the raylib target does not already exist.