### PR TITLE
[CAMEARA] Fix Orbital Camera Mode

### DIFF
--- a/examples/models/models_billboard.c
+++ b/examples/models/models_billboard.c
@@ -55,8 +55,6 @@ int main(void)
     float distanceRotating;
     float rotation = 0.0f;
 
-    DisableCursor();                    // Limit cursor to relative movement inside the window
-
     SetTargetFPS(60);                   // Set our game to run at 60 frames-per-second
     //--------------------------------------------------------------------------------------
 

--- a/examples/models/models_cubicmap.c
+++ b/examples/models/models_cubicmap.c
@@ -47,8 +47,6 @@ int main(void)
 
     UnloadImage(image);     // Unload cubesmap image from RAM, already uploaded to VRAM
 
-    DisableCursor();                    // Limit cursor to relative movement inside the window
-
     SetTargetFPS(60);                   // Set our game to run at 60 frames-per-second
     //--------------------------------------------------------------------------------------
 

--- a/examples/models/models_heightmap.c
+++ b/examples/models/models_heightmap.c
@@ -44,8 +44,6 @@ int main(void)
 
     UnloadImage(image);             // Unload heightmap image from RAM, already uploaded to VRAM
 
-    DisableCursor();                // Limit cursor to relative movement inside the window
-
     SetTargetFPS(60);               // Set our game to run at 60 frames-per-second
     //--------------------------------------------------------------------------------------
 

--- a/examples/models/models_loading_vox.c
+++ b/examples/models/models_loading_vox.c
@@ -69,8 +69,6 @@ int main(void)
 
     int currentModel = 0;
 
-    DisableCursor();                // Limit cursor to relative movement inside the window
-
     SetTargetFPS(60);               // Set our game to run at 60 frames-per-second
     //--------------------------------------------------------------------------------------
 

--- a/examples/models/models_mesh_generation.c
+++ b/examples/models/models_mesh_generation.c
@@ -68,8 +68,6 @@ int main(void)
 
     int currentModel = 0;
 
-    DisableCursor();                // Limit cursor to relative movement inside the window
-
     SetTargetFPS(60);               // Set our game to run at 60 frames-per-second
     //--------------------------------------------------------------------------------------
 

--- a/examples/models/models_rlgl_solar_system.c
+++ b/examples/models/models_rlgl_solar_system.c
@@ -56,8 +56,6 @@ int main(void)
     float moonRotation = 0.0f;          // Rotation of moon around itself
     float moonOrbitRotation = 0.0f;     // Rotation of moon around earth in degrees
 
-    DisableCursor();                    // Limit cursor to relative movement inside the window
-
     SetTargetFPS(60);                   // Set our game to run at 60 frames-per-second
     //--------------------------------------------------------------------------------------
 

--- a/examples/shaders/shaders_basic_lighting.c
+++ b/examples/shaders/shaders_basic_lighting.c
@@ -80,7 +80,6 @@ int main(void)
     lights[2] = CreateLight(LIGHT_POINT, (Vector3){ -2, 1, 2 }, Vector3Zero(), GREEN, shader);
     lights[3] = CreateLight(LIGHT_POINT, (Vector3){ 2, 1, -2 }, Vector3Zero(), BLUE, shader);
 
-    DisableCursor();                    // Limit cursor to relative movement inside the window
     SetTargetFPS(60);                   // Set our game to run at 60 frames-per-second
     //--------------------------------------------------------------------------------------
 

--- a/examples/shaders/shaders_fog.c
+++ b/examples/shaders/shaders_fog.c
@@ -85,7 +85,6 @@ int main(void)
     // Using just 1 point lights
     CreateLight(LIGHT_POINT, (Vector3){ 0, 2, 6 }, Vector3Zero(), WHITE, shader);
 
-    DisableCursor();                    // Limit cursor to relative movement inside the window
     SetTargetFPS(60);                   // Set our game to run at 60 frames-per-second
     //--------------------------------------------------------------------------------------
 

--- a/examples/shaders/shaders_hybrid_render.c
+++ b/examples/shaders/shaders_hybrid_render.c
@@ -86,7 +86,6 @@ int main(void)
     // Camera FOV is pre-calculated in the camera Distance.
     double camDist = 1.0/(tan(camera.fovy*0.5*DEG2RAD));
     
-    DisableCursor();                // Limit cursor to relative movement inside the window
     SetTargetFPS(60);               // Set our game to run at 60 frames-per-second
     //--------------------------------------------------------------------------------------
 

