### PR TITLE
Calculate exact image size in GenImageFontAtlas

### DIFF
--- a/src/rtext.c
+++ b/src/rtext.c
@@ -695,16 +695,18 @@ Image GenImageFontAtlas(const GlyphInfo *chars, Rectangle **charRecs, int glyphC
     Rectangle *recs = (Rectangle *)RL_MALLOC(glyphCount*sizeof(Rectangle));
 
     // Calculate image size based on total glyph width and glyph row count
-    int totalWidth = 0;
-    for (int i = 0; i < glyphCount; i++) totalWidth += chars[i].image.width + 2*padding;
-    int imageSize = 64;     // A minimum starting value to avoid unnecessary calculation steps for very small images
-    int rowCount = 0;
-    do
+    int totalWidth = 0, maxGlyphWidth = 0;
+    for (int i = 0; i < glyphCount; i++)
     {
-        imageSize *= 2;                                     // Double the size of image (to keep POT)
-        rowCount = imageSize/(fontSize + 2*padding);        // Calculate new row count for the new image size
+        if (chars[i].image.width > maxGlyphWidth) maxGlyphWidth = chars[i].image.width;
+        totalWidth += chars[i].image.width + 2*padding;
     }
-    while (totalWidth > imageSize*rowCount);
+    int rowCount = 0, imageSize = 64;  // A minimum starting value to avoid unnecessary calculation steps for very small images
+    while (totalWidth > (imageSize - maxGlyphWidth)*rowCount) // maxGlyphWidth is maximum possible space left at the end of row
+    {
+        imageSize *= 2;                                 // Double the size of image (to keep POT)
+        rowCount = imageSize/(fontSize + 2*padding);    // Calculate new row count for the new image size
+    }
 
     atlas.width = imageSize;   // Atlas bitmap width
     atlas.height = imageSize;  // Atlas bitmap height

--- a/src/rtext.c
+++ b/src/rtext.c
@@ -694,14 +694,17 @@ Image GenImageFontAtlas(const GlyphInfo *chars, Rectangle **charRecs, int glyphC
     // NOTE: Rectangles memory is loaded here!
     Rectangle *recs = (Rectangle *)RL_MALLOC(glyphCount*sizeof(Rectangle));
 
-    // Calculate image size based on required pixel area
-    // NOTE 1: Image is forced to be squared and POT... very conservative!
-    // NOTE 2: SDF font characters already contain an internal padding,
-    // so image size would result bigger than default font type
-    float requiredArea = 0;
-    for (int i = 0; i < glyphCount; i++) requiredArea += ((chars[i].image.width + 2*padding)*(fontSize + 2*padding));
-    float guessSize = sqrtf(requiredArea)*1.4f;
-    int imageSize = (int)powf(2, ceilf(logf((float)guessSize)/logf(2)));    // Calculate next POT
+    // Calculate image size based on total glyph width and glyph row count
+    int totalWidth = 0;
+    for (int i = 0; i < glyphCount; i++) totalWidth += chars[i].image.width + 2*padding;
+    int imageSize = 64;     // A minimum starting value to avoid unnecessary calculation steps for very small images
+    int rowCount = 0;
+    do
+    {
+        imageSize *= 2;                                     // Double the size of image (to keep POT)
+        rowCount = imageSize/(fontSize + 2*padding) + 1;    // Calculate new row count for the new image size
+    }
+    while (totalWidth > imageSize*rowCount);
 
     atlas.width = imageSize;   // Atlas bitmap width
     atlas.height = imageSize;  // Atlas bitmap height

--- a/src/rtext.c
+++ b/src/rtext.c
@@ -702,7 +702,7 @@ Image GenImageFontAtlas(const GlyphInfo *chars, Rectangle **charRecs, int glyphC
     do
     {
         imageSize *= 2;                                     // Double the size of image (to keep POT)
-        rowCount = imageSize/(fontSize + 2*padding) + 1;    // Calculate new row count for the new image size
+        rowCount = imageSize/(fontSize + 2*padding);        // Calculate new row count for the new image size
     }
     while (totalWidth > imageSize*rowCount);
 


### PR DESCRIPTION
Calculate exact image size with a method based on total glyph width and glyph row count.
Current method seemed a little bit overkill with square root, log and power functions and only approximates image size which can be wonky with some weird fonts like cursive fonts.
Proposed method calculates image size directly with a simpler (and probably faster) method and results exact image size needed.
