### PR TITLE
Added a wrapper for glfwSetWindowAspectRatio, called SetWindowAspectRatio

### DIFF
--- a/src/raylib.h
+++ b/src/raylib.h
@@ -957,6 +957,7 @@ RLAPI void SetWindowPosition(int x, int y);                       // Set window 
 RLAPI void SetWindowMonitor(int monitor);                         // Set monitor for the current window (fullscreen mode)
 RLAPI void SetWindowMinSize(int width, int height);               // Set window minimum dimensions (for FLAG_WINDOW_RESIZABLE)
 RLAPI void SetWindowSize(int width, int height);                  // Set window dimensions
+RLAPI void SetWindowAspectRatio(int numerator, int denominator);  // Set window aspect ratio (for FLAG_WINDOW_RESIZABLE)
 RLAPI void SetWindowOpacity(float opacity);                       // Set window opacity [0.0f..1.0f] (only PLATFORM_DESKTOP)
 RLAPI void *GetWindowHandle(void);                                // Get native window handle
 RLAPI int GetScreenWidth(void);                                   // Get current screen width

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -1692,6 +1692,15 @@ void SetWindowSize(int width, int height)
 #endif
 }
 
+// Set window aspect ratio (for FLAG_WINDOW_RESIZABLE)
+void SetWindowAspectRatio(int numerator, int denominator);
+{
+#if defined(PLATFORM_DESKTOP)
+    glfwSetWindowAspectRatio(CORE.Window.handle, numerator, denominator);
+#endif
+}
+
+
 // Set window opacity, value opacity is between 0.0 and 1.0
 void SetWindowOpacity(float opacity)
 {

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -1693,7 +1693,7 @@ void SetWindowSize(int width, int height)
 }
 
 // Set window aspect ratio (for FLAG_WINDOW_RESIZABLE)
-void SetWindowAspectRatio(int numerator, int denominator);
+void SetWindowAspectRatio(int numerator, int denominator)
 {
 #if defined(PLATFORM_DESKTOP)
     glfwSetWindowAspectRatio(CORE.Window.handle, numerator, denominator);


### PR DESCRIPTION
Added the function `SetWindowAspectRatio(int numerator, int denominator)` that simply calls `glfwSetWindowAspectRatio`. I believe this could come in handy for some.

Made a minor mistake so there are 2 identically named commits, sorry about that.