### PR TITLE
rtextures: Fix ImageFromImage crash

### DIFF
--- a/src/rtextures.c
+++ b/src/rtextures.c
@@ -879,7 +879,7 @@ Image ImageFromImage(Image image, Rectangle rec)
     result.format = image.format;
     result.mipmaps = 1;
 
-    for (int y = 0; y < rec.height; y++)
+    for (int y = 0; y < (int)rec.height; y++)
     {
         memcpy(((unsigned char *)result.data) + y*(int)rec.width*bytesPerPixel, ((unsigned char *)image.data) + ((y + (int)rec.y)*image.width + (int)rec.x)*bytesPerPixel, (int)rec.width*bytesPerPixel);
     }


### PR DESCRIPTION
Height of the rectangle can be float, which may lead to doing extra iteration of loop and writing out of bounds.

This only fixes problem reported in https://github.com/raysan5/raylib/issues/2577, but there may be another usages of using rect dimensions without casting in other pieces of code.