### PR TITLE
build.zig: let user decide how to set build mode + fix linker warning

### DIFF
--- a/src/build.zig
+++ b/src/build.zig
@@ -1,10 +1,6 @@
 const std = @import("std");
 
 pub fn addRaylib(b: *std.build.Builder, target: std.zig.CrossTarget) *std.build.LibExeObjStep {
-    // Standard release options allow the person running `zig build` to select
-    // between Debug, ReleaseSafe, ReleaseFast, and ReleaseSmall.
-    const mode = b.standardReleaseOptions();
-
     const raylib_flags = &[_][]const u8{
         "-std=gnu99",
         "-DPLATFORM_DESKTOP",
@@ -15,7 +11,6 @@ pub fn addRaylib(b: *std.build.Builder, target: std.zig.CrossTarget) *std.build.
 
     const raylib = b.addStaticLibrary("raylib", srcdir ++ "/raylib.h");
     raylib.setTarget(target);
-    raylib.setBuildMode(mode);
     raylib.linkLibC();
 
     raylib.addIncludePath(srcdir ++ "/external/glfw/include");
@@ -90,8 +85,8 @@ pub fn build(b: *std.build.Builder) void {
     lib.install();
 }
 
-const srcdir = getSrcDir();
-
-fn getSrcDir() []const u8 {
-    return std.fs.path.dirname(@src().file) orelse ".";
-}
+const srcdir = struct{
+    fn getSrcDir() []const u8 {
+        return std.fs.path.dirname(@src().file).?;
+    }
+}.getSrcDir();

--- a/src/build.zig
+++ b/src/build.zig
@@ -9,7 +9,7 @@ pub fn addRaylib(b: *std.build.Builder, target: std.zig.CrossTarget) *std.build.
         "-fno-sanitize=undefined", // https://github.com/raysan5/raylib/issues/1891
     };
 
-    const raylib = b.addStaticLibrary("raylib", srcdir ++ "/raylib.h");
+    const raylib = b.addStaticLibrary("raylib", null);
     raylib.setTarget(target);
     raylib.linkLibC();
 


### PR DESCRIPTION
This should delegate the responsibility of calling `standardReleaseOptions` and setting the build mode of the `*LibExeObjStep` step to the caller, especially since this might not be the process by which one wants to determine the build mode.

Also changes hides `getSrcDir` to enforce usage of `srcdir`, and asserts that the file is in fact inside a directory.

Also fixes a linker error, by passing `null` to the `root_src` param of `addStaticLibrary` instead of the header file.