### PR TITLE
Fix ScissorMode for RenderTextures on macOS

### DIFF
--- a/src/rcore.c
+++ b/src/rcore.c
@@ -2323,7 +2323,7 @@ void BeginScissorMode(int x, int y, int width, int height)
 
 #if defined(__APPLE__)
     Vector2 scale = GetWindowScaleDPI();
-    rlScissor((int)(x*scale.x), (int)(GetScreenHeight()*scale.y - (((y + height)*scale.y))), (int)(width*scale.x), (int)(height*scale.y));
+    rlScissor((int)(x*scale.x), (int)(CORE.Window.currentFbo.height*scale.y - (((y + height)*scale.y))), (int)(width*scale.x), (int)(height*scale.y));
 #else
     if ((CORE.Window.flags & FLAG_WINDOW_HIGHDPI) > 0)
     {


### PR DESCRIPTION
ScissorMode would previously use the window height when repositioning the scissor origin to the top left.