### PR TITLE
build.zig: Fix cross-compiling from Linux

### DIFF
--- a/src/build.zig
+++ b/src/build.zig
@@ -45,6 +45,7 @@ pub fn addRaylib(b: *std.Build, target: std.zig.CrossTarget, optimize: std.built
             raylib.linkSystemLibrary("dl");
             raylib.linkSystemLibrary("m");
             raylib.linkSystemLibrary("X11");
+            raylib.addIncludePath("/usr/include");
 
             raylib.defineCMacro("PLATFORM_DESKTOP", null);
         },


### PR DESCRIPTION
I've been using raylib for a game written in Zig, and the current build.zig works fine for me when building for my host, but when cross-compiling, the compile-raylib step fails with errors about not being able to find Xlib headers. This fixes it for me. (I am on Alpine Linux.)