### PR TITLE
Update BINDINGS.md with vaiorabbit/raylib-bindings

### DIFF
--- a/BINDINGS.md
+++ b/BINDINGS.md
@@ -114,6 +114,7 @@ These are older raylib bindings that are more than 2 versions old or have not be
 | raylib-pas         | 3.0 | [Pascal](https://en.wikipedia.org/wiki/Pascal_(programming_language))         | https://github.com/tazdij/raylib-pas      |
 | raylib-pascal      | 2.0 | [Pascal](https://en.wikipedia.org/wiki/Pascal_(programming_language))         | https://github.com/drezgames/raylib-pascal    |
 | Graphics-Raylib    | 1.4 | [Perl](https://www.perl.org/)         | https://github.com/athreef/Graphics-Raylib      |
+| raylib-bindings    | 4.5 | [Ruby](https://www.ruby-lang.org/en/) | https://github.com/vaiorabbit/raylib-bindings        |
 | raylib-ruby        | 2.6 | [Ruby](https://www.ruby-lang.org/en/) | https://github.com/a0/raylib-ruby        |
 | raylib-ruby-ffi    | 2.0 | [Ruby](https://www.ruby-lang.org/en/) | https://github.com/D3nX/raylib-ruby-ffi      |
 | raylib-mruby       | 2.5-dev | [mruby](https://github.com/mruby/mruby)  | https://github.com/lihaochen910/raylib-mruby    |


### PR DESCRIPTION
I learned about this repository [by absolute chance](https://github.com/a0/raylib-ruby/issues/4). While https://github.com/a0/raylib-ruby has the most idiomatic Ruby bindings, it targets an older version of Raylib and Ruby.

https://github.com/vaiorabbit/raylib-bindings seems quite active. I tried a few examples and they worked with no issues!