### PR TITLE
Add a None value for GamepadButton enum

### DIFF
--- a/src/raylib.h
+++ b/src/raylib.h
@@ -684,7 +684,8 @@ typedef enum {
 
 // Gamepad buttons
 typedef enum {
-    GAMEPAD_BUTTON_UNKNOWN = 0,         // Unknown button, just for error checking
+    GAMEPAD_BUTTON_NONE = -1,           // No button pressed
+    GAMEPAD_BUTTON_UNKNOWN,             // Unknown button, just for error checking
     GAMEPAD_BUTTON_LEFT_FACE_UP,        // Gamepad left DPAD up button
     GAMEPAD_BUTTON_LEFT_FACE_RIGHT,     // Gamepad left DPAD right button
     GAMEPAD_BUTTON_LEFT_FACE_DOWN,      // Gamepad left DPAD down button


### PR DESCRIPTION
GetGamepadButtonPressed may return -1 but the enum does not contained this value, for properly type checked languages this may create issues.