### PR TITLE
Add SetWindowMaxSize for desktop and web

### DIFF
--- a/src/raylib.h
+++ b/src/raylib.h
@@ -961,6 +961,7 @@ RLAPI void SetWindowTitle(const char *title);                     // Set title f
 RLAPI void SetWindowPosition(int x, int y);                       // Set window position on screen (only PLATFORM_DESKTOP)
 RLAPI void SetWindowMonitor(int monitor);                         // Set monitor for the current window
 RLAPI void SetWindowMinSize(int width, int height);               // Set window minimum dimensions (for FLAG_WINDOW_RESIZABLE)
+RLAPI void SetWindowMaxSize(int width, int height);               // Set window maximum dimensions (for FLAG_WINDOW_RESIZABLE)
 RLAPI void SetWindowSize(int width, int height);                  // Set window dimensions
 RLAPI void SetWindowOpacity(float opacity);                       // Set window opacity [0.0f..1.0f] (only PLATFORM_DESKTOP)
 RLAPI void SetWindowFocused(void);                                // Set window focused (only PLATFORM_DESKTOP)

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -356,7 +356,6 @@ typedef struct {
 
 typedef struct { int x; int y; } Point;
 typedef struct { unsigned int width; unsigned int height; } Size;
-typedef struct { int width; int height; } SizeInt;
 
 // Core global state context data
 typedef struct CoreData {
@@ -396,11 +395,11 @@ typedef struct CoreData {
         Size currentFbo;                    // Current render width and height (depends on active fbo)
         Size render;                        // Framebuffer width and height (render area, including black bars if required)
         Point renderOffset;                 // Offset from render area (must be divided by 2)
-        SizeInt windowMin;                  // Window minimum width and height (for resizable window)
-        SizeInt windowMax;                  // Window maximum width and height (for resizable window)
+        Size windowMin;                     // Window minimum width and height (for resizable window)
+        Size windowMax;                     // Window maximum width and height (for resizable window)
         Matrix screenScale;                 // Matrix to scale screen (framebuffer rendering)
 
-        char **dropFilepaths;         // Store dropped files paths pointers (provided by GLFW)
+        char **dropFilepaths;               // Store dropped files paths pointers (provided by GLFW)
         unsigned int dropFileCount;         // Count dropped files strings
 
     } Window;
@@ -1793,8 +1792,11 @@ void SetWindowMinSize(int width, int height)
     CORE.Window.windowMin.width = width;
     CORE.Window.windowMin.height = height;
 #if defined(PLATFORM_DESKTOP)
-    const GLFWvidmode *mode = glfwGetVideoMode(glfwGetPrimaryMonitor());
-    glfwSetWindowSizeLimits(CORE.Window.handle, CORE.Window.windowMin.width, CORE.Window.windowMin.height, CORE.Window.windowMax.width, CORE.Window.windowMax.height);
+    int minWidth  = (CORE.Window.windowMin.width  == 0) ? GLFW_DONT_CARE : CORE.Window.windowMin.width;
+    int minHeight = (CORE.Window.windowMin.height == 0) ? GLFW_DONT_CARE : CORE.Window.windowMin.height;
+    int maxWidth  = (CORE.Window.windowMax.width  == 0) ? GLFW_DONT_CARE : CORE.Window.windowMax.width;
+    int maxHeight = (CORE.Window.windowMax.height == 0) ? GLFW_DONT_CARE : CORE.Window.windowMax.height;
+    glfwSetWindowSizeLimits(CORE.Window.handle, minWidth, minHeight, maxWidth, maxHeight);
 #endif
 #if defined(PLATFORM_WEB)
     // Trigger the resize event once to update the window minimum width and height
@@ -1808,8 +1810,11 @@ void SetWindowMaxSize(int width, int height)
     CORE.Window.windowMax.width = width;
     CORE.Window.windowMax.height = height;
 #if defined(PLATFORM_DESKTOP)
-    const GLFWvidmode *mode = glfwGetVideoMode(glfwGetPrimaryMonitor());
-    glfwSetWindowSizeLimits(CORE.Window.handle, CORE.Window.windowMin.width, CORE.Window.windowMin.height, CORE.Window.windowMax.width, CORE.Window.windowMax.height);
+    int minWidth  = (CORE.Window.windowMin.width  == 0) ? GLFW_DONT_CARE : CORE.Window.windowMin.width;
+    int minHeight = (CORE.Window.windowMin.height == 0) ? GLFW_DONT_CARE : CORE.Window.windowMin.height;
+    int maxWidth  = (CORE.Window.windowMax.width  == 0) ? GLFW_DONT_CARE : CORE.Window.windowMax.width;
+    int maxHeight = (CORE.Window.windowMax.height == 0) ? GLFW_DONT_CARE : CORE.Window.windowMax.height;
+    glfwSetWindowSizeLimits(CORE.Window.handle, minWidth, minHeight, maxWidth, maxHeight);
 #endif
 #if defined(PLATFORM_WEB)
     // Trigger the resize event once to update the window maximum width and height
@@ -4244,11 +4249,11 @@ static bool InitGraphicsDevice(int width, int height)
     CORE.Window.screen.height = height;          // User desired height
     CORE.Window.screenScale = MatrixIdentity();  // No draw scaling required by default
 
-    // Set the window minimum and maximum default values to GLFW_DONT_CARE (-1)
-    CORE.Window.windowMin.width  = GLFW_DONT_CARE;
-    CORE.Window.windowMin.height = GLFW_DONT_CARE;
-    CORE.Window.windowMax.width  = GLFW_DONT_CARE;
-    CORE.Window.windowMax.height = GLFW_DONT_CARE;
+    // Set the window minimum and maximum default values to 0
+    CORE.Window.windowMin.width  = 0;
+    CORE.Window.windowMin.height = 0;
+    CORE.Window.windowMax.width  = 0;
+    CORE.Window.windowMax.height = 0;
 
     // NOTE: Framebuffer (render area - CORE.Window.render.width, CORE.Window.render.height) could include black bars...
     // ...in top-down or left-right to match display aspect ratio (no weird scaling)


### PR DESCRIPTION
### Summary

- Adds `SetWindowMaxSize()` for both `PLATFORM_DESKTOP` and `PLATFORM_WEB`.
- Changes `SetWindowMinSize()` so it can work alongside `SetWindowMaxSize()` keeping current compatibility.
- Finishes fixing https://github.com/raysan5/raylib/issues/3231.

### Explanation

1. Adds a `windowMin` and `windowMax` member to `CORE.Window` ([R399-R400](https://github.com/raysan5/raylib/pull/3309/files#diff-39fea0e3daa23741e81daf967717f35c7842426aab26a0bc3f525d6a2f03e339R399-R400)). This was necessary because although `GLFW` has a `glfwSetWindowSizeLimits()`, it doesn't have a `glfw*GET*WindowSizeLimits()` yet. And also because both `PLATFORM_DESKTOP` and `PLATFORM_WEB` needed a common dataset to be able to share the same functions.
<br>

2. Adds  `SetWindowMaxSize()` ([R1806](https://github.com/raysan5/raylib/pull/3309/files#diff-39fea0e3daa23741e81daf967717f35c7842426aab26a0bc3f525d6a2f03e339R1806)) that will receive an `int width` and an `int height` from the user.
3. `SetWindowMaxSize()` will then set `CORE.Window.windowMax` with those values ([R1808-R1809](https://github.com/raysan5/raylib/pull/3309/files#diff-39fea0e3daa23741e81daf967717f35c7842426aab26a0bc3f525d6a2f03e339R1808-R1809)).
4. Then, if it's `PLATFORM_DESKTOP`, it will `glfwSetWindowSizeLimits()` with the stored `CORE.Window.windowMin` and `CORE.Window.windowMax` values ([R1812](https://github.com/raysan5/raylib/pull/3309/files#diff-39fea0e3daa23741e81daf967717f35c7842426aab26a0bc3f525d6a2f03e339R1812)).
5. If it's `PLATFORM_WEB`, and `FLAG_WINDOW_RESIZABLE` is enabled, it will instead trigger the resize event so `EmscriptenResizeCallback()` can resize the canvas if necessary ([R1816](https://github.com/raysan5/raylib/pull/3309/files#diff-39fea0e3daa23741e81daf967717f35c7842426aab26a0bc3f525d6a2f03e339R1816)).
<br>

6. The default values of `windowMin` and `windowMax` are `GLFW_DONT_CARE` (equivalent to `-1`) ([R4247-R4251](https://github.com/raysan5/raylib/pull/3309/files#diff-39fea0e3daa23741e81daf967717f35c7842426aab26a0bc3f525d6a2f03e339R4247-R4251)) and are set on `InitGraphicsDevice()` ([R4241](https://github.com/raysan5/raylib/pull/3309/files#diff-39fea0e3daa23741e81daf967717f35c7842426aab26a0bc3f525d6a2f03e339R4241)). This was chosen because it integrates naturally to `glfwSetWindowSizeLimits()` and allow the resize to behave "unlimited" if no `windowMin` or `windowMax` are passed by the user.
<br>

7. Changes `SetWindowMinSize()` ([R1791](https://github.com/raysan5/raylib/pull/3309/files#diff-39fea0e3daa23741e81daf967717f35c7842426aab26a0bc3f525d6a2f03e339R1791)) that still receives an `int width` and an `int height` from the user, maintaining legacy compatibility.
8. `SetWindowMinSize()` now sets set `CORE.Window.windowMin` with those values ([R1793-R1794](https://github.com/raysan5/raylib/pull/3309/files#diff-39fea0e3daa23741e81daf967717f35c7842426aab26a0bc3f525d6a2f03e339R1793-R1794)).
9. Then, if it's `PLATFORM_DESKTOP`, it will `glfwSetWindowSizeLimits()` with the stored `CORE.Window.windowMin` and `CORE.Window.windowMax` values, like `SetWindowMaxSize()` ([R1797](https://github.com/raysan5/raylib/pull/3309/files#diff-39fea0e3daa23741e81daf967717f35c7842426aab26a0bc3f525d6a2f03e339R1797)).
10. If it's `PLATFORM_WEB`, and `FLAG_WINDOW_RESIZABLE` is enabled, it will instead trigger the resize event so `EmscriptenResizeCallback()` can resize the canvas if necessary ([R1801](https://github.com/raysan5/raylib/pull/3309/files#diff-39fea0e3daa23741e81daf967717f35c7842426aab26a0bc3f525d6a2f03e339R1801)), like `SetWindowMaxSize()`.
<br>

11. The resizing for `PLATFORM_DESKTOP` is handled as usual.
<br>

12. The resizing for `PLATFORM_WEB` is handled by `EmscriptenResizeCallback()` ([R6191](https://github.com/raysan5/raylib/pull/3309/files#diff-39fea0e3daa23741e81daf967717f35c7842426aab26a0bc3f525d6a2f03e339R6191)).
13. There, once it gets the `width` and `height` from `GetWindowInnerWidth()` and `GetWindowInnerHeight()` ([R6209-R6210](https://github.com/raysan5/raylib/pull/3309/files#diff-39fea0e3daa23741e81daf967717f35c7842426aab26a0bc3f525d6a2f03e339R6209-R6210)).
14. Then, it checks if they are smaller than the `windowMin`. If they are, it uses the `windowMin` values instead ([R6212](https://github.com/raysan5/raylib/pull/3309/files#diff-39fea0e3daa23741e81daf967717f35c7842426aab26a0bc3f525d6a2f03e339R6212), [R6215](https://github.com/raysan5/raylib/pull/3309/files#diff-39fea0e3daa23741e81daf967717f35c7842426aab26a0bc3f525d6a2f03e339R6215)).
15. If they aren't, it checks if they are larger than `windowMax` and if `windowMax` is larger than zero (necessary to handle the default `-1` value). If they are, it uses the `windowMax` values instead ([R6213](https://github.com/raysan5/raylib/pull/3309/files#diff-39fea0e3daa23741e81daf967717f35c7842426aab26a0bc3f525d6a2f03e339R6213), [R6216](https://github.com/raysan5/raylib/pull/3309/files#diff-39fea0e3daa23741e81daf967717f35c7842426aab26a0bc3f525d6a2f03e339R6216)).
16. Otherwise, it uses the `WindowInner` values it got.

### Notes

17. Added a "temporary" `SizeInt` ([R359](https://github.com/raysan5/raylib/pull/3309/files#diff-39fea0e3daa23741e81daf967717f35c7842426aab26a0bc3f525d6a2f03e339R359)) because it needed negative values (the `-1` from `GLFW_DONT_CARE`) and `Size` had `unsigned int` ([R358](https://github.com/raysan5/raylib/pull/3309/files#diff-39fea0e3daa23741e81daf967717f35c7842426aab26a0bc3f525d6a2f03e339R358)).
18. Could have used a `Point` ([R357](https://github.com/raysan5/raylib/pull/3309/files#diff-39fea0e3daa23741e81daf967717f35c7842426aab26a0bc3f525d6a2f03e339R357)) but `.x` and `.y` could make it harder to understand.
19. Despite https://github.com/raysan5/raylib/issues/3168#issuecomment-1703788272 I didn't want to change `Size` without asking first (I don't know if it will break something).
20. Which would be the preferable approach: `SizeInt`, `Point` or changing `Size`? @raysan5

### Testing environment

Tested this changes successfully on `PLATFORM_DESKTOP` on Linux (Mint 21.1 64-bit) and `PLATFORM_WEB` on Firefox (115.1.0esr 64-bit) and Chrome (115.0.5790.170 64-bit) both running on Linux Mint (21.1 64-bit).

### Code Example

Minimal reproduction code to test the PR:
```
#include "raylib.h"

int main(void) {
    SetConfigFlags(FLAG_WINDOW_RESIZABLE);
    InitWindow(800, 450, "test");
    SetTargetFPS(60);

    SetWindowMinSize( 200, 200);
    SetWindowMaxSize( 1000, 600);

    while (!WindowShouldClose()) {
        BeginDrawing();
        ClearBackground(RAYWHITE);
        DrawText(TextFormat("screen %i x %i", GetScreenWidth(), GetScreenHeight()), 20, 20, 20, BLACK);
        EndDrawing();
    }
    CloseWindow();
    return 0;
}
```

**Edit:** added the issue link and added line marks.
