### PR TITLE
[raudio] Fix warning on discarded const qualifier

### DIFF
--- a/src/raudio.c
+++ b/src/raudio.c
@@ -1287,7 +1287,7 @@ Music LoadMusicStream(const char *fileName)
 #if defined(SUPPORT_FILEFORMAT_QOA)
     else if (IsFileExtension(fileName, ".qoa"))
     {
-        qoaplay_desc *ctxQoa = qoaplay_open(fileName);
+        qoaplay_desc *ctxQoa = qoaplay_open((char *)fileName);
         music.ctxType = MUSIC_AUDIO_QOA;
         music.ctxData = ctxQoa;
 


### PR DESCRIPTION
The `qoaplay_open()` function expects a `char *`, but we are passing in a `const char *`. While this works just fine, it does issue a compiler warning when strict:

```
src/raudio.c: In function ‘LoadMusicStream’:
src/raudio.c:1290:45: warning: passing argument 1 of ‘qoaplay_open’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
 1290 |         qoaplay_desc *ctxQoa = qoaplay_open(fileName);
      |                                             ^~~~~~~~
In file included from src/raudio.c:233:
src/external/qoaplay.c:86:34: note: expected ‘char *’ but argument is of type ‘const char *’
   86 | qoaplay_desc *qoaplay_open(char *path)
      |                            ~~~~~~^~~~
```

This change casts the argument to a `char *` to fix the warning.