### PR TITLE
Win32: resolve some symbols re-definition of windows.h in glfw3native.h

### DIFF
--- a/src/external/glfw/include/GLFW/glfw3native.h
+++ b/src/external/glfw/include/GLFW/glfw3native.h
@@ -92,9 +92,6 @@ extern "C" {
 // @raysan5: Actually, only HWND handler needs to be defined
 // Including windows.h could suppose symbols re-definition issues (i.e Rectangle type)
 //#include <windows.h>
- typedef void *PVOID;
- typedef PVOID HANDLE;
- typedef HANDLE HWND;
 #elif defined(GLFW_EXPOSE_NATIVE_COCOA) || defined(GLFW_EXPOSE_NATIVE_NSGL)
  #if defined(__OBJC__)
   #import <Cocoa/Cocoa.h>

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -214,8 +214,12 @@
 
     // Support retrieving native window handlers
     #if defined(_WIN32)
+        typedef void *PVOID;
+        typedef PVOID HANDLE;
+        typedef HANDLE HWND;
         #define GLFW_EXPOSE_NATIVE_WIN32
-        #include "GLFW/glfw3native.h"       // WARNING: It requires customization to avoid windows.h inclusion!
+        #define GLFW_NATIVE_INCLUDE_NONE // To avoid some symbols re-definition in windows.h
+        #include "GLFW/glfw3native.h"
 
         #if defined(SUPPORT_WINMM_HIGHRES_TIMER) && !defined(SUPPORT_BUSY_WAIT_LOOP)
             // NOTE: Those functions require linking with winmm library


### PR DESCRIPTION
This reflects GLFW's fix: https://github.com/glfw/glfw/issues/1348

Currently, we can't build raylib with an external GLFW in Win32
since some symbol re-definition errors occur.

The internal GLFW in raylib seems to avoid this problem by customizing `glfw3native.h`: https://github.com/raysan5/raylib/commit/2feea87b616292b5bce4454a42c2d048f1cce7d8

This fix enables building with an external GLFW in Win32 without any customization,
if it contains the fix of https://github.com/glfw/glfw/issues/1348.

This fix is compatible with the current internal GLFW too.

If we update the internal GLFW to the latest before we merge this branch,
we don't need the commit: 6609c689248bf7931d30a468dd4631edc1a75a0a.
In that case, I will remove that commit from this branch.
