### PR TITLE
Disable UBSAN in zig builds.

### DIFF
--- a/src/build.zig
+++ b/src/build.zig
@@ -6,6 +6,7 @@ pub fn addRaylib(b: *std.Build, target: std.zig.CrossTarget, optimize: std.built
         "-std=gnu99",
         "-D_GNU_SOURCE",
         "-DGL_SILENCE_DEPRECATION=199309L",
+        "-fno-sanitize=undefined", // https://github.com/raysan5/raylib/issues/1891
     };
 
     const raylib = b.addStaticLibrary(.{


### PR DESCRIPTION
Zig debug builds automatically enable ubsan.
As the fix for #1891 had to be reverted, debug builds using zig will crash like so:

```
Illegal instruction at address 0x3237d2
raylib/src/rlgl.h:3690:91: 0x3237d2 in rlDrawVertexArrayElements (/home/rcorre/src/raylib-zig-template/raylib/src/rcore.c)
    glDrawElements(GL_TRIANGLES, count, GL_UNSIGNED_SHORT, (const unsigned short *)buffer + offset);
```

This disables UBSAN when using zig to build raylib.
