### PR TITLE
Changes SetWindowMonitor() to no longer force fullscreen

### DIFF
--- a/src/raylib.h
+++ b/src/raylib.h
@@ -954,7 +954,7 @@ RLAPI void SetWindowIcon(Image image);                            // Set icon fo
 RLAPI void SetWindowIcons(Image *images, int count);              // Set icon for window (multiple images, RGBA 32bit, only PLATFORM_DESKTOP)
 RLAPI void SetWindowTitle(const char *title);                     // Set title for window (only PLATFORM_DESKTOP)
 RLAPI void SetWindowPosition(int x, int y);                       // Set window position on screen (only PLATFORM_DESKTOP)
-RLAPI void SetWindowMonitor(int monitor);                         // Set monitor for the current window (fullscreen mode)
+RLAPI void SetWindowMonitor(int monitor);                         // Set monitor for the current window
 RLAPI void SetWindowMinSize(int width, int height);               // Set window minimum dimensions (for FLAG_WINDOW_RESIZABLE)
 RLAPI void SetWindowSize(int width, int height);                  // Set window dimensions
 RLAPI void SetWindowOpacity(float opacity);                       // Set window opacity [0.0f..1.0f] (only PLATFORM_DESKTOP)

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -1661,7 +1661,7 @@ void SetWindowPosition(int x, int y)
 #endif
 }
 
-// Set monitor for the current window (fullscreen mode)
+// Set monitor for the current window
 void SetWindowMonitor(int monitor)
 {
 #if defined(PLATFORM_DESKTOP)
@@ -1670,10 +1670,28 @@ void SetWindowMonitor(int monitor)
 
     if ((monitor >= 0) && (monitor < monitorCount))
     {
-        TRACELOG(LOG_INFO, "GLFW: Selected fullscreen monitor: [%i] %s", monitor, glfwGetMonitorName(monitors[monitor]));
+        if (!CORE.Window.fullscreen)
+        {
+            TRACELOG(LOG_INFO, "GLFW: Selected monitor: [%i] %s", monitor, glfwGetMonitorName(monitors[monitor]));
 
-        const GLFWvidmode *mode = glfwGetVideoMode(monitors[monitor]);
-        glfwSetWindowMonitor(CORE.Window.handle, monitors[monitor], 0, 0, mode->width, mode->height, mode->refreshRate);
+            const int screenWidth = CORE.Window.screen.width;
+            const int screenHeight = CORE.Window.screen.height;
+            int monitorWorkareaX = 0;
+            int monitorWorkareaY = 0;
+            int monitorWorkareaWidth = 0;
+            int monitorWorkareaHeight = 0;
+            glfwGetMonitorWorkarea(monitors[monitor], &monitorWorkareaX, &monitorWorkareaY, &monitorWorkareaWidth, &monitorWorkareaHeight);
+
+            // If the screen size is larger than the monitor workarea, anchor it on the top left corner, otherwise, center it
+            if ((screenWidth >= monitorWorkareaWidth) || (screenHeight >= monitorWorkareaHeight)) glfwSetWindowPos(CORE.Window.handle, monitorWorkareaX, monitorWorkareaY);
+            else
+            {
+                const int x = monitorWorkareaX + (monitorWorkareaWidth*0.5f) - (screenWidth*0.5f);
+                const int y = monitorWorkareaY + (monitorWorkareaHeight*0.5f) - (screenHeight*0.5f);
+                glfwSetWindowPos(CORE.Window.handle, x, y);
+            }
+        }
+        else TRACELOG(LOG_WARNING, "GLFW: Failed to find selected monitor because it's on fullscreen");
     }
     else TRACELOG(LOG_WARNING, "GLFW: Failed to find selected monitor");
 #endif

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -1670,7 +1670,14 @@ void SetWindowMonitor(int monitor)
 
     if ((monitor >= 0) && (monitor < monitorCount))
     {
-        if (!CORE.Window.fullscreen)
+        if (CORE.Window.fullscreen)
+        {
+            TRACELOG(LOG_INFO, "GLFW: Selected fullscreen monitor: [%i] %s", monitor, glfwGetMonitorName(monitors[monitor]));
+
+            const GLFWvidmode *mode = glfwGetVideoMode(monitors[monitor]);
+            glfwSetWindowMonitor(CORE.Window.handle, monitors[monitor], 0, 0, mode->width, mode->height, mode->refreshRate);
+        }
+        else
         {
             TRACELOG(LOG_INFO, "GLFW: Selected monitor: [%i] %s", monitor, glfwGetMonitorName(monitors[monitor]));
 
@@ -1691,7 +1698,6 @@ void SetWindowMonitor(int monitor)
                 glfwSetWindowPos(CORE.Window.handle, x, y);
             }
         }
-        else TRACELOG(LOG_WARNING, "GLFW: Failed to find selected monitor because it's on fullscreen");
     }
     else TRACELOG(LOG_WARNING, "GLFW: Failed to find selected monitor");
 #endif


