### PR TITLE
Add options to zig compile

### DIFF
--- a/src/build.zig
+++ b/src/build.zig
@@ -1,11 +1,5 @@
 const std = @import("std");
 
-const Options = struct {
-    raygui: bool = false,
-    raymath: bool = false,
-    physac: bool = false,
-};
-
 // This has been tested to work with zig master branch as of commit 87de821 or May 14 2023
 pub fn addRaylib(b: *std.Build, target: std.zig.CrossTarget, optimize: std.builtin.OptimizeMode, options: Options) *std.Build.CompileStep {
     const raylib_flags = &[_][]const u8{
@@ -130,6 +124,12 @@ pub fn addRaylib(b: *std.Build, target: std.zig.CrossTarget, optimize: std.built
 
     return raylib;
 }
+
+const Options = struct {
+    raygui: bool = false,
+    raymath: bool = false,
+    physac: bool = false,
+};
 
 pub fn build(b: *std.Build) void {
     // Standard target options allows the person running `zig build` to choose

--- a/src/build.zig
+++ b/src/build.zig
@@ -34,6 +34,7 @@ pub fn addRaylib(b: *std.Build, target: std.zig.CrossTarget, optimize: std.built
     if (options.raygui) {
         _ = gen_step.add(srcdir ++ "/raygui.c", "#define RAYGUI_IMPLEMENTATION\n#include \"raygui.h\"\n");
         raylib.addCSourceFile(srcdir ++ "/raygui.c", raylib_flags);
+        raylib.addIncludePath(srcdir);
         raylib.addIncludePath(srcdir ++ "/../../raygui/src");
     }
 

--- a/src/build.zig
+++ b/src/build.zig
@@ -129,14 +129,10 @@ pub fn build(b: *std.Build) void {
     // set a preferred release mode, allowing the user to decide how to optimize.
     const optimize = b.standardOptimizeOption(.{});
 
-    const raymath = b.option(bool, "raymath", "Compile with raymath support");
     const raygui = b.option(bool, "raygui", "Compile with raygui support");
-    const physac = b.option(bool, "physac", "Compile with physac support");
 
     const lib = addRaylib(b, target, optimize, .{
-        .raymath = raymath orelse false,
         .raygui = raygui orelse false,
-        .physac = physac orelse false,
     });
 
     lib.installHeader("src/raylib.h", "raylib.h");

--- a/src/build.zig
+++ b/src/build.zig
@@ -37,17 +37,6 @@ pub fn addRaylib(b: *std.Build, target: std.zig.CrossTarget, optimize: std.built
         raylib.addIncludePath(srcdir ++ "/../../raygui/src");
     }
 
-    if (options.raymath) {
-        _ = gen_step.add(srcdir ++ "/raymath.c", "#define RAYMATH_IMPLEMENTATION\n#include \"raymath.h\"\n");
-        raylib.addCSourceFile(srcdir ++ "/raymath.c", raylib_flags);
-    }
-
-    if (options.physac) {
-        _ = gen_step.add(srcdir ++ "/physac.c", "#define PHYSAC_IMPLEMENTATION\n#include \"physac.h\"\n");
-        raylib.addCSourceFile(srcdir ++ "/physac.c", raylib_flags);
-        raylib.addIncludePath(srcdir ++ "/../../physac/src");
-    }
-
     switch (target.getOsTag()) {
         .windows => {
             raylib.addCSourceFiles(&.{srcdir ++ "/rglfw.c"}, raylib_flags);
@@ -127,8 +116,6 @@ pub fn addRaylib(b: *std.Build, target: std.zig.CrossTarget, optimize: std.built
 
 const Options = struct {
     raygui: bool = false,
-    raymath: bool = false,
-    physac: bool = false,
 };
 
 pub fn build(b: *std.Build) void {
@@ -153,17 +140,11 @@ pub fn build(b: *std.Build) void {
     });
 
     lib.installHeader("src/raylib.h", "raylib.h");
-
-    if (raymath orelse false) {
-        lib.installHeader("src/raymath.h", "raymath.h");
-    }
+    lib.installHeader("src/raymath.h", "raymath.h");
+    lib.installHeader("src/rlgl.h", "rlgl.h");
 
     if (raygui orelse false) {
         lib.installHeader("../raygui/src/raygui.h", "raygui.h");
-    }
-
-    if (physac orelse false) {
-        lib.installHeader("../physac/src/physac.h", "physac.h");
     }
 
     b.installArtifact(lib);


### PR DESCRIPTION
Support for compiling with `raygui`, `raymath`, and `physac`.
Also outputs the required headers.

`addRaylib` gains an additional positional argument that takes an Options struct.

Raygui should be located `../raygui` relative to the repo root
Physac should be located `../physac` relative to the repo root

These locations match the options in the Makefile

One step generates `src/raygui.c`, `src/raymath.c`, or `src/physac.c` with the `[lib]_IMPLEMENTATION` macro defined depending on which are enabled