### PR TITLE
Vector2Angle and Vector2LineAngle swap

### DIFF
--- a/src/raymath.h
+++ b/src/raymath.h
@@ -310,34 +310,28 @@ RMAPI float Vector2DistanceSqr(Vector2 v1, Vector2 v2)
     return result;
 }
 
-// Calculate angle between two vectors
-// NOTE: Angle is calculated from origin point (0, 0)
-RMAPI float Vector2Angle(Vector2 v1, Vector2 v2)
+// Calculate angle to go from point "start" to point "end"
+RMAPI float Vector2LineAngle(Vector2 start, Vector2 end)
 {
-    float result = atan2f(v2.y - v1.y, v2.x - v1.x);
+    float result = atan2f(end.y - start.y, end.x - start.x);
 
     return result;
 }
 
-// Calculate angle defined by a two vectors line
+// Calculate angle between two vectors
 // NOTE: Parameters need to be normalized
 // Current implementation should be aligned with glm::angle
-RMAPI float Vector2LineAngle(Vector2 start, Vector2 end)
+RMAPI float Vector2Angle(Vector2 v1, Vector2 v2)
 {
     float result = 0.0f;
 
-    float dot = start.x*end.x + start.y*end.y;      // Dot product
+    float dot = v1.x*v2.x + v1.y*v2.y;      // Dot product
 
     float dotClamp = (dot < -1.0f)? -1.0f : dot;    // Clamp
     if (dotClamp > 1.0f) dotClamp = 1.0f;
 
     result = acosf(dotClamp);
-
-    // Alternative implementation, more costly
-    //float v1Length = sqrtf((start.x*start.x) + (start.y*start.y));
-    //float v2Length = sqrtf((end.x*end.x) + (end.y*end.y));
-    //float result = -acosf((start.x*end.x + start.y*end.y)/(v1Length*v2Length));
-
+    
     return result;
 }
 


### PR DESCRIPTION
The function names and parameter names were swapped for these functions. This PR fixes that. 
Improved explanation for LineAngle.
Removed old alternative implementation ( it's wrong and incomplete).