### PR TITLE
Build : Fix warnings in raylib for MSVC

### DIFF
--- a/src/raudio.c
+++ b/src/raudio.c
@@ -228,6 +228,14 @@ typedef struct tagBITMAPINFOHEADER {
     #define QOA_MALLOC RL_MALLOC
     #define QOA_FREE RL_FREE
 
+#if defined(_MSC_VER ) // par shapes has 2 warnings on windows, so disable them just fof this file
+#pragma warning( push )
+#pragma warning( disable : 4018)
+#pragma warning( disable : 4267)
+#pragma warning( disable : 4244)
+#endif
+
+
     #define QOA_IMPLEMENTATION
     #include "external/qoa.h"           // QOA loading and saving functions
     #include "external/qoaplay.c"       // QOA stream playing helper functions

--- a/src/utils.c
+++ b/src/utils.c
@@ -145,7 +145,7 @@ void TraceLog(int logType, const char *text, ...)
         default: break;
     }
 
-    unsigned int textSize = strlen(text);
+    unsigned int textSize = (unsigned int)strlen(text);
     memcpy(buffer + strlen(buffer), text, (textSize < (MAX_TRACELOG_MSG_LENGTH - 12))? textSize : (MAX_TRACELOG_MSG_LENGTH - 12));
     strcat(buffer, "\n");
     vprintf(buffer, args);


### PR DESCRIPTION
This is another warning fixup for the raylib library.

one size_t casting issue, and disable some warnings on the qoi headers
