### PR TITLE
Set initial window position for display-sized fullscreen

### DIFF
--- a/src/rcore.c
+++ b/src/rcore.c
@@ -4051,8 +4051,18 @@ static bool InitGraphicsDevice(int width, int height)
     if (CORE.Window.fullscreen)
     {
         // remember center for switchinging from fullscreen to window
-        CORE.Window.position.x = CORE.Window.display.width/2 - CORE.Window.screen.width/2;
-        CORE.Window.position.y = CORE.Window.display.height/2 - CORE.Window.screen.height/2;
+        if ((CORE.Window.screen.height == CORE.Window.display.height) && (CORE.Window.screen.width == CORE.Window.display.width))
+        {
+            // If screen width/height equal to the dislpay, we can't calclulate the window pos for toggling fullscreened/windowed.
+            // Toggling fullscreened/windowed with pos(0, 0) can cause problems in some platforms, such as X11.
+            CORE.Window.position.x = CORE.Window.display.width/4;
+            CORE.Window.position.y = CORE.Window.display.height/4;
+        }
+        else
+        {
+            CORE.Window.position.x = CORE.Window.display.width/2 - CORE.Window.screen.width/2;
+            CORE.Window.position.y = CORE.Window.display.height/2 - CORE.Window.screen.height/2;
+        }
 
         if (CORE.Window.position.x < 0) CORE.Window.position.x = 0;
         if (CORE.Window.position.y < 0) CORE.Window.position.y = 0;


### PR DESCRIPTION
Environment

* Ubuntu 20.04 LTS
* X11 window system

We can create a display-sized fullscreen as follows:

```c
SetConfigFlags(FLAG_FULLSCREEN_MODE);
InitWindow(0, 0, "title");
```

However, at this time, `window.position.x` and `window.position.y` are set to `0`.
There is no way to set that value for `ToggleFullscreen`.

This causes problems on X11 when `ToggleFullscreen`.

When toggling a display-sized fullscreen to windowed screen by `ToggleFullscreen`, the window is at (0, 0) as follows:

```c
ToggleFullscreen();
SetWindowSize(800, 450);
```

![Screenshot from 2022-10-06 16-39-58](https://user-images.githubusercontent.com/12229857/194246906-19157c43-774b-4890-9a6c-8552ff3a46d8.png)

However, sometimes (about 50%) it goes wrong as follows:

![Screenshot from 2022-10-06 16-40-20](https://user-images.githubusercontent.com/12229857/194247470-7456b15a-2e12-481d-9293-8e98f0b4f5c7.png)

* The side-bar and top-bar disappear.
* The header of the window doesn't appear.

The initial windowed position should be near the center, not just on this issue.