### PR TITLE
Add support for receiving control characters

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -70,6 +70,8 @@
 // By default EndDrawing() does this job: draws everything + SwapScreenBuffer() + manage frame timing + PollInputEvents()
 // Enabling this flag allows manual control of the frame processes, use at your own risk
 //#define SUPPORT_CUSTOM_FRAME_CONTROL    1
+// Support receiving input of control characters, mainly for backspace and newline characters
+//#define SUPPORT_INPUT_CONTROL_CHARS         1
 
 // rcore: Configuration values
 //------------------------------------------------------------------------------------

--- a/src/external/glfw/src/input.c
+++ b/src/external/glfw/src/input.c
@@ -314,7 +314,7 @@ void _glfwInputChar(_GLFWwindow* window, uint32_t codepoint, int mods, GLFWbool 
     assert(mods == (mods & GLFW_MOD_MASK));
     assert(plain == GLFW_TRUE || plain == GLFW_FALSE);
 
-    if (codepoint < 32 || (codepoint > 126 && codepoint < 160))
+    if (codepoint > 126 && codepoint < 160) // original: if (codepoint < 32 || (codepoint > 126 && codepoint < 160)) // @nthung-2k5
         return;
 
     if (!window->lockKeyMods)

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -5553,6 +5553,10 @@ static void CharCallback(GLFWwindow *window, unsigned int key)
     // Ref: https://github.com/glfw/glfw/issues/668#issuecomment-166794907
     // Ref: https://www.glfw.org/docs/latest/input_guide.html#input_char
 
+#if !defined(SUPPORT_INPUT_CONTROL_CHARS)
+    // Control characters
+    if (key < 32) return;
+#endif
     // Check if there is space available in the queue
     if (CORE.Input.Keyboard.charPressedQueueCount < MAX_CHAR_PRESSED_QUEUE)
     {


### PR DESCRIPTION
This helps receiving special control characters that are ignored by GLFW, such as backspace ('\b') or newline ('\n').

Mainly to fix Vietnamese typing through Unikey in raygui (which requires certain changes to raygui).