### PR TITLE
Fix mouse wheel not working in PLATFORM_RPI or PLATFORM_DRM

### DIFF
--- a/src/rcore.c
+++ b/src/rcore.c
@@ -468,6 +468,7 @@ typedef struct CoreData {
             Vector2 currentWheelMove;       // Registers current mouse wheel variation
             Vector2 previousWheelMove;      // Registers previous mouse wheel variation
 #if defined(PLATFORM_RPI) || defined(PLATFORM_DRM)
+            Vector2 eventWheelMove;         // Registers the event mouse wheel variation
             // NOTE: currentButtonState[] can't be written directly due to multithreading, app could miss the update
             char currentButtonStateEvdev[MAX_MOUSE_BUTTONS]; // Holds the new mouse state for the next polling event to grab
 #endif
@@ -5062,7 +5063,8 @@ void PollInputEvents(void)
 
     // Register previous mouse states
     CORE.Input.Mouse.previousWheelMove = CORE.Input.Mouse.currentWheelMove;
-    CORE.Input.Mouse.currentWheelMove = (Vector2){ 0.0f, 0.0f };
+    CORE.Input.Mouse.currentWheelMove = CORE.Input.Mouse.eventWheelMove;
+    CORE.Input.Mouse.eventWheelMove = (Vector2){ 0.0f, 0.0f };
     for (int i = 0; i < MAX_MOUSE_BUTTONS; i++)
     {
         CORE.Input.Mouse.previousButtonState[i] = CORE.Input.Mouse.currentButtonState[i];
@@ -6677,7 +6679,7 @@ static void *EventThread(void *arg)
                     gestureUpdate = true;
                 }
 
-                if (event.code == REL_WHEEL) CORE.Input.Mouse.currentWheelMove.y += event.value;
+                if (event.code == REL_WHEEL) CORE.Input.Mouse.eventWheelMove.y += event.value;
             }
 
             // Absolute movement parsing


### PR DESCRIPTION
In the meantime (just to not leave the mouse wheel broken) I think the problem was sharing the same variable for holding both "the event" and "the current" value since they run independently.

`GetMouseWheelMove()` returns the `CORE.Input.currentWheelMove` ([L3949-L3959](https://github.com/raysan5/raylib/blob/master/src/rcore.c#L3949-L3959)). But that is always zeroed by `PollInputEvents()` ([L5065](https://github.com/raysan5/raylib/blob/master/src/rcore.c#L5065)) when it runs on `EndDrawing()`. So the `event.value` ([L6680](https://github.com/raysan5/raylib/blob/master/src/rcore.c#L6680)) never ends up staying on `CORE.Input.currentWheelMove` long enough before it gets zeroed. This could be solved by storing the `event.value` in a new `CORE.Input.eventWheelMove` ([R471](https://github.com/raysan5/raylib/pull/3193/files#diff-39fea0e3daa23741e81daf967717f35c7842426aab26a0bc3f525d6a2f03e339R471), [R6682](https://github.com/raysan5/raylib/pull/3193/files#diff-39fea0e3daa23741e81daf967717f35c7842426aab26a0bc3f525d6a2f03e339R6682)). And, after updating the `CORE.Input.currentWheelMove` (that is what `GetMouseWheelMove()` needs), reset the `CORE.Input.eventWheelMove` instead ([L5065-R5067](https://github.com/raysan5/raylib/pull/3193/files#diff-39fea0e3daa23741e81daf967717f35c7842426aab26a0bc3f525d6a2f03e339L5065-R5067)).

Tested the fix successfully for `PLATFORM_DRM` on Raspberry Pi 3 Model B 1.2 with Raspberry Pi OS (11 Bullseye) 32-bit armhf.

Fix https://github.com/raysan5/raylib/issues/2660.

**Edit:** added line marks.
