### PR TITLE
Add raylib-sunder to BINDINGS.md

### DIFF
--- a/BINDINGS.md
+++ b/BINDINGS.md
@@ -70,6 +70,7 @@ Some people ported raylib to other languages in form of bindings or wrappers to 
 | raylib-zig         | **4.2** | [Zig](https://ziglang.org/)               | MIT | https://github.com/Not-Nik/raylib-zig     |
 | raylib.zig         | **4.2** | [Zig](https://ziglang.org/)               | MIT | https://github.com/ryupold/raylib.zig |
 | hare-raylib        | auto    | [Hare](https://harelang.org/)        | Zlib | https://git.sr.ht/~evantj/hare-raylib       |
+| raylib-sunder      | auto    | [Sunder](https://github.com/ashn-dot-dev/sunder) | 0BSD | https://github.com/ashn-dot-dev/raylib-sunder |
 
 
 


### PR DESCRIPTION
Adds auto generated (currently up to date with version 4.5) bindings for the [Sunder programming language](https://github.com/ashn-dot-dev/sunder) via Sunder's experimental C backend.

![raylib-sunder](https://user-images.githubusercontent.com/60763262/225318213-48853da5-b72c-4e88-babf-97cf66f6bc5e.png)
