### PR TITLE
Removed raylib_opengl_interop.c from PLATFORM=Web build

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -85,7 +85,7 @@ if (${PLATFORM} MATCHES "Android")
     list(REMOVE_ITEM example_sources ${CMAKE_CURRENT_SOURCE_DIR}/models/models_obj_viewer.c)
     list(REMOVE_ITEM example_sources ${CMAKE_CURRENT_SOURCE_DIR}/models/models_animation.c)
     list(REMOVE_ITEM example_sources ${CMAKE_CURRENT_SOURCE_DIR}/models/models_first_person_maze.c)
-	list(REMOVE_ITEM example_sources ${CMAKE_CURRENT_SOURCE_DIR}/models/models_magicavoxel_loading.c)
+    list(REMOVE_ITEM example_sources ${CMAKE_CURRENT_SOURCE_DIR}/models/models_magicavoxel_loading.c)
 
 
     list(REMOVE_ITEM example_sources ${CMAKE_CURRENT_SOURCE_DIR}/shaders/shaders_custom_uniform.c)
@@ -101,6 +101,8 @@ elseif (${PLATFORM} MATCHES "Web")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -s ALLOW_MEMORY_GROWTH=1 --no-heap-copy")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --shell-file ${CMAKE_SOURCE_DIR}/src/shell.html")
     set(CMAKE_EXECUTABLE_SUFFIX ".html")
+
+    list(REMOVE_ITEM example_sources ${CMAKE_CURRENT_SOURCE_DIR}/others/raylib_opengl_interop.c)
 
     # Remove the -rdynamic flag because otherwise emscripten
     # does not generate HTML+JS+WASM files, only a non-working


### PR DESCRIPTION
The build is fine with this change:

```
emmake make
make: make
[  0%] Building C object raylib/CMakeFiles/raylib.dir/rcore.c.o
emcc: warning: linker setting ignored during compilation: 'USE_GLFW' [-Wunused-command-line-argument]
emcc: warning: linker setting ignored during compilation: 'ASSERTIONS' [-Wunused-command-line-argument]
[  0%] Building C object raylib/CMakeFiles/raylib.dir/rmodels.c.o

...

[ 99%] Building C object examples/CMakeFiles/textures_to_image.dir/textures/textures_to_image.c.o
emcc: warning: linker setting ignored during compilation: 'USE_GLFW' [-Wunused-command-line-argument]
emcc: warning: linker setting ignored during compilation: 'ASSERTIONS' [-Wunused-command-line-argument]
emcc: warning: linker setting ignored during compilation: 'WASM' [-Wunused-command-line-argument]
emcc: warning: linker setting ignored during compilation: 'ASYNCIFY' [-Wunused-command-line-argument]
emcc: warning: linker setting ignored during compilation: 'ALLOW_MEMORY_GROWTH' [-Wunused-command-line-argument]
emcc: warning: linker flag ignored during compilation: '--shell-file' [-Wunused-command-line-argument]
[100%] Linking C executable textures_to_image.html
[100%] Built target textures_to_image
```

Resolves #2678. See the issue for more details.