### PR DESCRIPTION
Since invoking `glfwSetWindowMonitor()` ([L1676](https://github.com/raysan5/raylib/pull/3209/files#diff-39fea0e3daa23741e81daf967717f35c7842426aab26a0bc3f525d6a2f03e339L1676)) forces fullscreen, changes `SetWindowMonitor()` to instead move the window to the defined monitor.

To move the window it checks if the screen size is larger than the monitor [workarea](https://www.glfw.org/docs/3.3/group__monitor.html#ga7387a3bdb64bfe8ebf2b9e54f5b6c9d0) ([R1684-R1693](https://github.com/raysan5/raylib/pull/3209/files#diff-39fea0e3daa23741e81daf967717f35c7842426aab26a0bc3f525d6a2f03e339R1684-R1693)). If it is larger, then anchors it on the top left corner ([R1693](https://github.com/raysan5/raylib/pull/3209/files#diff-39fea0e3daa23741e81daf967717f35c7842426aab26a0bc3f525d6a2f03e339R1693)), otherwise, center it ([R1696-R1698](https://github.com/raysan5/raylib/pull/3209/files#diff-39fea0e3daa23741e81daf967717f35c7842426aab26a0bc3f525d6a2f03e339R1696-R1698)). This is done because if the window is larger than the workarea, centering could make the window bars/handles unreachable for the user.

~~Before this proposed change (while using the previous `SetWindowMonitor()` implementation [L1675-L1676](https://github.com/raysan5/raylib/pull/3209/files#diff-39fea0e3daa23741e81daf967717f35c7842426aab26a0bc3f525d6a2f03e339L1675-L1676)), I wasn't able to change the monitor while already on fullscreen. But, just be safe and prevent `SetWindowMonitor()` from being executed while already on fullscreen, added a check for it before attempting to move the window anyway ([R1673](https://github.com/raysan5/raylib/pull/3209/files#diff-39fea0e3daa23741e81daf967717f35c7842426aab26a0bc3f525d6a2f03e339R1673), [R1694](https://github.com/raysan5/raylib/pull/3209/files#diff-39fea0e3daa23741e81daf967717f35c7842426aab26a0bc3f525d6a2f03e339R1694)).~~ (Sorry, I retested this today and it's working. I probably messed something locally yesterday while testing multiple monitor layout configurations. I amended the commit to allow moving the fullscreen window again: [R1673-R1679](https://github.com/raysan5/raylib/pull/3209/files#diff-39fea0e3daa23741e81daf967717f35c7842426aab26a0bc3f525d6a2f03e339R1673-R1679))

This proposed change leaves up to the user to call `ToggleFullscreen()` or `SetWindowState(FLAG_FULLSCREEN_MODE)` when required.

### Environment

Tested this change successfully on `PLATFORM_DESKTOP` native Linux (Linux Mint 21.1 x86_64) with two monitors (1600x900 and 1280x1024 resolutions) in various layout configurations.

### Code Example

Minimal reproduction code to test the change:
```
#include "raylib.h"

void changeWindowSize(int monitor) {
    int monitorCount = GetMonitorCount();
    if ((monitor >= 0) && (monitor < monitorCount)) {
        SetWindowSize(GetMonitorWidth(monitor), GetMonitorHeight(monitor));
    } else {
        TraceLog(LOG_WARNING, "Monitor %i not found", monitor);
    }
}

int main(void) {
    InitWindow(800, 450, "Test");
    SetTargetFPS(60);
    while (!WindowShouldClose()) {

        if (IsKeyPressed(KEY_F1)) { SetWindowMonitor(0); }
        if (IsKeyPressed(KEY_F2)) { SetWindowMonitor(1); }
        if (IsKeyPressed(KEY_F3)) { SetWindowMonitor(2); }
        if (IsKeyPressed(KEY_F4)) { SetWindowMonitor(3); }

        if (IsKeyPressed(KEY_F5)) { changeWindowSize(0); }
        if (IsKeyPressed(KEY_F6)) { changeWindowSize(1); }
        if (IsKeyPressed(KEY_F7)) { changeWindowSize(2); }
        if (IsKeyPressed(KEY_F8)) { changeWindowSize(3); }

        if (IsKeyPressed(KEY_F9))  { SetWindowSize(800, 450); }
        if (IsKeyPressed(KEY_F10)) { TraceLog(LOG_INFO, "Current monitor: %i", GetCurrentMonitor()); }
        if (IsKeyPressed(KEY_F11)) { ToggleFullscreen(); }

        BeginDrawing();
        ClearBackground(RAYWHITE);
        DrawText("Move window to monitor 0 [F1], 1 [F2], 2 [F3], 3 [F4]", 20, 20, 20, BLACK);
        DrawText("Make window the size of monitor 0 [F5], 1 [F6], 2 [F7], 3 [F8], 800x450 [F9]", 20, 60, 20, BLACK);
        DrawText("Print current monitor on log [F10], Toggle fullscreen [F11]", 20, 100, 20, BLACK);
        EndDrawing();
    }
    CloseWindow();
    return 0;
}
```
**Edit 1:** added line marks.
**Edit 2:** fixes https://github.com/raysan5/raylib/issues/3198.
**Edit 3:** amended commit to allow moving the fullscreen window again.