### PR TITLE
Update BINDINGS.md - raylib-go is 4.5 now

### DIFF
--- a/BINDINGS.md
+++ b/BINDINGS.md
@@ -25,7 +25,7 @@ Some people ported raylib to other languages in form of bindings or wrappers to 
 | raylib-factor      | 4.0     | [Factor](https://factorcode.org/)        | BSD  | https://github.com/factor/factor/blob/master/extra/raylib/raylib.factor   |
 | raylib-freebasic   | **4.5** | [FreeBASIC](https://www.freebasic.net/) | MIT | https://github.com/WIITD/raylib-freebasic     |
 | raylib for Pascal  | **4.5** | [Object Pascal](https://en.wikipedia.org/wiki/Object_Pascal) | Modified Zlib | https://github.com/tinyBigGAMES/raylib |
-| raylib-go          | 4.2     | [Go](https://golang.org/)            | Zlib | https://github.com/gen2brain/raylib-go       |
+| raylib-go          | 4.5     | [Go](https://golang.org/)            | Zlib | https://github.com/gen2brain/raylib-go       |
 | raylib-guile       | **auto** | [Guile](https://www.gnu.org/software/guile/) | Zlib | https://github.com/petelliott/raylib-guile |
 | gforth-raylib      | 3.5     | [Gforth](https://gforth.org/)            | MIT  | https://github.com/ArnautDaniel/gforth-raylib   |
 | h-raylib           | **4.5** | [Haskell](https://haskell.org/)          | Apache-2.0 | https://github.com/Anut-py/h-raylib       |


### PR DESCRIPTION
Hey,

raylib-go released its 4.5 version  today: https://github.com/gen2brain/raylib-go/releases/tag/v4.5.0