### PR TITLE
Fixed a bug in the 2d camera platformer example

### DIFF
--- a/examples/core/core_2d_camera_platformer.c
+++ b/examples/core/core_2d_camera_platformer.c
@@ -177,7 +177,7 @@ void UpdatePlayer(Player *player, EnvItem *envItems, int envItemsLength, float d
             ei->rect.x <= p->x &&
             ei->rect.x + ei->rect.width >= p->x &&
             ei->rect.y >= p->y &&
-            ei->rect.y < p->y + player->speed*delta)
+            ei->rect.y <= p->y + player->speed*delta)
         {
             hitObstacle = 1;
             player->speed = 0.0f;


### PR DESCRIPTION
`canJump` used to alternate between `true` and `false` when on the ground.
When using `IsKeyPressed` instead of `IsKeyDown` for jumping, the player might not jump due to that behavior. This behavior got fixed by adjusting the condition for checking if an obstacle is being hit. With this change, `canJump` doesn't alternate between `true` and `false` when the player is on the ground and instead stays on `true`.