### PR TITLE
Add a new task the issue template about checking the wiki

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-issue-template.md
+++ b/.github/ISSUE_TEMPLATE/new-issue-template.md
@@ -21,6 +21,7 @@ Please, before submitting a new issue verify and check:
 
  - [ ] I tested it on latest raylib version from master branch
  - [ ] I checked there is no similar issue already reported
+ - [ ] I checked the documentation on the [wiki](https://github.com/raysan5/raylib/wiki)
  - [ ] My code has no errors or misuse of raylib
 
 ### Issue description


### PR DESCRIPTION
Would like to suggest adding a new task to the issue template reminding users to check the documentation on the wiki. The information there is excellent and is possibly being overlooked.