### PR TITLE
Add RAYLIB_VERSION numbers to raylib.h

### DIFF
--- a/src/raylib.h
+++ b/src/raylib.h
@@ -81,6 +81,9 @@
 
 #include <stdarg.h>     // Required for: va_list - Only used by TraceLogCallback
 
+#define RAYLIB_VERSION_MAJOR 4
+#define RAYLIB_VERSION_MINOR 5
+#define RAYLIB_VERSION_PATCH 0
 #define RAYLIB_VERSION  "4.5-dev"
 
 // Function specifiers in case library is build/used as a shared library (Windows)


### PR DESCRIPTION
Ran into an issue in raylib-cpp where a user was using raylib 4.5-dev, even though the library currently only targets 4.2. With having RAYLIB_VERSION_MAJOR and RAYLIB_VERSION_MINOR, we will be able to target different versions of raylib in different ways with the same code, using C preprocessor conditionals.

For example:
``` c
#if RAYLIB_VERSION_MAJOR >= 4 && RAYLIB_VERSION_MINOR >= 5
newColor = ColorTint(BLUE, RED);
#else
TraceLog(LOG_INFO, "The color should be tinted, but this isn't supported in raylib <= 4.2");
#endif
```