### PR TITLE
Fix example/models/models_loading_m3d.c controls

### DIFF
--- a/examples/models/models_loading_m3d.c
+++ b/examples/models/models_loading_m3d.c
@@ -40,7 +40,7 @@ int main(void)
     camera.projection = CAMERA_PERSPECTIVE;             // Camera projection type
 
     Vector3 position = { 0.0f, 0.0f, 0.0f };            // Set model position
-    
+
     char modelFileName[128] = "resources/models/m3d/cesium_man.m3d";
     bool drawMesh = 1;
     bool drawSkeleton = 1;
@@ -72,27 +72,27 @@ int main(void)
             if (IsKeyDown(KEY_SPACE) || IsKeyPressed(KEY_N))
             {
                 animFrameCounter++;
-                
+
                 if (animFrameCounter >= anims[animId].frameCount) animFrameCounter = 0;
-                
+
                 UpdateModelAnimation(model, anims[animId], animFrameCounter);
                 animPlaying = true;
             }
-            
-            // Select animation by pressing A
-            if (IsKeyPressed(KEY_A))
+
+            // Select animation by pressing C
+            if (IsKeyPressed(KEY_C))
             {
                 animFrameCounter = 0;
                 animId++;
-                
+
                 if (animId >= animsCount) animId = 0;
                 UpdateModelAnimation(model, anims[animId], 0);
                 animPlaying = true;
             }
         }
-        
+
         // Toggle skeleton drawing
-        if (IsKeyPressed(KEY_S)) drawSkeleton ^= 1;
+        if (IsKeyPressed(KEY_B)) drawSkeleton ^= 1;
 
         // Toggle mesh drawing
         if (IsKeyPressed(KEY_M)) drawMesh ^= 1;
@@ -112,19 +112,19 @@ int main(void)
                 // Draw the animated skeleton
                 if (drawSkeleton)
                 {
-                    // Loop to (boneCount - 1) because the last one is a special "no bone" bone, 
+                    // Loop to (boneCount - 1) because the last one is a special "no bone" bone,
                     // needed to workaround buggy models
                     // without a -1, we would always draw a cube at the origin
                     for (int i = 0; i < model.boneCount - 1; i++)
                     {
-                        // By default the model is loaded in bind-pose by LoadModel(). 
-                        // But if UpdateModelAnimation() has been called at least once 
+                        // By default the model is loaded in bind-pose by LoadModel().
+                        // But if UpdateModelAnimation() has been called at least once
                         // then the model is already in animation pose, so we need the animated skeleton
                         if (!animPlaying || !animsCount)
                         {
                             // Display the bind-pose skeleton
                             DrawCube(model.bindPose[i].translation, 0.04f, 0.04f, 0.04f, RED);
-                            
+
                             if (model.bones[i].parent >= 0)
                             {
                                 DrawLine3D(model.bindPose[i].translation,
@@ -135,7 +135,7 @@ int main(void)
                         {
                             // Display the frame-pose skeleton
                             DrawCube(anims[animId].framePoses[animFrameCounter][i].translation, 0.05f, 0.05f, 0.05f, RED);
-                            
+
                             if (anims[animId].bones[i].parent >= 0)
                             {
                                 DrawLine3D(anims[animId].framePoses[animFrameCounter][i].translation,
@@ -149,9 +149,10 @@ int main(void)
 
             EndMode3D();
 
-            DrawText("PRESS SPACE to PLAY MODEL ANIMATION", 10, GetScreenHeight() - 60, 10, MAROON);
-            DrawText("PRESS A to CYCLE THROUGH ANIMATIONS", 10, GetScreenHeight() - 40, 10, DARKGRAY);
-            DrawText("PRESS M to toggle MESH, S to toggle SKELETON DRAWING", 10, GetScreenHeight() - 20, 10, DARKGRAY);
+            DrawText("PRESS SPACE to PLAY MODEL ANIMATION", 10, GetScreenHeight() - 80, 10, MAROON);
+            DrawText("PRESS N to STEP ONE ANIMATION FRAME", 10, GetScreenHeight() - 60, 10, DARKGRAY);
+            DrawText("PRESS C to CYCLE THROUGH ANIMATIONS", 10, GetScreenHeight() - 40, 10, DARKGRAY);
+            DrawText("PRESS M to toggle MESH, B to toggle SKELETON DRAWING", 10, GetScreenHeight() - 20, 10, DARKGRAY);
             DrawText("(c) CesiumMan model by KhronosGroup", GetScreenWidth() - 210, GetScreenHeight() - 20, 10, GRAY);
 
         EndDrawing();


### PR DESCRIPTION
Hello,

Some binds on [models_loading_m3d.c](https://github.com/raysan5/raylib/blob/master/examples/models/models_loading_m3d.c) conflict (overlap) with the [camera controls](https://github.com/raysan5/raylib/blob/master/src/rcamera.h#L480-L481).

This pull request rebinds them to:

| From                              | To                                |
| --------------------------------- | --------------------------------- |
| ["A to CYCLE THROUGH ANIMATIONS"](https://github.com/raysan5/raylib/blob/master/examples/models/models_loading_m3d.c#L83) | "C to CYCLE THROUGH ANIMATIONS" |
| ["S to toggle SKELETON DRAWING"](https://github.com/raysan5/raylib/blob/master/examples/models/models_loading_m3d.c#L95)  | "B to toggle SKELETON DRAWING" |

Also adds the missing "PRESS N to STEP ONE ANIMATION FRAME" help instruction.

Best regards.
