### PR TITLE
Add the ability to change screenshot key

### DIFF
--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1099,6 +1099,7 @@ RLAPI bool IsKeyDown(int key);                                // Check if a key 
 RLAPI bool IsKeyReleased(int key);                            // Check if a key has been released once
 RLAPI bool IsKeyUp(int key);                                  // Check if a key is NOT being pressed
 RLAPI void SetExitKey(int key);                               // Set a custom key to exit program (default is ESC)
+RLAPI void SetScreenshotKey(int key);                         // Set a custom key to take a screnshot (default is F12)
 RLAPI int GetKeyPressed(void);                                // Get key pressed (keycode), call it multiple times for keys queued, returns 0 when the queue is empty
 RLAPI int GetCharPressed(void);                               // Get char pressed (unicode), call it multiple times for chars queued, returns 0 when the queue is empty
 

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -5315,7 +5315,7 @@ static void KeyCallback(GLFWwindow *window, int key, int scancode, int action, i
     if ((key == CORE.Input.Keyboard.exitKey) && (action == GLFW_PRESS)) glfwSetWindowShouldClose(CORE.Window.handle, GLFW_TRUE);
 
 #if defined(SUPPORT_SCREEN_CAPTURE)
-    if ((key == CORE.Input.Keyboad.screenshotKey) && (action == GLFW_PRESS))
+    if ((key == CORE.Input.Keyboard.screenshotKey) && (action == GLFW_PRESS))
     {
 #if defined(SUPPORT_GIF_RECORDING)
         if (mods == GLFW_MOD_CONTROL)
@@ -6439,7 +6439,7 @@ static void PollKeyboardEvents(void)
                     }
 
                 #if defined(SUPPORT_SCREEN_CAPTURE)
-                    if (CORE.Input.Keyboard.currentKeyState[CORE.Input.Keyboad.screenshotKey] == 1)
+                    if (CORE.Input.Keyboard.currentKeyState[CORE.Input.Keyboard.screenshotKey] == 1)
                     {
                         TakeScreenshot(TextFormat("screenshot%03i.png", screenshotCounter));
                         screenshotCounter++;

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -429,6 +429,7 @@ typedef struct CoreData {
 #endif
         struct {
             int exitKey;                    // Default exit key
+            int screenshotKey;              // Default screenshot key
             char currentKeyState[MAX_KEYBOARD_KEYS];        // Registers current frame key state
             char previousKeyState[MAX_KEYBOARD_KEYS];       // Registers previous frame key state
 
@@ -763,6 +764,7 @@ void InitWindow(int width, int height, const char *title)
     // Initialize global input state
     memset(&CORE.Input, 0, sizeof(CORE.Input));
     CORE.Input.Keyboard.exitKey = KEY_ESCAPE;
+    CORE.Input.Keyboard.screenshotKey = KEY_F12;
     CORE.Input.Mouse.scale = (Vector2){ 1.0f, 1.0f };
     CORE.Input.Mouse.cursor = MOUSE_CURSOR_ARROW;
     CORE.Input.Gamepad.lastButtonPressed = -1;
@@ -3558,6 +3560,15 @@ void SetExitKey(int key)
 #endif
 }
 
+// Set a custom key to take a screenshot
+// NOTE: default screenshotKey is F12
+void SetScreenshotKey(int key)
+{
+#if !defined(PLATFORM_ANDROID)
+    CORE.Input.Keyboard.screenshotKey = key;
+#endif
+}
+
 // NOTE: Gamepad support not implemented in emscripten GLFW3 (PLATFORM_WEB)
 
 // Check if a gamepad is available
@@ -5304,7 +5315,7 @@ static void KeyCallback(GLFWwindow *window, int key, int scancode, int action, i
     if ((key == CORE.Input.Keyboard.exitKey) && (action == GLFW_PRESS)) glfwSetWindowShouldClose(CORE.Window.handle, GLFW_TRUE);
 
 #if defined(SUPPORT_SCREEN_CAPTURE)
-    if ((key == GLFW_KEY_F12) && (action == GLFW_PRESS))
+    if ((key == CORE.Input.Keyboad.screenshotKey) && (action == GLFW_PRESS))
     {
 #if defined(SUPPORT_GIF_RECORDING)
         if (mods == GLFW_MOD_CONTROL)
@@ -6428,8 +6439,7 @@ static void PollKeyboardEvents(void)
                     }
 
                 #if defined(SUPPORT_SCREEN_CAPTURE)
-                    // Check screen capture key (raylib key: KEY_F12)
-                    if (CORE.Input.Keyboard.currentKeyState[301] == 1)
+                    if (CORE.Input.Keyboard.currentKeyState[CORE.Input.Keyboad.screenshotKey] == 1)
                     {
                         TakeScreenshot(TextFormat("screenshot%03i.png", screenshotCounter));
                         screenshotCounter++;


### PR DESCRIPTION
Currently in Raylib, F12 is always set as the screenshot key, so there is no way that a developer can use the F12 key for a different action without taking a screenshot. This pull request introduces a `SetScreenshotKey` function, very much like `SetExitKey`, that allows a developer to change the key used to take a screenshot or even disable screenshotting. It is useful for when a developer wants to use a different method of screenshotting, take screenshots of a RenderTexture or put screenshots into a different directory. For developers using bindings, this is a good way to disable screenshotting without access to the `SUPPORT_SCREEN_CAPTURE` macro.