### PR TITLE
[MODELS] Fix crash with some GLTF models

### DIFF
--- a/src/rmodels.c
+++ b/src/rmodels.c
@@ -4645,7 +4645,7 @@ static Image LoadImageFromCgltfImage(cgltf_image *cgltfImage, const char *texPat
                 if (result == cgltf_result_success)
                 {
                     image = LoadImageFromMemory(".png", (unsigned char *)data, outSize);
-                    cgltf_free((cgltf_data*)data);
+                    MemFree((cgltf_data*)data);
                 }
             }
         }


### PR DESCRIPTION
When a buffer is read using cgltf_load_buffer_base64, the data is a raw void*, so we can't call `cgltf_free`. `cgltf_free `assumes the data is a `cgltf_data `structure and will try to free the various buffers in that structure. 
This causes a crash with some files (attached)
[house.zip](https://github.com/raysan5/raylib/files/10453346/house.zip)

This PR calls a normal free for the data, so it's properly deallocated so it won't crash.
I could not find a pure free method in cgltf, so I just called raylib's free since it looks like that is what is installed for cgltf's allocators anyway.
