### PR TITLE
[CORE] Support for SetWindowTitle and InitWindow for web

### DIFF
--- a/src/raylib.h
+++ b/src/raylib.h
@@ -954,7 +954,7 @@ RLAPI void MinimizeWindow(void);                                  // Set window 
 RLAPI void RestoreWindow(void);                                   // Set window state: not minimized/maximized (only PLATFORM_DESKTOP)
 RLAPI void SetWindowIcon(Image image);                            // Set icon for window (single image, RGBA 32bit, only PLATFORM_DESKTOP)
 RLAPI void SetWindowIcons(Image *images, int count);              // Set icon for window (multiple images, RGBA 32bit, only PLATFORM_DESKTOP)
-RLAPI void SetWindowTitle(const char *title);                     // Set title for window (only PLATFORM_DESKTOP)
+RLAPI void SetWindowTitle(const char *title);                     // Set title for window (only PLATFORM_DESKTOP and PLATFORM_WEB)
 RLAPI void SetWindowPosition(int x, int y);                       // Set window position on screen (only PLATFORM_DESKTOP)
 RLAPI void SetWindowMonitor(int monitor);                         // Set monitor for the current window
 RLAPI void SetWindowMinSize(int width, int height);               // Set window minimum dimensions (for FLAG_WINDOW_RESIZABLE)

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -4436,6 +4436,11 @@ static bool InitGraphicsDevice(int width, int height)
         return false;
     }
 
+// glfwCreateWindow title doesn't work with emscripten.
+#if defined(PLATFORM_WEB)
+    emscripten_set_window_title((CORE.Window.title != 0)? CORE.Window.title : " ");
+#endif
+    
     // Set window callback events
     glfwSetWindowSizeCallback(CORE.Window.handle, WindowSizeCallback);      // NOTE: Resizing not allowed by default!
 #if !defined(PLATFORM_WEB)

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -1736,12 +1736,15 @@ void SetWindowIcons(Image *images, int count)
 #endif
 }
 
-// Set title for window (only PLATFORM_DESKTOP)
+// Set title for window (only PLATFORM_DESKTOP and PLATFORM_WEB)
 void SetWindowTitle(const char *title)
 {
     CORE.Window.title = title;
 #if defined(PLATFORM_DESKTOP)
     glfwSetWindowTitle(CORE.Window.handle, title);
+#endif
+#if defined(PLATFORM_WEB)
+    emscripten_set_window_title(title);
 #endif
 }
 


### PR DESCRIPTION
### Changes:
`SetWindowTitle` and `InitWindow` will now change the current tab name of the browser, if compiled for the web platform.
They use the emscripten function `emscripten_set_window_title`.

### Why:
As stated in the header file, the `SetWindowTitle` function works only for desktop.
But this feature can be useful also on the web, for example by setting the tab title to the one of your game/app to make it more recognizable without having to change the title manually in the HTML file or interacting directly with emscripten.

### Status:
Tested on Windows 11 with the latest version of emscripten on chrome with raylib's basic window example with no errors nor code changes.
