### PR TITLE
Fix string lacking null termination in IsFileExtension

### DIFF
--- a/src/rcore.c
+++ b/src/rcore.c
@@ -2842,7 +2842,7 @@ bool IsFileExtension(const char *fileName, const char *ext)
         int extCount = 0;
         const char **checkExts = TextSplit(ext, ';', &extCount);  // WARNING: Module required: rtext
 
-        char fileExtLower[MAX_FILE_EXTENSION_SIZE] = { 0 };
+        char fileExtLower[MAX_FILE_EXTENSION_SIZE + 1] = { 0 };
         strncpy(fileExtLower, TextToLower(fileExt),MAX_FILE_EXTENSION_SIZE);  // WARNING: Module required: rtext
 
         for (int i = 0; i < extCount; i++)


### PR DESCRIPTION
When file extension is longer or equal length compared to buffer holding lowercased string, strncpy does not null terminate the string.
Increased buffer size by 1 to ensure it will always be null-terminated, so that following strcmp does not read out of buffer bounds.