### PR TITLE
Minor fix in DrawLineBezier*

### DIFF
--- a/src/rshapes.c
+++ b/src/rshapes.c
@@ -241,7 +241,7 @@ void DrawLineBezierQuad(Vector2 startPos, Vector2 endPos, Vector2 controlPos, fl
 
     Vector2 points[2*BEZIER_LINE_DIVISIONS + 2] = { 0 };
 
-    for (int i = 0; i <= BEZIER_LINE_DIVISIONS; i++)
+    for (int i = 1; i <= BEZIER_LINE_DIVISIONS; i++)
     {
         t = step*i;
         float a = powf(1 - t, 2);
@@ -286,7 +286,7 @@ void DrawLineBezierCubic(Vector2 startPos, Vector2 endPos, Vector2 startControlP
 
     Vector2 points[2*BEZIER_LINE_DIVISIONS + 2] = { 0 };
 
-    for (int i = 0; i <= BEZIER_LINE_DIVISIONS; i++)
+    for (int i = 1; i <= BEZIER_LINE_DIVISIONS; i++)
     {
         t = step*i;
         float a = powf(1 - t, 3);


### PR DESCRIPTION
When `i` starts with `0`, `t` is also `0`, which results in `previous == startPos == current`, this segment is not only redundant, but it also causes division-by-zero since `sqrtf(dx*dx + dy*dy)` is zero.