### PR TITLE
Fix GLYPH_NOTFOUND_CHAR_FALLBACK index value

### DIFF
--- a/src/rtext.c
+++ b/src/rtext.c
@@ -1253,7 +1253,7 @@ int GetGlyphIndex(Font font, int codepoint)
 // Support charsets with any characters order
 #define SUPPORT_UNORDERED_CHARSET
 #if defined(SUPPORT_UNORDERED_CHARSET)
-    int index = GLYPH_NOTFOUND_CHAR_FALLBACK;
+    int index = GLYPH_NOTFOUND_CHAR_FALLBACK - 32;   // Index of '?' character (first character is space)
 
     for (int i = 0; i < font.glyphCount; i++)
     {

--- a/src/rtext.c
+++ b/src/rtext.c
@@ -1253,7 +1253,7 @@ int GetGlyphIndex(Font font, int codepoint)
 // Support charsets with any characters order
 #define SUPPORT_UNORDERED_CHARSET
 #if defined(SUPPORT_UNORDERED_CHARSET)
-    int index = GLYPH_NOTFOUND_CHAR_FALLBACK - 32;   // Index of '?' character (first character is space)
+    int index = GLYPH_NOTFOUND_CHAR_FALLBACK - 32;   // Index of fallback character (first character is space)
 
     for (int i = 0; i < font.glyphCount; i++)
     {


### PR DESCRIPTION
Currently if codepoint is not found; '_' character is returned. (Supposed to be '?')
It's fixed by using index value of fallback character instead of using the character value.