### PR TITLE
Adds BORDERLESS_WINDOWED_MODE for PLATFORM_DESKTOP

### DIFF
--- a/src/raylib.h
+++ b/src/raylib.h
@@ -526,6 +526,7 @@ typedef enum {
     FLAG_WINDOW_TRANSPARENT = 0x00000010,   // Set to allow transparent framebuffer
     FLAG_WINDOW_HIGHDPI     = 0x00002000,   // Set to support HighDPI
     FLAG_WINDOW_MOUSE_PASSTHROUGH = 0x00004000, // Set to support mouse passthrough, only supported when FLAG_WINDOW_UNDECORATED
+    FLAG_BORDERLESS_WINDOWED_MODE = 0x00008000, // Set to run program in borderless windowed mode
     FLAG_MSAA_4X_HINT       = 0x00000020,   // Set to try enabling MSAA 4X
     FLAG_INTERLACED_HINT    = 0x00010000    // Set to try enabling interlaced video format (for V3D)
 } ConfigFlags;
@@ -947,6 +948,7 @@ RLAPI bool IsWindowState(unsigned int flag);                      // Check if on
 RLAPI void SetWindowState(unsigned int flags);                    // Set window configuration state using flags (only PLATFORM_DESKTOP)
 RLAPI void ClearWindowState(unsigned int flags);                  // Clear window configuration state flags
 RLAPI void ToggleFullscreen(void);                                // Toggle window state: fullscreen/windowed (only PLATFORM_DESKTOP)
+RLAPI void ToggleBorderlessWindowed(void);                        // Toggle window state: borderless windowed (only PLATFORM_DESKTOP)
 RLAPI void MaximizeWindow(void);                                  // Set window state: maximized, if resizable (only PLATFORM_DESKTOP)
 RLAPI void MinimizeWindow(void);                                  // Set window state: minimized, if resizable (only PLATFORM_DESKTOP)
 RLAPI void RestoreWindow(void);                                   // Set window state: not minimized/maximized (only PLATFORM_DESKTOP)

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -412,6 +412,8 @@ typedef struct CoreData {
         Size render;                        // Framebuffer width and height (render area, including black bars if required)
         Point renderOffset;                 // Offset from render area (must be divided by 2)
         Matrix screenScale;                 // Matrix to scale screen (framebuffer rendering)
+        Point previousPosition;             // Previous screen position (required on borderless windowed toggle)
+        Size previousScreen;                // Previous screen size (required on borderless windowed toggle)
 
         char **dropFilepaths;         // Store dropped files paths pointers (provided by GLFW)
         unsigned int dropFileCount;         // Count dropped files strings
@@ -1324,6 +1326,82 @@ void ToggleFullscreen(void)
 #endif
 }
 
