### PR TITLE
Fix off-by-one error in CheckCollisionPointRec

### DIFF
--- a/src/rshapes.c
+++ b/src/rshapes.c
@@ -1601,7 +1601,7 @@ bool CheckCollisionPointRec(Vector2 point, Rectangle rec)
 {
     bool collision = false;
 
-    if ((point.x >= rec.x) && (point.x <= (rec.x + rec.width)) && (point.y >= rec.y) && (point.y <= (rec.y + rec.height))) collision = true;
+    if ((point.x >= rec.x) && (point.x < (rec.x + rec.width)) && (point.y >= rec.y) && (point.y < (rec.y + rec.height))) collision = true;
 
     return collision;
 }


### PR DESCRIPTION
Checking `<= x + w` causes off-by-one error where `CheckCollisionPointRec` will return true at the same time for two rectangles rendered right next to each, but which don't overlap (e.g. when making a 2D tile editor). This is clearly not what was intended.

The convention for collision checks of this nature should always be lower bound inclusive and upper bound exclusive.