### PR TITLE
Fix integer overflow when calculating memory allocation size

### DIFF
--- a/src/rtextures.c
+++ b/src/rtextures.c
@@ -668,17 +668,24 @@ bool ExportImageAsCode(Image image, const char *fileName)
 // Generate image: plain color
 Image GenImageColor(int width, int height, Color color)
 {
-    Color *pixels = (Color *)RL_CALLOC(width*height, sizeof(Color));
-
-    for (int i = 0; i < width*height; i++) pixels[i] = color;
-
     Image image = {
-        .data = pixels,
+        .data = NULL,
         .width = width,
         .height = height,
         .format = PIXELFORMAT_UNCOMPRESSED_R8G8B8A8,
         .mipmaps = 1
     };
+
+    if (height > INT_MAX / sizeof(Color)) {
+        return image;
+    }
+    Color *pixels = (Color *)RL_CALLOC(width, height*sizeof(Color));
+    if (pixels == NULL) {
+        return image;
+    }
+    image.data = pixels;
+
+    for (int i = 0; i < width*height; i++) pixels[i] = color;
 
     return image;
 }


### PR DESCRIPTION
Allocating memory with a size controlled by an external user can result in integer overflow.
Also, we need to check return values of malloc/calloc for null.

-----------
* There are more than 20 such patterns in the codebase. I will try to find and fix them all if this patch looks good to you.
* Is there a better way to indicate memory allocation error for function `GenImageColor()`, other than returning an `Image` with the `data` field set to `NULL`?