+// Toggle borderless windowed mode (only PLATFORM_DESKTOP)
+void ToggleBorderlessWindowed(void)
+{
+#if defined(PLATFORM_DESKTOP)
+    // Leave fullscreen before attempting to set borderless windowed mode and get screen position from it
+    bool wasOnFullscreen = false;
+    if (CORE.Window.fullscreen)
+    {
+        CORE.Window.previousPosition = CORE.Window.position;
+        ToggleFullscreen();
+        wasOnFullscreen = true;
+    }
+
+    const int monitor = GetCurrentMonitor();
+    int monitorCount;
+    GLFWmonitor **monitors = glfwGetMonitors(&monitorCount);
+    if ((monitor >= 0) && (monitor < monitorCount))
+    {
+        const GLFWvidmode *mode = glfwGetVideoMode(monitors[monitor]);
+        if (mode)
+        {
+            if (!IsWindowState(FLAG_BORDERLESS_WINDOWED_MODE))
+            {
+                // Store screen position and size
+                // NOTE: If it was on fullscreen, screen position was already stored, so skip setting it here
+                if (!wasOnFullscreen) glfwGetWindowPos(CORE.Window.handle, &CORE.Window.previousPosition.x, &CORE.Window.previousPosition.y);
+                CORE.Window.previousScreen = CORE.Window.screen;
+
+                // Set undecorated and topmost modes and flags
+                glfwSetWindowAttrib(CORE.Window.handle, GLFW_DECORATED, GLFW_FALSE);
+                CORE.Window.flags |= FLAG_WINDOW_UNDECORATED;
+                glfwSetWindowAttrib(CORE.Window.handle, GLFW_FLOATING, GLFW_TRUE);
+                CORE.Window.flags |= FLAG_WINDOW_TOPMOST;
+
+                // Get monitor position and size
+                int monitorPosX = 0;
+                int monitorPosY = 0;
+                glfwGetMonitorPos(monitors[monitor], &monitorPosX, &monitorPosY);
+                const int monitorWidth = mode->width;
+                const int monitorHeight = mode->height;
+                glfwSetWindowSize(CORE.Window.handle, monitorWidth, monitorHeight);
+
+                // Set screen position and size
+                glfwSetWindowPos(CORE.Window.handle, monitorPosX, monitorPosY);
+                glfwSetWindowSize(CORE.Window.handle, monitorWidth, monitorHeight);
+
+                // Refocus window
+                glfwFocusWindow(CORE.Window.handle);
+
+                CORE.Window.flags |= FLAG_BORDERLESS_WINDOWED_MODE;
+            }
+            else
+            {
+                // Remove topmost and undecorated modes and flags
+                glfwSetWindowAttrib(CORE.Window.handle, GLFW_FLOATING, GLFW_FALSE);
+                CORE.Window.flags &= ~FLAG_WINDOW_TOPMOST;
+                glfwSetWindowAttrib(CORE.Window.handle, GLFW_DECORATED, GLFW_TRUE);
+                CORE.Window.flags &= ~FLAG_WINDOW_UNDECORATED;
+
+                // Return previous screen size and position
+                // NOTE: The order matters here, it must set size first, then set position, otherwise the screen will be positioned incorrectly
+                glfwSetWindowSize(CORE.Window.handle,  CORE.Window.previousScreen.width, CORE.Window.previousScreen.height);
+                glfwSetWindowPos(CORE.Window.handle, CORE.Window.previousPosition.x, CORE.Window.previousPosition.y);
+
+                // Refocus window
+                glfwFocusWindow(CORE.Window.handle);
+
+                CORE.Window.flags &= ~FLAG_BORDERLESS_WINDOWED_MODE;
+            }
+        }
+        else TRACELOG(LOG_WARNING, "GLFW: Failed to find video mode for selected monitor");
+    }
+    else TRACELOG(LOG_WARNING, "GLFW: Failed to find selected monitor");
+#endif
+}
+
 // Set window state: maximized, if resizable (only PLATFORM_DESKTOP)
 void MaximizeWindow(void)
 {
@@ -1371,6 +1449,13 @@ void SetWindowState(unsigned int flags)
     {
         glfwSwapInterval(1);
         CORE.Window.flags |= FLAG_VSYNC_HINT;
+    }
+
+    // State change: FLAG_BORDERLESS_WINDOWED_MODE
+    // NOTE: This must be handled before FLAG_FULLSCREEN_MODE because ToggleBorderlessWindowed() needs to get some fullscreen values if fullscreen is running
+    if (((CORE.Window.flags & FLAG_BORDERLESS_WINDOWED_MODE) != (flags & FLAG_BORDERLESS_WINDOWED_MODE)) && ((flags & FLAG_BORDERLESS_WINDOWED_MODE) > 0))
+    {
+        ToggleBorderlessWindowed();     // NOTE: Window state flag updated inside function
     }
 
     // State change: FLAG_FULLSCREEN_MODE
@@ -1481,6 +1566,13 @@ void ClearWindowState(unsigned int flags)
     {
         glfwSwapInterval(0);
         CORE.Window.flags &= ~FLAG_VSYNC_HINT;
+    }
+
+    // State change: FLAG_BORDERLESS_WINDOWED_MODE
+    // NOTE: This must be handled before FLAG_FULLSCREEN_MODE because ToggleBorderlessWindowed() needs to get some fullscreen values if fullscreen is running
+    if (((CORE.Window.flags & FLAG_BORDERLESS_WINDOWED_MODE) > 0) && ((flags & FLAG_BORDERLESS_WINDOWED_MODE) > 0))
+    {
+        ToggleBorderlessWindowed();     // NOTE: Window state flag updated inside function
     }
 
     // State change: FLAG_FULLSCREEN_MODE


### PR DESCRIPTION
Adds the `FLAG_BORDERLESS_WINDOWED_MODE` flag to the `ConfigFlags` enum ([R529](https://github.com/raysan5/raylib/pull/3216/files#diff-008ec254b9e10087d979356eaa799f93f24b3173a6a0c44445c24fee791a1e90R529)).

Adds `CORE.Window.previousPosition` and `CORE.Window.previousScreen` to the `CoreData.Window` struct ([R415-R416](https://github.com/raysan5/raylib/pull/3216/files#diff-39fea0e3daa23741e81daf967717f35c7842426aab26a0bc3f525d6a2f03e339R415-R416)).

Adds `ToggleBorderlessWindowed()` ([R951](https://github.com/raysan5/raylib/pull/3216/files#diff-008ec254b9e10087d979356eaa799f93f24b3173a6a0c44445c24fee791a1e90R951), [R1329-R1403](https://github.com/raysan5/raylib/pull/3216/files#diff-39fea0e3daa23741e81daf967717f35c7842426aab26a0bc3f525d6a2f03e339R1329-R1403)) to handle the `FLAG_BORDERLESS_WINDOWED_MODE` on `PLATFORM_DESKTOP` that will be called from `SetWindowState()` ([R1454-R1459](https://github.com/raysan5/raylib/pull/3216/files#diff-39fea0e3daa23741e81daf967717f35c7842426aab26a0bc3f525d6a2f03e339R1454-R1459)), `ClearWindowState()` ([R1571-R1576](https://github.com/raysan5/raylib/pull/3216/files#diff-39fea0e3daa23741e81daf967717f35c7842426aab26a0bc3f525d6a2f03e339R1571-R1576)) and/or directly ([R951](https://github.com/raysan5/raylib/pull/3216/files#diff-008ec254b9e10087d979356eaa799f93f24b3173a6a0c44445c24fee791a1e90R951)). Didn't implement it inside `SetWindowState()` and `ClearWindowState()` because this flag required some checks and calculations, so I thought it would group better in a separated function.

The `ToggleBorderlessWindowed()` initially checks if it's in fullscreen mode ([R1335](https://github.com/raysan5/raylib/pull/3216/files#diff-39fea0e3daa23741e81daf967717f35c7842426aab26a0bc3f525d6a2f03e339R1335)). If it is:
1. Backups `CORE.Window.position` (that was saved by `ToggleFullscreen()` [L1216](https://github.com/raysan5/raylib/blob/master/src/rcore.c#L1216)) on `CORE.Window.previousPosition` ([R1337](https://github.com/raysan5/raylib/pull/3216/files#diff-39fea0e3daa23741e81daf967717f35c7842426aab26a0bc3f525d6a2f03e339R1337)) before leaving fullscreen mode. Didn't reuse `CORE.Window.position` to not interfere with the `ToggleFullscreen()` independent operation;
2. Leaves fullscreen mode ([R1338](https://github.com/raysan5/raylib/pull/3216/files#diff-39fea0e3daa23741e81daf967717f35c7842426aab26a0bc3f525d6a2f03e339R1338));
3. Sets a `wasOnFullscreen` var that will be required later ([R1334](https://github.com/raysan5/raylib/pull/3216/files#diff-39fea0e3daa23741e81daf967717f35c7842426aab26a0bc3f525d6a2f03e339R1334), [R1339](https://github.com/raysan5/raylib/pull/3216/files#diff-39fea0e3daa23741e81daf967717f35c7842426aab26a0bc3f525d6a2f03e339R1339)).

After that, `ToggleBorderlessWindowed()` checks:

4. For a valid monitor (that will be required for `glfwGetMonitorPos`) ([R1342-R1345](https://github.com/raysan5/raylib/pull/3216/files#diff-39fea0e3daa23741e81daf967717f35c7842426aab26a0bc3f525d6a2f03e339R1342-R1345));
5. For a video mode (that will be required for `glfwGetVideoMode` to get the monitor width and height) ([R1347-R1348](https://github.com/raysan5/raylib/pull/3216/files#diff-39fea0e3daa23741e81daf967717f35c7842426aab26a0bc3f525d6a2f03e339R1347-R1348));
6. For the `FLAG_BORDERLESS_WINDOWED_MODE` value ([R1350](https://github.com/raysan5/raylib/pull/3216/files#diff-39fea0e3daa23741e81daf967717f35c7842426aab26a0bc3f525d6a2f03e339R1350), [R1380](https://github.com/raysan5/raylib/pull/3216/files#diff-39fea0e3daa23741e81daf967717f35c7842426aab26a0bc3f525d6a2f03e339R1380)).

**If the `FLAG_BORDERLESS_WINDOWED_MODE` is not set**:

7. Backups the screen position to `CORE.Window.previousPosition` (if this didn't already happen it it was on fullscreen mode) ([R1354](https://github.com/raysan5/raylib/pull/3216/files#diff-39fea0e3daa23741e81daf967717f35c7842426aab26a0bc3f525d6a2f03e339R1354));
8. Backups the screen size to `CORE.Window.previousScreen` ([R1355](https://github.com/raysan5/raylib/pull/3216/files#diff-39fea0e3daa23741e81daf967717f35c7842426aab26a0bc3f525d6a2f03e339R1355));
9. Sets the `FLAG_WINDOW_UNDECORATED` mode and flag ([R1358-R1359](https://github.com/raysan5/raylib/pull/3216/files#diff-39fea0e3daa23741e81daf967717f35c7842426aab26a0bc3f525d6a2f03e339R1358-R1359));
10. Sets the `FLAG_WINDOW_TOPMOST` mode and flag ([R1360-R1361](https://github.com/raysan5/raylib/pull/3216/files#diff-39fea0e3daa23741e81daf967717f35c7842426aab26a0bc3f525d6a2f03e339R1360-R1361));
11. Gets the monitor position and size ([R1364-R1369](https://github.com/raysan5/raylib/pull/3216/files#diff-39fea0e3daa23741e81daf967717f35c7842426aab26a0bc3f525d6a2f03e339R1364-R1369));
12. Sets the screen position to the monitor position ([R1372](https://github.com/raysan5/raylib/pull/3216/files#diff-39fea0e3daa23741e81daf967717f35c7842426aab26a0bc3f525d6a2f03e339R1372));
13. Sets the screen size to the monitor size ([R1373](https://github.com/raysan5/raylib/pull/3216/files#diff-39fea0e3daa23741e81daf967717f35c7842426aab26a0bc3f525d6a2f03e339R1373));
14. Refocus the window ([R1376](https://github.com/raysan5/raylib/pull/3216/files#diff-39fea0e3daa23741e81daf967717f35c7842426aab26a0bc3f525d6a2f03e339R1376));
15. Sets the `FLAG_BORDERLESS_WINDOWED_MODE` flag on the `CORE.Window.flags` ([R1378](https://github.com/raysan5/raylib/pull/3216/files#diff-39fea0e3daa23741e81daf967717f35c7842426aab26a0bc3f525d6a2f03e339R1378)).

**If the `FLAG_BORDERLESS_WINDOWED_MODE` is set**:

16. Removes the `FLAG_WINDOW_TOPMOST` mode and flag ([R1383-R1384](https://github.com/raysan5/raylib/pull/3216/files#diff-39fea0e3daa23741e81daf967717f35c7842426aab26a0bc3f525d6a2f03e339R1383-R1384));
17. Removes the `FLAG_WINDOW_UNDECORATED` mode and flag ([R1385-R1386](https://github.com/raysan5/raylib/pull/3216/files#diff-39fea0e3daa23741e81daf967717f35c7842426aab26a0bc3f525d6a2f03e339R1385-R1386));
18. Sets the screen size to the `CORE.Window.previousScreen` ([R1390](https://github.com/raysan5/raylib/pull/3216/files#diff-39fea0e3daa23741e81daf967717f35c7842426aab26a0bc3f525d6a2f03e339R1390)). This must be done before setting the screen position, otherwise the screen will be positioned incorrectly;
19. Sets the screen position to the `CORE.Window.previousPosition` ([R1391](https://github.com/raysan5/raylib/pull/3216/files#diff-39fea0e3daa23741e81daf967717f35c7842426aab26a0bc3f525d6a2f03e339R1391));
20. Refocus the window ([R1394](https://github.com/raysan5/raylib/pull/3216/files#diff-39fea0e3daa23741e81daf967717f35c7842426aab26a0bc3f525d6a2f03e339R1394));
21. Removes the `FLAG_BORDERLESS_WINDOWED_MODE` flag from the `CORE.Window.flags` ([R1396](https://github.com/raysan5/raylib/pull/3216/files#diff-39fea0e3daa23741e81daf967717f35c7842426aab26a0bc3f525d6a2f03e339R1396)).

Also adds `FLAG_BORDERLESS_WINDOWED_MODE` to `SetWindowState()` ([R1456-R1459](https://github.com/raysan5/raylib/pull/3216/files#diff-39fea0e3daa23741e81daf967717f35c7842426aab26a0bc3f525d6a2f03e339R1456-R1459)) and `ClearWindowState()` ([R1573-R1576](https://github.com/raysan5/raylib/pull/3216/files#diff-39fea0e3daa23741e81daf967717f35c7842426aab26a0bc3f525d6a2f03e339R1573-R1576)). These must be handled before `FLAG_FULLSCREEN_MODE` because `ToggleBorderlessWindowed()` needs to get some fullscreen values if fullscreen is running.

Since no scaling is being applied and the monitor size (which already has some valid aspect ratio) is being used, this implementation doesn't make any aspect ratio calculations, using the monitor size (and aspect ratio) as is.

### Environment

Tested this change successfully on `PLATFORM_DESKTOP` native Linux (Linux Mint 21.1 x86_64) with two monitors (1600x900 and 1280x1024 resolutions).

### Code Example

Minimal reproduction code to test the change:
```
#include "raylib.h"

int main(void) {
    InitWindow(800, 450, "Test");
    SetTargetFPS(60);
    while (!WindowShouldClose()) {

        if (IsKeyPressed(KEY_F1))  { ToggleBorderlessWindowed(); TraceLog(LOG_INFO, "F1 - ToggleBorderlessWindowed()"); }
        if (IsKeyPressed(KEY_F2))  { SetWindowState(FLAG_BORDERLESS_WINDOWED_MODE); TraceLog(LOG_INFO, "F2 - SetWindowState(FLAG_BORDERLESS_WINDOWED_MODE)"); }
        if (IsKeyPressed(KEY_F3))  { ClearWindowState(FLAG_BORDERLESS_WINDOWED_MODE); TraceLog(LOG_INFO, "F3 - ClearWindowState(FLAG_BORDERLESS_WINDOWED_MODE)"); }
        if (IsKeyPressed(KEY_F11)) { ToggleFullscreen(); TraceLog(LOG_INFO, "F11 - ToggleFullscreen()"); }

        BeginDrawing();
        ClearBackground(RAYWHITE);
        DrawText("Test", 20, 20, 20, BLACK);
        DrawRectangle(20, 60, 40, 40, RED);
        EndDrawing();
    }
    CloseWindow();
    return 0;
}
```

Fixes https://github.com/raysan5/raylib/issues/3207.

**Edit 1:** added line marks.
**Edit 2:** formating.