### PR TITLE
[split] `rcore`, `rcore_web` and `rcore_desktop` changes (batch 2)

### DIFF
--- a/src/rcore.c
+++ b/src/rcore.c
@@ -1691,10 +1691,12 @@ unsigned char *CompressData(const unsigned char *data, int dataSize, int *compDa
 
 #if defined(SUPPORT_COMPRESSION_API)
     // Compress data and generate a valid DEFLATE stream
-    struct sdefl sdefl = { 0 };
-    int bounds = sdefl_bound(dataSize);
+    struct sdefl *sdefl = RL_CALLOC(1, sizeof(struct sdefl));   // WARNING: Possible stack overflow, struct sdefl is almost 1MB
+    int bounds = dataSize*2;//sdefl_bound(dataSize);
     compData = (unsigned char *)RL_CALLOC(bounds, 1);
-    *compDataSize = sdeflate(&sdefl, compData, data, dataSize, COMPRESSION_QUALITY_DEFLATE);   // Compression level 8, same as stbiw
+
+    *compDataSize = sdeflate(sdefl, compData, data, dataSize, COMPRESSION_QUALITY_DEFLATE);   // Compression level 8, same as stbiw
+    RL_FREE(sdefl);
 
     TRACELOG(LOG_INFO, "SYSTEM: Compress data: Original size: %i -> Comp. size: %i", dataSize, *compDataSize);
 #endif

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -99,12 +99,13 @@
 **********************************************************************************************/
 
 #include "raylib.h"                 // Declares module functions
-#include "rcore.h"
 
 // Check if config flags have been externally provided on compilation line
 #if !defined(EXTERNAL_CONFIG_FLAGS)
     #include "config.h"             // Defines module configuration flags
 #endif
+
+#include "rcore.h"
 
 #define RLGL_IMPLEMENTATION
 #include "rlgl.h"                   // OpenGL abstraction layer to OpenGL 1.1, 3.3+ or ES2

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -3366,15 +3366,11 @@ static void *EventThread(void *arg)
                 gestureEvent.touchAction = touchAction;
                 gestureEvent.pointCount = CORE.Input.Touch.pointCount;
 
-                gestureEvent.pointId[0] = 0;
-                gestureEvent.pointId[1] = 1;
-                gestureEvent.pointId[2] = 2;
-                gestureEvent.pointId[3] = 3;
-
-                gestureEvent.position[0] = CORE.Input.Touch.position[0];
-                gestureEvent.position[1] = CORE.Input.Touch.position[1];
-                gestureEvent.position[2] = CORE.Input.Touch.position[2];
-                gestureEvent.position[3] = CORE.Input.Touch.position[3];
+                for (int i = 0; i < MAX_TOUCH_POINTS; i++)
+                {
+                    gestureEvent.pointId[i] = i;
+                    gestureEvent.position[i] = CORE.Input.Touch.position[i];
+                }
 
                 ProcessGestureEvent(gestureEvent);
             }

