### PR TITLE
Allow excluding color constants from raylib.h

### DIFF
--- a/src/raylib.h
+++ b/src/raylib.h
@@ -161,6 +161,7 @@
 
 // Some Basic Colors
 // NOTE: Custom raylib color palette for amazing visuals on WHITE background
+#if !defined(RL_NO_COLOR_CONSTANTS)
 #define LIGHTGRAY  CLITERAL(Color){ 200, 200, 200, 255 }   // Light Gray
 #define GRAY       CLITERAL(Color){ 130, 130, 130, 255 }   // Gray
 #define DARKGRAY   CLITERAL(Color){ 80, 80, 80, 255 }      // Dark Gray
@@ -188,6 +189,7 @@
 #define BLANK      CLITERAL(Color){ 0, 0, 0, 0 }           // Blank (Transparent)
 #define MAGENTA    CLITERAL(Color){ 255, 0, 255, 255 }     // Magenta
 #define RAYWHITE   CLITERAL(Color){ 245, 245, 245, 255 }   // My own White (raylib logo)
+#endif
 
 //----------------------------------------------------------------------------------
 // Structures Definition

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -143,7 +143,7 @@
 // Some compilers (mostly macos clang) default to C++98,
 // where aggregate initialization can't be used
 // So, give a more clear error stating how to fix this
-#if !defined(_MSC_VER) && (defined(__cplusplus) && __cplusplus < 201103L)
+#if !defined(_MSC_VER) && (defined(__cplusplus) && __cplusplus < 201103L) && !defined(RL_NO_COLOR_CONSTANTS)
     #error "C++11 or later is required. Add -std=c++11"
 #endif
 


### PR DESCRIPTION
Add a macro, RL_NO_COLOR_CONSTANTS, to allow excluding the color macros
from raylib.h

Certain libraries conflict with raylib's color macros, and can't be
included in the same file

One library affected by this is reactphysics3d. the RED macro mangles
this particular line:
https://github.com/DanielChappuis/reactphysics3d/blob/17dd22e677ed861b0d4ece0c00a7e3cb503cc2f0/include/reactphysics3d/utils/DebugRenderer.h#L62
So, it cannot be used in the same TU as raylib.h

Users may also choose to provide their own choice of color constants,
different to raylib's choice. This gives users the freedom to do so,
without modifying raylib.h

One practical example of this is raylib-namespace.h
https://github.com/raylib-extras/extras-cpp/blob/master/raylib_namespace.h
which prefers to define the color constants as constants instead of
macros