### PR TITLE
Avoid warnings about [lossy] implicit type conversions

### DIFF
--- a/src/external/jar_mod.h
+++ b/src/external/jar_mod.h
@@ -217,7 +217,7 @@ typedef struct tracker_state_
     int cur_pattern;
     int cur_pattern_pos;
     int cur_pattern_table_pos;
-    unsigned int buf_index;
+    unsigned long buf_index;
     track_state tracks[32];
 }tracker_state;
 
@@ -1114,7 +1114,7 @@ bool jar_mod_setcfg(jar_mod_context_t * modctx, int samplerate, int bits, int st
 }
 
 // make certain that mod_data stays in memory while playing
-static bool jar_mod_load( jar_mod_context_t * modctx, void * mod_data, int mod_data_size )
+static bool jar_mod_load( jar_mod_context_t * modctx, void * mod_data, mulong mod_data_size )
 {
     muint i, max;
     unsigned short t;

--- a/src/external/jar_xm.h
+++ b/src/external/jar_xm.h
@@ -2196,7 +2196,7 @@ uint64_t jar_xm_get_remaining_samples(jar_xm_context_t* ctx) {
 
 int jar_xm_create_context_from_file(jar_xm_context_t** ctx, uint32_t rate, const char* filename) {
     FILE* xmf;
-    int size;
+    long size;
     int ret;
 
     xmf = fopen(filename, "rb");

--- a/src/external/qoi.h
+++ b/src/external/qoi.h
@@ -286,7 +286,7 @@ is filled with the description from the file header.
 
 The returned pixel data should be free()d after use. */
 
-void *qoi_decode(const void *data, int size, qoi_desc *desc, int channels);
+void *qoi_decode(const void *data, long size, qoi_desc *desc, int channels);
 
 
 #ifdef __cplusplus
@@ -485,13 +485,13 @@ void *qoi_encode(const void *data, const qoi_desc *desc, int *out_len) {
 	return bytes;
 }
 
-void *qoi_decode(const void *data, int size, qoi_desc *desc, int channels) {
+void *qoi_decode(const void *data, long size, qoi_desc *desc, int channels) {
 	const unsigned char *bytes;
 	unsigned int header_magic;
 	unsigned char *pixels;
 	qoi_rgba_t index[64];
 	qoi_rgba_t px;
-	int px_len, chunks_len, px_pos;
+	long px_len, chunks_len, px_pos;
 	int p = 0, run = 0;
 
 	if (
@@ -616,7 +616,7 @@ int qoi_write(const char *filename, const void *data, const qoi_desc *desc) {
 
 void *qoi_read(const char *filename, qoi_desc *desc, int channels) {
 	FILE *f = fopen(filename, "rb");
-	int size, bytes_read;
+	long size, bytes_read;
 	void *pixels, *data;
 
 	if (!f) {

--- a/src/external/sinfl.h
+++ b/src/external/sinfl.h
@@ -219,7 +219,7 @@ static int
 sinfl_peek(struct sinfl *s, int cnt) {
   assert(cnt >= 0 && cnt <= 56);
   assert(cnt <= s->bitcnt);
-  return s->bitbuf & ((1ull << cnt) - 1);
+  return (int)(s->bitbuf & ((1ull << cnt) - 1));
 }
 static void
 sinfl_consume(struct sinfl *s, int cnt) {

--- a/src/raudio.c
+++ b/src/raudio.c
@@ -1444,7 +1444,7 @@ Music LoadMusicStream(const char *fileName)
     {
         jar_mod_context_t *ctxMod = RL_CALLOC(1, sizeof(jar_mod_context_t));
         jar_mod_init(ctxMod);
-        int result = jar_mod_load_file(ctxMod, fileName);
+        mulong result = jar_mod_load_file(ctxMod, fileName);
 
         music.ctxType = MUSIC_MODULE_MOD;
         music.ctxData = ctxMod;

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -3148,8 +3148,8 @@ const char *GetApplicationDirectory(void)
 
     if (_NSGetExecutablePath(appDir, &size) == 0)
     {
-        int len = strlen(appDir);
-        for (int i = len; i >= 0; --i)
+        long len = strlen(appDir);
+        for (long i = len; i >= 0; --i)
         {
             if (appDir[i] == '/')
             {

--- a/src/utils.c
+++ b/src/utils.c
@@ -200,7 +200,7 @@ unsigned char *LoadFileData(const char *fileName, unsigned int *bytesRead)
             // WARNING: On binary streams SEEK_END could not be found,
             // using fseek() and ftell() could not work in some (rare) cases
             fseek(file, 0, SEEK_END);
-            int size = ftell(file);
+            size_t size = ftell(file);
             fseek(file, 0, SEEK_SET);
 
             if (size > 0)


### PR DESCRIPTION
I'm building another project that pulls and compiles raylib.  When I build my project with Xcode on the Mac, I get warnings from raylib compilation.  This avoids those.  Mostly, it extends some smaller data types from int to long.