### PR TITLE
[raymath] Added macros for EPSILON on each function it's used in

### DIFF
--- a/src/raymath.h
+++ b/src/raymath.h
@@ -214,6 +214,10 @@ RMAPI float Wrap(float value, float min, float max)
 // Check whether two given floats are almost equal
 RMAPI int FloatEquals(float x, float y)
 {
+#ifndef EPSILON
+    #define EPSILON 0.000001f
+#endif
+
     int result = (fabsf(x - y)) <= (EPSILON*fmaxf(1.0f, fmaxf(fabsf(x), fabsf(y))));
 
     return result;
@@ -506,6 +510,10 @@ RMAPI Vector2 Vector2ClampValue(Vector2 v, float min, float max)
 // Check whether two given vectors are almost equal
 RMAPI int Vector2Equals(Vector2 p, Vector2 q)
 {
+#ifndef EPSILON
+    #define EPSILON 0.000001f
+#endif
+
     int result = ((fabsf(p.x - q.x)) <= (EPSILON*fmaxf(1.0f, fmaxf(fabsf(p.x), fabsf(q.x))))) &&
                   ((fabsf(p.y - q.y)) <= (EPSILON*fmaxf(1.0f, fmaxf(fabsf(p.y), fabsf(q.y)))));
 
@@ -1090,6 +1098,10 @@ RMAPI Vector3 Vector3ClampValue(Vector3 v, float min, float max)
 // Check whether two given vectors are almost equal
 RMAPI int Vector3Equals(Vector3 p, Vector3 q)
 {
+#ifndef EPSILON
+    #define EPSILON 0.000001f
+#endif
+
     int result = ((fabsf(p.x - q.x)) <= (EPSILON*fmaxf(1.0f, fmaxf(fabsf(p.x), fabsf(q.x))))) &&
                  ((fabsf(p.y - q.y)) <= (EPSILON*fmaxf(1.0f, fmaxf(fabsf(p.y), fabsf(q.y))))) &&
                  ((fabsf(p.z - q.z)) <= (EPSILON*fmaxf(1.0f, fmaxf(fabsf(p.z), fabsf(q.z)))));
@@ -1846,6 +1858,10 @@ RMAPI Quaternion QuaternionSlerp(Quaternion q1, Quaternion q2, float amount)
 {
     Quaternion result = { 0 };
 
+#ifndef EPSILON
+    #define EPSILON 0.000001f
+#endif
+
     float cosHalfTheta = q1.x*q2.x + q1.y*q2.y + q1.z*q2.z + q1.w*q2.w;
 
     if (cosHalfTheta < 0)
@@ -2153,6 +2169,10 @@ RMAPI Quaternion QuaternionTransform(Quaternion q, Matrix mat)
 // Check whether two given quaternions are almost equal
 RMAPI int QuaternionEquals(Quaternion p, Quaternion q)
 {
+#ifndef EPSILON
+    #define EPSILON 0.000001f
+#endif
+
     int result = (((fabsf(p.x - q.x)) <= (EPSILON*fmaxf(1.0f, fmaxf(fabsf(p.x), fabsf(q.x))))) &&
                   ((fabsf(p.y - q.y)) <= (EPSILON*fmaxf(1.0f, fmaxf(fabsf(p.y), fabsf(q.y))))) &&
                   ((fabsf(p.z - q.z)) <= (EPSILON*fmaxf(1.0f, fmaxf(fabsf(p.z), fabsf(q.z))))) &&

--- a/src/raymath.h
+++ b/src/raymath.h
@@ -214,7 +214,7 @@ RMAPI float Wrap(float value, float min, float max)
 // Check whether two given floats are almost equal
 RMAPI int FloatEquals(float x, float y)
 {
-#ifndef EPSILON
+#if !defined(EPSILON)
     #define EPSILON 0.000001f
 #endif
 
@@ -510,7 +510,7 @@ RMAPI Vector2 Vector2ClampValue(Vector2 v, float min, float max)
 // Check whether two given vectors are almost equal
 RMAPI int Vector2Equals(Vector2 p, Vector2 q)
 {
-#ifndef EPSILON
+#if !defined(EPSILON)
     #define EPSILON 0.000001f
 #endif
 
@@ -1098,7 +1098,7 @@ RMAPI Vector3 Vector3ClampValue(Vector3 v, float min, float max)
 // Check whether two given vectors are almost equal
 RMAPI int Vector3Equals(Vector3 p, Vector3 q)
 {
-#ifndef EPSILON
+#if !defined(EPSILON)
     #define EPSILON 0.000001f
 #endif
 
@@ -1858,7 +1858,7 @@ RMAPI Quaternion QuaternionSlerp(Quaternion q1, Quaternion q2, float amount)
 {
     Quaternion result = { 0 };
 
-#ifndef EPSILON
+#if !defined(EPSILON)
     #define EPSILON 0.000001f
 #endif
 
@@ -2169,7 +2169,7 @@ RMAPI Quaternion QuaternionTransform(Quaternion q, Matrix mat)
 // Check whether two given quaternions are almost equal
 RMAPI int QuaternionEquals(Quaternion p, Quaternion q)
 {
-#ifndef EPSILON
+#if !defined(EPSILON)
     #define EPSILON 0.000001f
 #endif
 


### PR DESCRIPTION
This is so the functions can be easily copied and used. This was discussed in a separate pull:
https://github.com/raysan5/raylib/pull/3319#issuecomment-1722461911