### PR TITLE
Add WASM support for Zig build

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -67,8 +67,8 @@ ifeq ($(PLATFORM),PLATFORM_RPI)
     endif
 endif
 
-# Determine PLATFORM_OS in case PLATFORM_DESKTOP selected
-ifeq ($(PLATFORM),PLATFORM_DESKTOP)
+# Determine PLATFORM_OS in case PLATFORM_DESKTOP or PLATFORM_WEB selected
+ifeq ($(PLATFORM),$(filter $(PLATFORM),PLATFORM_DESKTOP PLATFORM_WEB))
     # No uname.exe on MinGW!, but OS=Windows_NT on Windows!
     # ifeq ($(UNAME),Msys) -> Windows
     ifeq ($(OS),Windows_NT)
@@ -127,16 +127,6 @@ endif
 
 # Define raylib release directory for compiled library
 RAYLIB_RELEASE_PATH 	?= $(RAYLIB_PATH)/src
-
-ifeq ($(PLATFORM),PLATFORM_WEB)
-    # Emscripten required variables
-    EMSDK_PATH         ?= C:/emsdk
-    EMSCRIPTEN_PATH    ?= $(EMSDK_PATH)/upstream/emscripten
-    CLANG_PATH          = $(EMSDK_PATH)/upstream/bin
-    PYTHON_PATH         = $(EMSDK_PATH)/python/3.9.2-1_64bit
-    NODE_PATH           = $(EMSDK_PATH)/node/14.15.5_64bit/bin
-    export PATH         = $(EMSDK_PATH);$(EMSCRIPTEN_PATH);$(CLANG_PATH);$(NODE_PATH);$(PYTHON_PATH):$$(PATH)
-endif
 
 # Define default C compiler: CC
 #------------------------------------------------------------------------------------------------
@@ -557,7 +547,7 @@ endif
 
 # Clean everything
 clean:
-ifeq ($(PLATFORM),PLATFORM_DESKTOP)
+ifeq ($(PLATFORM),$(filter $(PLATFORM),PLATFORM_DESKTOP PLATFORM_WEB))
     ifeq ($(PLATFORM_OS),WINDOWS)
 		del *.o *.exe /s
     endif
@@ -577,9 +567,6 @@ endif
 ifeq ($(PLATFORM),PLATFORM_DRM)
 	find . -type f -executable -delete
 	rm -fv *.o
-endif
-ifeq ($(PLATFORM),PLATFORM_WEB)
-	del *.o *.html *.js
 endif
 	@echo Cleaning done
 

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -126,7 +126,7 @@ ifeq ($(PLATFORM),PLATFORM_DRM)
 endif
 
 # Define raylib release directory for compiled library
-RAYLIB_RELEASE_PATH 	?= $(RAYLIB_PATH)/src
+RAYLIB_RELEASE_PATH    ?= $(RAYLIB_PATH)/src
 
 # Define default C compiler: CC
 #------------------------------------------------------------------------------------------------
@@ -547,7 +547,7 @@ endif
 
 # Clean everything
 clean:
-ifeq ($(PLATFORM),$(filter $(PLATFORM),PLATFORM_DESKTOP PLATFORM_WEB))
+ifeq ($(PLATFORM),PLATFORM_DESKTOP)
     ifeq ($(PLATFORM_OS),WINDOWS)
 		del *.o *.exe /s
     endif
@@ -568,5 +568,11 @@ ifeq ($(PLATFORM),PLATFORM_DRM)
 	find . -type f -executable -delete
 	rm -fv *.o
 endif
+ifeq ($(PLATFORM),PLATFORM_WEB)
+	ifeq ($(PLATFORM_OS),WINDOWS)
+		del *.wasm *.html *.js *.data
+	else
+		rm -f */*.wasm */*.html */*.js */*.data
+	endif
+endif
 	@echo Cleaning done
-

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -128,6 +128,18 @@ endif
 # Define raylib release directory for compiled library
 RAYLIB_RELEASE_PATH    ?= $(RAYLIB_PATH)/src
 
+ifeq ($(PLATFORM),PLATFORM_WEB)
+	ifeq ($(PLATFORM_OS),WINDOWS)
+        # Emscripten required variables
+		EMSDK_PATH         ?= C:/emsdk
+		EMSCRIPTEN_PATH    ?= $(EMSDK_PATH)/upstream/emscripten
+		CLANG_PATH          = $(EMSDK_PATH)/upstream/bin
+		PYTHON_PATH         = $(EMSDK_PATH)/python/3.9.2-1_64bit
+		NODE_PATH           = $(EMSDK_PATH)/node/14.15.5_64bit/bin
+		export PATH         = $(EMSDK_PATH);$(EMSCRIPTEN_PATH);$(CLANG_PATH);$(NODE_PATH);$(PYTHON_PATH):$$(PATH)
+	endif
+endif
+
 # Define default C compiler: CC
 #------------------------------------------------------------------------------------------------
 CC = gcc

--- a/src/build.zig
+++ b/src/build.zig
@@ -81,7 +81,7 @@ pub fn addRaylib(b: *std.build.Builder, target: std.zig.CrossTarget) *std.build.
             raylib.defineCMacro("GRAPHICS_API_OPENGL_ES2", null);
 
             if (b.sysroot == null) {
-                @panic("Pass '--sysroot \"$EMSDK/upstream/emscripten\"' or '--sysroot \"/usr/local/opt/emscripten/libexec\"' on macOS");
+                @panic("Pass '--sysroot \"$EMSDK/upstream/emscripten\"'");
             }
 
             const cache_include = std.fs.path.join(b.allocator, &.{ b.sysroot.?, "cache", "sysroot", "include" }) catch @panic("Out of memory");

--- a/src/build.zig
+++ b/src/build.zig
@@ -24,7 +24,7 @@ pub fn addRaylib(b: *std.build.Builder, target: std.zig.CrossTarget) *std.build.
         srcdir ++ "/utils.c",
     }, raylib_flags);
 
-    switch (raylib.target.toTarget().os.tag) {
+    switch (target.getOsTag()) {
         .windows => {
             raylib.addCSourceFiles(&.{srcdir ++ "/rglfw.c"}, raylib_flags);
             raylib.linkSystemLibrary("winmm");


### PR DESCRIPTION
Addresses #2884

This does create a `libraylib.a` using `zig build -Dtarget=wasm32-emscripten --sysroot /usr/local/opt/emscripten/libexec/` in `src` on macOS 13.2, but I couldn't yet get any programs to work with it.