### PR TITLE
Ignore unused function warnings from external headers when compiling with GCC and Clang

### DIFF
--- a/src/rtext.c
+++ b/src/rtext.c
@@ -71,12 +71,21 @@
 #include <ctype.h>          // Required for: toupper(), tolower() [Used in TextToUpper(), TextToLower()]
 
 #if defined(SUPPORT_FILEFORMAT_TTF)
+    #if defined(__GNUC__) // GCC and Clang
+        #pragma GCC diagnostic push
+        #pragma GCC diagnostic ignored "-Wunused-function"
+    #endif
+
     #define STB_RECT_PACK_IMPLEMENTATION
     #include "external/stb_rect_pack.h"     // Required for: ttf font rectangles packaging
 
     #define STBTT_STATIC
     #define STB_TRUETYPE_IMPLEMENTATION
     #include "external/stb_truetype.h"      // Required for: ttf font data reading
+
+    #if defined(__GNUC__) // GCC and Clang
+        #pragma GCC diagnostic pop
+    #endif
 #endif
 
 //----------------------------------------------------------------------------------

--- a/src/rtextures.c
+++ b/src/rtextures.c
@@ -138,6 +138,11 @@
      defined(SUPPORT_FILEFORMAT_PIC) || \
      defined(SUPPORT_FILEFORMAT_PNM))
 
+    #if defined(__GNUC__) // GCC and Clang
+        #pragma GCC diagnostic push
+        #pragma GCC diagnostic ignored "-Wunused-function"
+    #endif
+
     #define STBI_MALLOC RL_MALLOC
     #define STBI_FREE RL_FREE
     #define STBI_REALLOC RL_REALLOC
@@ -145,6 +150,10 @@
     #define STB_IMAGE_IMPLEMENTATION
     #include "external/stb_image.h"         // Required for: stbi_load_from_file()
                                             // NOTE: Used to read image data (multiple formats support)
+
+    #if defined(__GNUC__) // GCC and Clang
+        #pragma GCC diagnostic pop
+    #endif
 #endif
 
 #if (defined(SUPPORT_FILEFORMAT_DDS) || \
@@ -153,9 +162,18 @@
      defined(SUPPORT_FILEFORMAT_PVR) || \
      defined(SUPPORT_FILEFORMAT_ASTC))
 
+    #if defined(__GNUC__) // GCC and Clang
+        #pragma GCC diagnostic push
+        #pragma GCC diagnostic ignored "-Wunused-function"
+    #endif
+
     #define RL_GPUTEX_IMPLEMENTATION
     #include "external/rl_gputex.h"         // Required for: rl_load_xxx_from_memory()
                                             // NOTE: Used to read compressed textures data (multiple formats support)
+
+    #if defined(__GNUC__) // GCC and Clang
+        #pragma GCC diagnostic pop
+    #endif
 #endif
 
 #if defined(SUPPORT_FILEFORMAT_QOI)


### PR DESCRIPTION
Removes existing unused function warnings generated when compiling functions declared with `static` linkage in external headers. This changeset suppresses warnings with a set of pragmas around external header includes using the pattern:

```c
#if defined(__GNUC__) // GCC and Clang
    #pragma GCC diagnostic push
    #pragma GCC diagnostic ignored "-Wunused-function"
#endif

// include the libraries here

#if defined(__GNUC__) // GCC and Clang
    #pragma GCC diagnostic pop
#endif
```

This significantly reduces the warning noise when compiling on Linux, and has been tested with `CC=gcc` and `CC=clang`. I do not have a machine with MSVC set up, so I cannot test or confirm the behavior on Windows, but the `#if defined(__GNUC__)` guard *should* only have an effect with GCC and Clang and not produce any "unknown pragma GCC" warnings on Windows.

Putting the `#pragma GCC diagnostic push` and `#pragma GCC diagnostic pop` code around every external include is a little ugly, but is the simplest way to suppress these warnings for a specific set of includes as far as I can tell.