### PR TITLE
Add const qualifier to char * path argument in qoaplay_open()

### DIFF
--- a/src/external/qoaplay.c
+++ b/src/external/qoaplay.c
@@ -62,7 +62,7 @@ typedef struct {
 extern "C" {            // Prevents name mangling of functions
 #endif
 
-qoaplay_desc *qoaplay_open(char *path);
+qoaplay_desc *qoaplay_open(const char *path);
 qoaplay_desc *qoaplay_open_memory(const unsigned char *data, int data_size);
 void qoaplay_close(qoaplay_desc *qoa_ctx);
 
@@ -83,7 +83,7 @@ int qoaplay_get_frame(qoaplay_desc *qoa_ctx);
 //----------------------------------------------------------------------------------
 
 // Open QOA file, keep FILE pointer to keep reading from file
-qoaplay_desc *qoaplay_open(char *path)
+qoaplay_desc *qoaplay_open(const char *path)
 {
     FILE *file = fopen(path, "rb");
     if (!file) return NULL;

--- a/src/raudio.c
+++ b/src/raudio.c
@@ -1287,7 +1287,7 @@ Music LoadMusicStream(const char *fileName)
 #if defined(SUPPORT_FILEFORMAT_QOA)
     else if (IsFileExtension(fileName, ".qoa"))
     {
-        qoaplay_desc *ctxQoa = qoaplay_open((char *)fileName);
+        qoaplay_desc *ctxQoa = qoaplay_open(fileName);
         music.ctxType = MUSIC_AUDIO_QOA;
         music.ctxData = ctxQoa;
 


### PR DESCRIPTION
Function `qoaplay_open(char * path)` doesn't change the path it is given.
Therefore, it should be safe to add the const qualifier.
Avoids a compiler warning in rauido.c.

Tested on Win10+mingw-gcc 12.2 and Ubuntu-20.04 (on WSL2).