### PR TITLE
fix(build): Fix DLL build on Windows

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -62,7 +62,7 @@ if (NOT BUILD_SHARED_LIBS)
     add_library(raylib_static ALIAS raylib)
 else()
     MESSAGE(STATUS "Building raylib shared library")
-    if (MSVC)
+    if (WIN32)
         target_compile_definitions(raylib
                                    PRIVATE $<BUILD_INTERFACE:BUILD_LIBTYPE_SHARED>
                                    INTERFACE $<INSTALL_INTERFACE:USE_LIBTYPE_SHARED>


### PR DESCRIPTION
Changes the DLL export condition to apply to platform WIN32 instead of compiler MSVC.

Tested with:
Ninja with Clang 15.0.7
Ninja with MSVC 19.35
Visual Studio solution with MSVC 19.35