### PR TITLE
Fix text_unicode.c example crashing

### DIFF
--- a/examples/text/text_unicode.c
+++ b/examples/text/text_unicode.c
@@ -192,7 +192,14 @@ int main(void)
         {
             selected = hovered;
             selectedPos = hoveredPos;
-            SetClipboardText(messages[emoji[selected].message].text);
+            #if defined(PLATFORM_WEB)
+                // Line Feed (LF) (New Line) must be escaped for SetClipboardText() for web
+                char *escapedString = TextReplace(messages[emoji[selected].message].text, "\x0A", "\\n");
+                SetClipboardText(escapedString);
+                MemFree(escapedString);
+            #else
+                SetClipboardText(messages[emoji[selected].message].text);
+            #endif
         }
 
         Vector2 mouse = GetMousePosition();
@@ -267,7 +274,7 @@ int main(void)
                     a = b;
                     b = tmp;
                 }
-                
+
                 if (msgRect.x + msgRect.width > screenWidth) msgRect.x -= (msgRect.x + msgRect.width) - screenWidth + 10;
 
                 // Draw chat bubble
@@ -287,11 +294,11 @@ int main(void)
                 DrawText(info, (int)pos.x, (int)pos.y, 10, RAYWHITE);
             }
             //------------------------------------------------------------------------------
-            
+
             // Draw the info text
             DrawText("These emojis have something to tell you, click each to find out!", (screenWidth - 650)/2, screenHeight - 40, 20, GRAY);
             DrawText("Each emoji is a unicode character from a font, not a texture... Press [SPACEBAR] to refresh", (screenWidth - 484)/2, screenHeight - 16, 10, GRAY);
-            
+
         EndDrawing();
         //----------------------------------------------------------------------------------
     }
@@ -342,7 +349,7 @@ static void DrawTextBoxedSelectable(Font font, const char *text, Rectangle rec, 
 {
     int length = TextLength(text);  // Total length in bytes of the text, scanned by codepoints in loop
 
-    float textOffsetY = 0;          // Offset between lines (on line break '\n')
+    float textOffsetY = 0.0f;       // Offset between lines (on line break '\n')
     float textOffsetX = 0.0f;       // Offset X to next character to draw
 
     float scaleFactor = fontSize/(float)font.baseSize;     // Character rectangle scaling factor

--- a/examples/text/text_unicode.c
+++ b/examples/text/text_unicode.c
@@ -187,19 +187,11 @@ int main(void)
         // Add a new set of emojis when SPACE is pressed
         if (IsKeyPressed(KEY_SPACE)) RandomizeEmoji();
 
-        // Set the selected emoji and copy its text to clipboard
+        // Set the selected emoji
         if (IsMouseButtonPressed(MOUSE_BUTTON_LEFT) && (hovered != -1) && (hovered != selected))
         {
             selected = hovered;
             selectedPos = hoveredPos;
-            #if defined(PLATFORM_WEB)
-                // Line Feed (LF) (New Line) must be escaped for SetClipboardText() for web
-                char *escapedString = TextReplace(messages[emoji[selected].message].text, "\x0A", "\\n");
-                SetClipboardText(escapedString);
-                MemFree(escapedString);
-            #else
-                SetClipboardText(messages[emoji[selected].message].text);
-            #endif
         }
 
         Vector2 mouse = GetMousePosition();


### PR DESCRIPTION
The issue causing the `examples/text/text_unicode.c` to crash on `PLATFORM_WEB` was the `Line Feed (LF)` char `\x0A` on some entries of `messages[]` ([L71](https://github.com/raysan5/raylib/blob/master/examples/text/text_unicode.c#L71), [L77](https://github.com/raysan5/raylib/blob/master/examples/text/text_unicode.c#L77), [L78](https://github.com/raysan5/raylib/blob/master/examples/text/text_unicode.c#L78), [L79](https://github.com/raysan5/raylib/blob/master/examples/text/text_unicode.c#L79), [L80](https://github.com/raysan5/raylib/blob/master/examples/text/text_unicode.c#L80), [L81](https://github.com/raysan5/raylib/blob/master/examples/text/text_unicode.c#L81), [L119](https://github.com/raysan5/raylib/blob/master/examples/text/text_unicode.c#L119), [L120](https://github.com/raysan5/raylib/blob/master/examples/text/text_unicode.c#L120)) not being escaped when being passed to `SetClipboardText()` ([L195](https://github.com/raysan5/raylib/blob/master/examples/text/text_unicode.c#L195)). All chars on those messages resolve to a singular unicode char, however, the `Line Feed (LF)` resolves to `\n` (with the `\` plus `n`) which causes the unescaped error on web.

This can be solved by escaping the `\x0A` to `\\n` before passing it to `SetClipboardText()` if on `PLATFORM_WEB` ([R195-R202](https://github.com/raysan5/raylib/pull/3250/files#diff-e7b395c4916ca70c8cca98a16064c1b5fd19c53d6dea7c0d3cceee604f8f53a7R195-R202)).

@raysan5 Could you please check if that `MemFree()` call is correct? I saw the warning on the header about `TextReplace()` ([L1417](https://github.com/raysan5/raylib/blob/master/src/raylib.h#L1417)) but I'm not sure if I did that right.

Also (unrelated) small fix to `float textOffsetY` ([R352](https://github.com/raysan5/raylib/pull/3250/files#diff-e7b395c4916ca70c8cca98a16064c1b5fd19c53d6dea7c0d3cceee604f8f53a7R352)).

Tested these proposed changes on _Chromium_ (version 115.0.5790.170 64-bit) and _Firefox_ (version 115.1.0esr 64-bit) both running on _Linux_ (Linux Mint 21.1 64-bit).

Fixes https://github.com/raysan5/raylib/issues/3249.

**Edit 1:** added line marks.
**Edit 2:** forgot to add the test environment.
