### PR TITLE
[Models] Fix LoadMaterials

### DIFF
--- a/src/rmodels.c
+++ b/src/rmodels.c
@@ -1851,6 +1851,42 @@ bool ExportMesh(Mesh mesh, const char *fileName)
     return success;
 }
 
+#if defined(SUPPORT_FILEFORMAT_MTL)
+// Process obj materials
+
+static void ProcessOBJMaterials(Material* rayMaterials, tinyobj_material_t* materials, int materialCount)
+{
+	// Init model materials
+	for (unsigned int m = 0; m < materialCount; m++)
+	{
+		// Init material to default
+		// NOTE: Uses default shader, which only supports MATERIAL_MAP_DIFFUSE
+		rayMaterials[m] = LoadMaterialDefault();
+
+		// Get default texture, in case no texture is defined
+		// NOTE: rlgl default texture is a 1x1 pixel UNCOMPRESSED_R8G8B8A8
+		rayMaterials[m].maps[MATERIAL_MAP_DIFFUSE].texture = (Texture2D){ rlGetTextureIdDefault(), 1, 1, 1, PIXELFORMAT_UNCOMPRESSED_R8G8B8A8 };
+
+		if (materials[m].diffuse_texname != NULL) rayMaterials[m].maps[MATERIAL_MAP_DIFFUSE].texture = LoadTexture(materials[m].diffuse_texname);  //char *diffuse_texname; // map_Kd
+
+		rayMaterials[m].maps[MATERIAL_MAP_DIFFUSE].color = (Color){ (unsigned char)(materials[m].diffuse[0] * 255.0f), (unsigned char)(materials[m].diffuse[1] * 255.0f), (unsigned char)(materials[m].diffuse[2] * 255.0f), 255 }; //float diffuse[3];
+		rayMaterials[m].maps[MATERIAL_MAP_DIFFUSE].value = 0.0f;
+
+		if (materials[m].specular_texname != NULL) rayMaterials[m].maps[MATERIAL_MAP_SPECULAR].texture = LoadTexture(materials[m].specular_texname);  //char *specular_texname; // map_Ks
+		rayMaterials[m].maps[MATERIAL_MAP_SPECULAR].color = (Color){ (unsigned char)(materials[m].specular[0] * 255.0f), (unsigned char)(materials[m].specular[1] * 255.0f), (unsigned char)(materials[m].specular[2] * 255.0f), 255 }; //float specular[3];
+		rayMaterials[m].maps[MATERIAL_MAP_SPECULAR].value = 0.0f;
+
+		if (materials[m].bump_texname != NULL) rayMaterials[m].maps[MATERIAL_MAP_NORMAL].texture = LoadTexture(materials[m].bump_texname);  //char *bump_texname; // map_bump, bump
+		rayMaterials[m].maps[MATERIAL_MAP_NORMAL].color = WHITE;
+		rayMaterials[m].maps[MATERIAL_MAP_NORMAL].value = materials[m].shininess;
+
+		rayMaterials[m].maps[MATERIAL_MAP_EMISSION].color = (Color){ (unsigned char)(materials[m].emission[0] * 255.0f), (unsigned char)(materials[m].emission[1] * 255.0f), (unsigned char)(materials[m].emission[2] * 255.0f), 255 }; //float emission[3];
+
+		if (materials[m].displacement_texname != NULL) rayMaterials[m].maps[MATERIAL_MAP_HEIGHT].texture = LoadTexture(materials[m].displacement_texname);  //char *displacement_texname; // disp
+	}
+}
+#endif 
+
 // Load materials from model file
 Material *LoadMaterials(const char *fileName, int *materialCount)
 {
@@ -1867,23 +1903,14 @@ Material *LoadMaterials(const char *fileName, int *materialCount)
         int result = tinyobj_parse_mtl_file(&mats, &count, fileName);
         if (result != TINYOBJ_SUCCESS) TRACELOG(LOG_WARNING, "MATERIAL: [%s] Failed to parse materials file", fileName);
 
-        // TODO: Process materials to return
+        materials = MemAlloc(sizeof(Material) * count);
+        ProcessOBJMaterials(materials, mats, count);
 
         tinyobj_materials_free(mats, count);
     }
 #else
     TRACELOG(LOG_WARNING, "FILEIO: [%s] Failed to load material file", fileName);
 #endif
