### PR TITLE
Updated Touch events

### DIFF
--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1136,6 +1136,10 @@ RLAPI int GetTouchY(void);                                    // Get touch posit
 RLAPI Vector2 GetTouchPosition(int index);                    // Get touch position XY for a touch point index (relative to screen size)
 RLAPI int GetTouchPointId(int index);                         // Get touch point identifier for given index
 RLAPI int GetTouchPointCount(void);                           // Get number of touch points
+bool IsTouchPointPressed(int index);                          // Check if a Touch point is pressed once (if the finger touch got in contact with the the screen once, a.k.a TAP, also found in gestures)
+bool IsTouchPointReleased(int index);                         // Check if a Touch point has been released once (if the finger touch was in contact with the screen and now is not anymore)
+bool IsTouchPointDown(int index);                             // Check if a Touch Point is being pressed (if the finger touch is in contact with the screen)
+bool IsTouchPointUp(int index);                               // Check if a Touch Point was released (if the finger touch no longer in contact with the screen)
 
 //------------------------------------------------------------------------------------
 // Gestures and Touch Handling Functions (Module: rgestures)

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -3907,6 +3907,40 @@ int GetTouchPointCount(void)
     return CORE.Input.Touch.pointCount;
 }
 
+// Check if a Touch point is pressed once (if the finger touch got in contact with the the screen once, a.k.a TAP, also found in gestures)
+bool IsTouchPointPressed(int index)
+{
+    // Compare the previous and current Touch point state
+    if ((CORE.Input.Touch.currentTouchState[index] == 1) && (CORE.Input.Touch.previousTouchState[index] == 0)) return true;
+
+    return false;
+}
+
+// Check if a Touch point has been released once (if the finger touch was in contact with the screen and now is not anymore)
+bool IsTouchPointReleased(int index)
+{
+    // Compare the previous and current Touch point state
+    if ((CORE.Input.Touch.currentTouchState[index] == 0) && (CORE.Input.Touch.previousTouchState[index] == 1)) return true;
+
+    return false;
+}
+
+// Check if a Touch Point is being pressed (if the finger touch is in contact with the screen)
+bool IsTouchPointDown(int index)
+{
+    // Get the state of the Touch point
+    if (CORE.Input.Touch.currentTouchState[index] == 1) return true;
+
+    return false;
+}
+
+// Check if a Touch Point was released (if the finger touch no longer in contact with the screen)
+bool IsTouchPointUp(int index)
+{
+    // Reverse the state of the IsTouchPointDown() function
+    return !IsTouchPointDown(index);
+}
+
 //----------------------------------------------------------------------------------
 // Module specific Functions Definition
 //----------------------------------------------------------------------------------


### PR DESCRIPTION
Touch events updated in both rcore.c and raylib.h
now it is possible to check if a Touch point was pressed or released, or either pressed once as in TAP or released after a press
CAUTION : these functions wont work on desktop as it will add another layer of complexity to Raylib, some mouse functions are mapped to touches in Raylib, but it should be all up to the user if they want to map Mouse input to Touches. This is irrelevant with Gesture as they are two different structures.
PS : this was tested on 3 mobile devices and proved to work normally.