### PR TITLE
examples/core/core_custom_logging.c: Fix typo

### DIFF
--- a/examples/core/core_custom_logging.c
+++ b/examples/core/core_custom_logging.c
@@ -18,7 +18,7 @@
 #include <stdio.h>                  // Required for: fopen(), fclose(), fputc(), fwrite(), printf(), fprintf(), funopen()
 #include <time.h>                   // Required for: time_t, tm, time(), localtime(), strftime()
 
-// Custom logging funtion
+// Custom logging function
 void CustomLog(int msgType, const char *text, va_list args)
 {
     char timeStr[64] = { 0 };


### PR DESCRIPTION
Fix a minor typo in a comment