### PR TITLE
[textures] Fix LoadTextureCubemap for manual layouts

### DIFF
--- a/src/rtextures.c
+++ b/src/rtextures.c
@@ -3369,9 +3369,15 @@ TextureCubemap LoadTextureCubemap(Image image, int layout)
             if ((image.height/6) == image.width) { layout = CUBEMAP_LAYOUT_LINE_VERTICAL; cubemap.width = image.height/6; }
             else if ((image.width/3) == (image.height/4)) { layout = CUBEMAP_LAYOUT_CROSS_THREE_BY_FOUR; cubemap.width = image.width/3; }
         }
-
-        cubemap.height = cubemap.width;
+    } else {
+        if (layout == CUBEMAP_LAYOUT_LINE_VERTICAL) cubemap.width = image.height/6;
+        if (layout == CUBEMAP_LAYOUT_LINE_HORIZONTAL) cubemap.width = image.width/6;
+        if (layout == CUBEMAP_LAYOUT_CROSS_THREE_BY_FOUR) cubemap.width = image.width/3;
+        if (layout == CUBEMAP_LAYOUT_CROSS_FOUR_BY_THREE) cubemap.width = image.width/4;
+        if (layout == CUBEMAP_LAYOUT_PANORAMA) cubemap.width = image.width/4;
     }
+
+    cubemap.height = cubemap.width;
 
     // Layout provided or already auto-detected
     if (layout != CUBEMAP_LAYOUT_AUTO_DETECT)


### PR DESCRIPTION
Passing any other layout than `CUBEMAP_LAYOUT_AUTO_DETECT` to `LoadTextureCubemap` loads an empty texture with 0 by 0 dimensions. This is because the size of each face is caculated like so
```c
int size = cubemap.width;
```
but `cubemap` is zero initialized and only set when auto detecting the layout.

This PR fixes this issue, by manually setting the width for each layout.