### PR TITLE
GLTF: fix segfault in animNormals memcpy when mesh.normals == NULL

### DIFF
--- a/src/rmodels.c
+++ b/src/rmodels.c
@@ -5201,7 +5201,9 @@ static Model LoadGLTF(const char *fileName)
                 model.meshes[meshIndex].animVertices = RL_CALLOC(model.meshes[meshIndex].vertexCount*3, sizeof(float));
                 memcpy(model.meshes[meshIndex].animVertices, model.meshes[meshIndex].vertices, model.meshes[meshIndex].vertexCount*3*sizeof(float));
                 model.meshes[meshIndex].animNormals = RL_CALLOC(model.meshes[meshIndex].vertexCount*3, sizeof(float));
-                memcpy(model.meshes[meshIndex].animNormals, model.meshes[meshIndex].normals, model.meshes[meshIndex].vertexCount*3*sizeof(float));
+                if (model.meshes[meshIndex].normals != NULL) {
+                    memcpy(model.meshes[meshIndex].animNormals, model.meshes[meshIndex].normals, model.meshes[meshIndex].vertexCount*3*sizeof(float));
+                }
 
                 meshIndex++;       // Move to next mesh
             }


### PR DESCRIPTION
I ran across a GLTF file with animation data but no normals which caused raylib to segfault on a memcpy since normals were expected to be defined. This PR fixes it.