### PR TITLE
Fixes GetCurrentMonitor() detection inconsistency issue

### DIFF
--- a/src/rcore.c
+++ b/src/rcore.c
@@ -1835,20 +1835,24 @@ int GetCurrentMonitor(void)
                 int mx = 0;
                 int my = 0;
 
-                int width = 0;
-                int height = 0;
-
                 monitor = monitors[i];
-                glfwGetMonitorWorkarea(monitor, &mx, &my, &width, &height);
-
-                if ((x >= mx) &&
-                    (x < (mx + width)) &&
-                    (y >= my) &&
-                    (y < (my + height)))
+                glfwGetMonitorPos(monitor, &mx, &my);
+                const GLFWvidmode *mode = glfwGetVideoMode(monitor);
+                if (mode)
                 {
-                    index = i;
-                    break;
+                    const int width = mode->width;
+                    const int height = mode->height;
+
+                    if ((x >= mx) &&
+                        (x < (mx + width)) &&
+                        (y >= my) &&
+                        (y < (my + height)))
+                    {
+                        index = i;
+                        break;
+                    }
                 }
+                else TRACELOG(LOG_WARNING, "GLFW: Failed to find video mode for selected monitor");
             }
         }
     }


### PR DESCRIPTION
Changes the `GetCurrentMonitor()` to use `glfwGetMonitorPos()` ([R1839](https://github.com/raysan5/raylib/pull/3215/files#diff-39fea0e3daa23741e81daf967717f35c7842426aab26a0bc3f525d6a2f03e339R1839)) and `glfwGetVideoMode()` ([R1840-R1844](https://github.com/raysan5/raylib/pull/3215/files#diff-39fea0e3daa23741e81daf967717f35c7842426aab26a0bc3f525d6a2f03e339R1840-R1844)) instead of `glfwGetMonitorWorkarea()` ([L1842](https://github.com/raysan5/raylib/pull/3215/files#diff-39fea0e3daa23741e81daf967717f35c7842426aab26a0bc3f525d6a2f03e339L1842)) for non-fullscreen monitor detection on `PLATFORM_DESKTOP`.

Fixes https://github.com/raysan5/raylib/issues/3213.

**Edit:** added line marks.
