### PR TITLE
Add new file formats to FAQ

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -119,8 +119,8 @@ raylib can load data from multiple standard file formats:
 
  - Image/Textures: PNG, BMP, TGA, JPG, GIF, QOI, PSD, DDS, HDR, KTX, ASTC, PKM, PVR
  - Fonts: FNT (sprite font), TTF, OTF
- - Models/Meshes: OBJ, IQM, GLTF, VOX
- - Audio: WAV, OGG, MP3, FLAC, XM, MOD
+ - Models/Meshes: OBJ, IQM, GLTF, VOX, M3D
+ - Audio: WAV, OGG, MP3, FLAC, XM, MOD, QOA
  
 ### Does raylib support the Vulkan API?
 


### PR DESCRIPTION
I noticed some file formats from the new release of raylib were missing so I decided to help out and update it!

added M3D model format and QOA file format to the list