### PR TITLE
Add error if raylib.h is included in a C++98 program

### DIFF
--- a/src/raylib.h
+++ b/src/raylib.h
@@ -133,10 +133,18 @@
 
 // NOTE: MSVC C++ compiler does not support compound literals (C99 feature)
 // Plain structures in C++ (without constructors) can be initialized with { }
+// This is called aggregate initialization (C++11 feature)
 #if defined(__cplusplus)
     #define CLITERAL(type)      type
 #else
     #define CLITERAL(type)      (type)
+#endif
+
+// Some compilers (mostly macos clang) default to C++98,
+// where aggregate initialization can't be used
+// So, give a more clear error stating how to fix this
+#if !defined(_MSC_VER) && (defined(__cplusplus) && __cplusplus < 201103L)
+    #error "C++11 or later is required. Add -std=c++11"
 #endif
 
 // NOTE: We set some defines with some data types declared by raylib


### PR DESCRIPTION
The color macros don't work properly in C++98, because they require
aggregate initialzation, which is a C++11 feature. So, explicitly state
how to fix this issue, instead of letting the compiler give a more vague
error message like:

main.cpp:8:23: error: expected '(' for function-style cast or type construction
      ClearBackground(BLACK);
                      ^~~~~
/opt/homebrew/Cellar/raylib/4.5.0/include/raylib.h:179:35: note: expanded from macro 'BLACK'
 #define BLACK      CLITERAL(Color){ 0, 0, 0, 255 }         // Black

NOTE: Don't use this check with MSVC because by default, it reports
199711L  regardless of any C++ version passed on command line
Only passing `/Zc:__cplusplus` will make MSVC set this correctly

see: https://learn.microsoft.com/en-us/cpp/build/reference/zc-cplusplus