### PR TITLE
Clear PCM buffer state when closing audio device

### DIFF
--- a/src/raudio.c
+++ b/src/raudio.c
@@ -509,7 +509,9 @@ void CloseAudioDevice(void)
 
         AUDIO.System.isReady = false;
         RL_FREE(AUDIO.System.pcmBuffer);
-
+        AUDIO.System.pcmBuffer = NULL;
+        AUDIO.System.pcmBufferSize = 0;
+        
         TRACELOG(LOG_INFO, "AUDIO: Device closed successfully");
     }
     else TRACELOG(LOG_WARNING, "AUDIO: Device could not be closed, not currently initialized");


### PR DESCRIPTION
Fix for #2714
Code used for testing:

```
#include "raylib.h"

int main(void)
{
    bool restarting = true;
    while (restarting) {
        // Initialization
        //--------------------------------------------------------------------------------------
        const int screenWidth = 800;
        const int screenHeight = 450;

        InitWindow(screenWidth, screenHeight, "raylib [audio] example - music playing (streaming)");

        InitAudioDevice();              // Initialize audio device

        Music music = LoadMusicStream("resources/country.mp3");

        PlayMusicStream(music);

        SetTargetFPS(60);               // Set our game to run at 60 frames-per-second
        //--------------------------------------------------------------------------------------

        // Main game loop
        while (restarting && (!WindowShouldClose()))    // Detect window close button or ESC key
        {
            // Update
            if (IsKeyPressed(KEY_Q)) {
                restarting = false;
            }
            //----------------------------------------------------------------------------------
            UpdateMusicStream(music);   // Update music buffer with new stream data
            //----------------------------------------------------------------------------------
        
            // Draw
            //----------------------------------------------------------------------------------
            BeginDrawing();
                ClearBackground(RAYWHITE);

                DrawText("MUSIC SHOULD BE PLAYING!", 255, 150, 20, LIGHTGRAY);

                DrawText("PRESS ESC TO RESTART", 215, 250, 20, LIGHTGRAY);
                DrawText("PRESS Q TO QUIT", 208, 280, 20, LIGHTGRAY);
            EndDrawing();
            //----------------------------------------------------------------------------------
        }
        // De-Initialization
        //--------------------------------------------------------------------------------------
        UnloadMusicStream(music);   // Unload music stream buffers from RAM

        CloseAudioDevice();         // Close audio device (music streaming is automatically stopped)

        CloseWindow();              // Close window and OpenGL context
        //--------------------------------------------------------------------------------------
    }
    return 0;
}
```