### PR TITLE
Fix PATH for Web target

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -187,7 +187,7 @@ ifeq ($(PLATFORM),PLATFORM_WEB)
     CLANG_PATH          = $(EMSDK_PATH)/upstream/bin
     PYTHON_PATH         = $(EMSDK_PATH)/python/3.9.2-1_64bit
     NODE_PATH           = $(EMSDK_PATH)/node/14.15.5_64bit/bin
-    export PATH         = $(EMSDK_PATH);$(EMSCRIPTEN_PATH);$(CLANG_PATH);$(NODE_PATH);$(PYTHON_PATH);C:\raylib\MinGW\bin:$$(PATH)
+    export PATH         := $(EMSDK_PATH):$(EMSCRIPTEN_PATH):$(CLANG_PATH):$(NODE_PATH):$(PYTHON_PATH):C:\raylib\MinGW\bin:$(PATH)
 endif
 
 ifeq ($(PLATFORM),PLATFORM_ANDROID)


### PR DESCRIPTION
The current Makefile ignores the system PATH variable when appending the emsdk paths. This PR corrects this for both Windows and Linux