### PR TITLE
Store GLTF model animation names

### DIFF
--- a/examples/models/models_loading_gltf.c
+++ b/examples/models/models_loading_gltf.c
@@ -86,6 +86,7 @@ int main(void)
             EndMode3D();
 
             DrawText("Use the UP/DOWN arrow keys to switch animation", 10, 10, 20, GRAY);
+            DrawText(TextFormat("Animation: %s", anim.name), 10, GetScreenHeight() - 20, 10, DARKGRAY);
 
         EndDrawing();
         //----------------------------------------------------------------------------------

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -402,6 +402,7 @@ typedef struct ModelAnimation {
     int frameCount;         // Number of animation frames
     BoneInfo *bones;        // Bones information (skeleton)
     Transform **framePoses; // Poses array by frame
+    char name[32];          // Animation name
 } ModelAnimation;
 
 // Ray, ray for raycasting

--- a/src/rmodels.c
+++ b/src/rmodels.c
@@ -5379,6 +5379,9 @@ static ModelAnimation *LoadModelAnimationsGLTF(const char *fileName, unsigned in
                     animDuration = (t > animDuration)? t : animDuration;
                 }
 
+                strncpy(animations[i].name, animData.name, sizeof(animations[i].name));
+                animations[i].name[sizeof(animations[i].name) - 1] = '\0';
+                
                 animations[i].frameCount = (int)(animDuration*1000.0f/GLTF_ANIMDELAY);
                 animations[i].framePoses = RL_MALLOC(animations[i].frameCount*sizeof(Transform *));
 


### PR DESCRIPTION
- Added ModelAnimation.name in order to keep GLTF animation names.
- Updated models_loading_gltf, showing the name of the animation currently playing at the bottom

Why?
- In the creation of tools, it allows picking animations by name
- In the creation of a game, it allows choosing an animation to run by name instead of only by array position (currently by being based only by index position it's either error prone or confusing/hard).

![imagen](https://user-images.githubusercontent.com/248383/236469358-077e9877-e53b-4608-906c-66fd361226a3.png)
