### PR TITLE
Update build.zig to work with last GLFW update

### DIFF
--- a/src/build.zig
+++ b/src/build.zig
@@ -8,6 +8,7 @@ pub fn addRaylib(b: *std.build.Builder, target: std.zig.CrossTarget) *std.build.
     const raylib_flags = &[_][]const u8{
         "-std=gnu99",
         "-DPLATFORM_DESKTOP",
+        "-D_GNU_SOURCE",
         "-DGL_SILENCE_DEPRECATION=199309L",
         "-fno-sanitize=undefined", // https://github.com/raysan5/raylib/issues/1891
     };


### PR DESCRIPTION
The recent GLFW update([9e0e08c](https://github.com/raysan5/raylib/commit/9e0e08cba495cb8799171c113b55591b46827459)) made build.zig no longer work. It would fail compilation by saying that `ppoll()` was undeclared. Adding the `-D_GNU_SOURCE` flag to compilation fixes this issue(same fix as this one done on the Makefile: [be2328f](https://github.com/raysan5/raylib/commit/be2328f848d96a788f9f40f1ed302c64335d47df)).

This change was tested and works on Linux(Artix), I have not tested on Windows or MacOS as I do not have either of those platforms.