### PR TITLE
[zig build] update to latest zig master

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -2,17 +2,5 @@ const std = @import("std");
 const raylib = @import("src/build.zig");
 
 pub fn build(b: *std.Build) void {
-    // Standard target options allows the person running `zig build` to choose
-    // what target to build for. Here we do not override the defaults, which
-    // means any target is allowed, and the default is native. Other options
-    // for restricting supported target set are available.
-    const target = b.standardTargetOptions(.{});
-    // Standard optimization options allow the person running `zig build` to select
-    // between Debug, ReleaseSafe, ReleaseFast, and ReleaseSmall. Here we do not
-    // set a preferred release mode, allowing the user to decide how to optimize.
-    const optimize = b.standardOptimizeOption(.{});
-
-    const lib = raylib.addRaylib(b, target, optimize);
-    lib.installHeader("src/raylib.h", "raylib.h");
-    lib.install();
+    raylib.build(b);
 }

--- a/examples/build.zig
+++ b/examples/build.zig
@@ -26,10 +26,10 @@ fn add_module(comptime module: []const u8, b: *std.Build, target: std.zig.CrossT
         exe.addCSourceFile(path, &[_][]const u8{});
         exe.linkLibC();
         exe.addObjectFile(switch (target.getOsTag()) {
-            .windows => "../src/raylib.lib",
-            .linux => "../src/libraylib.a",
-            .macos => "../src/libraylib.a",
-            .emscripten => "../src/libraylib.a",
+            .windows => "../src/zig-out/lib/raylib.lib",
+            .linux => "../src/zig-out/lib/libraylib.a",
+            .macos => "../src/zig-out/lib/libraylib.a",
+            .emscripten => "../src/zig-out/lib/libraylib.a",
             else => @panic("Unsupported OS"),
         });
 
@@ -70,10 +70,8 @@ fn add_module(comptime module: []const u8, b: *std.Build, target: std.zig.CrossT
             },
         }
 
-        exe.setOutputDir(module);
-
-        var run = exe.run();
-        run.step.dependOn(&b.addInstallArtifact(exe).step);
+        b.installArtifact(exe);
+        var run = b.addRunArtifact(exe);
         run.cwd = module;
         b.step(name, name).dependOn(&run.step);
         all.dependOn(&exe.step);

--- a/src/build.zig
+++ b/src/build.zig
@@ -90,7 +90,7 @@ pub fn addRaylib(b: *std.Build, target: std.zig.CrossTarget, optimize: std.built
             const cache_include = std.fs.path.join(b.allocator, &.{ b.sysroot.?, "cache", "sysroot", "include" }) catch @panic("Out of memory");
             defer b.allocator.free(cache_include);
 
-            var dir = std.fs.openDirAbsolute(cache_include, std.fs.Dir.OpenDirOptions{.access_sub_paths = true, .no_follow = true}) catch @panic("No emscripten cache. Generate it!");
+            var dir = std.fs.openDirAbsolute(cache_include, std.fs.Dir.OpenDirOptions{ .access_sub_paths = true, .no_follow = true }) catch @panic("No emscripten cache. Generate it!");
             dir.close();
 
             raylib.addIncludePath(cache_include);
@@ -115,11 +115,11 @@ pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
 
     const lib = addRaylib(b, target, optimize);
-    lib.setOutputDir(srcdir);
-    lib.install();
+    lib.installHeader("src/raylib.h", "raylib.h");
+    b.installArtifact(lib);
 }
 
-const srcdir = struct{
+const srcdir = struct {
     fn getSrcDir() []const u8 {
         return std.fs.path.dirname(@src().file).?;
     }


### PR DESCRIPTION
update for `zig 0.11.0-dev.2868+1a455b2dd` and upper

main changes:

- `lib.install()` or `exe.install()` replaced with `b.installArtifact`
- `lib.setOutputDir()` and `exe.setOutputDir()` are removed
- root `build.zig` just calls `src/build.zig`

All examples are working. But output path is set to default `zig-out`. There are some workarounds, but it requires to set CLI paramater `--prefix`, so it's kinda complicated.