### PR TITLE
Update cmake SUPPORT_FILEFORMAT_SVG default value

### DIFF
--- a/CMakeOptions.txt
+++ b/CMakeOptions.txt
@@ -71,7 +71,7 @@ cmake_dependent_option(SUPPORT_FILEFORMAT_QOI "Support loading QOI as textures" 
 cmake_dependent_option(SUPPORT_FILEFORMAT_PSD "Support loading PSD as textures" ${OFF} CUSTOMIZE_BUILD OFF)
 cmake_dependent_option(SUPPORT_FILEFORMAT_PKM "Support loading PKM as textures" ${OFF} CUSTOMIZE_BUILD OFF)
 cmake_dependent_option(SUPPORT_FILEFORMAT_PVR "Support loading PVR as textures" ${OFF} CUSTOMIZE_BUILD OFF)
-cmake_dependent_option(SUPPORT_FILEFORMAT_SVG "Support loading SVG as textures" ON CUSTOMIZE_BUILD ON)
+cmake_dependent_option(SUPPORT_FILEFORMAT_SVG "Support loading SVG as textures" ${OFF} CUSTOMIZE_BUILD OFF)
 
 # rtext.c
 cmake_dependent_option(SUPPORT_FILEFORMAT_FNT "Support loading fonts in FNT format" ON CUSTOMIZE_BUILD ON)


### PR DESCRIPTION
Hello,

This pull request updates the `SUPPORT_FILEFORMAT_SVG` default value on [CMakeOptions.txt](https://github.com/raysan5/raylib/blob/master/CMakeOptions.txt) to match https://github.com/raysan5/raylib/commit/c104a975904f23d011cb6072f98945b8d38eff17.

Best regards.
