### PR TITLE
[CORE] Fix the emscripten_set_main_loop_timing warning when enabling VSync on web

### DIFF
--- a/src/rcore.c
+++ b/src/rcore.c
@@ -4470,13 +4470,16 @@ static bool InitGraphicsDevice(int width, int height)
 #endif
 
     // Try to enable GPU V-Sync, so frames are limited to screen refresh rate (60Hz -> 60 FPS)
-    // NOTE: V-Sync can be enabled by graphic driver configuration
+    // NOTE: V-Sync can be enabled by graphic driver configuration, it doesn't need
+    // to be activated on web platforms since VSync is enforced there.
+#if !defined(PLATFORM_WEB)
     if (CORE.Window.flags & FLAG_VSYNC_HINT)
     {
         // WARNING: It seems to hit a critical render path in Intel HD Graphics
         glfwSwapInterval(1);
         TRACELOG(LOG_INFO, "DISPLAY: Trying to enable VSYNC");
     }
+#endif
 
     int fbWidth = CORE.Window.screen.width;
     int fbHeight = CORE.Window.screen.height;


### PR DESCRIPTION
### Changes:
When setting the flag `FLAG_VSYNC_HINT` with `SetConfigFlags` the warning

> emscripten_set_main_loop_timing: Cannot set timing mode for main loop since a main loop does not exist! Call emscripten_set_main_loop first to set one up.

caused by `glfwSwapInterval(1)` won't appear anymore.

### Why:
This fix was [already added](https://github.com/raysan5/raylib/commit/0bacc978c39a234da4a2b73ce3cb5b43e072a103) into the source code of raylib but it was since then removed.

I think it was accidental since adding this fix to my up-to-date local build of raylib fixed the problem and didn't seem to cause any problems on platforms that do "support" VSync like desktop.
