### PR TITLE
[CORE] expose a function to get the raw frame buffer size regardless of DPI mode.

### DIFF
--- a/src/raylib.h
+++ b/src/raylib.h
@@ -979,6 +979,7 @@ RLAPI int GetMonitorPhysicalHeight(int monitor);                  // Get specifi
 RLAPI int GetMonitorRefreshRate(int monitor);                     // Get specified monitor refresh rate
 RLAPI Vector2 GetWindowPosition(void);                            // Get window position XY on monitor
 RLAPI Vector2 GetWindowScaleDPI(void);                            // Get window scale DPI factor
+RLAPI Vector2 GetFrameBufferSize(void);                           // Get the actual frame buffer size regardless of DPI mode
 RLAPI const char *GetMonitorName(int monitor);                    // Get the human-readable, UTF-8 encoded name of the specified monitor
 RLAPI void SetClipboardText(const char *text);                    // Set clipboard text content
 RLAPI const char *GetClipboardText(void);                         // Get clipboard text content

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -2117,6 +2117,21 @@ Vector2 GetWindowScaleDPI(void)
     return scale;
 }
 
+// Get the actual frame buffer size regardless of DPI mode
+RLAPI Vector2 GetFrameBufferSize(void)
+{
+    Vector2 size = { (float)CORE.Window.currentFbo.width, (float)CORE.Window.currentFbo.height };
+#if defined(PLATFORM_DESKTOP)
+    int w = 0;
+    int h = 0;
+
+    glfwGetFramebufferSize(glfwGetCurrentContext(), &w, &h);
+    size = (Vector2){ (float)w, (float)h };
+#endif
+
+    return size;
+}
+
 // Get the human-readable, UTF-8 encoded name of the selected monitor
 const char *GetMonitorName(int monitor)
 {


### PR DESCRIPTION
This PR adds a single function to raylib core. It exposes the raw GLFW frame buffer size.

This is needed for integrations with third party libs such as DearImGui. In order to have these libraries know the correct sizes for the frame buffer (and scissors), and to work aground some problems on MacOS.

I have been trying for about a year to find a way to get this to work on all platforms without adding a function to raylib, but there is just no consistent way to get the data.
I've been directly calling GLFW and that works for platforms that link raylib static, but any binding that uses raylib dynamic (like C#) can't do that, so I need a function that exposes this that is part of the export library.

This PR will make these external libs (mainly rlImGui) cleaner and easier to maintain.

If there is any other way to get this data, please let me know.