### PR TITLE
Add `IsKeyPressedRepeat` (desktop only)

### DIFF
--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1115,6 +1115,7 @@ RLAPI unsigned char *DecodeDataBase64(const unsigned char *data, int *outputSize
 
 // Input-related functions: keyboard
 RLAPI bool IsKeyPressed(int key);                             // Check if a key has been pressed once
+RLAPI bool IsKeyPressedRepeat(int key);                       // Check if a key has been pressed again (Only PLATFORM_DESKTOP)
 RLAPI bool IsKeyDown(int key);                                // Check if a key is being pressed
 RLAPI bool IsKeyReleased(int key);                            // Check if a key has been released once
 RLAPI bool IsKeyUp(int key);                                  // Check if a key is NOT being pressed


### PR DESCRIPTION
Hi Ray!

Currently `IsKeyPressed` ignores key repeats. This PR keeps the current behavior the same while adding the additional `IsKeyPressedRepeat`.
Another approach could be changing the existing `IsKeyPressed` functionality to take into account key repeats as well, and add `IsKeyPressedExt`, expecting an extra `bool repeat` flag for taking into account key repeats or not.

Personally I would be in favor of the second approach (changing existing behavior), but it's up for discussion.