### PR TITLE
Fix CMake extraneous -lglfw

### DIFF
--- a/cmake/InstallConfigurations.cmake
+++ b/cmake/InstallConfigurations.cmake
@@ -9,8 +9,7 @@ install(
 # PKG_CONFIG_LIBS_PRIVATE is used in raylib.pc.in
 if (NOT BUILD_SHARED_LIBS)
     include(LibraryPathToLinkerFlags)
-    library_path_to_linker_flags(__PKG_CONFIG_LIBS_PRIVATE "${LIBS_PRIVATE}")
-    set(PKG_CONFIG_LIBS_PRIVATE ${__PKG_CONFIG_LIBS_PRIVATE} ${GLFW_PKG_LIBS})
+    set(PKG_CONFIG_LIBS_PRIVATE ${GLFW_PKG_LIBS})
     string(REPLACE ";" " " PKG_CONFIG_LIBS_PRIVATE "${PKG_CONFIG_LIBS_PRIVATE}")
 elseif (BUILD_SHARED_LIBS)
     set(PKG_CONFIG_LIBS_EXTRA "")


### PR DESCRIPTION
Closes #3265.

The problem: LIBS_PRIVATE is a list of library names (used by pkg-config), but the shared library of the same name doesn't always exist. In this case, `pkg-config glfw` is valid, while `-lglfw` is not. Therefore, `library_path_to_linker_flags` can't be used, since `LIBS_PRIVATE` are not executable library names.

I'm not sure if this doesn't break other platforms (other than Linux). @raysan5, can you find someone good at CMake to look at this?