### PR TITLE
Fix SetClipboardText for web

### DIFF
--- a/src/rcore.c
+++ b/src/rcore.c
@@ -2150,7 +2150,7 @@ void SetClipboardText(const char *text)
 #if defined(PLATFORM_WEB)
     // Security check to (partially) avoid malicious code
     if (strchr(text, '\'') != NULL) TRACELOG(LOG_WARNING, "SYSTEM: Provided Clipboard could be potentially malicious, avoid [\'] character");
-    else emscripten_run_script(TextFormat("navigator.clipboard.writeText('%s')", text));
+    else EM_ASM( { navigator.clipboard.writeText(UTF8ToString($0)); }, text);
 #endif
 }
 


### PR DESCRIPTION
### Issue cause

So, to the best of my knowledge and as deep as I could dig, the cause of the issue is as following:

1. `text` ([L2145](https://github.com/raysan5/raylib/blob/master/src/rcore.c#L2145)) has the correct string;
2. If `text` contains a `\n`, it will be passed exactly as `\n` to `emscripten_run_script()` ([L2153](https://github.com/raysan5/raylib/blob/master/src/rcore.c#L2153));
3. So, instead of this:
```
str = "This is\na test."
```
4. It will end up like this (on the JS string):
```
str = "This is
a test."
```
5. And that will cause a `SyntaxError: unterminated string literal` ([excellent example/demo here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Unterminated_string_literal#multiple_lines)).
6. And, incidentally, confirms why using `backticks` `template literals` worked.

### Proposed solution

After going through Emscripten's documentation (specially [Calling JavaScript from C/C++](https://emscripten.org/docs/porting/connecting_cpp_and_javascript/Interacting-with-code.html#calling-javascript-from-c-c) and [Inline assembly/JavaScript](https://emscripten.org/docs/api_reference/emscripten.h.html#inline-assembly-javascript)), the best solution I could find was:

7. Replacing `emscripten_run_script()` by `EM_ASM()` ([R2153](https://github.com/raysan5/raylib/pull/3257/files#diff-39fea0e3daa23741e81daf967717f35c7842426aab26a0bc3f525d6a2f03e339R2153)) ([doc](https://emscripten.org/docs/api_reference/emscripten.h.html#c.EM_ASM));
8. And passing `text` to it with `UTF8ToString()` ([R2153](https://github.com/raysan5/raylib/pull/3257/files#diff-39fea0e3daa23741e81daf967717f35c7842426aab26a0bc3f525d6a2f03e339R2153)) ([doc](https://emscripten.org/docs/api_reference/preamble.js.html#UTF8ToString)).

I believe this not only fixes the issue, but also improves the call because:

9. It's faster than `emscripten_run_script()` as the [documentation mentions](https://emscripten.org/docs/porting/connecting_cpp_and_javascript/Interacting-with-code.html#calling-javascript-from-c-c);
10. Gives us more control/flexibility over the JS syntax;
11. And, I think (please, correct me if I'm wrong) that it's also safer, because it doesn't use `eval()` like `emscripten_run_script()` (Mozilla documentation: [_eval()_](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/eval) and [_Never use eval()!_](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/eval#never_use_eval!)).

If there's any particular reason (specially security reasons) for not using `EM_ASM()` that I missed, please let me know.

Tested these proposed changes successfully on `PLATFORM_WEB` with _Chromium_ (version 115.0.5790.170 64-bit) and _Firefox_ (version 115.1.0esr 64-bit) both running on _Linux_ (Linux Mint 21.1 64-bit).

Fixes https://github.com/raysan5/raylib/issues/3251.

**Edit 1:** added line marks; editing.
**Edit 2:** added the test environment info.
**Edit 3:** added `eval()` documentation references.