### PR TITLE
Fix Codepoint position truncation

### DIFF
--- a/src/rtext.c
+++ b/src/rtext.c
@@ -1093,8 +1093,8 @@ void DrawTextCodepoint(Font font, int codepoint, Vector2 position, float fontSiz
 
     // Character destination rectangle on screen
     // NOTE: We consider glyphPadding on drawing
-    Rectangle dstRec = { (int)position.x + font.glyphs[index].offsetX*scaleFactor - (float)font.glyphPadding*scaleFactor,
-                      (int)position.y + font.glyphs[index].offsetY*scaleFactor - (float)font.glyphPadding*scaleFactor,
+    Rectangle dstRec = { position.x + font.glyphs[index].offsetX*scaleFactor - (float)font.glyphPadding*scaleFactor,
+                      position.y + font.glyphs[index].offsetY*scaleFactor - (float)font.glyphPadding*scaleFactor,
                       (font.recs[index].width + 2.0f*font.glyphPadding)*scaleFactor,
                       (font.recs[index].height + 2.0f*font.glyphPadding)*scaleFactor };
 


### PR DESCRIPTION
This truncation causes text that spans the zero coord boundary to round differently left of zero vs. right of zero, in turn causing letters to appear squished together. If you actually need the position to be an integer, you should instead `floorf()` the float, rather than doing an integer truncation, but I don't see any reason to convert it to an integer in the first place. Everything else in the equation is a float.

Here's an example of the visual "squishing" artifact that occurs before this fix:
https://i.imgur.com/mxpq0rS.mp4
