### PR TITLE
Added UBSAN complaint fix to rLoadTexture #1891

### DIFF
--- a/src/rlgl.h
+++ b/src/rlgl.h
@@ -3009,11 +3009,15 @@ unsigned int rlLoadTexture(const void *data, int width, int height, int format, 
 
         TRACELOGD("TEXTURE: Load mipmap level %i (%i x %i), size: %i, offset: %i", i, mipWidth, mipHeight, mipSize, mipOffset);
 
+        // NOTE: Added pointer math separately from function to avoid UBSAN complaining
+        unsigned char *dataPtr = (unsigned char*)data;
+        if (mipOffset > 0) dataPtr = (unsigned char*)data + mipOffset;
+
         if (glInternalFormat != -1)
         {
-            if (format < RL_PIXELFORMAT_COMPRESSED_DXT1_RGB) glTexImage2D(GL_TEXTURE_2D, i, glInternalFormat, mipWidth, mipHeight, 0, glFormat, glType, (unsigned char *)data + mipOffset);
+            if (format < RL_PIXELFORMAT_COMPRESSED_DXT1_RGB) glTexImage2D(GL_TEXTURE_2D, i, glInternalFormat, mipWidth, mipHeight, 0, glFormat, glType, dataPtr);
 #if !defined(GRAPHICS_API_OPENGL_11)
-            else glCompressedTexImage2D(GL_TEXTURE_2D, i, glInternalFormat, mipWidth, mipHeight, 0, mipSize, (unsigned char *)data + mipOffset);
+            else glCompressedTexImage2D(GL_TEXTURE_2D, i, glInternalFormat, mipWidth, mipHeight, 0, mipSize, dataPtr);
 #endif
 
 #if defined(GRAPHICS_API_OPENGL_33)


### PR DESCRIPTION
I managed to trigger the ubsan by simply calling `LoadRenderTexture(1280, 720);` from zig. Looking at recent PR's and issues it seems like this issue has already been mitigated elsewhere, but still exists in the codepath for LoadRenderTexture.

All I did was apply a similar fix (as seen in 30a9a24db9d2561335a2a42d423cf9cfeab6e769) for #1891 to the rLoadTextures function. This seems to fix the issue.