### PR TITLE
[split] Fix compilation for web (and desktop)

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -505,7 +505,7 @@ AUDIO = \
 OTHERS = \
     others/easings_testbed \
     others/embedded_files_loading \
-    others/raylib_opengl_interop \
+#    others/raylib_opengl_interop \
     others/raymath_vector_angle \
     others/rlgl_compute_shader \
     others/rlgl_standalone

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -505,7 +505,7 @@ AUDIO = \
 OTHERS = \
     others/easings_testbed \
     others/embedded_files_loading \
-#    others/raylib_opengl_interop \
+    others/raylib_opengl_interop \
     others/raymath_vector_angle \
     others/rlgl_compute_shader \
     others/rlgl_standalone

--- a/examples/core/core_input_gestures_web.c
+++ b/examples/core/core_input_gestures_web.c
@@ -135,7 +135,7 @@ void Update(void)
             }
         }
     }
-    
+
     int fillLog = 0; // Gate variable to be used to allow or not the gesture log to be filled
     if (currentGesture !=0)
     {
@@ -156,16 +156,16 @@ void Update(void)
             fillLog = 1;
         }
     }
-    
+
     if (fillLog) // If one of the conditions from logMode was met, fill the gesture log
     {
         previousGesture = currentGesture;
         gestureColor = GetGestureColor(currentGesture);
         if (gestureLogIndex <= 0) gestureLogIndex = GESTURE_LOG_SIZE;
         gestureLogIndex--;
-        
+
         // Copy the gesture respective name to the gesture log array
-        TextCopy(gestureLog[gestureLogIndex], GetGestureName(currentGesture)); 
+        TextCopy(gestureLog[gestureLogIndex], GetGestureName(currentGesture));
     }
 
     // Handle protractor
@@ -182,14 +182,14 @@ void Update(void)
     {
         currentAngleDegrees = 0.0f;
     }
-    
+
     float currentAngleRadians = ((currentAngleDegrees +90.0f)*PI/180); // Convert the current angle to Radians
     finalVector = (Vector2){ (angleLength*sinf(currentAngleRadians)) + protractorPosition.x, (angleLength*cosf(currentAngleRadians)) + protractorPosition.y }; // Calculate the final vector for display
 
     // Handle touch and mouse pointer points
     //--------------------------------------------------------------------------------------
     #define MAX_TOUCH_COUNT     32
-    
+
     Vector2 touchPosition[MAX_TOUCH_COUNT] = { 0 };
     Vector2 mousePosition = {0, 0};
     if (currentGesture != GESTURE_NONE)
@@ -204,7 +204,7 @@ void Update(void)
     // Draw
     //--------------------------------------------------------------------------------------
     BeginDrawing();
-        
+
         ClearBackground(RAYWHITE);
 
         // Draw common
@@ -235,7 +235,7 @@ void Update(void)
         // Draw gesture log
         //--------------------------------------------------------------------------------------
         DrawText("Log", gestureLogPosition.x, gestureLogPosition.y, 20, BLACK);
-        
+
         // Loop in both directions to print the gesture log array in the inverted order (and looping around if the index started somewhere in the middle)
         for (i = 0, ii = gestureLogIndex; i < GESTURE_LOG_SIZE; i++, ii = (ii + 1) % GESTURE_LOG_SIZE) DrawText(gestureLog[ii], gestureLogPosition.x, gestureLogPosition.y + 410 - i*20, 20, (i == 0 ? gestureColor : LIGHTGRAY));
         Color logButton1Color, logButton2Color;
@@ -286,7 +286,7 @@ void Update(void)
                     DrawCircleV(touchPosition[i], 50.0f, Fade(gestureColor, 0.5f));
                     DrawCircleV(touchPosition[i], 5.0f, gestureColor);
                 }
-                
+
                 if (touchCount == 2) DrawLineEx(touchPosition[0], touchPosition[1], ((currentGesture == 512)? 8 : 12), gestureColor);
             }
             else
