### PR TITLE
Fix Android x86 Architecture name

### DIFF
--- a/examples/Makefile.Android
+++ b/examples/Makefile.Android
@@ -48,7 +48,7 @@ ifeq ($(ANDROID_ARCH),ARM64)
     ANDROID_ARCH_NAME   = arm64-v8a
 endif
 ifeq ($(ANDROID_ARCH),x86)
-    ANDROID_ARCH_NAME   = i686
+    ANDROID_ARCH_NAME   = x86
 endif
 ifeq ($(ANDROID_ARCH),x86_64)
     ANDROID_ARCH_NAME   = x86_64


### PR DESCRIPTION
### The issue

When using the Android.Makefile that is inside examples for building a project, if chosen Android architecture is **x86** then the makefile will create a folder inside **_lib_** called **i686**. However, in order to install, Android actually expects this folder to be called **x86**.

Basically, the **_lib\i686\\_** folder should actually be named **_lib\x86\\_** in order to be able to install the app on a x86 Android.

### The fix
In order to fix this, I just changed the _ANDROID_ARCH_NAME_ variable from **i686** to **x86**.

### Notes

- The problem also exists in the _Android.Makefile_ on the [raylib-game-template](https://github.com/raysan5/raylib-game-template) repo, so you probably should take a look on that.
- The Makefile for the raylib library itself doesn't appear to have this issue.