### PR TITLE
avoid leading spaces in `text_rectangle_bounds`

### DIFF
--- a/examples/text/text_rectangle_bounds.c
+++ b/examples/text/text_rectangle_bounds.c
@@ -263,6 +263,6 @@ static void DrawTextBoxedSelectable(Font font, const char *text, Rectangle rec, 
             }
         }
 
-        textOffsetX += glyphWidth;
+        if ((textOffsetX != 0) || (codepoint != ' ')) textOffsetX += glyphWidth;  // avoid leading spaces
     }
 }


### PR DESCRIPTION
Hello! I copied the `DrawTextBoxed()` code into my project and noticed this glitch. Wrapped spaces are currently moved into the start of the next line. Hence this PR. Cheers!