### PR TITLE
Alternative fix for unused functions warnings on stb_truetype.h (and …

### DIFF
--- a/src/external/stb_image.h
+++ b/src/external/stb_image.h
@@ -7758,6 +7758,14 @@ STBIDEF int stbi_is_16_bit_from_callbacks(stbi_io_callbacks const *c, void *user
    return stbi__is_16_main(&s);
 }
 
+// Workaround to hide the following unused functions warnings while compiling raylib
+void unused_stb_image(void)
+{
+    (void)&stbi__addints_valid;
+    (void)&stbi__mul2shorts_valid;
+    return;
+}
+
 #endif // STB_IMAGE_IMPLEMENTATION
 
 /*

--- a/src/external/stb_truetype.h
+++ b/src/external/stb_truetype.h
@@ -4964,6 +4964,41 @@ STBTT_DEF int stbtt_CompareUTF8toUTF16_bigendian(const char *s1, int len1, const
    return stbtt_CompareUTF8toUTF16_bigendian_internal((char *) s1, len1, (char *) s2, len2);
 }
 
+// Workaround to hide the following unused functions warnings while compiling raylib
+void unused_stb_truetype(void)
+{
+    (void)&stbtt_CompareUTF8toUTF16_bigendian;
+    (void)&stbtt_FindMatchingFont;
+    (void)&stbtt_GetNumberOfFonts;
+    (void)&stbtt_BakeFontBitmap;
+    (void)&stbtt_GetFontNameString;
+    (void)&stbtt_FreeSDF;
+    (void)&stbtt_GetPackedQuad;
+    (void)&stbtt_GetScaledFontVMetrics;
+    (void)&stbtt_PackFontRange;
+    (void)&stbtt_PackSetSkipMissingCodepoints;
+    (void)&stbtt_PackSetOversampling;
+    (void)&stbtt_PackEnd;
+    (void)&stbtt_PackBegin;
+    (void)&stbtt_GetBakedQuad;
+    (void)&stbtt_MakeCodepointBitmap;
+    (void)&stbtt_MakeCodepointBitmapSubpixelPrefilter;
+    (void)&stbtt_GetGlyphBitmap;
+    (void)&stbtt_FreeBitmap;
+    (void)&stbtt_GetCodepointBitmapBox;
+    (void)&stbtt_GetCodepointSVG;
+    (void)&stbtt_FreeShape;
+    (void)&stbtt_GetFontBoundingBox;
+    (void)&stbtt_GetFontVMetricsOS2;
+    (void)&stbtt_GetCodepointKernAdvance;
+    (void)&stbtt_GetKerningTable;
+    (void)&stbtt_GetKerningTableLength;
+    (void)&stbtt_IsGlyphEmpty;
+    (void)&stbtt_GetCodepointBox;
+    (void)&stbtt_GetCodepointShape;
+    return;
+}
+
 #if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic pop
 #endif

--- a/src/rtext.c
+++ b/src/rtext.c
@@ -71,21 +71,12 @@
 #include <ctype.h>          // Required for: toupper(), tolower() [Used in TextToUpper(), TextToLower()]
 
 #if defined(SUPPORT_FILEFORMAT_TTF)
-    #if defined(__GNUC__) // GCC and Clang
-        #pragma GCC diagnostic push
-        #pragma GCC diagnostic ignored "-Wunused-function"
-    #endif
-
     #define STB_RECT_PACK_IMPLEMENTATION
     #include "external/stb_rect_pack.h"     // Required for: ttf font rectangles packaging
 
     #define STBTT_STATIC
     #define STB_TRUETYPE_IMPLEMENTATION
     #include "external/stb_truetype.h"      // Required for: ttf font data reading
-
-    #if defined(__GNUC__) // GCC and Clang
-        #pragma GCC diagnostic pop
-    #endif
 #endif
 
 //----------------------------------------------------------------------------------
@@ -852,7 +843,7 @@ Image GenImageFontAtlas(const GlyphInfo *chars, Rectangle **charRecs, int glyphC
         RL_FREE(nodes);
         RL_FREE(context);
     }
-    
+
 #if defined(SUPPORT_FONT_ATLAS_WHITE_REC)
     // Add a 3x3 white rectangle at the bottom-right corner of the generated atlas,
     // useful to use as the white texture to draw shapes with raylib, using this rectangle
@@ -865,7 +856,7 @@ Image GenImageFontAtlas(const GlyphInfo *chars, Rectangle **charRecs, int glyphC
         k -= atlas.width;
     }
 #endif
-    
+
     // Convert image data from GRAYSCALE to GRAY_ALPHA
     unsigned char *dataGrayAlpha = (unsigned char *)RL_MALLOC(atlas.width*atlas.height*sizeof(unsigned char)*2); // Two channels
 

--- a/src/rtextures.c
+++ b/src/rtextures.c
@@ -138,11 +138,6 @@
      defined(SUPPORT_FILEFORMAT_PIC) || \
      defined(SUPPORT_FILEFORMAT_PNM))
 
-    #if defined(__GNUC__) // GCC and Clang
-        #pragma GCC diagnostic push
-        #pragma GCC diagnostic ignored "-Wunused-function"
-    #endif
-
     #define STBI_MALLOC RL_MALLOC
     #define STBI_FREE RL_FREE
     #define STBI_REALLOC RL_REALLOC
@@ -150,10 +145,6 @@
     #define STB_IMAGE_IMPLEMENTATION
     #include "external/stb_image.h"         // Required for: stbi_load_from_file()
                                             // NOTE: Used to read image data (multiple formats support)
-
-    #if defined(__GNUC__) // GCC and Clang
-        #pragma GCC diagnostic pop
-    #endif
 #endif
 
 #if (defined(SUPPORT_FILEFORMAT_DDS) || \
@@ -162,18 +153,9 @@
      defined(SUPPORT_FILEFORMAT_PVR) || \
      defined(SUPPORT_FILEFORMAT_ASTC))
 
-    #if defined(__GNUC__) // GCC and Clang
-        #pragma GCC diagnostic push
-        #pragma GCC diagnostic ignored "-Wunused-function"
-    #endif
-
     #define RL_GPUTEX_IMPLEMENTATION
     #include "external/rl_gputex.h"         // Required for: rl_load_xxx_from_memory()
                                             // NOTE: Used to read compressed textures data (multiple formats support)
-
-    #if defined(__GNUC__) // GCC and Clang
-        #pragma GCC diagnostic pop
-    #endif
 #endif
 
 #if defined(SUPPORT_FILEFORMAT_QOI)
@@ -184,7 +166,7 @@
         #pragma warning(push)
         #pragma warning(disable : 4267)
     #endif
-    
+
     #define QOI_IMPLEMENTATION
     #include "external/qoi.h"
 
@@ -3300,13 +3282,13 @@ void ImageDrawRectangleRec(Image *dst, Rectangle rec, Color color)
     {
         memcpy(pSrcPixel + x*bytesPerPixel, pSrcPixel, bytesPerPixel);
     }
-	
-	// Repeat the first row data for all other rows
-	int bytesPerRow = bytesPerPixel * (int)rec.width;
-	for (int y = 1; y < (int)rec.height; y++)
-	{
-		memcpy(pSrcPixel + (y*dst->width)*bytesPerPixel, pSrcPixel, bytesPerRow);
-	}
+
+    // Repeat the first row data for all other rows
+    int bytesPerRow = bytesPerPixel * (int)rec.width;
+    for (int y = 1; y < (int)rec.height; y++)
+    {
+        memcpy(pSrcPixel + (y*dst->width)*bytesPerPixel, pSrcPixel, bytesPerRow);
+    }
 }
 
 // Draw rectangle lines within an image


### PR DESCRIPTION
…stb_image.h)

As mentioned on https://github.com/raysan5/raylib/pull/3235, submiting this for consideration since it could be an alternative way to workaround the unused functions warnings on `stb_truetype.h` (and `stb_image.h`).

Adds a `void unused_stb_truetype(void)` at the end of `stb_truetype.h` ([R4967-R5000](https://github.com/raysan5/raylib/pull/3237/files#diff-ec465671789b4f2d7a1b14f0e6cc1c8f610d842aedee5bef71e4f15221f28643R4967-R5000)) and `void unused_stb_image(void)` at the end of `stb_image.h` ([R7761-R7767](https://github.com/raysan5/raylib/pull/3237/files#diff-e2531e5b48996cf16eea235efeec566eea51274e4787a21b9532aee77bb67342R7761-R7767)) with the list of unused functions.

**Downsides:**
- Has to be readded when `stb_truetype.h` and `stb_image` are updated;
- Has to be manually populated;
- Can be a bit verbose if there are too many unused functions (like this case on `stb_truetype.h`).

**Upsides:**
- Fairly benign (shouldn't interfere or affect in any way the libraries operation, nor return anything if ever called);
- Fairly simple and contained (just a single function with the list of unused functions in the end of the file it directly relates to);
- Platform agnostic;
- Doesn't affect the building system;
- Maintains the warnings active, which, IMHO, are helpful.

Since it's an alternative method, this PR also reverts https://github.com/raysan5/raylib/pull/3235 (`rtext.c` [L74-L77](https://github.com/raysan5/raylib/pull/3237/files#diff-6f1fe84ccc0076f84a73e0d81ebdb1804c2fd972bb78084ced6336db2f8b8363L74-L77), [L86-L88](https://github.com/raysan5/raylib/pull/3237/files#diff-6f1fe84ccc0076f84a73e0d81ebdb1804c2fd972bb78084ced6336db2f8b8363L86-L88)) (`rtexture.c` [L141-L144](https://github.com/raysan5/raylib/pull/3237/files#diff-dd413e2d4cd85989a953b899ac2460398a88402b5717efc95fb11e592b83a767L141-L144), [L154-L156](https://github.com/raysan5/raylib/pull/3237/files#diff-dd413e2d4cd85989a953b899ac2460398a88402b5717efc95fb11e592b83a767L154-L156), [L165-L168](https://github.com/raysan5/raylib/pull/3237/files#diff-dd413e2d4cd85989a953b899ac2460398a88402b5717efc95fb11e592b83a767L165-L168), [L174-L176](https://github.com/raysan5/raylib/pull/3237/files#diff-dd413e2d4cd85989a953b899ac2460398a88402b5717efc95fb11e592b83a767L174-L176)).

Tested successfully on `PLATFORM_DESKTOP` on Linux (Linux Mint 21.1 x86_64) and `PLATFORM_WEB`.

I think @ashn-dot-dev solution is pretty good. Just submiting this because it looked like an option worth testing.

**Edit:** added line marks.