### PR TITLE
Update BINDINGS.md to include rayjs

### DIFF
--- a/BINDINGS.md
+++ b/BINDINGS.md
@@ -75,7 +75,7 @@ Some people ported raylib to other languages in form of bindings or wrappers to 
 | hare-raylib        | **auto** | [Hare](https://harelang.org/)        | Zlib | https://git.sr.ht/~evantj/hare-raylib       |
 | raylib-sunder      | **auto** | [Sunder](https://github.com/ashn-dot-dev/sunder) | 0BSD | https://github.com/ashn-dot-dev/raylib-sunder |
 | rayed-bqn          | **auto** | [BQN](https://mlochbaum.github.io/BQN/) | MIT | https://github.com/Brian-ED/rayed-bqn | 
-
+| rayjs              | 4.6-dev | [QuickJS](https://bellard.org/quickjs/)    | MIT | https://github.com/mode777/rayjs    |
 
 ### Utility Wrapers
 These are utility wrappers for specific languages, they are not required to use raylib in the language but may adapt the raylib API to be more inline with the language's pardigm.


### PR DESCRIPTION
Hi everyone, I made a standalone Javascript interpreter based on [QuickJS](https://bellard.org/quickjs/) with bindings for [Raylib](https://www.raylib.com/) and would like to add it to the list.