-
-    // Set materials shader to default (DIFFUSE, SPECULAR, NORMAL)
-    if (materials != NULL)
-    {
-        for (unsigned int i = 0; i < count; i++)
-        {
-            materials[i].shader.id = rlGetShaderIdDefault();
-            materials[i].shader.locs = rlGetShaderLocsDefault();
-        }
-    }
 
     *materialCount = count;
     return materials;
@@ -3989,33 +4016,7 @@ static Model LoadOBJ(const char *fileName)
         }
 
         // Init model materials
-        for (unsigned int m = 0; m < materialCount; m++)
-        {
-            // Init material to default
-            // NOTE: Uses default shader, which only supports MATERIAL_MAP_DIFFUSE
-            model.materials[m] = LoadMaterialDefault();
-
-            // Get default texture, in case no texture is defined
-            // NOTE: rlgl default texture is a 1x1 pixel UNCOMPRESSED_R8G8B8A8
-            model.materials[m].maps[MATERIAL_MAP_DIFFUSE].texture = (Texture2D){ rlGetTextureIdDefault(), 1, 1, 1, PIXELFORMAT_UNCOMPRESSED_R8G8B8A8 };
-
-            if (materials[m].diffuse_texname != NULL) model.materials[m].maps[MATERIAL_MAP_DIFFUSE].texture = LoadTexture(materials[m].diffuse_texname);  //char *diffuse_texname; // map_Kd
-
-            model.materials[m].maps[MATERIAL_MAP_DIFFUSE].color = (Color){ (unsigned char)(materials[m].diffuse[0]*255.0f), (unsigned char)(materials[m].diffuse[1]*255.0f), (unsigned char)(materials[m].diffuse[2]*255.0f), 255 }; //float diffuse[3];
-            model.materials[m].maps[MATERIAL_MAP_DIFFUSE].value = 0.0f;
-
-            if (materials[m].specular_texname != NULL) model.materials[m].maps[MATERIAL_MAP_SPECULAR].texture = LoadTexture(materials[m].specular_texname);  //char *specular_texname; // map_Ks
-            model.materials[m].maps[MATERIAL_MAP_SPECULAR].color = (Color){ (unsigned char)(materials[m].specular[0]*255.0f), (unsigned char)(materials[m].specular[1]*255.0f), (unsigned char)(materials[m].specular[2]*255.0f), 255 }; //float specular[3];
-            model.materials[m].maps[MATERIAL_MAP_SPECULAR].value = 0.0f;
-
-            if (materials[m].bump_texname != NULL) model.materials[m].maps[MATERIAL_MAP_NORMAL].texture = LoadTexture(materials[m].bump_texname);  //char *bump_texname; // map_bump, bump
-            model.materials[m].maps[MATERIAL_MAP_NORMAL].color = WHITE;
-            model.materials[m].maps[MATERIAL_MAP_NORMAL].value = materials[m].shininess;
-
-            model.materials[m].maps[MATERIAL_MAP_EMISSION].color = (Color){ (unsigned char)(materials[m].emission[0]*255.0f), (unsigned char)(materials[m].emission[1]*255.0f), (unsigned char)(materials[m].emission[2]*255.0f), 255 }; //float emission[3];
-
-            if (materials[m].displacement_texname != NULL) model.materials[m].maps[MATERIAL_MAP_HEIGHT].texture = LoadTexture(materials[m].displacement_texname);  //char *displacement_texname; // disp
-        }
+		ProcessOBJMaterials(model.materials, materials, materialCount);
 
         tinyobj_attrib_free(&attrib);
         tinyobj_shapes_free(meshes, meshCount);


### PR DESCRIPTION
The function `LoadMaterials `did not do anything with the materials parsed from the MTL file. This PR moves the code that the OBJ reader uses for materials into a function that can be used by both `LoadObj `and `LoadMaterials`.

I'm not sure if you want to keep `LoadMaterials `as a function because nobody has used it, but if you do, this PR makes it work. 
I can see justification for removing `LoadMaterials `too.

This should resolve issue #2869