### PR TITLE
Changed the button logic

### DIFF
--- a/examples/textures/textures_sprite_button.c
+++ b/examples/textures/textures_sprite_button.c
@@ -36,7 +36,7 @@ int main(void)
 
     int btnState = 0;               // Button state: 0-NORMAL, 1-MOUSE_HOVER, 2-PRESSED
     bool btnAction = false;         // Button action should be activated
-	bool btnPressed = false;		// Check if button has been actually pressed
+    bool btnPressed = false;		// Check if button has been actually pressed
 
     Vector2 mousePoint = { 0.0f, 0.0f };
 
@@ -50,7 +50,7 @@ int main(void)
         //----------------------------------------------------------------------------------
         mousePoint = GetMousePosition();
         btnAction = false;
-		if (IsMouseButtonPressed(MOUSE_BUTTON_LEFT) && CheckCollisionPointRec(mousePoint, btnBounds)) btnPressed = true;
+        if (IsMouseButtonPressed(MOUSE_BUTTON_LEFT) && CheckCollisionPointRec(mousePoint, btnBounds)) btnPressed = true;
 
         // Check button state
         if (CheckCollisionPointRec(mousePoint, btnBounds))
@@ -59,18 +59,18 @@ int main(void)
             else btnState = 1;
 
             if (btnPressed && IsMouseButtonReleased(MOUSE_BUTTON_LEFT))
-			{
-				btnAction = true;
-				btnPressed = false;
-			}
+            {
+                btnAction = true;
+                btnPressed = false;
+            }
         }
         else if (btnPressed)
-		{
-			btnAction = true;
-			btnState = 0;
-			btnPressed = false;
-		}
-		else btnState = 0;
+        {
+            btnAction = true;
+            btnState = 0;
+            btnPressed = false;
+        }
+        else btnState = 0;
 
         if (btnAction)
         {

--- a/examples/textures/textures_sprite_button.c
+++ b/examples/textures/textures_sprite_button.c
@@ -2,12 +2,10 @@
 *
 *   raylib [textures] example - sprite button
 *
-*   Example originally created with raylib 2.5, last time updated with raylib 2.5
+*   This example has been created using raylib 2.5 (www.raylib.com)
+*   raylib is licensed under an unmodified zlib/libpng license (View raylib.h for details)
 *
-*   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
-*   BSD-like license that allows static linking with closed source software
-*
-*   Copyright (c) 2019-2022 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2019 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 
@@ -15,9 +13,6 @@
 
 #define NUM_FRAMES  3       // Number of frames (rectangles) for the button sprite texture
 
-//------------------------------------------------------------------------------------
-// Program main entry point
-//------------------------------------------------------------------------------------
 int main(void)
 {
     // Initialization
@@ -41,6 +36,7 @@ int main(void)
 
     int btnState = 0;               // Button state: 0-NORMAL, 1-MOUSE_HOVER, 2-PRESSED
     bool btnAction = false;         // Button action should be activated
+	bool btnPressed = false;		// Check if button has been actually pressed
 
     Vector2 mousePoint = { 0.0f, 0.0f };
 
@@ -54,16 +50,27 @@ int main(void)
         //----------------------------------------------------------------------------------
         mousePoint = GetMousePosition();
         btnAction = false;
+		if (IsMouseButtonPressed(MOUSE_BUTTON_LEFT) && CheckCollisionPointRec(mousePoint, btnBounds)) btnPressed = true;
 
         // Check button state
         if (CheckCollisionPointRec(mousePoint, btnBounds))
         {
-            if (IsMouseButtonDown(MOUSE_BUTTON_LEFT)) btnState = 2;
+            if (btnPressed && IsMouseButtonDown(MOUSE_BUTTON_LEFT)) btnState = 2;
             else btnState = 1;
 
-            if (IsMouseButtonReleased(MOUSE_BUTTON_LEFT)) btnAction = true;
+            if (btnPressed && IsMouseButtonReleased(MOUSE_BUTTON_LEFT))
+			{
+				btnAction = true;
+				btnPressed = false;
+			}
         }
-        else btnState = 0;
+        else if (btnPressed)
+		{
+			btnAction = true;
+			btnState = 0;
+			btnPressed = false;
+		}
+		else btnState = 0;
 
         if (btnAction)
         {


### PR DESCRIPTION
I only wanted to make a better logic button for this particular example.
Before, you could hold mouse button left outside the button, then drag the mouse unto the button and, upon release, the sfx would play. It would also change the sprite of the button to the one where appears to be pressed.
This time, you actually have to press the button in order to change the sprite and play the sfx. I also made it so that if you hold mouse button left on the button and then you drag the mouse outside, the button will release and play the sfx.
Maybe the way it was was the intended way, so if it's not welcomed, I'll understand.