### PR TITLE
Revert "Disable UBSAN in zig builds. (#3292)"

### DIFF
--- a/src/build.zig
+++ b/src/build.zig
@@ -6,7 +6,6 @@ pub fn addRaylib(b: *std.Build, target: std.zig.CrossTarget, optimize: std.built
         "-std=gnu99",
         "-D_GNU_SOURCE",
         "-DGL_SILENCE_DEPRECATION=199309L",
-        "-fno-sanitize=undefined", // https://github.com/raysan5/raylib/issues/1891
     };
 
     const raylib = b.addStaticLibrary(.{


### PR DESCRIPTION
This reverts commit a316f9e7fc7f8e06852a40544e57f89018672ee4.

Issue #1891 was fixed again, so this is no longer needed.
