### PR TITLE
Fix repeating keys, like Enter or Backspace

### DIFF
--- a/src/rcore.c
+++ b/src/rcore.c
@@ -5460,7 +5460,7 @@ static void KeyCallback(GLFWwindow *window, int key, int scancode, int action, i
 #endif
 
     // Check if there is space available in the key queue
-    if ((CORE.Input.Keyboard.keyPressedQueueCount < MAX_KEY_PRESSED_QUEUE) && (action == GLFW_PRESS))
+    if ((CORE.Input.Keyboard.keyPressedQueueCount < MAX_KEY_PRESSED_QUEUE) && (action == GLFW_PRESS || action == GLFW_REPEAT))
     {
         // Add character to the queue
         CORE.Input.Keyboard.keyPressedQueue[CORE.Input.Keyboard.keyPressedQueueCount] = key;


### PR DESCRIPTION
`GetCharPressed()` handles character repetition as expected, but `GetKeyPressed()` didn't repeat keys (like ENTER and BACKSPACE).
Adding a check for GLFW_REPEAT fixes the problem.

Tested: Built and tested on Linux, GCC12.