### PR TITLE
rtextures: Improve numerical stability of float multiplication

### DIFF
--- a/src/rtextures.c
+++ b/src/rtextures.c
@@ -875,7 +875,7 @@ Image ImageFromImage(Image image, Rectangle rec)
 
     result.width = (int)rec.width;
     result.height = (int)rec.height;
-    result.data = RL_CALLOC((int)(rec.width*rec.height)*bytesPerPixel, 1);
+    result.data = RL_CALLOC((int)rec.width*(int)rec.height*bytesPerPixel, 1);
     result.format = image.format;
     result.mipmaps = 1;
 


### PR DESCRIPTION
Dimensions of Rectangle should be casted to int before multiplication,
otherwise there is a risk for underallocation/overallocation of memory.

In case of overallocation its just a waste of memory. In case of underacllocation its a crash in best case.

Example: https://godbolt.org/z/zjhKh7xr8