### PR TITLE
Ignore unused return value of GetCodepointNext in GetCodepointCount

### DIFF
--- a/src/rtext.c
+++ b/src/rtext.c
@@ -1766,7 +1766,7 @@ int GetCodepointCount(const char *text)
     while (*ptr != '\0')
     {
         int next = 0;
-        int letter = GetCodepointNext(ptr, &next);
+        (void)GetCodepointNext(ptr, &next);
 
         ptr += next;
 

--- a/src/rtext.c
+++ b/src/rtext.c
@@ -1766,7 +1766,7 @@ int GetCodepointCount(const char *text)
     while (*ptr != '\0')
     {
         int next = 0;
-        (void)GetCodepointNext(ptr, &next);
+        GetCodepointNext(ptr, &next);
 
         ptr += next;
 


### PR DESCRIPTION
Removes the last warning from non-external libraries when compiling with the default build configuration on x64 Linux.