### PR TITLE
Add option to process key repeats as presses

### DIFF
--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1105,6 +1105,7 @@ RLAPI bool IsKeyDown(int key);                                // Check if a key 
 RLAPI bool IsKeyReleased(int key);                            // Check if a key has been released once
 RLAPI bool IsKeyUp(int key);                                  // Check if a key is NOT being pressed
 RLAPI void SetExitKey(int key);                               // Set a custom key to exit program (default is ESC)
+RLAPI void SetUseRepeats(bool useRepeats);                    // Treat key repeats as key presses (default is false)
 RLAPI int GetKeyPressed(void);                                // Get key pressed (keycode), call it multiple times for keys queued, returns 0 when the queue is empty
 RLAPI int GetCharPressed(void);                               // Get char pressed (unicode), call it multiple times for chars queued, returns 0 when the queue is empty
 

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -441,6 +441,7 @@ typedef struct CoreData {
 
             int charPressedQueue[MAX_CHAR_PRESSED_QUEUE];   // Input characters queue (unicode)
             int charPressedQueueCount;      // Input characters queue count
+            bool useRepeats;                // If true, key repeats are treated as key presses
 
 #if defined(PLATFORM_RPI) || defined(PLATFORM_DRM)
             int defaultMode;                // Default keyboard mode
@@ -767,6 +768,7 @@ void InitWindow(int width, int height, const char *title)
     // Initialize global input state
     memset(&CORE.Input, 0, sizeof(CORE.Input));
     CORE.Input.Keyboard.exitKey = KEY_ESCAPE;
+    CORE.Input.Keyboard.useRepeats = false;
     CORE.Input.Mouse.scale = (Vector2){ 1.0f, 1.0f };
     CORE.Input.Mouse.cursor = MOUSE_CURSOR_ARROW;
     CORE.Input.Gamepad.lastButtonPressed = 0;       // GAMEPAD_BUTTON_UNKNOWN
@@ -3680,6 +3682,13 @@ void SetExitKey(int key)
 #endif
 }
 
+// Treat key repeats as key presses
+// NOTE: default is false
+void SetUseRepeats(bool useRepeats)
+{
+  CORE.Input.Keyboard.useRepeats = useRepeats;
+}
+
 // NOTE: Gamepad support not implemented in emscripten GLFW3 (PLATFORM_WEB)
 
 // Check if a gamepad is available
@@ -5427,7 +5436,8 @@ static void KeyCallback(GLFWwindow *window, int key, int scancode, int action, i
 #endif
 
     // Check if there is space available in the key queue
-    if ((CORE.Input.Keyboard.keyPressedQueueCount < MAX_KEY_PRESSED_QUEUE) && (action == GLFW_PRESS))
+    bool is_press = action == GLFW_PRESS || (CORE.Input.Keyboard.useRepeats && action == GLFW_REPEAT);
+    if ((CORE.Input.Keyboard.keyPressedQueueCount < MAX_KEY_PRESSED_QUEUE) && is_press)
     {
         // Add character to the queue
         CORE.Input.Keyboard.keyPressedQueue[CORE.Input.Keyboard.keyPressedQueueCount] = key;


### PR DESCRIPTION
A while ago I opened #2041 asking about key repeat behaviour in raylib

You mentioned this wouldn't be put into raylib & I should instead patch the source

Recently I settled on a very simple fix that was easier to keep rebased against upstream. It was so unobtrusive I thought I'd add an option to toggle it & submit a PR, on the off-chance it gets merged :pleading_face: 

It's *massively* useful when making tools that need text input, because otherwise you can't hold backspace to delete text, or arrow keys, etc. You can use IsKeyDown / IsKeyUp & a timer to simulate key repeats, but this won't match the user's keyboard settings. Basically the only way to get good text input is to patch raylib, which is a shame!