### PR TITLE
Update zig build to latest master

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1,0 +1,18 @@
+const std = @import("std");
+const raylib = @import("src/build.zig");
+
+pub fn build(b: *std.Build) void {
+    // Standard target options allows the person running `zig build` to choose
+    // what target to build for. Here we do not override the defaults, which
+    // means any target is allowed, and the default is native. Other options
+    // for restricting supported target set are available.
+    const target = b.standardTargetOptions(.{});
+    // Standard optimization options allow the person running `zig build` to select
+    // between Debug, ReleaseSafe, ReleaseFast, and ReleaseSmall. Here we do not
+    // set a preferred release mode, allowing the user to decide how to optimize.
+    const optimize = b.standardOptimizeOption(.{});
+
+    const lib = raylib.addRaylib(b, target, optimize);
+    lib.installHeader("src/raylib.h", "raylib.h");
+    lib.install();
+}

--- a/examples/build.zig
+++ b/examples/build.zig
@@ -1,14 +1,10 @@
 const std = @import("std");
 const builtin = @import("builtin");
 
-fn add_module(comptime module: []const u8, b: *std.build.Builder, target: std.zig.CrossTarget) !*std.build.Step {
+fn add_module(comptime module: []const u8, b: *std.build.Builder, target: std.zig.CrossTarget, optimize: std.builtin.OptimizeMode) !*std.build.Step {
     if (target.getOsTag() == .emscripten) {
         @panic("Emscripten building via Zig unsupported");
     }
-
-    // Standard release options allow the person running `zig build` to select
-    // between Debug, ReleaseSafe, ReleaseFast, and ReleaseSmall.
-    const mode = b.standardReleaseOptions();
 
     const all = b.step(module, "All " ++ module ++ " examples");
     const dir = try std.fs.cwd().openIterableDir(module, .{});
@@ -22,10 +18,12 @@ fn add_module(comptime module: []const u8, b: *std.build.Builder, target: std.zi
         // zig's mingw headers do not include pthread.h
         if (std.mem.eql(u8, "core_loading_thread", name) and target.getOsTag() == .windows) continue;
 
-        const exe = b.addExecutable(name, null);
+        const exe = b.addExecutable(.{
+            .name = name,
+            .target = target,
+            .optimize = optimize,
+        });
         exe.addCSourceFile(path, &[_][]const u8{});
-        exe.setTarget(target);
-        exe.setBuildMode(mode);
         exe.linkLibC();
         exe.addObjectFile(switch (target.getOsTag()) {
             .windows => "../src/raylib.lib",
@@ -89,15 +87,19 @@ pub fn build(b: *std.build.Builder) !void {
     // means any target is allowed, and the default is native. Other options
     // for restricting supported target set are available.
     const target = b.standardTargetOptions(.{});
+    // Standard optimization options allow the person running `zig build` to select
+    // between Debug, ReleaseSafe, ReleaseFast, and ReleaseSmall. Here we do not
+    // set a preferred release mode, allowing the user to decide how to optimize.
+    const optimize = b.standardOptimizeOption(.{});
 
     const all = b.getInstallStep();
 
-    all.dependOn(try add_module("audio", b, target));
-    all.dependOn(try add_module("core", b, target));
-    all.dependOn(try add_module("models", b, target));
-    all.dependOn(try add_module("others", b, target));
-    all.dependOn(try add_module("shaders", b, target));
-    all.dependOn(try add_module("shapes", b, target));
-    all.dependOn(try add_module("text", b, target));
-    all.dependOn(try add_module("textures", b, target));
+    all.dependOn(try add_module("audio", b, target, optimize));
+    all.dependOn(try add_module("core", b, target, optimize));
+    all.dependOn(try add_module("models", b, target, optimize));
+    all.dependOn(try add_module("others", b, target, optimize));
+    all.dependOn(try add_module("shaders", b, target, optimize));
+    all.dependOn(try add_module("shapes", b, target, optimize));
+    all.dependOn(try add_module("text", b, target, optimize));
+    all.dependOn(try add_module("textures", b, target, optimize));
 }

--- a/src/build.zig
+++ b/src/build.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 
-pub fn addRaylib(b: *std.build.Builder, target: std.zig.CrossTarget) *std.build.LibExeObjStep {
+pub fn addRaylib(b: *std.build.Builder, target: std.zig.CrossTarget, optimize: std.builtin.OptimizeMode) *std.build.LibExeObjStep {
     const raylib_flags = &[_][]const u8{
         "-std=gnu99",
         "-D_GNU_SOURCE",
@@ -8,8 +8,11 @@ pub fn addRaylib(b: *std.build.Builder, target: std.zig.CrossTarget) *std.build.
         "-fno-sanitize=undefined", // https://github.com/raysan5/raylib/issues/1891
     };
 
-    const raylib = b.addStaticLibrary("raylib", null);
-    raylib.setTarget(target);
+    const raylib = b.addStaticLibrary(.{
+        .name = "raylib",
+        .target = target,
+        .optimize = optimize,
+    });
     raylib.linkLibC();
 
     raylib.addIncludePath(srcdir ++ "/external/glfw/include");
@@ -106,8 +109,12 @@ pub fn build(b: *std.build.Builder) void {
     // means any target is allowed, and the default is native. Other options
     // for restricting supported target set are available.
     const target = b.standardTargetOptions(.{});
+    // Standard optimization options allow the person running `zig build` to select
+    // between Debug, ReleaseSafe, ReleaseFast, and ReleaseSmall. Here we do not
+    // set a preferred release mode, allowing the user to decide how to optimize.
+    const optimize = b.standardOptimizeOption(.{});
 
-    const lib = addRaylib(b, target);
+    const lib = addRaylib(b, target, optimize);
     lib.setOutputDir(srcdir);
     lib.install();
 }


### PR DESCRIPTION
Version: approximately usable at `zig 0.11.0-dev.1571+c1f71963a`.

Also, adds package manager support (early MVP).

We need to add root build zig file to support Zig Package Manager. Once package manager gets support for overidding build root directory - we can move this logic in `src/build.zig` and remove root `build.zig`.

Also, now every build artifacts must accept target and optimize arguments, so it is also adjusted.

For now, there is not much info about how to use package manager in Zig, so I will leave it here:

Create `build.zig.zon`:
```zig
.{
    .name = "raylib_usage",
    .version = "0.0.0",

    .dependencies = .{
        .raylib = .{
            .url = "https://github.com/raysan5/raylib/archive/543333cae47c397f9bce93fe654aeba7cbe7e33d.tar.gz",
            .hash = "1220a2bf5e5a53060256428b107b7a86077581861e9cb7b42c5083f443575646d59f",
        },
    },
}
```

Hashes and commits may need adjusting (once merged).

Then in `build.zig` of your project:

```zig
...
const raylib_dep = b.dependency("raylib", .{
    .target = target,
    .optimize = optimize,
});
...
exe.linkLibrary(raylib_dep.artifact("raylib"));
...
```