### PR TITLE
Document buffer format for audio processors.

### DIFF
--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1591,7 +1591,7 @@ RLAPI void SetAudioStreamCallback(AudioStream stream, AudioCallback callback);  
 RLAPI void AttachAudioStreamProcessor(AudioStream stream, AudioCallback processor); // Attach audio stream processor to stream
 RLAPI void DetachAudioStreamProcessor(AudioStream stream, AudioCallback processor); // Detach audio stream processor from stream
 
-RLAPI void AttachAudioMixedProcessor(AudioCallback processor); // Attach audio stream processor to the entire audio pipeline
+RLAPI void AttachAudioMixedProcessor(AudioCallback processor); // Attach audio stream processor to the entire audio pipeline, receives the samples as <float>s
 RLAPI void DetachAudioMixedProcessor(AudioCallback processor); // Detach audio stream processor from the entire audio pipeline
 
 #if defined(__cplusplus)


### PR DESCRIPTION
There is a comment in the example https://github.com/raysan5/raylib/blob/d6f16b76649944f65491633a75ad648a6ddfdacf/examples/audio/audio_mixed_processor.c#L26 about this, but it is more discoverable in the API docs.