--- a/src/rcore.h
+++ b/src/rcore.h
@@ -143,9 +143,11 @@ typedef struct CoreData {
         Size currentFbo;                    // Current render width and height (depends on active fbo)
         Size render;                        // Framebuffer width and height (render area, including black bars if required)
         Point renderOffset;                 // Offset from render area (must be divided by 2)
+        Size screenMin;                     // Screen minimum width and height (for resizable window)
+        Size screenMax;                     // Screen maximum width and height (for resizable window)
         Matrix screenScale;                 // Matrix to scale screen (framebuffer rendering)
 
-        char **dropFilepaths;         // Store dropped files paths pointers (provided by GLFW)
+        char **dropFilepaths;               // Store dropped files paths pointers (provided by GLFW)
         unsigned int dropFileCount;         // Count dropped files strings
 
         struct {

--- a/src/rcore.h
+++ b/src/rcore.h
@@ -7,7 +7,6 @@
 #include <time.h>                   // Required for: time() [Used in InitTimer()]
 #include <math.h>                   // Required for: tan() [Used in BeginMode3D()], atan2f() [Used in LoadVrStereoConfig()]
 
-#define SUPPORT_TRACELOG
 #include "utils.h"                  // Required for: TRACELOG() macros
 
 #if defined(PLATFORM_DESKTOP) || defined(PLATFORM_WEB)

--- a/src/rcore_desktop.c
+++ b/src/rcore_desktop.c
@@ -189,11 +189,11 @@ static bool InitGraphicsDevice(int width, int height)
     CORE.Window.screen.height = height;          // User desired height
     CORE.Window.screenScale = MatrixIdentity();  // No draw scaling required by default
 
-    // Set the window minimum and maximum default values to 0
-    CORE.Window.windowMin.width  = 0;
-    CORE.Window.windowMin.height = 0;
-    CORE.Window.windowMax.width  = 0;
-    CORE.Window.windowMax.height = 0;
+    // Set the screen minimum and maximum default values to 0
+    CORE.Window.screenMin.width  = 0;
+    CORE.Window.screenMin.height = 0;
+    CORE.Window.screenMax.width  = 0;
+    CORE.Window.screenMax.height = 0;
 
     // NOTE: Framebuffer (render area - CORE.Window.render.width, CORE.Window.render.height) could include black bars...
     // ...in top-down or left-right to match display aspect ratio (no weird scaling)
@@ -1093,24 +1093,24 @@ void SetWindowMonitor(int monitor)
 // Set window minimum dimensions (FLAG_WINDOW_RESIZABLE)
 void SetWindowMinSize(int width, int height)
 {
-    CORE.Window.windowMin.width = width;
-    CORE.Window.windowMin.height = height;
-    int minWidth  = (CORE.Window.windowMin.width  == 0) ? GLFW_DONT_CARE : CORE.Window.windowMin.width;
-    int minHeight = (CORE.Window.windowMin.height == 0) ? GLFW_DONT_CARE : CORE.Window.windowMin.height;
-    int maxWidth  = (CORE.Window.windowMax.width  == 0) ? GLFW_DONT_CARE : CORE.Window.windowMax.width;
-    int maxHeight = (CORE.Window.windowMax.height == 0) ? GLFW_DONT_CARE : CORE.Window.windowMax.height;
+    CORE.Window.screenMin.width = width;
+    CORE.Window.screenMin.height = height;
+    int minWidth  = (CORE.Window.screenMin.width  == 0) ? GLFW_DONT_CARE : CORE.Window.screenMin.width;
+    int minHeight = (CORE.Window.screenMin.height == 0) ? GLFW_DONT_CARE : CORE.Window.screenMin.height;
+    int maxWidth  = (CORE.Window.screenMax.width  == 0) ? GLFW_DONT_CARE : CORE.Window.screenMax.width;
+    int maxHeight = (CORE.Window.screenMax.height == 0) ? GLFW_DONT_CARE : CORE.Window.screenMax.height;
     glfwSetWindowSizeLimits(CORE.Window.handle, minWidth, minHeight, maxWidth, maxHeight);
 }
 
 // Set window maximum dimensions (FLAG_WINDOW_RESIZABLE)
 void SetWindowMaxSize(int width, int height)
 {
-    CORE.Window.windowMax.width = width;
-    CORE.Window.windowMax.height = height;
-    int minWidth  = (CORE.Window.windowMin.width  == 0) ? GLFW_DONT_CARE : CORE.Window.windowMin.width;
-    int minHeight = (CORE.Window.windowMin.height == 0) ? GLFW_DONT_CARE : CORE.Window.windowMin.height;
-    int maxWidth  = (CORE.Window.windowMax.width  == 0) ? GLFW_DONT_CARE : CORE.Window.windowMax.width;
-    int maxHeight = (CORE.Window.windowMax.height == 0) ? GLFW_DONT_CARE : CORE.Window.windowMax.height;
+    CORE.Window.screenMax.width = width;
+    CORE.Window.screenMax.height = height;
+    int minWidth  = (CORE.Window.screenMin.width  == 0) ? GLFW_DONT_CARE : CORE.Window.screenMin.width;
+    int minHeight = (CORE.Window.screenMin.height == 0) ? GLFW_DONT_CARE : CORE.Window.screenMin.height;
+    int maxWidth  = (CORE.Window.screenMax.width  == 0) ? GLFW_DONT_CARE : CORE.Window.screenMax.width;
+    int maxHeight = (CORE.Window.screenMax.height == 0) ? GLFW_DONT_CARE : CORE.Window.screenMax.height;
     glfwSetWindowSizeLimits(CORE.Window.handle, minWidth, minHeight, maxWidth, maxHeight);
 }
 

--- a/src/rcore_web.c
+++ b/src/rcore_web.c
@@ -159,9 +159,9 @@ void InitWindow(int width, int height, const char *title)
     // Check fullscreen change events(note this is done on the window since most browsers don't support this on #canvas)
     // emscripten_set_fullscreenchange_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW, NULL, 1, EmscriptenResizeCallback);
     // Check Resize event (note this is done on the window since most browsers don't support this on #canvas)
-    // emscripten_set_resize_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW, NULL, 1, EmscriptenResizeCallback);
+    emscripten_set_resize_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW, NULL, 1, EmscriptenResizeCallback);
     // Trigger this once to get initial window sizing
-    // EmscriptenResizeCallback(EMSCRIPTEN_EVENT_RESIZE, NULL, NULL);
+    EmscriptenResizeCallback(EMSCRIPTEN_EVENT_RESIZE, NULL, NULL);
 
     // Support keyboard events -> Not used, GLFW.JS takes care of that
     // emscripten_set_keypress_callback("#canvas", NULL, 1, EmscriptenKeyboardCallback);
@@ -202,8 +202,8 @@ static EM_BOOL EmscriptenWindowResizedCallback(int eventType, const EmscriptenUi
     return 1; // The event was consumed by the callback handler
 }
 
-EM_JS(int, GetCanvasWidth, (), { return canvas.clientWidth; });
-EM_JS(int, GetCanvasHeight, (), { return canvas.clientHeight; });
+EM_JS(int, GetWindowInnerWidth, (), { return window.innerWidth; });
+EM_JS(int, GetWindowInnerHeight, (), { return window.innerHeight; });
 
 // Register DOM element resize event
 static EM_BOOL EmscriptenResizeCallback(int eventType, const EmscriptenUiEvent *event, void *userData)
@@ -213,8 +213,8 @@ static EM_BOOL EmscriptenResizeCallback(int eventType, const EmscriptenUiEvent *
 
     // This event is called whenever the window changes sizes,
     // so the size of the canvas object is explicitly retrieved below
-    int width = GetCanvasWidth();
-    int height = GetCanvasHeight();
+    int width = GetWindowInnerWidth();
+    int height = GetWindowInnerHeight();
     emscripten_set_canvas_element_size("#canvas", width, height);
 
     SetupViewport(width, height); // Reset viewport and projection matrix for new size

--- a/src/rcore_web.c
+++ b/src/rcore_web.c
@@ -83,8 +83,7 @@ void InitWindow(int width, int height, const char *title)
     TRACELOG(LOG_INFO, "    > raudio:.... not loaded (optional)");
 #endif
 
-    if ((title != NULL) && (title[0] != 0))
-        CORE.Window.title = title;
+    if ((title != NULL) && (title[0] != 0)) CORE.Window.title = title;
 
     // Initialize global input state
     memset(&CORE.Input, 0, sizeof(CORE.Input));
@@ -105,8 +104,7 @@ void InitWindow(int width, int height, const char *title)
         TRACELOG(LOG_FATAL, "Failed to initialize Graphic Device");
         return;
     }
-    else
-        SetWindowPosition(GetMonitorWidth(GetCurrentMonitor()) / 2 - CORE.Window.screen.width / 2, GetMonitorHeight(GetCurrentMonitor()) / 2 - CORE.Window.screen.height / 2);
+    else SetWindowPosition(GetMonitorWidth(GetCurrentMonitor()) / 2 - CORE.Window.screen.width / 2, GetMonitorHeight(GetCurrentMonitor()) / 2 - CORE.Window.screen.height / 2);
 
     // Initialize hi-res timer
     InitTimer();
@@ -211,8 +209,7 @@ EM_JS(int, GetCanvasHeight, (), { return canvas.clientHeight; });
 static EM_BOOL EmscriptenResizeCallback(int eventType, const EmscriptenUiEvent *event, void *userData)
 {
     // Don't resize non-resizeable windows
-    if ((CORE.Window.flags & FLAG_WINDOW_RESIZABLE) == 0)
-        return 1;
+    if ((CORE.Window.flags & FLAG_WINDOW_RESIZABLE) == 0) return 1;
 
     // This event is called whenever the window changes sizes,
     // so the size of the canvas object is explicitly retrieved below
@@ -226,8 +223,7 @@ static EM_BOOL EmscriptenResizeCallback(int eventType, const EmscriptenUiEvent *
     CORE.Window.currentFbo.height = height;
     CORE.Window.resizedLastFrame = true;
 
-    if (IsWindowFullscreen())
-        return 1;
+    if (IsWindowFullscreen()) return 1;
 
     // Set current screen size
     CORE.Window.screen.width = width;
@@ -263,8 +259,7 @@ static EM_BOOL EmscriptenGamepadCallback(int eventType, const EmscriptenGamepadE
         CORE.Input.Gamepad.ready[gamepadEvent->index] = true;
         sprintf(CORE.Input.Gamepad.name[gamepadEvent->index], "%s", gamepadEvent->id);
     }
-    else
-        CORE.Input.Gamepad.ready[gamepadEvent->index] = false;
+    else CORE.Input.Gamepad.ready[gamepadEvent->index] = false;
 
     return 1; // The event was consumed by the callback handler
 }
@@ -294,10 +289,8 @@ static EM_BOOL EmscriptenTouchCallback(int eventType, const EmscriptenTouchEvent
         CORE.Input.Touch.position[i].x *= ((float)GetScreenWidth() / (float)canvasWidth);
         CORE.Input.Touch.position[i].y *= ((float)GetScreenHeight() / (float)canvasHeight);
 
-        if (eventType == EMSCRIPTEN_EVENT_TOUCHSTART)
-            CORE.Input.Touch.currentTouchState[i] = 1;
-        else if (eventType == EMSCRIPTEN_EVENT_TOUCHEND)
-            CORE.Input.Touch.currentTouchState[i] = 0;
+        if (eventType == EMSCRIPTEN_EVENT_TOUCHSTART) CORE.Input.Touch.currentTouchState[i] = 1;
+        else if (eventType == EMSCRIPTEN_EVENT_TOUCHEND) CORE.Input.Touch.currentTouchState[i] = 0;
     }
 
 #if defined(SUPPORT_GESTURES_SYSTEM) // PLATFORM_WEB
@@ -306,14 +299,10 @@ static EM_BOOL EmscriptenTouchCallback(int eventType, const EmscriptenTouchEvent
     gestureEvent.pointCount = CORE.Input.Touch.pointCount;
 
     // Register touch actions
-    if (eventType == EMSCRIPTEN_EVENT_TOUCHSTART)
-        gestureEvent.touchAction = TOUCH_ACTION_DOWN;
-    else if (eventType == EMSCRIPTEN_EVENT_TOUCHEND)
-        gestureEvent.touchAction = TOUCH_ACTION_UP;
-    else if (eventType == EMSCRIPTEN_EVENT_TOUCHMOVE)
-        gestureEvent.touchAction = TOUCH_ACTION_MOVE;
-    else if (eventType == EMSCRIPTEN_EVENT_TOUCHCANCEL)
-        gestureEvent.touchAction = TOUCH_ACTION_CANCEL;
+    if (eventType == EMSCRIPTEN_EVENT_TOUCHSTART) gestureEvent.touchAction = TOUCH_ACTION_DOWN;
+    else if (eventType == EMSCRIPTEN_EVENT_TOUCHEND) gestureEvent.touchAction = TOUCH_ACTION_UP;
+    else if (eventType == EMSCRIPTEN_EVENT_TOUCHMOVE) gestureEvent.touchAction = TOUCH_ACTION_MOVE;
+    else if (eventType == EMSCRIPTEN_EVENT_TOUCHCANCEL) gestureEvent.touchAction = TOUCH_ACTION_CANCEL;
 
     for (int i = 0; (i < gestureEvent.pointCount) && (i < MAX_TOUCH_POINTS); i++)
     {
@@ -329,8 +318,7 @@ static EM_BOOL EmscriptenTouchCallback(int eventType, const EmscriptenTouchEvent
     ProcessGestureEvent(gestureEvent);
 
     // Reset the pointCount for web, if it was the last Touch End event
-    if (eventType == EMSCRIPTEN_EVENT_TOUCHEND && CORE.Input.Touch.pointCount == 1)
-        CORE.Input.Touch.pointCount = 0;
+    if (eventType == EMSCRIPTEN_EVENT_TOUCHEND && CORE.Input.Touch.pointCount == 1) CORE.Input.Touch.pointCount = 0;
 #endif
 
     return 1; // The event was consumed by the callback handler
@@ -389,48 +377,33 @@ static bool InitGraphicsDevice(int width, int height)
     // glfwWindowHint(GLFW_AUX_BUFFERS, 0);          // Number of auxiliar buffers
 
     // Check window creation flags
-    if ((CORE.Window.flags & FLAG_FULLSCREEN_MODE) > 0)
-        CORE.Window.fullscreen = true;
+    if ((CORE.Window.flags & FLAG_FULLSCREEN_MODE) > 0) CORE.Window.fullscreen = true;
 
-    if ((CORE.Window.flags & FLAG_WINDOW_HIDDEN) > 0)
-        glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE); // Visible window
-    else
-        glfwWindowHint(GLFW_VISIBLE, GLFW_TRUE); // Window initially hidden
+    if ((CORE.Window.flags & FLAG_WINDOW_HIDDEN) > 0) glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE); // Visible window
+    else glfwWindowHint(GLFW_VISIBLE, GLFW_TRUE); // Window initially hidden
 
-    if ((CORE.Window.flags & FLAG_WINDOW_UNDECORATED) > 0)
-        glfwWindowHint(GLFW_DECORATED, GLFW_FALSE); // Border and buttons on Window
-    else
-        glfwWindowHint(GLFW_DECORATED, GLFW_TRUE); // Decorated window
+    if ((CORE.Window.flags & FLAG_WINDOW_UNDECORATED) > 0) glfwWindowHint(GLFW_DECORATED, GLFW_FALSE); // Border and buttons on Window
+    else glfwWindowHint(GLFW_DECORATED, GLFW_TRUE); // Decorated window
 
-    if ((CORE.Window.flags & FLAG_WINDOW_RESIZABLE) > 0)
-        glfwWindowHint(GLFW_RESIZABLE, GLFW_TRUE); // Resizable window
-    else
-        glfwWindowHint(GLFW_RESIZABLE, GLFW_FALSE); // Avoid window being resizable
+    if ((CORE.Window.flags & FLAG_WINDOW_RESIZABLE) > 0) glfwWindowHint(GLFW_RESIZABLE, GLFW_TRUE); // Resizable window
+    else glfwWindowHint(GLFW_RESIZABLE, GLFW_FALSE); // Avoid window being resizable
 
     // Disable FLAG_WINDOW_MINIMIZED, not supported on initialization
-    if ((CORE.Window.flags & FLAG_WINDOW_MINIMIZED) > 0)
-        CORE.Window.flags &= ~FLAG_WINDOW_MINIMIZED;
+    if ((CORE.Window.flags & FLAG_WINDOW_MINIMIZED) > 0) CORE.Window.flags &= ~FLAG_WINDOW_MINIMIZED;
 
     // Disable FLAG_WINDOW_MAXIMIZED, not supported on initialization
-    if ((CORE.Window.flags & FLAG_WINDOW_MAXIMIZED) > 0)
-        CORE.Window.flags &= ~FLAG_WINDOW_MAXIMIZED;
+    if ((CORE.Window.flags & FLAG_WINDOW_MAXIMIZED) > 0) CORE.Window.flags &= ~FLAG_WINDOW_MAXIMIZED;
 
-    if ((CORE.Window.flags & FLAG_WINDOW_UNFOCUSED) > 0)
-        glfwWindowHint(GLFW_FOCUSED, GLFW_FALSE);
-    else
-        glfwWindowHint(GLFW_FOCUSED, GLFW_TRUE);
+    if ((CORE.Window.flags & FLAG_WINDOW_UNFOCUSED) > 0) glfwWindowHint(GLFW_FOCUSED, GLFW_FALSE);
+    else glfwWindowHint(GLFW_FOCUSED, GLFW_TRUE);
 
-    if ((CORE.Window.flags & FLAG_WINDOW_TOPMOST) > 0)
-        glfwWindowHint(GLFW_FLOATING, GLFW_TRUE);
-    else
-        glfwWindowHint(GLFW_FLOATING, GLFW_FALSE);
+    if ((CORE.Window.flags & FLAG_WINDOW_TOPMOST) > 0) glfwWindowHint(GLFW_FLOATING, GLFW_TRUE);
+    else glfwWindowHint(GLFW_FLOATING, GLFW_FALSE);
 
         // NOTE: Some GLFW flags are not supported on HTML5
 #if defined(PLATFORM_DESKTOP)
-    if ((CORE.Window.flags & FLAG_WINDOW_TRANSPARENT) > 0)
-        glfwWindowHint(GLFW_TRANSPARENT_FRAMEBUFFER, GLFW_TRUE); // Transparent framebuffer
-    else
-        glfwWindowHint(GLFW_TRANSPARENT_FRAMEBUFFER, GLFW_FALSE); // Opaque framebuffer
+    if ((CORE.Window.flags & FLAG_WINDOW_TRANSPARENT) > 0) glfwWindowHint(GLFW_TRANSPARENT_FRAMEBUFFER, GLFW_TRUE); // Transparent framebuffer
+    else glfwWindowHint(GLFW_TRANSPARENT_FRAMEBUFFER, GLFW_FALSE); // Opaque framebuffer
 
     if ((CORE.Window.flags & FLAG_WINDOW_HIGHDPI) > 0)
     {
@@ -442,14 +415,11 @@ static bool InitGraphicsDevice(int width, int height)
         glfwWindowHint(GLFW_COCOA_RETINA_FRAMEBUFFER, GLFW_TRUE);
 #endif
     }
-    else
-        glfwWindowHint(GLFW_SCALE_TO_MONITOR, GLFW_FALSE);
+    else glfwWindowHint(GLFW_SCALE_TO_MONITOR, GLFW_FALSE);
 
     // Mouse passthrough
-    if ((CORE.Window.flags & FLAG_WINDOW_MOUSE_PASSTHROUGH) > 0)
-        glfwWindowHint(GLFW_MOUSE_PASSTHROUGH, GLFW_TRUE);
-    else
-        glfwWindowHint(GLFW_MOUSE_PASSTHROUGH, GLFW_FALSE);
+    if ((CORE.Window.flags & FLAG_WINDOW_MOUSE_PASSTHROUGH) > 0) glfwWindowHint(GLFW_MOUSE_PASSTHROUGH, GLFW_TRUE);
+    else glfwWindowHint(GLFW_MOUSE_PASSTHROUGH, GLFW_FALSE);
 #endif
 
     if (CORE.Window.flags & FLAG_MSAA_4X_HINT)
@@ -520,8 +490,7 @@ static bool InitGraphicsDevice(int width, int height)
     // Forcing this initialization here avoids doing it on PollInputEvents() called by EndDrawing() after first frame has been just drawn.
     // The initialization will still happen and possible delays still occur, but before the window is shown, which is a nicer experience.
     // REF: https://github.com/raysan5/raylib/issues/1554
-    if (MAX_GAMEPADS > 0)
-        glfwSetJoystickCallback(NULL);
+    if (MAX_GAMEPADS > 0) glfwSetJoystickCallback(NULL);
 #endif
 
 #if defined(PLATFORM_DESKTOP)
@@ -539,10 +508,8 @@ static bool InitGraphicsDevice(int width, int height)
     CORE.Window.display.height = mode->height;
 
     // Set screen width/height to the display width/height if they are 0
-    if (CORE.Window.screen.width == 0)
-        CORE.Window.screen.width = CORE.Window.display.width;
-    if (CORE.Window.screen.height == 0)
-        CORE.Window.screen.height = CORE.Window.display.height;
+    if (CORE.Window.screen.width == 0) CORE.Window.screen.width = CORE.Window.display.width;
+    if (CORE.Window.screen.height == 0) CORE.Window.screen.height = CORE.Window.display.height;
 #endif // PLATFORM_DESKTOP
 
 #if defined(PLATFORM_WEB)
@@ -567,10 +534,8 @@ static bool InitGraphicsDevice(int width, int height)
             CORE.Window.position.y = CORE.Window.display.height / 2 - CORE.Window.screen.height / 2;
         }
 
-        if (CORE.Window.position.x < 0)
-            CORE.Window.position.x = 0;
-        if (CORE.Window.position.y < 0)
-            CORE.Window.position.y = 0;
+        if (CORE.Window.position.x < 0) CORE.Window.position.x = 0;
+        if (CORE.Window.position.y < 0) CORE.Window.position.y = 0;
 
         // Obtain recommended CORE.Window.display.width/CORE.Window.display.height from a valid videomode for the monitor
         int count = 0;
@@ -823,16 +788,13 @@ static bool InitGraphicsDevice(int width, int height)
     CORE.Window.modeIndex = FindExactConnectorMode(CORE.Window.connector, CORE.Window.screen.width, CORE.Window.screen.height, fps, allowInterlaced);
 
     // If nothing found, try to find a nearly matching mode
-    if (CORE.Window.modeIndex < 0)
-        CORE.Window.modeIndex = FindNearestConnectorMode(CORE.Window.connector, CORE.Window.screen.width, CORE.Window.screen.height, fps, allowInterlaced);
+    if (CORE.Window.modeIndex < 0) CORE.Window.modeIndex = FindNearestConnectorMode(CORE.Window.connector, CORE.Window.screen.width, CORE.Window.screen.height, fps, allowInterlaced);
 
     // If nothing found, try to find an exactly matching mode including interlaced
-    if (CORE.Window.modeIndex < 0)
-        CORE.Window.modeIndex = FindExactConnectorMode(CORE.Window.connector, CORE.Window.screen.width, CORE.Window.screen.height, fps, true);
+    if (CORE.Window.modeIndex < 0) CORE.Window.modeIndex = FindExactConnectorMode(CORE.Window.connector, CORE.Window.screen.width, CORE.Window.screen.height, fps, true);
 
     // If nothing found, try to find a nearly matching mode including interlaced
-    if (CORE.Window.modeIndex < 0)
-        CORE.Window.modeIndex = FindNearestConnectorMode(CORE.Window.connector, CORE.Window.screen.width, CORE.Window.screen.height, fps, true);
+    if (CORE.Window.modeIndex < 0) CORE.Window.modeIndex = FindNearestConnectorMode(CORE.Window.connector, CORE.Window.screen.width, CORE.Window.screen.height, fps, true);
 
     // If nothing found, there is no suitable mode
     if (CORE.Window.modeIndex < 0)
@@ -1094,8 +1056,7 @@ static bool InitGraphicsDevice(int width, int height)
     CORE.Window.ready = true;
 #endif
 
-    if ((CORE.Window.flags & FLAG_WINDOW_MINIMIZED) > 0)
-        MinimizeWindow();
+    if ((CORE.Window.flags & FLAG_WINDOW_MINIMIZED) > 0) MinimizeWindow();
 
     return true;
 }
@@ -1484,7 +1445,7 @@ void EnableCursor(void)
 // Disables cursor (lock cursor)
 void DisableCursor(void)
 {
-    // TODO: figure out how not to hard code the canvas ID here. 
+    // TODO: figure out how not to hard code the canvas ID here.
     emscripten_request_pointerlock("#canvas", 1);
 
     // Set cursor position in the middle
@@ -1509,7 +1470,7 @@ void TakeScreenshot(const char *fileName)
 {
 #if defined(SUPPORT_MODULE_RTEXTURES)
     // Security check to (partially) avoid malicious code on PLATFORM_WEB
-    if (strchr(fileName, '\'') != NULL) { TRACELOG(LOG_WARNING, "SYSTEM: Provided fileName could be potentially malicious, avoid [\'] character");  return; }
+    if (strchr(fileName, '\'') != NULL) { TRACELOG(LOG_WARNING, "SYSTEM: Provided fileName could be potentially malicious, avoid [\'] character"); return; }
 
     Vector2 scale = GetWindowScaleDPI();
     unsigned char *imgData = rlReadScreenPixels((int)((float)CORE.Window.render.width*scale.x), (int)((float)CORE.Window.render.height*scale.y));

--- a/src/rcore_web.c
+++ b/src/rcore_web.c
@@ -215,6 +215,13 @@ static EM_BOOL EmscriptenResizeCallback(int eventType, const EmscriptenUiEvent *
     // so the size of the canvas object is explicitly retrieved below
     int width = GetWindowInnerWidth();
     int height = GetWindowInnerHeight();
+
+    if (width < CORE.Window.screenMin.width) width = CORE.Window.screenMin.width;
+    else if (width > CORE.Window.screenMax.width && CORE.Window.screenMax.width > 0) width = CORE.Window.screenMax.width;
+
+    if (height < CORE.Window.screenMin.height) height = CORE.Window.screenMin.height;
+    else if (height > CORE.Window.screenMax.height && CORE.Window.screenMax.height > 0) height = CORE.Window.screenMax.height;
+
     emscripten_set_canvas_element_size("#canvas", width, height);
 
     SetupViewport(width, height); // Reset viewport and projection matrix for new size
@@ -334,11 +341,11 @@ static bool InitGraphicsDevice(int width, int height)
     CORE.Window.screen.height = height;         // User desired height
     CORE.Window.screenScale = MatrixIdentity(); // No draw scaling required by default
 
-    // Set the window minimum and maximum default values to 0
-    CORE.Window.windowMin.width = 0;
-    CORE.Window.windowMin.height = 0;
-    CORE.Window.windowMax.width = 0;
-    CORE.Window.windowMax.height = 0;
+    // Set the screen minimum and maximum default values to 0
+    CORE.Window.screenMin.width  = 0;
+    CORE.Window.screenMin.height = 0;
+    CORE.Window.screenMax.width  = 0;
+    CORE.Window.screenMax.height = 0;
 
     // NOTE: Framebuffer (render area - CORE.Window.render.width, CORE.Window.render.height) could include black bars...
     // ...in top-down or left-right to match display aspect ratio (no weird scaling)
@@ -1282,8 +1289,8 @@ void SetWindowMonitor(int monitor)
 // Set window minimum dimensions (FLAG_WINDOW_RESIZABLE)
 void SetWindowMinSize(int width, int height)
 {
-    CORE.Window.windowMin.width = width;
-    CORE.Window.windowMin.height = height;
+    CORE.Window.screenMin.width = width;
+    CORE.Window.screenMin.height = height;
     // Trigger the resize event once to update the window minimum width and height
     if ((CORE.Window.flags & FLAG_WINDOW_RESIZABLE) != 0) EmscriptenResizeCallback(EMSCRIPTEN_EVENT_RESIZE, NULL, NULL);
 }
@@ -1291,8 +1298,8 @@ void SetWindowMinSize(int width, int height)
 // Set window maximum dimensions (FLAG_WINDOW_RESIZABLE)
 void SetWindowMaxSize(int width, int height)
 {
-    CORE.Window.windowMax.width = width;
-    CORE.Window.windowMax.height = height;
+    CORE.Window.screenMax.width = width;
+    CORE.Window.screenMax.height = height;
     // Trigger the resize event once to update the window maximum width and height
     if ((CORE.Window.flags & FLAG_WINDOW_RESIZABLE) != 0) EmscriptenResizeCallback(EMSCRIPTEN_EVENT_RESIZE, NULL, NULL);
 }


### PR DESCRIPTION
### PR changes
1. Fixes formatting on `rcore_web.c` so it's easier to compare with current master branch `rcore.c`.
On `rcore_web.c`: [R86](https://github.com/raysan5/raylib/pull/3334/files#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdR86), [R107](https://github.com/raysan5/raylib/pull/3334/files#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdR107), [R212](https://github.com/raysan5/raylib/pull/3334/files#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdR212), [R226](https://github.com/raysan5/raylib/pull/3334/files#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdR226), [R262](https://github.com/raysan5/raylib/pull/3334/files#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdR262), [R292-R293](https://github.com/raysan5/raylib/pull/3334/files#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdR292-R293), [R302-R305](https://github.com/raysan5/raylib/pull/3334/files#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdR302-R305), [R321](https://github.com/raysan5/raylib/pull/3334/files#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdR321), [R380](https://github.com/raysan5/raylib/pull/3334/files#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdR380), [R382-R383](https://github.com/raysan5/raylib/pull/3334/files#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdR382-R383), [R385-R386](https://github.com/raysan5/raylib/pull/3334/files#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdR385-R386), [R388-R389](https://github.com/raysan5/raylib/pull/3334/files#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdR388-R389), [R392](https://github.com/raysan5/raylib/pull/3334/files#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdR392), [R395](https://github.com/raysan5/raylib/pull/3334/files#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdR395), [R397-R398](https://github.com/raysan5/raylib/pull/3334/files#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdR397-R398), [R400-R401](https://github.com/raysan5/raylib/pull/3334/files#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdR400-R401), [R405-R406](https://github.com/raysan5/raylib/pull/3334/files#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdR405-R406), [R418](https://github.com/raysan5/raylib/pull/3334/files#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdR418), [R421-R422](https://github.com/raysan5/raylib/pull/3334/files#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdR421-R422), [R493](https://github.com/raysan5/raylib/pull/3334/files#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdR493), [R511-R512](https://github.com/raysan5/raylib/pull/3334/files#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdR511-R512), [R537-R538](https://github.com/raysan5/raylib/pull/3334/files#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdR537-R538), [R791](https://github.com/raysan5/raylib/pull/3334/files#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdR791), [R794](https://github.com/raysan5/raylib/pull/3334/files#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdR794), [R797](https://github.com/raysan5/raylib/pull/3334/files#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdR797), [R1059](https://github.com/raysan5/raylib/pull/3334/files#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdR1059), [R1448](https://github.com/raysan5/raylib/pull/3334/files#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdR1448), [R1473](https://github.com/raysan5/raylib/pull/3334/files#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdR1473).

2. Reapplies commit 9d230d7 (#3305) that was missing for `PLATFORM_WEB`.
On `rcore_web.c`: [R162](
https://github.com/raysan5/raylib/pull/3334/files#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdR162), [R164](https://github.com/raysan5/raylib/pull/3334/files#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdR164), [R205-R206](https://github.com/raysan5/raylib/pull/3334/files#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdR205-R206), [R216-R217](https://github.com/raysan5/raylib/pull/3334/files#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdR216-R217).

3. Reapplies commits 719365f (#3309) and 8a1779b (#3312) that were missing for both `PLATFORM_WEB` and `PLATFORM_DESKTOP`.
On `rcore.h`: [R146-R147](https://github.com/raysan5/raylib/pull/3334/files#diff-7341b65fe444443a67b5c67d194f97dd0c919b63c579f15ce018de206cf84864R146-R147).
On `rcore_web.c`: [R219-R223](https://github.com/raysan5/raylib/pull/3334/files#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdR219-R223), [R344-R348](https://github.com/raysan5/raylib/pull/3334/files#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdR344-R348), [R1292-R1293](https://github.com/raysan5/raylib/pull/3334/files#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdR1292-R1293), [R1301-R1302](https://github.com/raysan5/raylib/pull/3334/files#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdR1301-R1302).
On `rcore_desktop.c`: [R192-R196](https://github.com/raysan5/raylib/pull/3334/files#diff-10e13300b4588e538a0c2c603707242b63d716e3ab2b80b81db9a54c308ca3acR192-R196), [R1096-R1101](https://github.com/raysan5/raylib/pull/3334/files#diff-10e13300b4588e538a0c2c603707242b63d716e3ab2b80b81db9a54c308ca3acR1096-R1101), [R1108-R1113](https://github.com/raysan5/raylib/pull/3334/files#diff-10e13300b4588e538a0c2c603707242b63d716e3ab2b80b81db9a54c308ca3acR1108-R1113).

4. Reapplies commit 5c9cc3f (#3323) that was missing for `PLATFORM_DESKTOP`.
On `rcore.c`: [R3369-R3373](https://github.com/raysan5/raylib/pull/3334/files#diff-39fea0e3daa23741e81daf967717f35c7842426aab26a0bc3f525d6a2f03e339R3369-R3373).

5. Reapplies commit a2b3b1e that was missing for all platforms.
On `rcore.c`: [R1694-R1695](https://github.com/raysan5/raylib/pull/3334/files#diff-39fea0e3daa23741e81daf967717f35c7842426aab26a0bc3f525d6a2f03e339R1694-R1695), [R1697-R1699](https://github.com/raysan5/raylib/pull/3334/files#diff-39fea0e3daa23741e81daf967717f35c7842426aab26a0bc3f525d6a2f03e339R1697-R1699).

6. Revert my previous commit cef25c6 to fix the `warning: 'SUPPORT_TRACELOG' macro redefined` (I forgot it was already defined on `config.h`, sorry).
On `rcore.h`: [L10](https://github.com/raysan5/raylib/pull/3334/files#diff-7341b65fe444443a67b5c67d194f97dd0c919b63c579f15ce018de206cf84864L10).

7. Moves `#include "rcore.h"` to after `#include "config.h"` on `rcore.c` to fix the `macro redefined` warnings. This way the definitions on `config.h` get carried to `rcore.h`.
On `rcore.c`: [L102](https://github.com/raysan5/raylib/pull/3334/files#diff-39fea0e3daa23741e81daf967717f35c7842426aab26a0bc3f525d6a2f03e339L102), [R108](https://github.com/raysan5/raylib/pull/3334/files#diff-39fea0e3daa23741e81daf967717f35c7842426aab26a0bc3f525d6a2f03e339R108).

### Current PLATFORM_WEB status
| module | compiled | tested | comment |
| --- | --- | --- | --- |
| `raylib` | :heavy_check_mark: all  | in progress  | - |
| `examples/audio` | :heavy_check_mark: all  | :heavy_check_mark: all  | - |
| `examples/core` | :heavy_check_mark: all  | :x: `core_custom_frame_control`<br>:x: `core_loading_thread`<br>:x: `core_window_flags`<br>:heavy_check_mark: all others | See note A |
| `examples/models` | :heavy_check_mark: all  | :x: `models_skybox`<br>:heavy_check_mark: all others | - |
| `examples/others` | :x: `raylib_opengl_interop`<br>:x: `rlgl_standalone`<br>:heavy_check_mark: all others | :x: `rlgl_compute_shader`<br>:heavy_check_mark: all others | See note B |
| `examples/shaders` | :heavy_check_mark: all  | :heavy_check_mark: all  | - |
| `examples/shapes` | :heavy_check_mark: all  | :heavy_check_mark: all  | - |
| `examples/text` | :heavy_check_mark: all  | :heavy_check_mark: all  | - |
| `examples/textures` | :heavy_check_mark: all  | :heavy_check_mark: all  | - |

### Notes
- A. For `PLATFORM_WEB` the `core_custom_frame_control`, `core_loading_thread` and `core_window_flags` examples also don't work on current master branch (https://github.com/raysan5/raylib/commit/a2b3b1ebe43cdf394b49f901cbaedb2c87959168). So I'll skip these ones for now and review them later.

- B. For `PLATFORM_WEB` the `raylib_opengl_interop` and `rlgl_standalone` examples are not compiling, but they are also not compiling on current master branch (https://github.com/raysan5/raylib/commit/a2b3b1ebe43cdf394b49f901cbaedb2c87959168). `rlgl_compute_shader` compiles on both, but doesn't work on either. Since `examples/others` is not part of `Makefile.Web` I'll skip these ones for now and review them later (not even sure if they are meant to run on `PLATFORM_WEB`).

### Environment
- Compiled with `emscripten/emsdk` on Linux (Mint 21.1 64-bit).
- Tested on Firefox (115.1.0esr 64-bit) and Chromium (115.0.5790.170 64-bit) both running on Linux Mint (21.1 64-bit).

**Edit 1:** added line marks.
**Edit 2, 3, 4, 5:** added missing commits.
**Edit 6:** updated status and notes.
**Edit 7:** revert a previous commit.
**Edit 8:** added line marks and editting.
**Edit 9:** added macro redefinition fix.