### PR TITLE
[core] debug `LoadVrStereoConfig()` so it accepts `RL_OPENGL_43` and `RL_OPENGL_21`

### DIFF
--- a/src/rcore.c
+++ b/src/rcore.c
@@ -2602,7 +2602,7 @@ VrStereoConfig LoadVrStereoConfig(VrDeviceInfo device)
 {
     VrStereoConfig config = { 0 };
 
-    if ((rlGetVersion() == RL_OPENGL_33) || (rlGetVersion() >= RL_OPENGL_ES_20))
+    if (rlGetVersion() != RL_OPENGL_11)
     {
         // Compute aspect ratio
         float aspect = ((float)device.hResolution*0.5f)/(float)device.vResolution;


### PR DESCRIPTION
I think there was a confusion about whether `rlGetVersion()` returns `RL_OPENGL_33` or `GRAPHICS_OPENGL_33` in the code of `LoadVrStereoConfig()` which was thus rejecting OpenGL4.3 and OpenGL2.1 with a `WARNING: RLGL: VR Simulator not supported on OpenGL 1.1` ... 

This patch solves it, and the `core_vr_simulator` example works with all version of OpenGL (other than 1.1 indeed)