### PR TITLE
Fixed broken build.zig files.

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 const raylib = @import("src/build.zig");
 
-pub fn build(b: *std.Build) void {
+pub fn build(b: *std.build.Builder) void {
     raylib.build(b);
 }

--- a/src/build.zig
+++ b/src/build.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 
-pub fn addRaylib(b: *std.Build, target: std.zig.CrossTarget, optimize: std.builtin.OptimizeMode) *std.Build.CompileStep {
+pub fn addRaylib(b: *std.build.Builder, target: std.zig.CrossTarget) *std.build.LibExeObjStep {
     const raylib_flags = &[_][]const u8{
         "-std=gnu99",
         "-D_GNU_SOURCE",
@@ -8,11 +8,7 @@ pub fn addRaylib(b: *std.Build, target: std.zig.CrossTarget, optimize: std.built
         "-fno-sanitize=undefined", // https://github.com/raysan5/raylib/issues/1891
     };
 
-    const raylib = b.addStaticLibrary(.{
-        .name = "raylib",
-        .target = target,
-        .optimize = optimize,
-    });
+    const raylib = b.addStaticLibrary("raylib", null);
     raylib.linkLibC();
 
     raylib.addIncludePath(srcdir ++ "/external/glfw/include");
@@ -103,7 +99,7 @@ pub fn addRaylib(b: *std.Build, target: std.zig.CrossTarget, optimize: std.built
     return raylib;
 }
 
-pub fn build(b: *std.Build) void {
+pub fn build(b: *std.build.Builder) void {
     // Standard target options allows the person running `zig build` to choose
     // what target to build for. Here we do not override the defaults, which
     // means any target is allowed, and the default is native. Other options
@@ -112,10 +108,10 @@ pub fn build(b: *std.Build) void {
     // Standard optimization options allow the person running `zig build` to select
     // between Debug, ReleaseSafe, ReleaseFast, and ReleaseSmall. Here we do not
     // set a preferred release mode, allowing the user to decide how to optimize.
-    const optimize = b.standardOptimizeOption(.{});
+    // const optimize = b.standardReleaseOptions();
 
-    const lib = addRaylib(b, target, optimize);
-    lib.installHeader("src/raylib.h", "raylib.h");
+    const lib = addRaylib(b, target);
+    b.installFile("src/raylib.h", "raylib.h");
     b.installArtifact(lib);
 }
 


### PR DESCRIPTION
I noticed the build.zig file wasn't working with the latest zig compiler. So I went ahead and fixed it. It went ahead and built fine on my linux machine, and I used the resulting library to compile the basic example, so I don't think there were any hidden errors.

(Small side note, is the zig build script community maintained? I'd want to add a notice to the build file itself if that was the case.)