### PR TITLE
zig build: do not use deprecated functions

### DIFF
--- a/examples/build.zig
+++ b/examples/build.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const builtin = @import("builtin");
 
-fn add_module(comptime module: []const u8, b: *std.build.Builder, target: std.zig.CrossTarget, optimize: std.builtin.OptimizeMode) !*std.build.Step {
+fn add_module(comptime module: []const u8, b: *std.Build, target: std.zig.CrossTarget, optimize: std.builtin.OptimizeMode) !*std.Build.Step {
     if (target.getOsTag() == .emscripten) {
         @panic("Emscripten building via Zig unsupported");
     }
@@ -81,7 +81,7 @@ fn add_module(comptime module: []const u8, b: *std.build.Builder, target: std.zi
     return all;
 }
 
-pub fn build(b: *std.build.Builder) !void {
+pub fn build(b: *std.Build) !void {
     // Standard target options allows the person running `zig build` to choose
     // what target to build for. Here we do not override the defaults, which
     // means any target is allowed, and the default is native. Other options

--- a/src/build.zig
+++ b/src/build.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 
-pub fn addRaylib(b: *std.build.Builder, target: std.zig.CrossTarget, optimize: std.builtin.OptimizeMode) *std.build.LibExeObjStep {
+pub fn addRaylib(b: *std.Build, target: std.zig.CrossTarget, optimize: std.builtin.OptimizeMode) *std.Build.CompileStep {
     const raylib_flags = &[_][]const u8{
         "-std=gnu99",
         "-D_GNU_SOURCE",
@@ -103,7 +103,7 @@ pub fn addRaylib(b: *std.build.Builder, target: std.zig.CrossTarget, optimize: s
     return raylib;
 }
 
-pub fn build(b: *std.build.Builder) void {
+pub fn build(b: *std.Build) void {
     // Standard target options allows the person running `zig build` to choose
     // what target to build for. Here we do not override the defaults, which
     // means any target is allowed, and the default is native. Other options


### PR DESCRIPTION
this is follow up of #2910.

i renamed deprecated functions/structs std.build.Builder and related stuff.