### PR TITLE
Expose GetClientRect width & height

### DIFF
--- a/src/raylib.h
+++ b/src/raylib.h
@@ -955,6 +955,8 @@ RLAPI int GetScreenWidth(void);                                   // Get current
 RLAPI int GetScreenHeight(void);                                  // Get current screen height
 RLAPI int GetRenderWidth(void);                                   // Get current render width (it considers HiDPI)
 RLAPI int GetRenderHeight(void);                                  // Get current render height (it considers HiDPI)
+RLAPI int GetClientWidth(void);                                   // Get current client width
+RLAPI int GetClientHeight(void);                                  // Get current client height
 RLAPI int GetMonitorCount(void);                                  // Get number of connected monitors
 RLAPI int GetCurrentMonitor(void);                                // Get current connected monitor
 RLAPI Vector2 GetMonitorPosition(int monitor);                    // Get specified monitor position

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -1694,6 +1694,22 @@ int GetScreenHeight(void)
     return CORE.Window.screen.height;
 }
 
+// Get current client width
+int GetClientWidth(void)
+{
+    int width;
+    glfwGetWindowSize(CORE.Window.handle, &width, NULL);
+    return width;
+}
+
+// Get current client height
+int GetClientHeight(void)
+{
+    int height;
+    glfwGetWindowSize(CORE.Window.handle, NULL, &height);
+    return height;
+}
+
 // Get current render width which is equal to screen width * dpi scale
 int GetRenderWidth(void)
 {


### PR DESCRIPTION
Exposes `glfwGetWindowSize` as 

```c
RLAPI int GetClientWidth(void);                                   // Get current client width
RLAPI int GetClientHeight(void);                                  // Get current client height
```

Below is some background on why I believe this is useful. I'm new to raylib and a bit rusty with OpenGL, so maybe there's already better way to address my issue?

I attempt to draw a circle in the center of the screen with `DrawCircle(GetScreenWidth()/2, GetScreenHeight()/2, GetScreenHeight()/2, ...)` in xorg with a basic Camera2D. To my surprise, the circle radius appears larger than the screen height:

![before](https://github.com/raysan5/raylib/assets/48462986/7ccb459c-4341-4a0a-91ad-378dfb6cfb56)

It turns out that the window borders are included in the screen dimensions [per this explanation on SO](https://stackoverflow.com/a/7561187) (not shown in the screenshot, but my window manager is applying a 10px border to exaggerate the effect). Using `GetClientWidth` and `GetClientHeight` instead results in the expected behavior:

![after](https://github.com/raysan5/raylib/assets/48462986/4312676e-c366-4ab8-ae88-5c2523146d5e)

I've tested the build on Linux, unable to test on Windows.