### PR TITLE
Addition of support for vox files in version 200.

### DIFF
--- a/src/external/vox_loader.h
+++ b/src/external/vox_loader.h
@@ -555,7 +555,7 @@ int Vox_LoadFromMemory(unsigned char* pvoxData, unsigned int voxDataSize, VoxArr
 	version = ((unsigned int*)fileDataPtr)[0];
 	fileDataPtr += 4;
 
-	if (version != 150)
+	if (version != 150 && version != 200)
 	{
 		return VOX_ERROR_FILE_VERSION_NOT_MATCH; //"MagicaVoxel version doesn't match"
 	}


### PR DESCRIPTION
I propose this small change to allow loading MagicaVox files in version 200. The Vox files saved by the MagicaVox editor have been in version 200 since version 0.99.7, although no specification for this new version can be found on the internet.

At the end of the message, I am including two links to support my statement, which seem to confirm that loading can still be done in the same way as with version 150 Vox files.

The only noticeable issue is that when exporting the file via the editor instead of saving it, it appears to have been compressed or minified, and therefore the first line containing "VOX " is not present. Even when removing this check, no voxel loads properly, so a solution to this problem would need to be found in the future. However, the strings "SIZE," "XYZI," and "RGBA" remain present in the exported files.

I have conducted tests on 15 .vox models saved via the editor in version 200, and everything is working normally. I can share this test if needed.

https://github.com/ephtracy/ephtracy.github.io/issues/264
https://github.com/AnotherCraft/ac-worldgen/issues/9