### PR TITLE
Updated rcore.c, renamed 'time' to 'nanoSeconds'

### DIFF
--- a/src/rcore.c
+++ b/src/rcore.c
@@ -2763,9 +2763,9 @@ double GetTime(void)
 #if defined(PLATFORM_ANDROID) || defined(PLATFORM_RPI) || defined(PLATFORM_DRM)
     struct timespec ts = { 0 };
     clock_gettime(CLOCK_MONOTONIC, &ts);
-    unsigned long long int time_nsec = (unsigned long long int)ts.tv_sec*1000000000LLU + (unsigned long long int)ts.tv_nsec;
+    unsigned long long int nanoSeconds = (unsigned long long int)ts.tv_sec*1000000000LLU + (unsigned long long int)ts.tv_nsec;
 
-    time = (double)(time_nsec - CORE.Time.base)*1e-9;  // Elapsed time since InitTimer()
+    time = (double)(nanoSeconds - CORE.Time.base)*1e-9;  // Elapsed time since InitTimer()
 #endif
     return time;
 }

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -2763,9 +2763,9 @@ double GetTime(void)
 #if defined(PLATFORM_ANDROID) || defined(PLATFORM_RPI) || defined(PLATFORM_DRM)
     struct timespec ts = { 0 };
     clock_gettime(CLOCK_MONOTONIC, &ts);
-    unsigned long long int time = (unsigned long long int)ts.tv_sec*1000000000LLU + (unsigned long long int)ts.tv_nsec;
+    unsigned long long int time_nsec = (unsigned long long int)ts.tv_sec*1000000000LLU + (unsigned long long int)ts.tv_nsec;
 
-    time = (double)(time - CORE.Time.base)*1e-9;  // Elapsed time since InitTimer()
+    time = (double)(time_nsec - CORE.Time.base)*1e-9;  // Elapsed time since InitTimer()
 #endif
     return time;
 }


### PR DESCRIPTION
When PLATFORM_ANDROID, PLATFORM_RPI or PLATFORM_DRM are defined, there is a compilation error due to redefinition of the variable 'time' in the function GetTime. So the second instance of 'time' was changed to 'time_nsec'. This both resolves the name collision and more accurately describes what that variable represents.

Verified working on Raspberry Pi 3B+ with Raspbian Buster.