### PR TITLE
Update Makefile comment to indicate arm64 as a supported Linux desktop platform

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -4,7 +4,7 @@
 #
 #  Platforms supported:
 #    PLATFORM_DESKTOP:  Windows (Win32, Win64)
-#    PLATFORM_DESKTOP:  Linux (i386, x64)
+#    PLATFORM_DESKTOP:  Linux (arm64, i386, x64)
 #    PLATFORM_DESKTOP:  OSX/macOS (arm64, x86_64)
 #    PLATFORM_DESKTOP:  FreeBSD, OpenBSD, NetBSD, DragonFly
 #    PLATFORM_ANDROID:  Android (arm, i686, arm64, x86_64)


### PR DESCRIPTION
I have been able to build and run raylib applications on a [Pinebook Pro](https://www.pine64.org/pinebook-pro/), which uses a set of ARM64 processors. Currently, the Makefile and wiki indicate that the x86 and x86-64 platforms are the only supported platforms, but ARM64 *does* seem to be working.

Pong made with raylib running on a Pinebook Pro:

![raylib-arm64-LIBGL_ALWAYS_SOFTWARE-eq-true](https://user-images.githubusercontent.com/60763262/226113220-3dffb4b5-e640-4b1b-8255-943e1606a777.png)

The one caveat is that I needed to set `LIBGL_ALWAYS_SOFTWARE=true` to force software rendering, as otherwise the application was unable to initialize the OpenGL context, producing a `GLXBadFBConfig` error:

![raylib-arm64-GLXBadFBConfig](https://user-images.githubusercontent.com/60763262/226113223-8e094c75-bf65-4803-a793-9f7ac23dbfec.png)

However, I suspect this is a hardware issue with the Pinebook Pro, which is closer to a system-on-a-chip than a traditional desktop platform. I tested building raylib with OpenGL 1.1 support and still received the same error, which indicates to me that something else is the root cause, and that a more traditional ARM64 machine would suffer from this issue, especially given that [Arch Linux ARM aarch64](https://repology.org/project/raylib/versions) already contains a package for raylib version 4.2.0.