### PR TITLE
Fixed blur issue on opaque pictures & added example

### DIFF
--- a/examples/textures/textures_image_processing.c
+++ b/examples/textures/textures_image_processing.c
@@ -17,7 +17,7 @@
 
 #include <stdlib.h>             // Required for: free()
 
-#define NUM_PROCESSES    8
+#define NUM_PROCESSES    9
 
 typedef enum {
     NONE = 0,
@@ -26,6 +26,7 @@ typedef enum {
     COLOR_INVERT,
     COLOR_CONTRAST,
     COLOR_BRIGHTNESS,
+    GAUSSIAN_BLUR,
     FLIP_VERTICAL,
     FLIP_HORIZONTAL
 } ImageProcess;
@@ -37,6 +38,7 @@ static const char *processText[] = {
     "COLOR INVERT",
     "COLOR CONTRAST",
     "COLOR BRIGHTNESS",
+    "GAUSSIAN BLUR",
     "FLIP VERTICAL",
     "FLIP HORIZONTAL"
 };
@@ -125,6 +127,7 @@ int main(void)
                 case COLOR_INVERT: ImageColorInvert(&imCopy); break;
                 case COLOR_CONTRAST: ImageColorContrast(&imCopy, -40); break;
                 case COLOR_BRIGHTNESS: ImageColorBrightness(&imCopy, -80); break;
+                case GAUSSIAN_BLUR: ImageBlurGaussian(&imCopy, 10); break;
                 case FLIP_VERTICAL: ImageFlipVertical(&imCopy); break;
                 case FLIP_HORIZONTAL: ImageFlipHorizontal(&imCopy); break;
                 default: break;

--- a/src/rtextures.c
+++ b/src/rtextures.c
@@ -1506,7 +1506,6 @@ void ImageBlurGaussian(Image *image, int blurSize) {
     ImageAlphaPremultiply(image);
 
     Color *pixels = LoadImageColors(*image);
-    Color *pixelsCopy = LoadImageColors(*image);
 
     // Loop switches between pixelsCopy1 and pixelsCopy2
     Vector4 *pixelsCopy1 = RL_MALLOC((image->height)*(image->width)*sizeof(Vector4));
@@ -1623,14 +1622,14 @@ void ImageBlurGaussian(Image *image, int blurSize) {
     // Reverse premultiply
     for (int i = 0; i < (image->width)*(image->height); i++)
     {
-        if (pixelsCopy1[i].w == 0)
+        if (pixelsCopy1[i].w == 0.0f)
         {
             pixels[i].r = 0;
             pixels[i].g = 0;
             pixels[i].b = 0;
             pixels[i].a = 0;
         }
-        else if (pixelsCopy1[i].w < 255.0f)
+        else if (pixelsCopy1[i].w <= 255.0f)
         {
             float alpha = (float)pixelsCopy1[i].w/255.0f;
             pixels[i].r = (unsigned char)((float)pixelsCopy1[i].x/alpha);


### PR DESCRIPTION
Sorry for the second pull request on this, there was a problem on opaque pictures.
Also added blur on an example.