### PR TITLE
Add frameworks needed on macos

### DIFF
--- a/src/build.zig
+++ b/src/build.zig
@@ -64,6 +64,10 @@ pub fn addRaylib(b: *std.build.Builder, target: std.zig.CrossTarget) *std.build.
                 raylib_flags ++ raylib_flags_extra_macos,
             );
             raylib.linkFramework("Foundation");
+            raylib.linkFramework("CoreServices");
+            raylib.linkFramework("CoreGraphics");
+            raylib.linkFramework("AppKit");
+            raylib.linkFramework("IOKit");
         },
         else => {
             @panic("Unsupported OS");


### PR DESCRIPTION
I just built the project on mac os, and needed to add several frameworks to resolve missing symbol linker errors.