### PR TITLE
Fix full screen resolution issue

### DIFF
--- a/src/rcore.c
+++ b/src/rcore.c
@@ -1230,8 +1230,17 @@ void ToggleFullscreen(void)
         {
             CORE.Window.fullscreen = true;
             CORE.Window.flags |= FLAG_FULLSCREEN_MODE;
+            const GLFWvidmode* mode = glfwGetVideoMode(monitor);
+            if (!mode)
+            {
+                TRACELOG(LOG_WARNING, "GLFW: Failed to get monitor video mode");
+                glfwSetWindowMonitor(CORE.Window.handle, monitor, 0, 0, CORE.Window.screen.width, CORE.Window.screen.height, GLFW_DONT_CARE);
+            }
+            else
+            {
+                glfwSetWindowMonitor(CORE.Window.handle, monitor, 0, 0, mode->width, mode->height, GLFW_DONT_CARE);
+            }
 
-            glfwSetWindowMonitor(CORE.Window.handle, monitor, 0, 0, CORE.Window.screen.width, CORE.Window.screen.height, GLFW_DONT_CARE);
         }
     }
     else


### PR DESCRIPTION
I was writing a image viewer in Raylib and high res images appeared  in the same low resolution as the small window. Investigating the issue showed that glfwSetWindowMonitor is called with the screen resolution, not the current monitor resolution.

It is possible I am misunderstanding things here and the current work flow is desired for pixelart games with not resizable windows ?