### PR TITLE
[CORE] Add include guard to config.h

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -24,7 +24,8 @@
 *     3. This notice may not be removed or altered from any source distribution.
 *
 **********************************************************************************************/
-
+#ifndef CONFIG_H
+#define CONFIG_H
 //------------------------------------------------------------------------------------
 // Module selection - Some modules could be avoided
 // Mandatory modules: rcore, rlgl, utils
@@ -236,3 +237,5 @@
 // utils: Configuration values
 //------------------------------------------------------------------------------------
 #define MAX_TRACELOG_MSG_LENGTH          128    // Max length of one trace-log message
+
+#endif // CONFIG_H


### PR DESCRIPTION
The file config.h doesn't have any kind of include guards. This means that if some external library (like raylib extras) needs to check options in in raylib, it will get warning/errors if it tries to include config.h.

This PR simply adds a guard to the file to prevent that.