### PR TITLE
Update raylib.pc.in to fix colors on macs running raylib.

### DIFF
--- a/raylib.pc.in
+++ b/raylib.pc.in
@@ -10,4 +10,4 @@ Version: @PROJECT_VERSION@
 Libs: -L"${libdir}" -lraylib @PKG_CONFIG_LIBS_EXTRA@
 Libs.private: @PKG_CONFIG_LIBS_PRIVATE@
 Requires.private: @GLFW_PKG_DEPS@
-Cflags: -I"${includedir}"
+Cflags: -I"${includedir}" -std=c++11


### PR DESCRIPTION
Raylib is using c++11 colors, by default macOS does not use c++11 colors, so to fix this we have to put a flag to specify.

For example, this will not work for now :
DrawRectangle(X, Y, size, size, YELLOW);

As "YELLOW" is using c++11 colors. So for this to work we have to fix the raylib.pc to include "-std=c++11".