### PR TITLE
CORE : Disable warning logs when loading shaders 

### DIFF
--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1044,6 +1044,7 @@ RLAPI void TakeScreenshot(const char *fileName);                  // Takes a scr
 RLAPI void SetConfigFlags(unsigned int flags);                    // Setup init configuration flags (view FLAGS)
 
 RLAPI void TraceLog(int logLevel, const char *text, ...);         // Show trace log messages (LOG_DEBUG, LOG_INFO, LOG_WARNING, LOG_ERROR...)
+RLAPI int GetTraceLogLevel();                                     // Get the trace log message level (LOG_DEBUG, LOG_INFO, LOG_WARNING, LOG_ERROR...)
 RLAPI void SetTraceLogLevel(int logLevel);                        // Set the current threshold (minimum) log level
 RLAPI void *MemAlloc(unsigned int size);                          // Internal memory allocator
 RLAPI void *MemRealloc(void *ptr, unsigned int size);             // Internal memory reallocator

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -2549,6 +2549,10 @@ Shader LoadShaderFromMemory(const char *vsCode, const char *fsCode)
         // All locations reset to -1 (no location)
         for (int i = 0; i < RL_MAX_SHADER_LOCATIONS; i++) shader.locs[i] = -1;
 
+        // Set to error log level so we don't warn if these aren't found, we don't want to spam the user with false warnings
+        int logLevel = GetTraceLogLevel();
+        SetTraceLogLevel(RL_LOG_ERROR);
+
         // Get handles to GLSL input attribute locations
         shader.locs[SHADER_LOC_VERTEX_POSITION] = rlGetLocationAttrib(shader.id, RL_DEFAULT_SHADER_ATTRIB_NAME_POSITION);
         shader.locs[SHADER_LOC_VERTEX_TEXCOORD01] = rlGetLocationAttrib(shader.id, RL_DEFAULT_SHADER_ATTRIB_NAME_TEXCOORD);
@@ -2569,6 +2573,8 @@ Shader LoadShaderFromMemory(const char *vsCode, const char *fsCode)
         shader.locs[SHADER_LOC_MAP_DIFFUSE] = rlGetLocationUniform(shader.id, RL_DEFAULT_SHADER_SAMPLER2D_NAME_TEXTURE0);  // SHADER_LOC_MAP_ALBEDO
         shader.locs[SHADER_LOC_MAP_SPECULAR] = rlGetLocationUniform(shader.id, RL_DEFAULT_SHADER_SAMPLER2D_NAME_TEXTURE1); // SHADER_LOC_MAP_METALNESS
         shader.locs[SHADER_LOC_MAP_NORMAL] = rlGetLocationUniform(shader.id, RL_DEFAULT_SHADER_SAMPLER2D_NAME_TEXTURE2);
+
+        SetTraceLogLevel(logLevel);
     }
 
     return shader;

--- a/src/utils.c
+++ b/src/utils.c
@@ -103,6 +103,9 @@ static int android_close(void *cookie);
 // Set the current threshold (minimum) log level
 void SetTraceLogLevel(int logType) { logTypeLevel = logType; }
 
+//Get the current threshold (minimum) log level
+int GetTraceLogLevel() { return logTypeLevel; }
+
 // Show trace log messages (LOG_INFO, LOG_WARNING, LOG_ERROR, LOG_DEBUG)
 void TraceLog(int logType, const char *text, ...)
 {


### PR DESCRIPTION
This PR sets the log level to only log errors when loading the default shader locations. This is to prevent log spam for these uniforms and attributes that most likely do not exist in custom shaders. This is to prevent warning fatigue to users.