### PR TITLE
Fix ImageDraw() source clipping when drawing beyond top left

### DIFF
--- a/src/rtextures.c
+++ b/src/rtextures.c
@@ -3481,7 +3481,7 @@ void ImageDraw(Image *dst, Image src, Rectangle srcRec, Rectangle dstRec, Color 
         // Destination rectangle out-of-bounds security checks
         if (dstRec.x < 0)
         {
-            srcRec.x = -dstRec.x;
+            srcRec.x -= dstRec.x;
             srcRec.width += dstRec.x;
             dstRec.x = 0;
         }
@@ -3489,7 +3489,7 @@ void ImageDraw(Image *dst, Image src, Rectangle srcRec, Rectangle dstRec, Color 
 
         if (dstRec.y < 0)
         {
-            srcRec.y = -dstRec.y;
+            srcRec.y -= dstRec.y;
             srcRec.height += dstRec.y;
             dstRec.y = 0;
         }


### PR DESCRIPTION
Rather than the source becoming the inverse of the destination, we should instead minus it from the source coordinates. This is usually not a problem when rendering entire images or when there is scaling. However, it is an issue when your source rectangle starts at a coordinate away from `0,0`, and you're not scaling it.

This change fixes the source rectangle mapping to have it change bassed on the destination coordinate, rather than just becoming inverse of the destination.

Fixes #3259