### PR TITLE
Use GLVND also for old cmake versions

### DIFF
--- a/cmake/LibraryConfigurations.cmake
+++ b/cmake/LibraryConfigurations.cmake
@@ -1,3 +1,12 @@
+# Set OpenGL_GL_PREFERENCE to new "GLVND" even when legacy library exists and
+# cmake is <= 3.10
+#
+# See https://cmake.org/cmake/help/latest/policy/CMP0072.html for more
+# information.
+if(POLICY CMP0072)
+  cmake_policy(SET CMP0072 NEW)
+endif()
+
 if (${PLATFORM} MATCHES "Desktop")
     set(PLATFORM_CPP "PLATFORM_DESKTOP")
 


### PR DESCRIPTION
Use GLVND also when legacy implementations exist for old cmake versions <= 3.10. This is a breaking change for old cmake versions (prior to around 2017-10-05) which will now use GLVND rather than defaulting to libGL.

This fixes the following warning when building:

    CMake Warning (dev) at /gnu/store/qv13zgbmyx0vjav8iiqp772kp6rxvwnd-cmake-3.24.2/share/cmake-3.24/Modules/FindOpenGL.cmake:315 (message):
      Policy CMP0072 is not set: FindOpenGL prefers GLVND by default when
      available.  Run "cmake --help-policy CMP0072" for policy details.  Use the
      cmake_policy command to set the policy and suppress this warning.

      FindOpenGL found both a legacy GL library:

        OPENGL_gl_LIBRARY: /home/simendsjo/.guix-profile/lib/libGL.so

      and GLVND libraries for OpenGL and GLX:

        OPENGL_opengl_LIBRARY: /home/simendsjo/.guix-profile/lib/libOpenGL.so
        OPENGL_glx_LIBRARY: /home/simendsjo/.guix-profile/lib/libGLX.so

      OpenGL_GL_PREFERENCE has not been set to "GLVND" or "LEGACY", so for
      compatibility with CMake 3.10 and below the legacy GL library will be used.
    Call Stack (most recent call first):
      cmake/LibraryConfigurations.cmake:21 (find_package)
      src/CMakeLists.txt:46 (include)
    This warning is for project developers.  Use -Wno-dev to suppress it.

See https://cmake.org/cmake/help/latest/policy/CMP0072.html

Closes #2825