### PR TITLE
Makefile change for cross compiling.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -308,6 +308,17 @@ ifeq ($(PLATFORM),PLATFORM_ANDROID)
     AR = $(ANDROID_TOOLCHAIN)/bin/llvm-ar
 endif
 
+# This section is here to help handle cross compilation. eg build on Linux for Windows. If you are doing this, you better know what you are doing!
+ifdef TARGET_OS
+    ifdef CROSS_CC
+        CC = ${CROSS_CC}
+    endif
+    ifdef CROSS_AR
+        AR = ${CROSS_AR}
+    endif
+    PLATFORM_OS = ${TARGET_OS}
+endif
+
 # Define compiler flags: CFLAGS
 #------------------------------------------------------------------------------------------------
 #  -O1                      defines optimization level


### PR DESCRIPTION
Working from wsl and compiling for windows this change makes it much easier to compile a static library for windows on arm. To compile a static library for windows on arm:

```
make PLATFORM=PLATFORM_DESKTOP TARGET_OS=WINDOWS CROSS_CC=/llvm/bin/aarch64-w64-mingw32-gcc CROSS_AR=/llvm/bin/aarch64-w64-mingw32-ar
```

This does not work to compile a shared library yet, only static.