### PR TITLE
Update rmodels.c; free fileData for LoadModelAnimationsGLTF

### DIFF
--- a/src/rmodels.c
+++ b/src/rmodels.c
@@ -5434,7 +5434,7 @@ static ModelAnimation *LoadModelAnimationsGLTF(const char *fileName, unsigned in
 
         cgltf_free(data);
     }
-
+    UnloadFileData(fileData);
     return animations;
 }
 #endif


### PR DESCRIPTION
fileData wasn't freed for LoadModelAnimationsGLTF causing a memory leak. Added UnloadFileData line, freeing it.

With a test of just loading and unloading animations from a glb file; this change clears up the following memory leak reported via valgrind.

```
==7704== 
==7704== HEAP SUMMARY:
==7704==     in use at exit: 62,960 bytes in 1 blocks
==7704==   total heap usage: 193 allocs, 192 frees, 388,008 bytes allocated
==7704== 
==7704== 62,960 bytes in 1 blocks are definitely lost in loss record 1 of 1
==7704==    at 0x4842794: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==7704==    by 0x493EA95: LoadFileData (in /raylib/libraylib.so.450)
==7704==    by 0x48E0A1B: LoadModelAnimations (in /raylib/libraylib.so.450)
==7704==    by 0x10967E: main (animtest.c:22)
==7704== 
==7704== LEAK SUMMARY:
==7704==    definitely lost: 62,960 bytes in 1 blocks
==7704==    indirectly lost: 0 bytes in 0 blocks
==7704==      possibly lost: 0 bytes in 0 blocks
==7704==    still reachable: 0 bytes in 0 blocks
==7704==         suppressed: 0 bytes in 0 blocks
==7704== 
==7704== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
```
becomes
```
==7912== HEAP SUMMARY:
==7912==     in use at exit: 0 bytes in 0 blocks
==7912==   total heap usage: 193 allocs, 193 frees, 388,008 bytes allocated
==7912== 
==7912== All heap blocks were freed -- no leaks are possible
==7912== 
==7912== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```
I'm unsure if there's anything else to be aware of in the block of code preceding the change; please let me know if there is.
Thanks!