### PR TITLE
Fix examples/others/rlgl_standalone.c compilation issue

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -261,6 +261,11 @@ ifeq ($(PLATFORM),PLATFORM_DRM)
     INCLUDE_PATHS += -I/usr/include/libdrm
 endif
 
+# Include GLFW required for examples/others/rlgl_standalone.c
+ifeq ($(USE_EXTERNAL_GLFW),FALSE)
+all others: INCLUDE_PATHS += -I$(RAYLIB_PATH)/src/external/glfw/include
+endif
+
 # Define library paths containing required libs: LDFLAGS
 #------------------------------------------------------------------------------------------------
 LDFLAGS = -L. -L$(RAYLIB_RELEASE_PATH) -L$(RAYLIB_PATH)/src


### PR DESCRIPTION
After seeing the lastest revision on the wiki's [Working-on-GNU-Linux](https://github.com/raysan5/raylib/wiki/Working-on-GNU-Linux), tried compiling all examples and indeed encountered an error:

```
~$ cd test/
~/test$ ls
raylib-master.zip
~/test$ unzip raylib-master.zip
[...]
~/test$ cd raylib-master/src/
~/test/raylib-master/src$ make PLATFORM=PLATFORM_DESKTOP
[...]
ar rcs ../src/libraylib.a rcore.o rshapes.o rtextures.o rtext.o utils.o rglfw.o rmodels.o raudio.o
raylib static library generated (libraylib.a) in ../src!
~/test/raylib-master/src$ cd ../examples/
~/test/raylib-master/examples$ make PLATFORM=PLATFORM_DESKTOP
[...]
others/rlgl_standalone.c:70:10: fatal error: GLFW/glfw3.h: No such file or directory
   70 | #include "GLFW/glfw3.h"         // Windows/Context and inputs management
      |          ^~~~~~~~~~~~~~
compilation terminated.
make: *** [Makefile:571: others/rlgl_standalone] Error 1
```

This error can be addressed by adding `-I$(RAYLIB_PATH)/src/external/glfw/include` to the `INCLUDE_PATHS` of the `all` and `others` recipes if `USE_EXTERNAL_GLFW` is set to `FALSE` on the examples `Makefile` ([R265-R267](https://github.com/raysan5/raylib/pull/3242/files#diff-ae8bb09b4bbb919309d4c8bb8ffc46e031bf63b7274502171a183a4dc1138f53R265-R267)).

IMHO this would be preferable than requiring the users to get `libglfw3` and `libglfw3-dev` since raylib already packs its version of GLFW and users can still set `USE_EXTERNAL_GLFW` to `TRUE` if required.

Tested these proposed changes successfully on `PLATFORM_DESKTOP` on Linux (Linux Mint 21.1 x86_64).

**Edit:** added line marks.
