### PR TITLE
[rtext] Fix GetCodepointNext() to return default value on invalid input with size=0

### DIFF
--- a/src/rtext.c
+++ b/src/rtext.c
@@ -1704,7 +1704,9 @@ int *LoadCodepoints(const char *text, int *count)
     for (int i = 0; i < textLength; codepointCount++)
     {
         codepoints[codepointCount] = GetCodepointNext(text + i, &codepointSize);
-        i += codepointSize;
+
+        if (codepoints[codepointCount] == 0x3f) i += 1;
+        else i += codepointSize;
     }
 
     // Re-allocate buffer to the actual number of codepoints loaded
@@ -1917,7 +1919,7 @@ int GetCodepointNext(const char *text, int *codepointSize)
         codepoint = ((0x1f & ptr[0]) << 6) | (0x3f & ptr[1]);
         *codepointSize = 2;
     }
-    else
+    else if (0x00 == (0x80 & ptr[0]))
     {
         // 1 byte UTF-8 codepoint
         codepoint = ptr[0];

--- a/src/rtext.c
+++ b/src/rtext.c
@@ -1894,18 +1894,21 @@ int GetCodepointNext(const char *text, int *codepointSize)
     if (0xf0 == (0xf8 & ptr[0]))
     {
         // 4 byte UTF-8 codepoint
+        if(((ptr[1] & 0xC0) ^ 0x80) || ((ptr[2] & 0xC0) ^ 0x80) || ((ptr[3] & 0xC0) ^ 0x80)) { return codepoint; } //10xxxxxx checks
         codepoint = ((0x07 & ptr[0]) << 18) | ((0x3f & ptr[1]) << 12) | ((0x3f & ptr[2]) << 6) | (0x3f & ptr[3]);
         *codepointSize = 4;
     }
     else if (0xe0 == (0xf0 & ptr[0]))
     {
         // 3 byte UTF-8 codepoint */
+        if(((ptr[1] & 0xC0) ^ 0x80) || ((ptr[2] & 0xC0) ^ 0x80)) { return codepoint; } //10xxxxxx checks
         codepoint = ((0x0f & ptr[0]) << 12) | ((0x3f & ptr[1]) << 6) | (0x3f & ptr[2]);
         *codepointSize = 3;
     }
     else if (0xc0 == (0xe0 & ptr[0]))
     {
         // 2 byte UTF-8 codepoint
+        if((ptr[1] & 0xC0) ^ 0x80) { return codepoint; } //10xxxxxx checks
         codepoint = ((0x1f & ptr[0]) << 6) | (0x3f & ptr[1]);
         *codepointSize = 2;
     }

--- a/src/rtext.c
+++ b/src/rtext.c
@@ -1201,7 +1201,7 @@ Vector2 MeasureTextEx(Font font, const char *text, float fontSize, float spacing
     int letter = 0;                 // Current character
     int index = 0;                  // Index position in sprite font
 
-    for (int i = 0; i < size; i++)
+    for (int i = 0; i < size;)
     {
         byteCounter++;
 
@@ -1209,7 +1209,7 @@ Vector2 MeasureTextEx(Font font, const char *text, float fontSize, float spacing
         letter = GetCodepointNext(&text[i], &next);
         index = GetGlyphIndex(font, letter);
 
-        i += next - 1;
+        i += next;
 
         if (letter != '\n')
         {

--- a/src/rtextures.c
+++ b/src/rtextures.c
@@ -1266,7 +1266,7 @@ Image ImageTextEx(Font font, const char *text, float fontSize, float spacing, Co
     // Create image to store text
     imText = GenImageColor((int)imSize.x, (int)imSize.y, BLANK);
 
-    for (int i = 0; i < size; i++)
+    for (int i = 0; i < size;)
     {
         // Get next codepoint from byte string and glyph index in font
         int codepointByteCount = 0;
@@ -1292,7 +1292,7 @@ Image ImageTextEx(Font font, const char *text, float fontSize, float spacing, Co
             else textOffsetX += font.glyphs[index].advanceX + (int)spacing;
         }
 
-        i += (codepointByteCount - 1);   // Move text bytes counter to next codepoint
+        i += codepointByteCount;   // Move text bytes counter to next codepoint
     }
 
     // Scale image depending on text size

--- a/src/rtextures.c
+++ b/src/rtextures.c
@@ -1273,10 +1273,6 @@ Image ImageTextEx(Font font, const char *text, float fontSize, float spacing, Co
         int codepoint = GetCodepointNext(&text[i], &codepointByteCount);    // WARNING: Module required: rtext
         int index = GetGlyphIndex(font, codepoint);                         // WARNING: Module required: rtext
 
-        // NOTE: Normally we exit the decoding sequence as soon as a bad byte is found (and return 0x3f)
-        // but we need to draw all the bad bytes using the '?' symbol moving one byte
-        if (codepoint == 0x3f) codepointByteCount = 1;
-
         if (codepoint == '\n')
         {
             // NOTE: Fixed line spacing of 1.5 line-height


### PR DESCRIPTION
Fixes #2996 
- Fixed GetCodepointNext in the minimal way possible, when the first byte of an encoding is invalid '?' is now returned with size=0. Not all invalid input is replaced with '?' but the vast majority is
- Checked all usage of GetCodepointNext in rtext.c and rtextures.c, there are two places size==0 were not properly handled, LoadCodepoints() and GetCodepointPrev()
- LoadCodepoints() now handles size==0 the same as everywhere else in the code, without the fix there would have been a buffer overflow on invalid input
- Left GetCodepointPrev as-is
- Internally raylib should be fixed, but external code may break when encountering invalid input if they never properly handled size==0, for either GetCodepointNext or GetCodepointPrev

There's a few remaining issues to become bulletproof that haven't been fixed, probably won't be implemented but mentioned for completeness:
- Checking that the last codepoint is not truncated (arbitrary data can be read up to 3 bytes past the buffer which might but unlikely lead to a crash, very unlikely to trigger accidentally and it can be hotfixed externally if desired by overallocating the input buffer by 4)
- Checking 10xxxxxx of bytes 1..3 for multibyte encodings (currently a valid encoding is returned even if it's invalid, not a big deal if good input is expected)
- Overlong encodings are technically invalid UTF-8 but there's nothing wrong with allowing them

Tested on Linux with this.
```
#include "raylib.h"
#include <stdio.h>
int main(int argc, char *argv) {
	char t[]={0,0,0,0}, t2[]={0xFF,1,1,0xFE,1,0};
	int len, codepoint, count;
	//GetCodepointNext
	for(int i=0;i<256;++i){
		t[0]=i;
		codepoint=GetCodepointNext(t, &len);
		printf("%d : codepoint %d length %d\n", i, codepoint, len);
	}
	//LoadCodepoints
	LoadCodepoints(t2, &count);
	printf("count %d\n", count);
}
```