### PR TITLE
integer to float warnings in rcore

### DIFF
--- a/src/rcore.c
+++ b/src/rcore.c
@@ -1693,8 +1693,8 @@ void SetWindowMonitor(int monitor)
             if ((screenWidth >= monitorWorkareaWidth) || (screenHeight >= monitorWorkareaHeight)) glfwSetWindowPos(CORE.Window.handle, monitorWorkareaX, monitorWorkareaY);
             else
             {
-                const int x = monitorWorkareaX + (monitorWorkareaWidth*0.5f) - (screenWidth*0.5f);
-                const int y = monitorWorkareaY + (monitorWorkareaHeight*0.5f) - (screenHeight*0.5f);
+                const int x = monitorWorkareaX + (monitorWorkareaWidth/2) - (screenWidth/2);
+                const int y = monitorWorkareaY + (monitorWorkareaHeight/2) - (screenHeight/2);
                 glfwSetWindowPos(CORE.Window.handle, x, y);
             }
         }


### PR DESCRIPTION
This PR fixes two float to int casting warnings in rcore. All the arguments are ints, so the divide should be ints too.