### PR TITLE
Fix android soname in src/Makefile

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -516,7 +516,7 @@ ifeq ($(PLATFORM),PLATFORM_DRM)
     endif
 endif
 ifeq ($(PLATFORM),PLATFORM_ANDROID)
-    LDFLAGS += -Wl,-soname,libraylib.$(API_VERSION).so -Wl,--exclude-libs,libatomic.a
+    LDFLAGS += -Wl,-soname,libraylib.$(RAYLIB_API_VERSION).so -Wl,--exclude-libs,libatomic.a
     LDFLAGS += -Wl,--build-id -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now -Wl,--warn-shared-textrel -Wl,--fatal-warnings
     # Force linking of library module to define symbol
     LDFLAGS += -u ANativeActivity_onCreate


### PR DESCRIPTION
Since **API_VERSION** not exist   libraylib.$(**API_VERSION**).so  is equal to  libraylib..so