### PR TITLE
Fix degrees of swipe gestures for web

### DIFF
--- a/src/rgestures.h
+++ b/src/rgestures.h
@@ -311,10 +311,10 @@ void ProcessGestureEvent(GestureEvent event)
                 // NOTE: Angle should be inverted in Y
                 GESTURES.Drag.angle = 360.0f - rgVector2Angle(GESTURES.Touch.downPositionA, GESTURES.Touch.upPosition);
 
-                if ((GESTURES.Drag.angle < 30) || (GESTURES.Drag.angle > 330)) GESTURES.current = GESTURE_SWIPE_RIGHT;        // Right
-                else if ((GESTURES.Drag.angle > 30) && (GESTURES.Drag.angle < 120)) GESTURES.current = GESTURE_SWIPE_UP;      // Up
-                else if ((GESTURES.Drag.angle > 120) && (GESTURES.Drag.angle < 210)) GESTURES.current = GESTURE_SWIPE_LEFT;   // Left
-                else if ((GESTURES.Drag.angle > 210) && (GESTURES.Drag.angle < 300)) GESTURES.current = GESTURE_SWIPE_DOWN;   // Down
+                if ((GESTURES.Drag.angle < 30) || (GESTURES.Drag.angle > 330)) GESTURES.current = GESTURE_SWIPE_RIGHT;          // Right
+                else if ((GESTURES.Drag.angle >= 30) && (GESTURES.Drag.angle <= 150)) GESTURES.current = GESTURE_SWIPE_UP;      // Up
+                else if ((GESTURES.Drag.angle > 150) && (GESTURES.Drag.angle < 210)) GESTURES.current = GESTURE_SWIPE_LEFT;     // Left
+                else if ((GESTURES.Drag.angle >= 210) && (GESTURES.Drag.angle <= 330)) GESTURES.current = GESTURE_SWIPE_DOWN;   // Down
                 else GESTURES.current = GESTURE_NONE;
             }
             else


### PR DESCRIPTION
Changes `300` to `330` on `GESTURE_SWIPE_DOWN` to complete the 360° arc.

Changes `120` to `150` on `GESTURE_SWIPE_UP` and `GESTURE_SWIPE_LEFT` so they align with `330` and both have a 60° range.

Changes `>` to `>=` on `GESTURE_SWIPE_UP` and `GESTURE_SWIPE_DOWN` to catch the exact `30.0f`, `150.0f`, `210.0f` and `330.0f` degrees if they happen.

Fixes https://github.com/raysan5/raylib/issues/3154.