@@ -308,14 +308,6 @@ int main(void)
 {
     // Initialization
     //--------------------------------------------------------------------------------------
-    #if defined( PLATFORM_WEB )
-        // Using Emscripten EM_ASM_INT macro, get the page canvas width
-        const int canvasWidth = EM_ASM_INT( return document.getElementById('canvas').getBoundingClientRect().width; );
-        
-        if (canvasWidth > 400) screenWidth = canvasWidth;
-        else screenWidth = 400; // Set a minimum width for the screen
-    #endif
-
     InitWindow(screenWidth, screenHeight, "raylib [core] example - input gestures web");
     //--------------------------------------------------------------------------------------
 

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -109,7 +109,6 @@
 #define RLGL_IMPLEMENTATION
 #include "rlgl.h"                   // OpenGL abstraction layer to OpenGL 1.1, 3.3+ or ES2
 
-#define RAYMATH_IMPLEMENTATION      // Define external out-of-line implementation
 #include "raymath.h"                // Vector3, Quaternion and Matrix functionality
 
 #if defined(SUPPORT_GESTURES_SYSTEM)

--- a/src/rcore.h
+++ b/src/rcore.h
@@ -9,7 +9,7 @@
 
 #include "utils.h"                  // Required for: TRACELOG() macros
 
-#if defined(PLATFORM_DESKTOP)
+#if defined(PLATFORM_DESKTOP) || defined(PLATFORM_WEB)
     #define GLFW_INCLUDE_NONE       // Disable the standard OpenGL header inclusion on GLFW3
                                     // NOTE: Already provided by rlgl implementation (on glad.h)
     #include "GLFW/glfw3.h"         // GLFW3 library: Windows, OpenGL context and Input management
@@ -21,7 +21,7 @@
 /*
 
     Status:
-    InitWindow: DRM, 
+    InitWindow: DRM,
 
 */
 

--- a/src/rcore.h
+++ b/src/rcore.h
@@ -27,6 +27,8 @@
 
 #include "raylib.h"
 #include "rlgl.h"
+
+#define RAYMATH_IMPLEMENTATION
 #include "raymath.h"
 
 

--- a/src/rcore.h
+++ b/src/rcore.h
@@ -7,6 +7,7 @@
 #include <time.h>                   // Required for: time() [Used in InitTimer()]
 #include <math.h>                   // Required for: tan() [Used in BeginMode3D()], atan2f() [Used in LoadVrStereoConfig()]
 
+#define SUPPORT_TRACELOG
 #include "utils.h"                  // Required for: TRACELOG() macros
 
 #if defined(PLATFORM_DESKTOP) || defined(PLATFORM_WEB)


### PR DESCRIPTION
### PR changes
1. Fixes compilation for `PLATFORM_WEB` ([R12](https://github.com/raysan5/raylib/pull/3329/files#diff-7341b65fe444443a67b5c67d194f97dd0c919b63c579f15ce018de206cf84864R12)). `#include "GLFW/glfw3.h"` ([R15)](https://github.com/raysan5/raylib/pull/3329/files#diff-7341b65fe444443a67b5c67d194f97dd0c919b63c579f15ce018de206cf84864R15) is necessary for `CoreData`'s `GLFWwindow *handle;` ([R109](https://github.com/raysan5/raylib/pull/3329/files#diff-7341b65fe444443a67b5c67d194f97dd0c919b63c579f15ce018de206cf84864R109)) on `PLATFORM_WEB`.

2. Removes `EM_ASM_INT` from `core_input_gestures_web` example ([L311-L317](https://github.com/raysan5/raylib/pull/3329/files#diff-6bb5ee6018759da67168502ea865172f16f99f175c871a405024c1a219b85d87L311-L317)) as per https://github.com/raysan5/raylib/pull/3328#pullrequestreview-1635184774.

3. Fixes `undefined symbol` compilation errors from `raymath` for `PLATFORM_DESKTOP` and `PLATFORM_WEB`, by moving `#define RAYMATH_IMPLEMENTATION` from `rcore.c` ([L112](https://github.com/raysan5/raylib/pull/3329/files#diff-39fea0e3daa23741e81daf967717f35c7842426aab26a0bc3f525d6a2f03e339L112)) to `rcore.h` ([R31](https://github.com/raysan5/raylib/pull/3329/files#diff-7341b65fe444443a67b5c67d194f97dd0c919b63c579f15ce018de206cf84864R31)).<br>
**Alternative solution for item 3:** https://github.com/raysan5/raylib/pull/3331/commits/b75e631084c8095ffdc03145a27221d746d37ea8 at https://github.com/raysan5/raylib/pull/3331

4. Fixes `TraceLog` on `PLATFORM_DESKTOP` and `PLATFORM_WEB` by adding `#define SUPPORT_TRACELOG` to `rcore.h` ([R10](https://github.com/raysan5/raylib/pull/3329/files#diff-7341b65fe444443a67b5c67d194f97dd0c919b63c579f15ce018de206cf84864R10)). Also fixes the `core_custom_logging` example.

### Current PLATFORM_WEB status
| module | compiled | tested | comment |
| --- | --- | --- | --- |
| `raylib` | :heavy_check_mark: all  | pending  | - |
| `examples/audio` | :heavy_check_mark: all  | :heavy_check_mark: all  | - |
| `examples/core` | :heavy_check_mark: all  | :x: `core_custom_frame_control`<br>:x: `core_loading_thread`<br>:x: `core_window_flags`<br>:heavy_check_mark: all others | See note C |
| `examples/models` | :heavy_check_mark: all  | :x: `models_skybox`<br>:heavy_check_mark: all others | - |
| `examples/others` | :x: `raylib_opengl_interop`<br>:x: `rlgl_standalone`<br>:heavy_check_mark: all others | :x: `rlgl_compute_shader`<br>:heavy_check_mark: all others | See note B |
| `examples/shaders` | :heavy_check_mark: all  | :heavy_check_mark: all  | - |
| `examples/shapes` | :heavy_check_mark: all  | :heavy_check_mark: all  | - |
| `examples/text` | :heavy_check_mark: all  | :heavy_check_mark: all  | - |
| `examples/textures` | :heavy_check_mark: all  | :heavy_check_mark: all  | - |

### Notes
- A. This PR is a follow-up from https://github.com/raysan5/raylib/pull/3328.

- ~`examples/others` has some very singular/specific examples. I'll review them last. - The only example in `examples/others` not working is `raylib_opengl_interop`. However, it's also not compiling on current master branch (c9020ece5da5dcb4760b32080fdeddbba96d885c) and `examples/others` is not part of `Makefile.Web`. So I'm skipping this one. I'll review it later (not even sure if it's meant to run on `PLATFORM_WEB`).~
- B. For `PLATFORM_WEB` the `raylib_opengl_interop` and `rlgl_standalone` examples are not compiling, but they are also not compiling on current master branch (c9020ece5da5dcb4760b32080fdeddbba96d885c). `rlgl_compute_shader` compiles on both, but doesn't work on either. Since `examples/others` is not part of `Makefile.Web` I'll skip these ones for now and review them later (not even sure if they are meant to run on `PLATFORM_WEB`).

- C. For `PLATFORM_WEB` the `core_custom_frame_control`, `core_loading_thread` and `core_window_flags` examples also don't work on current master branch (c9020ece5da5dcb4760b32080fdeddbba96d885c). So I'll skip these ones for now and review them later.

- D. I'm now reviewing each function for web.

### Environment
- Compiled with `emscripten/emsdk` on Linux (Mint 21.1 64-bit).
- Tested on Firefox (115.1.0esr 64-bit) and Chromium (115.0.5790.170 64-bit) both running on Linux Mint (21.1 64-bit).

**Edit 1:** added line marks; added core_input_gestures_web fix.
**Edit 2:** updated status.
**Edit 3:** added fix for raymath undefined symbols for desktop and web; updated status.
**Edit 4:** added line marks; formatting.
**Edit 5:** updated status; updated comment regarding the raylib_opengl_interop example for web.
**Edit 6, 7, 8, 9, 10, 11, 12, 13:** updated status.
**Edit 14:** updated notes about examples/others.
**Edit 15:** linked alternative solution for item 3.
**Edit 16:** updated status and notes; formatting.
**Edit 17:** added fix for TraceLog and core_custom_logging example.