### PR TITLE
Fix Vector2Angle()

### DIFF
--- a/src/raymath.h
+++ b/src/raymath.h
@@ -309,7 +309,7 @@ RMAPI float Vector2DistanceSqr(Vector2 v1, Vector2 v2)
 // Calculate angle from two vectors
 RMAPI float Vector2Angle(Vector2 v1, Vector2 v2)
 {
-    float result = atan2f(v2.y, v2.x) - atan2f(v1.y, v1.x);
+    float result = -acos(v1.x*v2.x + v1.y*v2.y);
 
     return result;
 }


### PR DESCRIPTION
This fix ensures that the angle can be computed for all normalized vectors. But we still return negative values, which is not correct, but is required to maintain backwards compatibility.

Fixes #2828