### PR TITLE
fix: gif recordering doesn't work if num/caps lock is active.

### DIFF
--- a/src/rcore.c
+++ b/src/rcore.c
@@ -5609,7 +5609,7 @@ static void KeyCallback(GLFWwindow *window, int key, int scancode, int action, i
     if ((key == GLFW_KEY_F12) && (action == GLFW_PRESS))
     {
 #if defined(SUPPORT_GIF_RECORDING)
-        if (mods == GLFW_MOD_CONTROL)
+        if (mods & GLFW_MOD_CONTROL)
         {
             if (gifRecording)
             {


### PR DESCRIPTION
- current behavior is to check if only the ctrl modifier is active, the result is that gif recording will not work if num or caps lock are active, which seems like a bug to me.
- note: this fix allows other modifiers to be set at the same time (ctrl+shift+f12 will also trigger gif recording).
I don't consider this as a problem, but if you want I can explicitly remove the caps/num lock bits and _after_ that check if `mods` is _equal_ to `GLFW_MOD_CONTROL`