### PR TITLE
Tiny documentation fix in reasings.h

### DIFF
--- a/examples/others/reasings.h
+++ b/examples/others/reasings.h
@@ -109,7 +109,7 @@ EASEDEF float EaseLinearInOut(float t, float b, float c, float d) { return (c*t/
 // Sine Easing functions
 EASEDEF float EaseSineIn(float t, float b, float c, float d) { return (-c*cosf(t/d*(PI/2.0f)) + c + b); }            // Ease: Sine In
 EASEDEF float EaseSineOut(float t, float b, float c, float d) { return (c*sinf(t/d*(PI/2.0f)) + b); }                // Ease: Sine Out
-EASEDEF float EaseSineInOut(float t, float b, float c, float d) { return (-c/2.0f*(cosf(PI*t/d) - 1.0f) + b); }      // Ease: Sine Out
+EASEDEF float EaseSineInOut(float t, float b, float c, float d) { return (-c/2.0f*(cosf(PI*t/d) - 1.0f) + b); }      // Ease: Sine In Out
 
 // Circular Easing functions
 EASEDEF float EaseCircIn(float t, float b, float c, float d) { t /= d; return (-c*(sqrtf(1.0f - t*t) - 1.0f) + b); } // Ease: Circular In

--- a/examples/shapes/reasings.h
+++ b/examples/shapes/reasings.h
@@ -109,7 +109,7 @@ EASEDEF float EaseLinearInOut(float t, float b, float c, float d) { return (c*t/
 // Sine Easing functions
 EASEDEF float EaseSineIn(float t, float b, float c, float d) { return (-c*cosf(t/d*(PI/2.0f)) + c + b); }            // Ease: Sine In
 EASEDEF float EaseSineOut(float t, float b, float c, float d) { return (c*sinf(t/d*(PI/2.0f)) + b); }                // Ease: Sine Out
-EASEDEF float EaseSineInOut(float t, float b, float c, float d) { return (-c/2.0f*(cosf(PI*t/d) - 1.0f) + b); }      // Ease: Sine Out
+EASEDEF float EaseSineInOut(float t, float b, float c, float d) { return (-c/2.0f*(cosf(PI*t/d) - 1.0f) + b); }      // Ease: Sine In Out
 
 // Circular Easing functions
 EASEDEF float EaseCircIn(float t, float b, float c, float d) { t /= d; return (-c*(sqrtf(1.0f - t*t) - 1.0f) + b); } // Ease: Circular In


### PR DESCRIPTION
The header comments for the function `EaseSineInOut` were mislabeled as `EaseSineOut`. This has been fixed. Not much else to say... weather's nice, huh?