### PR TITLE
Adds CMake option for SUPPORT_CUSTOM_FRAME_CONTROL

### DIFF
--- a/CMakeOptions.txt
+++ b/CMakeOptions.txt
@@ -46,6 +46,7 @@ cmake_dependent_option(SUPPORT_BUSY_WAIT_LOOP "Use busy wait loop for timing syn
 cmake_dependent_option(SUPPORT_EVENTS_WAITING "Wait for events passively (sleeping while no events) instead of polling them actively every frame" OFF CUSTOMIZE_BUILD OFF)
 cmake_dependent_option(SUPPORT_WINMM_HIGHRES_TIMER "Setting a higher resolution can improve the accuracy of time-out intervals in wait functions" OFF CUSTOMIZE_BUILD OFF)
 cmake_dependent_option(SUPPORT_COMPRESSION_API "Support for compression API" ON CUSTOMIZE_BUILD ON)
+cmake_dependent_option(SUPPORT_CUSTOM_FRAME_CONTROL "Enabling this flag allows manual control of the frame processes, use at your own risk" OFF CUSTOMIZE_BUILD OFF)
 
 # rshapes.c
 cmake_dependent_option(SUPPORT_QUADS_DRAW_MODE "Use QUADS instead of TRIANGLES for drawing when possible. Some lines-based shapes could still use lines" ON CUSTOMIZE_BUILD ON)

--- a/cmake/CompileDefinitions.cmake
+++ b/cmake/CompileDefinitions.cmake
@@ -28,6 +28,7 @@ if (${CUSTOMIZE_BUILD})
     define_if("raylib" SUPPORT_EVENTS_WAITING)
     define_if("raylib" SUPPORT_WINMM_HIGHRES_TIMER)
     define_if("raylib" SUPPORT_COMPRESSION_API)
+    define_if("raylib" SUPPORT_CUSTOM_FRAME_CONTROL)
     define_if("raylib" SUPPORT_QUADS_DRAW_MODE)
     define_if("raylib" SUPPORT_IMAGE_EXPORT)
     define_if("raylib" SUPPORT_IMAGE_GENERATION)
@@ -69,17 +70,17 @@ if (${CUSTOMIZE_BUILD})
     else ()
         target_compile_definitions("raylib" PUBLIC "MAX_FILEPATH_LENGTH=512")
     endif ()
-    
+
     target_compile_definitions("raylib" PUBLIC "MAX_GAMEPADS=4")
     target_compile_definitions("raylib" PUBLIC "MAX_GAMEPAD_AXIS=8")
     target_compile_definitions("raylib" PUBLIC "MAX_GAMEPAD_BUTTONS=32")
     target_compile_definitions("raylib" PUBLIC "MAX_TOUCH_POINTS=10")
     target_compile_definitions("raylib" PUBLIC "MAX_KEY_PRESSED_QUEUE=16")
-    
+
     target_compile_definitions("raylib" PUBLIC "STORAGE_DATA_FILE=\"storage.data\"")
     target_compile_definitions("raylib" PUBLIC "MAX_CHAR_PRESSED_QUEUE=16")
     target_compile_definitions("raylib" PUBLIC "MAX_DECOMPRESSION_SIZE=64")
-    
+
     if (${GRAPHICS} MATCHES "GRAPHICS_API_OPENGL_33" OR ${GRAPHICS} MATCHES "GRAPHICS_API_OPENGL_11")
         target_compile_definitions("raylib" PUBLIC "DEFAULT_BATCH_BUFFER_ELEMENTS=8192")
     elseif (${GRAPHICS} MATCHES "GRAPHICS_API_OPENGL_ES2")


### PR DESCRIPTION
Adds `SUPPORT_CUSTOM_FRAME_CONTROL` CMake option to `CMakeOptions.txt` and `cmake/CompileDefinitions.cmake`.

@jestarray @raysan5 I tested it and I think this is correct, but I don't use CMake much, could you please check if I didn't miss anything?

Minimal reproduction code to test the change:
```
cd raylib/
mkdir build
cd build
cmake -DCUSTOMIZE_BUILD:BOOL=ON -DSUPPORT_CUSTOM_FRAME_CONTROL:BOOL=ON ..
cmake --build .
./examples/core_custom_frame_control
```

Fixes https://github.com/raysan5/raylib/issues/3201.
