### PR TITLE
Fixed bug : touches become sticky

### DIFF
--- a/examples/core/core_input_multitouch.c
+++ b/examples/core/core_input_multitouch.c
@@ -39,8 +39,12 @@ int main(void)
     {
         // Update
         //----------------------------------------------------------------------------------
-        // Get multiple touchpoints
-        for (int i = 0; i < MAX_TOUCH_POINTS; ++i) touchPositions[i] = GetTouchPosition(i);
+        // Get the touch point count ( how many fingers are touching the screen )
+        int tCount = GetTouchPointCount();
+        // Clamp touch points available ( set the maximum touch points allowed )
+        if(tCount > MAX_TOUCH_POINTS) tCount = MAX_TOUCH_POINTS;
+        // Get touch points positions
+        for (int i = 0; i < tCount; ++i) touchPositions[i] = GetTouchPosition(i);
         //----------------------------------------------------------------------------------
 
         // Draw
@@ -49,7 +53,7 @@ int main(void)
 
             ClearBackground(RAYWHITE);
             
-            for (int i = 0; i < MAX_TOUCH_POINTS; ++i)
+            for (int i = 0; i < tCount; ++i)
             {
                 // Make sure point is not (0, 0) as this means there is no touch for it
                 if ((touchPositions[i].x > 0) && (touchPositions[i].y > 0))


### PR DESCRIPTION
Touches became sticky and didn't disappear after using more than 2 fingers, fixed by getting the touch count of how many fingers are on the screen, and only looping through the available/pressed down touch points instead of looping through the maximum touch points. Tested with more than 10 touch points, and with different MAX points value, working perfectly.