### PR TITLE
fix typos in rmodels, rshapes, rtext modules

### DIFF
--- a/src/rmodels.c
+++ b/src/rmodels.c
@@ -2457,7 +2457,7 @@ Mesh GenMeshCube(float width, float height, float length)
 // Platonic solids:
 par_shapes_mesh* par_shapes_create_tetrahedron();       // 4 sides polyhedron (pyramid)
 par_shapes_mesh* par_shapes_create_cube();              // 6 sides polyhedron (cube)
-par_shapes_mesh* par_shapes_create_octahedron();        // 8 sides polyhedron (dyamond)
+par_shapes_mesh* par_shapes_create_octahedron();        // 8 sides polyhedron (diamond)
 par_shapes_mesh* par_shapes_create_dodecahedron();      // 12 sides polyhedron
 par_shapes_mesh* par_shapes_create_icosahedron();       // 20 sides polyhedron
 */
@@ -4244,7 +4244,7 @@ static Model LoadIQM(const char *fileName)
         model.meshes[i].triangleCount = imesh[i].num_triangles;
         model.meshes[i].indices = RL_CALLOC(model.meshes[i].triangleCount*3, sizeof(unsigned short));
 
-        // Animated verted data, what we actually process for rendering
+        // Animated vertex data, what we actually process for rendering
         // NOTE: Animated vertex should be re-uploaded to GPU (if not using GPU skinning)
         model.meshes[i].animVertices = RL_CALLOC(model.meshes[i].vertexCount*3, sizeof(float));
         model.meshes[i].animNormals = RL_CALLOC(model.meshes[i].vertexCount*3, sizeof(float));
@@ -4787,7 +4787,7 @@ static Model LoadGLTF(const char *fileName)
 
         RESTRICTIONS:
           - Only triangle meshes supported
-          - Vertex attibute types and formats supported:
+          - Vertex attribute types and formats supported:
               > Vertices (position): vec3: float
               > Normals: vec3: float
               > Texcoords: vec2: float
@@ -5286,7 +5286,7 @@ static bool GetPoseAtTimeGLTF(cgltf_accessor *input, cgltf_accessor *output, flo
         Vector4 v2 = {tmp[0], tmp[1], tmp[2], tmp[3]};
         Vector4 *r = data;
 
-        // Only v4 is for rotations, so we know it's a quat
+        // Only v4 is for rotations, so we know it's a quaternion
         *r = QuaternionSlerp(v1, v2, t);
     }
 

--- a/src/rshapes.c
+++ b/src/rshapes.c
@@ -99,7 +99,7 @@ void SetShapesTexture(Texture2D texture, Rectangle source)
 {
     // Reset texture to default pixel if required
     // WARNING: Shapes texture should be probably better validated,
-    // it can break the rendering of all shapes if missused
+    // it can break the rendering of all shapes if misused
     if ((texture.id == 0) || (source.width == 0) || (source.height == 0))
     {
         texShapes = (Texture2D){ 1, 1, 1, 1, 7 };

--- a/src/rtext.c
+++ b/src/rtext.c
@@ -1688,7 +1688,7 @@ const char *TextToPascal(const char *text)
 // WARNING: Allocated memory must be manually freed
 char *LoadUTF8(const int *codepoints, int length)
 {
-    // We allocate enough memory fo fit all possible codepoints
+    // We allocate enough memory to fit all possible codepoints
     // NOTE: 5 bytes for every codepoint should be enough
     char *text = (char *)RL_CALLOC(length*5, 1);
     const char *utf8 = NULL;


### PR DESCRIPTION
Found around 6 comment typos in rmodels, rshapes, and rtext modules.
I accidentally undid these changes (and more I believe) at one point so there may be something I missed. If thats the case then let me know.

rmodels:

-  'dyamond' > diamond
- 'verted' > vertex
- 'attibute' > attribute
- (_not a typo but im lengthening it just in case, so it doesnt get confused with quad_) 'quat' > quaternion

rshapes:

 - 'missused' > misused

rtext:

 - 'fo' > to