--- a/examples/shaders/shaders_mesh_instancing.c
+++ b/examples/shaders/shaders_mesh_instancing.c
@@ -94,7 +94,6 @@ int main(void)
     Material matDefault = LoadMaterialDefault();
     matDefault.maps[MATERIAL_MAP_DIFFUSE].color = BLUE;
 
-    DisableCursor();                    // Limit cursor to relative movement inside the window
     SetTargetFPS(60);                   // Set our game to run at 60 frames-per-second
     //--------------------------------------------------------------------------------------
 

--- a/examples/shaders/shaders_postprocessing.c
+++ b/examples/shaders/shaders_postprocessing.c
@@ -112,7 +112,6 @@ int main(void)
     // Create a RenderTexture2D to be used for render to texture
     RenderTexture2D target = LoadRenderTexture(screenWidth, screenHeight);
 
-    DisableCursor();                    // Limit cursor to relative movement inside the window
     SetTargetFPS(60);                   // Set our game to run at 60 frames-per-second
     //--------------------------------------------------------------------------------------
 

--- a/examples/shaders/shaders_write_depth.c
+++ b/examples/shaders/shaders_write_depth.c
@@ -59,7 +59,6 @@ int main(void)
         .projection = CAMERA_PERSPECTIVE              // Camera projection type
     };
     
-    DisableCursor();                    // Limit cursor to relative movement inside the window
     SetTargetFPS(60);                   // Set our game to run at 60 frames-per-second
     //--------------------------------------------------------------------------------------
 

--- a/src/rcamera.h
+++ b/src/rcamera.h
@@ -172,7 +172,7 @@ Matrix GetCameraProjectionMatrix(Camera* camera, float aspect);
 #define CAMERA_MOUSE_MOVE_SENSITIVITY                   0.003f    // TODO: it should be independant of framerate
 #define CAMERA_MOUSE_SCROLL_SENSITIVITY                 1.5f
 
-#define CAMERA_ORBITAL_SPEED                            0.01f       // Radians per frame
+#define CAMERA_ORBITAL_SPEED                            0.5f       // Radians per second
 
 
 #define CAMERA_FIRST_PERSON_STEP_TRIGONOMETRIC_DIVIDER  8.0f
@@ -418,30 +418,44 @@ void UpdateCamera(Camera *camera, int mode)
     bool rotateAroundTarget = mode == CAMERA_THIRD_PERSON || mode == CAMERA_ORBITAL;
     bool lockView = mode == CAMERA_FIRST_PERSON || mode == CAMERA_THIRD_PERSON || mode == CAMERA_ORBITAL;
     bool rotateUp = mode == CAMERA_FREE;
-
-    // Camera rotation
-    if (IsKeyDown(KEY_DOWN)) CameraPitch(camera, -CAMERA_ROTATION_SPEED, lockView, rotateAroundTarget, rotateUp);
-    if (IsKeyDown(KEY_UP)) CameraPitch(camera, CAMERA_ROTATION_SPEED, lockView, rotateAroundTarget, rotateUp);
-    if (IsKeyDown(KEY_RIGHT)) CameraYaw(camera, -CAMERA_ROTATION_SPEED, rotateAroundTarget);
-    if (IsKeyDown(KEY_LEFT)) CameraYaw(camera, CAMERA_ROTATION_SPEED, rotateAroundTarget);
-    if (IsKeyDown(KEY_Q)) CameraRoll(camera, -CAMERA_ROTATION_SPEED);
-    if (IsKeyDown(KEY_E)) CameraRoll(camera, CAMERA_ROTATION_SPEED);
-
-    CameraYaw(camera, -mousePositionDelta.x*CAMERA_MOUSE_MOVE_SENSITIVITY, rotateAroundTarget);
-    CameraPitch(camera, -mousePositionDelta.y*CAMERA_MOUSE_MOVE_SENSITIVITY, lockView, rotateAroundTarget, rotateUp);
-
-    // Camera movement
-    if (IsKeyDown(KEY_W)) CameraMoveForward(camera, CAMERA_MOVE_SPEED, moveInWorldPlane);
-    if (IsKeyDown(KEY_A)) CameraMoveRight(camera, -CAMERA_MOVE_SPEED, moveInWorldPlane);
-    if (IsKeyDown(KEY_S)) CameraMoveForward(camera, -CAMERA_MOVE_SPEED, moveInWorldPlane);
-    if (IsKeyDown(KEY_D)) CameraMoveRight(camera, CAMERA_MOVE_SPEED, moveInWorldPlane);
-    //if (IsKeyDown(KEY_SPACE)) CameraMoveUp(camera, CAMERA_MOVE_SPEED);
-    //if (IsKeyDown(KEY_LEFT_CONTROL)) CameraMoveUp(camera, -CAMERA_MOVE_SPEED);
     
