### PR TITLE
Fix viewport scaling bug on android after context rebind

### DIFF
--- a/src/rcore.c
+++ b/src/rcore.c
@@ -5484,7 +5484,14 @@ static void AndroidCommandCallback(struct android_app *app, int32_t cmd)
                     // Reset screen scaling to full display size
                     EGLint displayFormat = 0;
                     eglGetConfigAttrib(CORE.Window.device, CORE.Window.config, EGL_NATIVE_VISUAL_ID, &displayFormat);
-                    ANativeWindow_setBuffersGeometry(app->window, CORE.Window.render.width, CORE.Window.render.height, displayFormat);
+
+                    // Adding renderOffset here feels rather hackish, but the viewport scaling is wrong after the
+                    // context rebinding if the screen is scaled unless offsets are added. There's probably a more
+                    // appropriate way to fix this
+                    ANativeWindow_setBuffersGeometry(app->window,
+                        CORE.Window.render.width + CORE.Window.renderOffset.x,
+                        CORE.Window.render.height + CORE.Window.renderOffset.y,
+                        displayFormat);
 
                     // Recreate display surface and re-attach OpenGL context
                     CORE.Window.surface = eglCreateWindowSurface(CORE.Window.device, CORE.Window.config, app->window, NULL);


### PR DESCRIPTION
On android after rebinding context (which happens when you minimize and navigate back to an app, or when you turn a screen off and back on) there's a bug that viewport has a wrong scale and part of it is off screen.

The change fixes it on devices I tried, but the solution feels hacky to me. However when I attempted instead to call SetupViewport() again which feels like a more proper solution, it didn't fix it.