### PR TITLE
fix vector angle example mode 0 circle segment drawing

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -536,12 +536,20 @@ AUDIO = \
     audio/audio_stream_effects \
     audio/audio_mixed_processor
 
+OTHERS = \
+    others/easings_testbed \
+    others/embedded_files_loading \
+    others/raylib_opengl_interop \
+    others/raymath_vector_angle \
+    others/rlgl_compute_shader \
+    others/rlgl_standalone
+
 CURRENT_MAKEFILE = $(lastword $(MAKEFILE_LIST))
 
 # Define processes to execute
 #------------------------------------------------------------------------------------------------
 # Default target entry
-all: $(CORE) $(SHAPES) $(TEXT) $(TEXTURES) $(MODELS) $(SHADERS) $(AUDIO)
+all: $(CORE) $(SHAPES) $(TEXT) $(TEXTURES) $(MODELS) $(SHADERS) $(AUDIO) $(OTHERS)
 
 core: $(CORE)
 shapes: $(SHAPES)
@@ -550,6 +558,7 @@ text: $(TEXT)
 models: $(MODELS)
 shaders: $(SHADERS)
 audio: $(AUDIO)
+others: $(OTHERS)
 
 # Generic compilation pattern
 # NOTE: Examples must be ready for Android compilation!

--- a/examples/others/raymath_vector_angle.c
+++ b/examples/others/raymath_vector_angle.c
@@ -49,14 +49,14 @@ int main(void)
             // Calculate angle between two vectors, considering a common origin (v0)
             v1 = Vector2Add(v0, (Vector2){ 100.0f, 80.0f });
             v2 = GetMousePosition();
-            angle = Vector2Angle(Vector2Normalize(Vector2Subtract(v1, v0)), Vector2Normalize(Vector2Subtract(v2, v0)))*RAD2DEG;
+            angle = 90 - Vector2LineAngle(v0, v2) * RAD2DEG;
         }
         else if (angleMode == 1)
         {
             // Calculate angle defined by a two vectors line, in reference to horizontal line
             v1 = (Vector2){ screenWidth/2, screenHeight/2 };
             v2 = GetMousePosition();
-            angle = Vector2LineAngle(v1, v2)*RAD2DEG;
+            angle = Vector2LineAngle(v1, v2) * RAD2DEG;
         }
         //----------------------------------------------------------------------------------
 
@@ -77,8 +77,7 @@ int main(void)
                 DrawLineEx(v0, v1, 2.0f, BLACK);
                 DrawLineEx(v0, v2, 2.0f, RED);
                 
-                // TODO: Properly draw circle sector
-                DrawCircleSector(v0, 40.0f, Vector2LineAngle(v0, v1)*RAD2DEG, angle, 32, Fade(GREEN, 0.6f));
+                DrawCircleSector(v0, 40.0f, 90 - Vector2LineAngle(v0, v1) * RAD2DEG, angle, 32, Fade(GREEN, 0.6f));
             }
             else if (angleMode == 1)
             {


### PR DESCRIPTION
also expanded the makefile to add "others" as an option and to compile those examples by default. requires libglfw3, of course.