### PR TITLE
Correct the set paths in bat files in examples/

### DIFF
--- a/examples/raylib_compile_execute.bat
+++ b/examples/raylib_compile_execute.bat
@@ -4,10 +4,10 @@
 :: .
 :: > Setup required Environment
 :: -------------------------------------
-set RAYLIB_INCLUDE_DIR=C:\raylib\src
-set RAYLIB_LIB_DIR=C:\raylib\src
-set RAYLIB_RES_FILE=C:\raylib\src\raylib.rc.data
-set COMPILER_DIR=C:\raylib\mingw\bin
+set RAYLIB_INCLUDE_DIR=C:\raylib\raylib\src
+set RAYLIB_LIB_DIR=C:\raylib\raylib\src
+set RAYLIB_RES_FILE=C:\raylib\raylib\src\raylib.rc.data
+set COMPILER_DIR=C:\raylib\w64devkit\bin
 set PATH=%PATH%;%COMPILER_DIR%
 :: Get full filename path for input file %1
 set FILENAME=%~f1

--- a/examples/raylib_makefile_example.bat
+++ b/examples/raylib_makefile_example.bat
@@ -4,10 +4,10 @@
 :: .
 :: > Setup required Environment
 :: -------------------------------------
-set RAYLIB_INCLUDE_DIR=C:\raylib\src
-set RAYLIB_LIB_DIR=C:\raylib\src
-set RAYLIB_RES_FILE=C:\raylib\src\raylib.rc.data
-set COMPILER_DIR=C:\raylib\mingw\bin
+set RAYLIB_INCLUDE_DIR=C:\raylib\raylib\src
+set RAYLIB_LIB_DIR=C:\raylib\raylib\src
+set RAYLIB_RES_FILE=C:\raylib\raylib\src\raylib.rc.data
+set COMPILER_DIR=C:\raylib\w64devkit\bin
 set PATH=%PATH%;%COMPILER_DIR%
 set FILENAME=%1
 set FILENAME_FULL_PATH=%~f1


### PR DESCRIPTION
The directory structure of the windows release has changed:

- mingw -> w64devkit
- raylib source: C:\raylib\src -> C:\raylib\raylib\src

I corrected these paths in the two .bat files in the examples/ directory.