-    // Zoom target distance
-    CameraMoveToTarget(camera, -GetMouseWheelMove());
-    if (IsKeyPressed(KEY_KP_SUBTRACT)) CameraMoveToTarget(camera, 2.0f);
-    if (IsKeyPressed(KEY_KP_ADD)) CameraMoveToTarget(camera, -2.0f);
+	if (mode == CAMERA_ORBITAL)
+	{
+        // Obital can just orbit
+		Matrix rotatation = MatrixRotate(GetCameraUp(camera), CAMERA_ORBITAL_SPEED * GetFrameTime());
+		Vector3 viewVector = Vector3Subtract(camera->position, camera->target);
+		viewVector = Vector3Transform(viewVector, rotatation);
+		camera->position = Vector3Add(camera->target, viewVector);
+	}
+    else
+    {
+		// Camera rotation
+		if (IsKeyDown(KEY_DOWN)) CameraPitch(camera, -CAMERA_ROTATION_SPEED, lockView, rotateAroundTarget, rotateUp);
+		if (IsKeyDown(KEY_UP)) CameraPitch(camera, CAMERA_ROTATION_SPEED, lockView, rotateAroundTarget, rotateUp);
+		if (IsKeyDown(KEY_RIGHT)) CameraYaw(camera, -CAMERA_ROTATION_SPEED, rotateAroundTarget);
+		if (IsKeyDown(KEY_LEFT)) CameraYaw(camera, CAMERA_ROTATION_SPEED, rotateAroundTarget);
+		if (IsKeyDown(KEY_Q)) CameraRoll(camera, -CAMERA_ROTATION_SPEED);
+		if (IsKeyDown(KEY_E)) CameraRoll(camera, CAMERA_ROTATION_SPEED);
+
+		CameraYaw(camera, -mousePositionDelta.x * CAMERA_MOUSE_MOVE_SENSITIVITY, rotateAroundTarget);
+		CameraPitch(camera, -mousePositionDelta.y * CAMERA_MOUSE_MOVE_SENSITIVITY, lockView, rotateAroundTarget, rotateUp);
+  
+        // Camera movement
+        if (IsKeyDown(KEY_W)) CameraMoveForward(camera, CAMERA_MOVE_SPEED, moveInWorldPlane);
+        if (IsKeyDown(KEY_A)) CameraMoveRight(camera, -CAMERA_MOVE_SPEED, moveInWorldPlane);
+        if (IsKeyDown(KEY_S)) CameraMoveForward(camera, -CAMERA_MOVE_SPEED, moveInWorldPlane);
+        if (IsKeyDown(KEY_D)) CameraMoveRight(camera, CAMERA_MOVE_SPEED, moveInWorldPlane);
+        //if (IsKeyDown(KEY_SPACE)) CameraMoveUp(camera, CAMERA_MOVE_SPEED);
+        //if (IsKeyDown(KEY_LEFT_CONTROL)) CameraMoveUp(camera, -CAMERA_MOVE_SPEED);
+    }
+
+    if (mode == CAMERA_THIRD_PERSON || mode == CAMERA_ORBITAL)
+    {
+        // Zoom target distance
+        CameraMoveToTarget(camera, -GetMouseWheelMove());
+        if (IsKeyPressed(KEY_KP_SUBTRACT)) CameraMoveToTarget(camera, 2.0f);
+        if (IsKeyPressed(KEY_KP_ADD)) CameraMoveToTarget(camera, -2.0f);
+    }
 }
 #endif // !CAMERA_STANDALONE
 


### PR DESCRIPTION
This PR makes the orbital camera mode work like it used to before the change to the new camera system.

I think there was some confusion that the author of the camera system had about what the orbital camera did and they just made it a copy of the third person camera. It is not that. It is a always turning camera that has no other input. You move the camera by moving the camera manually.

This PR restores that functionality using the new camera logic.

Also during the camera update the cursor was disabled in all examples that used an orbit camera, possibly because they thought it was a third person camera. This PR restores the cursor because the mouse is not used with orbital camera.

With this PR all the demos should be back to working like they used to, with the new camera logic.