### PR TITLE
Ensure distance is greater than 0 in CameraMoveToTarget

### DIFF
--- a/src/rcamera.h
+++ b/src/rcamera.h
@@ -294,7 +294,7 @@ void CameraMoveToTarget(Camera *camera, float delta)
     distance += delta;
 
     // Distance must be greater than 0
-    if (distance < 0) distance = 0.001f;
+    if (distance <= 0) distance = 0.001f;
 
     // Set new distance by moving the position along the forward vector
     Vector3 forward = GetCameraForward(camera);


### PR DESCRIPTION
Hello! This fixes the distance check in `CameraMoveToTarget` to avoid a 0 value. Thank you!