### PR TITLE
Update screen scale and mouse scale when window size is changed

### DIFF
--- a/src/rcore.c
+++ b/src/rcore.c
@@ -5376,6 +5376,13 @@ static void WindowSizeCallback(GLFWwindow *window, int width, int height)
 
         CORE.Window.screen.width = (unsigned int)(width/windowScaleDPI.x);
         CORE.Window.screen.height = (unsigned int)(height/windowScaleDPI.y);
+
+        int fbWidth = 0;
+        int fbHeight = 0;
+        glfwGetFramebufferSize(CORE.Window.handle, &fbWidth, &fbHeight);
+
+        CORE.Window.screenScale = MatrixScale((float)fbWidth/CORE.Window.screen.width, (float)fbHeight/CORE.Window.screen.height, 1.0f);
+        SetMouseScale((float)CORE.Window.screen.width/fbWidth, (float)CORE.Window.screen.height/fbHeight);
     }
     else
     {


### PR DESCRIPTION
I am unsure how the scaling works exactly, but the mouse scale and screen scale is not updated when the window is resized, leading to (at least) incorrect mouse positions. I just copied this code from the `InitGraphicsDevice` function.

The following videos show me starting a program and resizing the window. The mouse position is reported in the main loop with `std::cout << GetMousePosition().x << ", " << GetMousePosition().y << std::endl;` In withoutfix.mp4, the window size has to be very oblong before the reported mouse position is close to a square, in withfix.mp4 this is not the case.


https://user-images.githubusercontent.com/30801498/234382097-1c050f39-3265-4474-90ff-ac96d4ebff96.mp4


https://user-images.githubusercontent.com/30801498/234382103-ecab12e6-acde-4053-abeb-047dfdee77d2.mp4


