### PR TITLE
Fix SetClipboardText for web

### DIFF
--- a/src/rcore.c
+++ b/src/rcore.c
@@ -2148,7 +2148,7 @@ void SetClipboardText(const char *text)
 #if defined(PLATFORM_WEB)
     // Security check to (partially) avoid malicious code
     if (strchr(text, '\'') != NULL) TRACELOG(LOG_WARNING, "SYSTEM: Provided Clipboard could be potentially malicious, avoid [\'] character");
-    else emscripten_run_script(TextFormat("navigator.clipboard.writeText('%s')", text));
+    else emscripten_run_script(TextFormat("navigator.clipboard.writeText(`%s`)", text));
 #endif
 }
 


### PR DESCRIPTION
Changes the `single quotations` for `backticks` on the `string` of the javascript line that gets executed by `emscripten_run_script`. The `single quotations` were likely getting mixed at somepoint between emscripten and the browser.

Tested these proposed changes successfully on Chromium (version 115.0.5790.170 64-bit) and Firefox (version 115.1.0esr 64-bit) both running on Linux (Linux Mint 21.1 64-bit).

Fixes https://github.com/raysan5/raylib/issues/3251.