### PR TITLE
Tweak build.zig to work with cross-compiling

### DIFF
--- a/src/build.zig
+++ b/src/build.zig
@@ -59,6 +59,7 @@ pub fn addRaylib(b: *std.Build, target: std.zig.CrossTarget, optimize: std.built
                 raylib.linkSystemLibrary("dl");
                 raylib.linkSystemLibrary("m");
                 raylib.linkSystemLibrary("X11");
+                raylib.addLibraryPath(.{ .path = "/usr/lib" });
                 raylib.addIncludePath(.{ .path = "/usr/include" });
 
                 raylib.defineCMacro("PLATFORM_DESKTOP", null);


### PR DESCRIPTION
I made a similar change a while ago (#3090), but the same failure mode has reappeared for me when cross-compiling. I suspect the recent Zig updates have changed requirements. In particular, I see:
```
zig build-lib raylib Debug x86_64-linux-musl: error: error: unable to find Dynamic system library 'GL' using strategy 'paths_first'. searched paths: none
error: unable to find Dynamic system library 'X11' using strategy 'paths_first'. searched paths: none
```

This patch fixes it for me. I suspect similar changes are necessary for the other targets, but I only added this one because I haven't tested building from other targets.