### PR TITLE
[AUDIO] Add a function to make an alias of a sound and share it's sample data

### DIFF
--- a/src/raudio.c
+++ b/src/raudio.c
@@ -912,7 +912,6 @@ Sound LoadSoundFromWave(Wave wave)
         sound.stream.sampleSize = 32;
         sound.stream.channels = AUDIO_DEVICE_CHANNELS;
         sound.stream.buffer = audioBuffer;
-        sound.noFree = false;
     }
 
     return sound;
@@ -921,25 +920,24 @@ Sound LoadSoundFromWave(Wave wave)
 // Clone sound from existing sound data, clone does not own wave data
 // Wave data must 
 // NOTE: Wave data must be unallocated manually and will be shared across all clones
-Sound CloneSound(Sound sourceSound)
+Sound LoadSoundAlias(Sound source)
 {
     Sound sound = { 0 };
 
-    if (sourceSound.stream.buffer->data != NULL)
+    if (source.stream.buffer->data != NULL)
     {
-        AudioBuffer* audioBuffer = LoadAudioBuffer(AUDIO_DEVICE_FORMAT, AUDIO_DEVICE_CHANNELS, AUDIO.System.device.sampleRate, sourceSound.frameCount, AUDIO_BUFFER_USAGE_STATIC);
+        AudioBuffer* audioBuffer = LoadAudioBuffer(AUDIO_DEVICE_FORMAT, AUDIO_DEVICE_CHANNELS, AUDIO.System.device.sampleRate, source.frameCount, AUDIO_BUFFER_USAGE_STATIC);
         if (audioBuffer == NULL)
         {
             TRACELOG(LOG_WARNING, "SOUND: Failed to create buffer");
             return sound; // early return to avoid dereferencing the audioBuffer null pointer
         }
-        audioBuffer->data = sourceSound.stream.buffer->data;
-        sound.frameCount = sourceSound.frameCount;
+        audioBuffer->data = source.stream.buffer->data;
+        sound.frameCount = source.frameCount;
         sound.stream.sampleRate = AUDIO.System.device.sampleRate;
         sound.stream.sampleSize = 32;
         sound.stream.channels = AUDIO_DEVICE_CHANNELS;
         sound.stream.buffer = audioBuffer;
-        sound.noFree = true;
     }
 
     return sound;
@@ -965,7 +963,13 @@ void UnloadWave(Wave wave)
 // Unload sound
 void UnloadSound(Sound sound)
 {
-    UnloadAudioBuffer(sound.stream.buffer, !sound.noFree);
+    UnloadAudioBuffer(sound.stream.buffer, true);
+    //TRACELOG(LOG_INFO, "SOUND: Unloaded sound data from RAM");
+}
+
+void UnloadSoundAlias(Sound alias)
+{
+    UnloadAudioBuffer(alias.stream.buffer, false);
     //TRACELOG(LOG_INFO, "SOUND: Unloaded sound data from RAM");
 }
 

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -461,7 +461,6 @@ typedef struct AudioStream {
 typedef struct Sound {
     AudioStream stream;         // Audio stream
     unsigned int frameCount;    // Total number of frames (considering channels)
-    bool noFree;                // The sound data buffer is owned by something else, don't free it
 } Sound;
 
 // Music, audio stream, anything longer than ~10 seconds should be streamed
@@ -1532,11 +1531,12 @@ RLAPI Wave LoadWaveFromMemory(const char *fileType, const unsigned char *fileDat
 RLAPI bool IsWaveReady(Wave wave);                                    // Checks if wave data is ready
 RLAPI Sound LoadSound(const char *fileName);                          // Load sound from file
 RLAPI Sound LoadSoundFromWave(Wave wave);                             // Load sound from wave data
-RLAPI Sound CloneSound(Sound sourceSound);                            // Create a new sound that shares the same sample data as the source sound, does not own the sound data
+RLAPI Sound LoadSoundAlias(Sound source);                            // Create a new sound that shares the same sample data as the source sound, does not own the sound data
 RLAPI bool IsSoundReady(Sound sound);                                 // Checks if a sound is ready
 RLAPI void UpdateSound(Sound sound, const void *data, int sampleCount); // Update sound buffer with new data
 RLAPI void UnloadWave(Wave wave);                                     // Unload wave data
 RLAPI void UnloadSound(Sound sound);                                  // Unload sound
+RLAPI void UnloadSoundAlias(Sound alias);                             // Unload a sound alias (does not deallocate sample data)
 RLAPI bool ExportWave(Wave wave, const char *fileName);               // Export wave data to file, returns true on success
 RLAPI bool ExportWaveAsCode(Wave wave, const char *fileName);         // Export wave sample data to code (.h), returns true on success
 

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -461,6 +461,7 @@ typedef struct AudioStream {
 typedef struct Sound {
     AudioStream stream;         // Audio stream
     unsigned int frameCount;    // Total number of frames (considering channels)
+    bool noFree;                // The sound data buffer is owned by something else, don't free it
 } Sound;
 
 // Music, audio stream, anything longer than ~10 seconds should be streamed
@@ -1531,6 +1532,7 @@ RLAPI Wave LoadWaveFromMemory(const char *fileType, const unsigned char *fileDat
 RLAPI bool IsWaveReady(Wave wave);                                    // Checks if wave data is ready
 RLAPI Sound LoadSound(const char *fileName);                          // Load sound from file
 RLAPI Sound LoadSoundFromWave(Wave wave);                             // Load sound from wave data
+RLAPI Sound CloneSound(Sound sourceSound);                            // Create a new sound that shares the same sample data as the source sound, does not own the sound data
 RLAPI bool IsSoundReady(Sound sound);                                 // Checks if a sound is ready
 RLAPI void UpdateSound(Sound sound, const void *data, int sampleCount); // Update sound buffer with new data
 RLAPI void UnloadWave(Wave wave);                                     // Unload wave data


### PR DESCRIPTION
This PR adds a function that makes an alias from an existing sound. The new sound has a pointer to the sound buffer used by the donor sound and does not own the sample buffer memory.

Since PlaySoundMulti was removed, this feature makes it easy to make shallow copies of sounds that can be played multiple times with out the need to load multiple copies of the sample data. Since each sound is still it's own audio buffer, the sound instances are controllable with the existing sound API.