### PR TITLE
Optimize and simplify the gesture system

### DIFF
--- a/src/rgestures.h
+++ b/src/rgestures.h
@@ -180,7 +180,7 @@ float GetGesturePinchAngle(void);                       // Get gesture pinch ang
 //----------------------------------------------------------------------------------
 #define FORCE_TO_SWIPE      0.2f        // Swipe force, measured in normalized screen units/time
 #define MINIMUM_DRAG        0.015f      // Drag minimum force, measured in normalized screen units (0.0f to 1.0f)
-#define DRAG_TIMEOUT        0.2f        // Drag minimum time for web, measured in seconds
+#define DRAG_TIMEOUT        0.3f        // Drag minimum time for web, measured in seconds
 #define MINIMUM_PINCH       0.005f      // Pinch minimum force, measured in normalized screen units (0.0f to 1.0f)
 #define TAP_TIMEOUT         0.3f        // Tap minimum time, measured in seconds
 #define PINCH_TIMEOUT       0.3f        // Pinch minimum time, measured in seconds
@@ -305,7 +305,7 @@ void ProcessGestureEvent(GestureEvent event)
             GESTURES.Drag.intensity = GESTURES.Drag.distance/(float)((rgGetCurrentTime() - GESTURES.Swipe.startTime));
 
             // Detect GESTURE_SWIPE
-            if ((GESTURES.Drag.intensity > FORCE_TO_SWIPE))
+            if ((GESTURES.Drag.intensity > FORCE_TO_SWIPE) && (GESTURES.current != GESTURE_DRAG))
             {
                 // NOTE: Angle should be inverted in Y
                 GESTURES.Drag.angle = 360.0f - rgVector2Angle(GESTURES.Touch.downPositionA, GESTURES.Touch.upPosition);
@@ -339,12 +339,7 @@ void ProcessGestureEvent(GestureEvent event)
                 GESTURES.Hold.resetRequired = false;
 
                 // Detect GESTURE_DRAG
-#if defined(PLATFORM_WEB)
-                // An alternative check to detect gesture drag is necessary since moveDownPositionA on touch for web is always zero, causing the distance calculation to be inaccurate
                 if ((rgGetCurrentTime() - GESTURES.Touch.eventTime) > DRAG_TIMEOUT)
-#else
-                if (rgVector2Distance(GESTURES.Touch.downPositionA, GESTURES.Touch.moveDownPositionA) >= MINIMUM_DRAG)
-#endif
                 {
                     GESTURES.Touch.eventTime = rgGetCurrentTime();
                     GESTURES.current = GESTURE_DRAG;


### PR DESCRIPTION
**Optimize and simplify the gesture system** does:

1. Stops `GESTURE_DRAG` from triggering `GESTURE_HOLD` on `UpdateGestures()` ([L439-L445](https://github.com/raysan5/raylib/pull/3190/files#diff-ce52e9b8602ff61fde52fcdd30064097c84ee6583a4f08bd155922349424a5c1L439-L445)). "hold" is not needed for "drag". Simplifies "drag" handling while keeping its funcionality.

2. Removes `GESTURES.Touch.eventTime` update for `GESTURE_DRAG` ([L336](https://github.com/raysan5/raylib/pull/3190/files#diff-ce52e9b8602ff61fde52fcdd30064097c84ee6583a4f08bd155922349424a5c1L336)) since it no longer needs to trigger `GESTURE_HOLD` on `UpdateGestures()`.

3. Removes `GESTURES.Touch.firstId` updating from `TOUCH_ACTION_DOWN` ([L295](https://github.com/raysan5/raylib/pull/3190/files#diff-ce52e9b8602ff61fde52fcdd30064097c84ee6583a4f08bd155922349424a5c1L295)). It's only used on the condition to detect a `GESTURE_SWIPE`, but since its value is always zero, its achieving no purpose. It's also not needed for the "swipe" detection ([L311](https://github.com/raysan5/raylib/pull/3190/files#diff-ce52e9b8602ff61fde52fcdd30064097c84ee6583a4f08bd155922349424a5c1L311)).

4. Removes the `GESTURES.Swipe.start` ([L222](https://github.com/raysan5/raylib/pull/3190/files#diff-ce52e9b8602ff61fde52fcdd30064097c84ee6583a4f08bd155922349424a5c1L222), [L308](https://github.com/raysan5/raylib/pull/3190/files#diff-ce52e9b8602ff61fde52fcdd30064097c84ee6583a4f08bd155922349424a5c1L308)) and its check ([L338-L343](https://github.com/raysan5/raylib/pull/3190/files#diff-ce52e9b8602ff61fde52fcdd30064097c84ee6583a4f08bd155922349424a5c1L338-L343)) during `TOUCH_ACTION_MOVE`. Updating it under `TOUCH_ACTION_MOVE` actually causes its value to be delayed from its actual start time that happens on `TOUCH_ACTION_DOWN`.

5. Renames `GESTURES.Swipe.timeDuration` to `GESTURES.Swipe.startTime` ([L223-R222](https://github.com/raysan5/raylib/pull/3190/files#diff-ce52e9b8602ff61fde52fcdd30064097c84ee6583a4f08bd155922349424a5c1L223-R222), [R305](https://github.com/raysan5/raylib/pull/3190/files#diff-ce52e9b8602ff61fde52fcdd30064097c84ee6583a4f08bd155922349424a5c1R305)) and moves it update to under `TOUCH_ACTION_DOWN` ([R294](https://github.com/raysan5/raylib/pull/3190/files#diff-ce52e9b8602ff61fde52fcdd30064097c84ee6583a4f08bd155922349424a5c1R294)) so its time value is accurate.

**Decouples GESTURE_SWIPE_\* from GESTURE_DRAG** does:

6. Makes the "time" method the standard way to detect "drag" ([R342](https://github.com/raysan5/raylib/pull/3190/files#diff-ce52e9b8602ff61fde52fcdd30064097c84ee6583a4f08bd155922349424a5c1R342)). Makes its detection more consistent. Also makes its detection no longer compete with "swipe".

7. Adds another condition (`GESTURES.current` must not be `GESTURE_DRAG`) to detect "swipe" ([R308](https://github.com/raysan5/raylib/pull/3190/files#diff-ce52e9b8602ff61fde52fcdd30064097c84ee6583a4f08bd155922349424a5c1R308)). Makes "drag" stop triggering a "swipe" when it ends. This is now reliable due to the `GESTURES.Swipe.startTime` change ([R294](https://github.com/raysan5/raylib/pull/3190/files#diff-ce52e9b8602ff61fde52fcdd30064097c84ee6583a4f08bd155922349424a5c1R294)), that makes the `GESTURES.Drag.intensity` calculation to be accurate now.

8. Tweaks the `DRAG_TIMEOUT` value ([R183](https://github.com/raysan5/raylib/pull/3190/files#diff-ce52e9b8602ff61fde52fcdd30064097c84ee6583a4f08bd155922349424a5c1R183)).

Tested these changes successfully on Firefox (115.0.1) and Chrome (95.0.4638.74) for Android; Firefox (102.11.0esr 64-bit) and Chrome (114.0.5735.106 64-bit) with Touch Emulation enabled and disabled for Linux; and native on Linux.

**Edit 1:** added line marks of the proposed changes.
**Edit 2:** added the second commit.
