### PR TITLE
Catch key repeats for non-char keys

### DIFF
--- a/src/rcore.c
+++ b/src/rcore.c
@@ -5324,6 +5324,16 @@ static void KeyCallback(GLFWwindow *window, int key, int scancode, int action, i
 {
     if (key < 0) return;    // Security check, macOS fn key generates -1
 
+    // Check if there is space available in the key queue
+    if (CORE.Input.Keyboard.keyPressedQueueCount < MAX_KEY_PRESSED_QUEUE &&
+        (action == GLFW_PRESS || action == GLFW_REPEAT) &&
+        !IsKeyPressed(key))
+    {
+        // Add character to the queue
+        CORE.Input.Keyboard.keyPressedQueue[CORE.Input.Keyboard.keyPressedQueueCount] = key;
+        CORE.Input.Keyboard.keyPressedQueueCount++;
+    }
+
     // WARNING: GLFW could return GLFW_REPEAT, we need to consider it as 1
     // to work properly with our implementation (IsKeyDown/IsKeyUp checks)
     if (action == GLFW_RELEASE) CORE.Input.Keyboard.currentKeyState[key] = 0;
@@ -5334,14 +5344,6 @@ static void KeyCallback(GLFWwindow *window, int key, int scancode, int action, i
     if (((key == KEY_CAPS_LOCK) && ((mods & GLFW_MOD_CAPS_LOCK) > 0)) ||
         ((key == KEY_NUM_LOCK) && ((mods & GLFW_MOD_NUM_LOCK) > 0))) CORE.Input.Keyboard.currentKeyState[key] = 1;
 #endif
-
-    // Check if there is space available in the key queue
-    if ((CORE.Input.Keyboard.keyPressedQueueCount < MAX_KEY_PRESSED_QUEUE) && (action == GLFW_PRESS))
-    {
-        // Add character to the queue
-        CORE.Input.Keyboard.keyPressedQueue[CORE.Input.Keyboard.keyPressedQueueCount] = key;
-        CORE.Input.Keyboard.keyPressedQueueCount++;
-    }
 
     // Check the exit key to set close window
     if ((key == CORE.Input.Keyboard.exitKey) && (action == GLFW_PRESS)) glfwSetWindowShouldClose(CORE.Window.handle, GLFW_TRUE);


### PR DESCRIPTION
This fixes a bug in Raylib's input handling where non-character keys have their repeat events completely discarded in a way that makes it impossible to detect such events (without calling IsKeyPressed on every key code every frame and re-inventing the key queue).

Specifically, this bugfix enables you to handle Backspace, Delete, arrow keys, etc. repeat events in a way that respects the user's OS key repeat delay and interval settings.

It seems like glfw triggers both a PRESS and REPEAT event on the first frame, so it's necessary to change the order of the code slightly such that you can check the IsKeyPressed state in order to de-duplicate adding both events for the same key to the queue (though if the queue also stored some extra metadata about the event, this wouldn't be necessary and would give the caller more discretion). Theoretically this could discard legitimate events if the user presses the same key twice during a single frame, but considering the general use-case of Raylib for real-time applications, this seems quite unlikely. The trade-off seems very worth it vs. the current behavior of completely discarding all repeat events.