### PR TITLE
Fix rendering issue in audio_raw_stream.c example

### DIFF
--- a/examples/audio/audio_raw_stream.c
+++ b/examples/audio/audio_raw_stream.c
@@ -135,6 +135,11 @@ int main(void)
             {
                 data[i] = (short)(sinf(((2*PI*(float)i/waveLength)))*32000);
             }
+            // Make sure the rest of the line is flat
+            for (int j = waveLength*2; j < MAX_SAMPLES; j++)
+            {
+                data[j] = (short)0;
+            }
 
             // Scale read cursor's position to minimize transition artifacts
             //readCursor = (int)(readCursor * ((float)waveLength / (float)oldWavelength));


### PR DESCRIPTION
Fix issue where old sine waves are still rendered if you decrease the wavelength on the audio_raw_stream example.