### PR TITLE
Add examples/shaders/shaders_lightmap.c to Makefiles

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -529,6 +529,7 @@ SHADERS = \
     shaders/shaders_simple_mask \
     shaders/shaders_spotlight \
     shaders/shaders_hot_reloading \
+    shaders/shaders_lightmap \
     shaders/shaders_mesh_instancing \
     shaders/shaders_multi_sample2d \
     shaders/shaders_write_depth \

--- a/examples/Makefile.Web
+++ b/examples/Makefile.Web
@@ -504,6 +504,7 @@ SHADERS = \
     shaders/shaders_simple_mask \
     shaders/shaders_spotlight \
     shaders/shaders_hot_reloading \
+    shaders/shaders_lightmap \
     shaders/shaders_mesh_instancing \
     shaders/shaders_multi_sample2d \
     shaders/shaders_write_depth \


### PR DESCRIPTION
Hello,

This pull request includes [examples/shaders/shaders_lightmap.c](https://github.com/raysan5/raylib/blob/master/examples/shaders/shaders_lightmap.c) to the Makefiles ([Makefile](https://github.com/raysan5/raylib/blob/master/examples/Makefile), [Makefile.Web](https://github.com/raysan5/raylib/blob/master/examples/Makefile.Web)), since it was missing.

Best regards.
