### PR TITLE
Add note about sample format to AttachAudioStreamProcessor()

### DIFF
--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1588,7 +1588,7 @@ RLAPI void SetAudioStreamPan(AudioStream stream, float pan);          // Set pan
 RLAPI void SetAudioStreamBufferSizeDefault(int size);                 // Default size for new audio streams
 RLAPI void SetAudioStreamCallback(AudioStream stream, AudioCallback callback);  // Audio thread callback to request new data
 
-RLAPI void AttachAudioStreamProcessor(AudioStream stream, AudioCallback processor); // Attach audio stream processor to stream
+RLAPI void AttachAudioStreamProcessor(AudioStream stream, AudioCallback processor); // Attach audio stream processor to stream, receives the samples as <float>s
 RLAPI void DetachAudioStreamProcessor(AudioStream stream, AudioCallback processor); // Detach audio stream processor from stream
 
 RLAPI void AttachAudioMixedProcessor(AudioCallback processor); // Attach audio stream processor to the entire audio pipeline, receives the samples as <float>s


### PR DESCRIPTION
Please excuse the noise, I should have included this in the previous PR https://github.com/raysan5/raylib/pull/3186 instead of asking there whether I should do it. I wasn’t sure whether the buffer passed to `AttachAudioStreamProcessor()` always used the same type as `AttachAudioMixedProcessor()` although it looked like that in the example.

I’ve been reading carefully the example for `AttachAutdioStreamProcessor()` and the source code, and it is now clear to me that this function too uses `float` for the samples in `buffer`.