### PR TITLE
[split] `rcore`, `web`, `desktop`, `android` changes (batch 3)

### DIFF
--- a/src/rcore.c
+++ b/src/rcore.c
@@ -2106,20 +2106,20 @@ Vector2 GetMouseWheelMoveV(void)
     return result;
 }
 
-// Set mouse cursor
-// NOTE: This is a no-op on platforms other than PLATFORM_DESKTOP
-void SetMouseCursor(int cursor)
-{
-#if defined(PLATFORM_DESKTOP)
-    CORE.Input.Mouse.cursor = cursor;
-    if (cursor == MOUSE_CURSOR_DEFAULT) glfwSetCursor(CORE.Window.handle, NULL);
-    else
-    {
-        // NOTE: We are relating internal GLFW enum values to our MouseCursor enum values
-        glfwSetCursor(CORE.Window.handle, glfwCreateStandardCursor(0x00036000 + cursor));
-    }
-#endif
-}
+//// Set mouse cursor
+//// NOTE: This is a no-op on platforms other than PLATFORM_DESKTOP
+//void SetMouseCursor(int cursor)
+//{
+//#if defined(PLATFORM_DESKTOP)
+//    CORE.Input.Mouse.cursor = cursor;
+//    if (cursor == MOUSE_CURSOR_DEFAULT) glfwSetCursor(CORE.Window.handle, NULL);
+//    else
+//    {
+//        // NOTE: We are relating internal GLFW enum values to our MouseCursor enum values
+//        glfwSetCursor(CORE.Window.handle, glfwCreateStandardCursor(0x00036000 + cursor));
+//    }
+//#endif
+//}
 
 //// Get touch position X for touch point 0 (relative to screen size)
 //int GetTouchX(void)

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -2121,45 +2121,45 @@ void SetMouseCursor(int cursor)
 #endif
 }
 
-// Get touch position X for touch point 0 (relative to screen size)
-int GetTouchX(void)
-{
-#if defined(PLATFORM_ANDROID) || defined(PLATFORM_WEB)
-    return (int)CORE.Input.Touch.position[0].x;
-#else   // PLATFORM_DESKTOP, PLATFORM_DRM
-    return GetMouseX();
-#endif
-}
+//// Get touch position X for touch point 0 (relative to screen size)
+//int GetTouchX(void)
+//{
+//#if defined(PLATFORM_ANDROID) || defined(PLATFORM_WEB)
+//    return (int)CORE.Input.Touch.position[0].x;
+//#else   // PLATFORM_DESKTOP, PLATFORM_DRM
+//    return GetMouseX();
+//#endif
+//}
 
-// Get touch position Y for touch point 0 (relative to screen size)
-int GetTouchY(void)
-{
-#if defined(PLATFORM_ANDROID) || defined(PLATFORM_WEB)
-    return (int)CORE.Input.Touch.position[0].y;
-#else   // PLATFORM_DESKTOP, PLATFORM_DRM
-    return GetMouseY();
-#endif
-}
+//// Get touch position Y for touch point 0 (relative to screen size)
+//int GetTouchY(void)
+//{
+//#if defined(PLATFORM_ANDROID) || defined(PLATFORM_WEB)
+//    return (int)CORE.Input.Touch.position[0].y;
+//#else   // PLATFORM_DESKTOP, PLATFORM_DRM
+//    return GetMouseY();
+//#endif
+//}
 
-// Get touch position XY for a touch point index (relative to screen size)
-// TODO: Touch position should be scaled depending on display size and render size
-Vector2 GetTouchPosition(int index)
-{
-    Vector2 position = { -1.0f, -1.0f };
-
-#if defined(PLATFORM_DESKTOP)
-    // TODO: GLFW does not support multi-touch input just yet
-    // https://www.codeproject.com/Articles/668404/Programming-for-Multi-Touch
-    // https://docs.microsoft.com/en-us/windows/win32/wintouch/getting-started-with-multi-touch-messages
-    if (index == 0) position = GetMousePosition();
-#endif
-#if defined(PLATFORM_ANDROID) || defined(PLATFORM_WEB) || defined(PLATFORM_DRM)
-    if (index < MAX_TOUCH_POINTS) position = CORE.Input.Touch.position[index];
-    else TRACELOG(LOG_WARNING, "INPUT: Required touch point out of range (Max touch points: %i)", MAX_TOUCH_POINTS);
-#endif
-
-    return position;
-}
+//// Get touch position XY for a touch point index (relative to screen size)
+//// TODO: Touch position should be scaled depending on display size and render size
+//Vector2 GetTouchPosition(int index)
+//{
+//    Vector2 position = { -1.0f, -1.0f };
+//
+//#if defined(PLATFORM_DESKTOP)
+//    // TODO: GLFW does not support multi-touch input just yet
+//    // https://www.codeproject.com/Articles/668404/Programming-for-Multi-Touch
+//    // https://docs.microsoft.com/en-us/windows/win32/wintouch/getting-started-with-multi-touch-messages
+//    if (index == 0) position = GetMousePosition();
+//#endif
+//#if defined(PLATFORM_ANDROID) || defined(PLATFORM_WEB) || defined(PLATFORM_DRM)
+//    if (index < MAX_TOUCH_POINTS) position = CORE.Input.Touch.position[index];
+//    else TRACELOG(LOG_WARNING, "INPUT: Required touch point out of range (Max touch points: %i)", MAX_TOUCH_POINTS);
+//#endif
+//
+//    return position;
+//}
 
 // Get touch point identifier for given index
 int GetTouchPointId(int index)

--- a/src/rcore_android.c
+++ b/src/rcore_android.c
@@ -1677,20 +1677,41 @@ void SetMousePosition(int x, int y)
     CORE.Input.Mouse.previousPosition = CORE.Input.Mouse.currentPosition;
 }
 
-
 // Get mouse wheel movement Y
 float GetMouseWheelMove(void)
 {
     return 0.0f;
 }
 
+// Get touch position X for touch point 0 (relative to screen size)
+int GetTouchX(void)
+{
+    return (int)CORE.Input.Touch.position[0].x;
+}
+
+// Get touch position Y for touch point 0 (relative to screen size)
+int GetTouchY(void)
+{
+    return (int)CORE.Input.Touch.position[0].y;
+}
+
+// Get touch position XY for a touch point index (relative to screen size)
+// TODO: Touch position should be scaled depending on display size and render size
+Vector2 GetTouchPosition(int index)
+{
+    Vector2 position = { -1.0f, -1.0f };
+
+    if (index < MAX_TOUCH_POINTS) position = CORE.Input.Touch.position[index];
+    else TRACELOG(LOG_WARNING, "INPUT: Required touch point out of range (Max touch points: %i)", MAX_TOUCH_POINTS);
+
+    return position;
+}
 
 // Swap back buffer with front buffer (screen drawing)
 void SwapScreenBuffer(void)
 {
     eglSwapBuffers(CORE.Window.device, CORE.Window.surface);
 }
-
 
 // Register all input events
 void PollInputEvents(void)

--- a/src/rcore_android.c
+++ b/src/rcore_android.c
@@ -1683,6 +1683,13 @@ float GetMouseWheelMove(void)
     return 0.0f;
 }
 
+// Set mouse cursor
+// NOTE: This is a no-op on platforms other than PLATFORM_DESKTOP
+void SetMouseCursor(int cursor)
+{
+    TRACELOG(LOG_INFO, "SetMouseCursor not implemented in rcore_android.c");
+}
+
 // Get touch position X for touch point 0 (relative to screen size)
 int GetTouchX(void)
 {

--- a/src/rcore_desktop.c
+++ b/src/rcore_desktop.c
@@ -1568,7 +1568,6 @@ void SetMousePosition(int x, int y)
     glfwSetCursorPos(CORE.Window.handle, CORE.Input.Mouse.currentPosition.x, CORE.Input.Mouse.currentPosition.y);
 }
 
-
 // Get mouse wheel movement Y
 float GetMouseWheelMove(void)
 {
@@ -1580,13 +1579,37 @@ float GetMouseWheelMove(void)
     return result;
 }
 
+// Get touch position X for touch point 0 (relative to screen size)
+int GetTouchX(void)
+{
+    return GetMouseX();
+}
+
+// Get touch position Y for touch point 0 (relative to screen size)
+int GetTouchY(void)
+{
+    return GetMouseY();
+}
+
+// Get touch position XY for a touch point index (relative to screen size)
+// TODO: Touch position should be scaled depending on display size and render size
+Vector2 GetTouchPosition(int index)
+{
+    Vector2 position = { -1.0f, -1.0f };
+
+    // TODO: GLFW does not support multi-touch input just yet
+    // https://www.codeproject.com/Articles/668404/Programming-for-Multi-Touch
+    // https://docs.microsoft.com/en-us/windows/win32/wintouch/getting-started-with-multi-touch-messages
+    if (index == 0) position = GetMousePosition();
+
+    return position;
+}
 
 // Swap back buffer with front buffer (screen drawing)
 void SwapScreenBuffer(void)
 {
     glfwSwapBuffers(CORE.Window.handle);
 }
-
 
 // Register all input events
 void PollInputEvents(void)

--- a/src/rcore_desktop.c
+++ b/src/rcore_desktop.c
@@ -1579,6 +1579,19 @@ float GetMouseWheelMove(void)
     return result;
 }
 
+// Set mouse cursor
+// NOTE: This is a no-op on platforms other than PLATFORM_DESKTOP
+void SetMouseCursor(int cursor)
+{
+    CORE.Input.Mouse.cursor = cursor;
+    if (cursor == MOUSE_CURSOR_DEFAULT) glfwSetCursor(CORE.Window.handle, NULL);
+    else
+    {
+        // NOTE: We are relating internal GLFW enum values to our MouseCursor enum values
+        glfwSetCursor(CORE.Window.handle, glfwCreateStandardCursor(0x00036000 + cursor));
+    }
+}
+
 // Get touch position X for touch point 0 (relative to screen size)
 int GetTouchX(void)
 {

--- a/src/rcore_web.c
+++ b/src/rcore_web.c
@@ -1099,7 +1099,6 @@ void SetMousePosition(int x, int y)
     glfwSetCursorPos(CORE.Window.handle, CORE.Input.Mouse.currentPosition.x, CORE.Input.Mouse.currentPosition.y);
 }
 
-
 // Get mouse wheel movement Y
 float GetMouseWheelMove(void)
 {
@@ -1109,6 +1108,13 @@ float GetMouseWheelMove(void)
     else result = (float)CORE.Input.Mouse.currentWheelMove.y;
 
     return result;
+}
+
+// Set mouse cursor
+// NOTE: This is a no-op on platforms other than PLATFORM_DESKTOP
+void SetMouseCursor(int cursor)
+{
+    TRACELOG(LOG_INFO, "SetMouseCursor not implemented in rcore_web.c");
 }
 
 // Get touch position X for touch point 0 (relative to screen size)

--- a/src/rcore_web.c
+++ b/src/rcore_web.c
@@ -350,7 +350,6 @@ static bool InitGraphicsDevice(int width, int height)
     // NOTE: Framebuffer (render area - CORE.Window.render.width, CORE.Window.render.height) could include black bars...
     // ...in top-down or left-right to match display aspect ratio (no weird scaling)
 
-// HERE 1 //#if defined(PLATFORM_DESKTOP) || defined(PLATFORM_WEB)
     glfwSetErrorCallback(ErrorCallback);
 /*
     // TODO: Setup GLFW custom allocators to match raylib ones
@@ -363,9 +362,6 @@ static bool InitGraphicsDevice(int width, int height)
 
     glfwInitAllocator(&allocator);
 */
-// HERE 2 //#if defined(__APPLE__)
-// HERE 2 //    glfwInitHint(GLFW_COCOA_CHDIR_RESOURCES, GLFW_FALSE);
-// HERE 2 //#endif
 
     if (!glfwInit())
     {
@@ -408,26 +404,7 @@ static bool InitGraphicsDevice(int width, int height)
     else glfwWindowHint(GLFW_FLOATING, GLFW_FALSE);
 
         // NOTE: Some GLFW flags are not supported on HTML5
-// HERE 3 //#if defined(PLATFORM_DESKTOP)
-// HERE 3 //    if ((CORE.Window.flags & FLAG_WINDOW_TRANSPARENT) > 0) glfwWindowHint(GLFW_TRANSPARENT_FRAMEBUFFER, GLFW_TRUE); // Transparent framebuffer
-// HERE 3 //    else glfwWindowHint(GLFW_TRANSPARENT_FRAMEBUFFER, GLFW_FALSE); // Opaque framebuffer
-// HERE 3 //
-// HERE 3 //    if ((CORE.Window.flags & FLAG_WINDOW_HIGHDPI) > 0)
-// HERE 3 //    {
-// HERE 3 //        // Resize window content area based on the monitor content scale.
-// HERE 3 //        // NOTE: This hint only has an effect on platforms where screen coordinates and pixels always map 1:1 such as Windows and X11.
-// HERE 3 //        // On platforms like macOS the resolution of the framebuffer is changed independently of the window size.
-// HERE 3 //        glfwWindowHint(GLFW_SCALE_TO_MONITOR, GLFW_TRUE); // Scale content area based on the monitor content scale where window is placed on
-// HERE 3 //#if defined(__APPLE__)
-// HERE 3 //        glfwWindowHint(GLFW_COCOA_RETINA_FRAMEBUFFER, GLFW_TRUE);
-// HERE 3 //#endif
-// HERE 3 //    }
-// HERE 3 //    else glfwWindowHint(GLFW_SCALE_TO_MONITOR, GLFW_FALSE);
-// HERE 3 //
-// HERE 3 //    // Mouse passthrough
-// HERE 3 //    if ((CORE.Window.flags & FLAG_WINDOW_MOUSE_PASSTHROUGH) > 0) glfwWindowHint(GLFW_MOUSE_PASSTHROUGH, GLFW_TRUE);
-// HERE 3 //    else glfwWindowHint(GLFW_MOUSE_PASSTHROUGH, GLFW_FALSE);
-// HERE 3 //#endif
+        // e.g.: GLFW_TRANSPARENT_FRAMEBUFFER, GLFW_SCALE_TO_MONITOR, GLFW_COCOA_RETINA_FRAMEBUFFER, GLFW_MOUSE_PASSTHROUGH
 
     if (CORE.Window.flags & FLAG_MSAA_4X_HINT)
     {
@@ -452,11 +429,7 @@ static bool InitGraphicsDevice(int width, int height)
         glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);                 // Choose OpenGL minor version (just hint)
         glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE); // Profiles Hint: Only 3.3 and above!
                                                                        // Values: GLFW_OPENGL_CORE_PROFILE, GLFW_OPENGL_ANY_PROFILE, GLFW_OPENGL_COMPAT_PROFILE
-// HERE 4 //#if defined(__APPLE__)
-// HERE 4 //        glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GLFW_TRUE); // OSX Requires forward compatibility
-// HERE 4 //#else
         glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GLFW_FALSE); // Forward Compatibility Hint: Only 3.3 and above!
-// HERE 4 //#endif
         // glfwWindowHint(GLFW_OPENGL_DEBUG_CONTEXT, GLFW_TRUE); // Request OpenGL DEBUG context
     }
     else if (rlGetVersion() == RL_OPENGL_43)
@@ -474,56 +447,19 @@ static bool InitGraphicsDevice(int width, int height)
         glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 2);
         glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 0);
         glfwWindowHint(GLFW_CLIENT_API, GLFW_OPENGL_ES_API);
-// HERE 5 //#if defined(PLATFORM_DESKTOP)
-// HERE 5 //        glfwWindowHint(GLFW_CONTEXT_CREATION_API, GLFW_EGL_CONTEXT_API);
-// HERE 5 //#else
         glfwWindowHint(GLFW_CONTEXT_CREATION_API, GLFW_NATIVE_CONTEXT_API);
-// HERE 5 //#endif
     }
     else if (rlGetVersion() == RL_OPENGL_ES_30) // Request OpenGL ES 3.0 context
     {
         glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
         glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 0);
         glfwWindowHint(GLFW_CLIENT_API, GLFW_OPENGL_ES_API);
-// HERE 6 //#if defined(PLATFORM_DESKTOP)
-// HERE 6 //        glfwWindowHint(GLFW_CONTEXT_CREATION_API, GLFW_EGL_CONTEXT_API);
-// HERE 6 //#else
         glfwWindowHint(GLFW_CONTEXT_CREATION_API, GLFW_NATIVE_CONTEXT_API);
-// HERE 6 //#endif
     }
 
-// HERE 7 //#if defined(PLATFORM_DESKTOP)
-// HERE 7 //    // NOTE: GLFW 3.4+ defers initialization of the Joystick subsystem on the first call to any Joystick related functions.
-// HERE 7 //    // Forcing this initialization here avoids doing it on PollInputEvents() called by EndDrawing() after first frame has been just drawn.
-// HERE 7 //    // The initialization will still happen and possible delays still occur, but before the window is shown, which is a nicer experience.
-// HERE 7 //    // REF: https://github.com/raysan5/raylib/issues/1554
-// HERE 7 //    if (MAX_GAMEPADS > 0) glfwSetJoystickCallback(NULL);
-// HERE 7 //#endif
-
-// HERE 8 //#if defined(PLATFORM_DESKTOP)
-// HERE 8 //    // Find monitor resolution
-// HERE 8 //    GLFWmonitor *monitor = glfwGetPrimaryMonitor();
-// HERE 8 //    if (!monitor)
-// HERE 8 //    {
-// HERE 8 //        TRACELOG(LOG_WARNING, "GLFW: Failed to get primary monitor");
-// HERE 8 //        return false;
-// HERE 8 //    }
-// HERE 8 //
-// HERE 8 //    const GLFWvidmode *mode = glfwGetVideoMode(monitor);
-// HERE 8 //
-// HERE 8 //    CORE.Window.display.width = mode->width;
-// HERE 8 //    CORE.Window.display.height = mode->height;
-// HERE 8 //
-// HERE 8 //    // Set screen width/height to the display width/height if they are 0
-// HERE 8 //    if (CORE.Window.screen.width == 0) CORE.Window.screen.width = CORE.Window.display.width;
-// HERE 8 //    if (CORE.Window.screen.height == 0) CORE.Window.screen.height = CORE.Window.display.height;
-// HERE 8 //#endif // PLATFORM_DESKTOP
-
-// HERE 9 //#if defined(PLATFORM_WEB)
     // NOTE: Getting video modes is not implemented in emscripten GLFW3 version
     CORE.Window.display.width = CORE.Window.screen.width;
     CORE.Window.display.height = CORE.Window.screen.height;
-// HERE 9 //#endif // PLATFORM_WEB
 
     if (CORE.Window.fullscreen)
     {
@@ -582,13 +518,6 @@ static bool InitGraphicsDevice(int width, int height)
     }
     else
     {
-// HERE 10 //#if defined(PLATFORM_DESKTOP)
-// HERE 10 //        // If we are windowed fullscreen, ensures that window does not minimize when focus is lost
-// HERE 10 //        if ((CORE.Window.screen.height == CORE.Window.display.height) && (CORE.Window.screen.width == CORE.Window.display.width))
-// HERE 10 //        {
-// HERE 10 //            glfwWindowHint(GLFW_AUTO_ICONIFY, 0);
-// HERE 10 //        }
-// HERE 10 //#endif
         // No-fullscreen window creation
         CORE.Window.handle = glfwCreateWindow(CORE.Window.screen.width, CORE.Window.screen.height, (CORE.Window.title != 0) ? CORE.Window.title : " ", NULL, NULL);
 
@@ -607,15 +536,10 @@ static bool InitGraphicsDevice(int width, int height)
     }
 
 // glfwCreateWindow title doesn't work with emscripten.
-// HERE 11 //#if defined(PLATFORM_WEB)
     emscripten_set_window_title((CORE.Window.title != 0) ? CORE.Window.title : " ");
-// HERE 11 //#endif
 
     // Set window callback events
     glfwSetWindowSizeCallback(CORE.Window.handle, WindowSizeCallback); // NOTE: Resizing not allowed by default!
-// HERE 12 //#if !defined(PLATFORM_WEB)
-// HERE 12 //    glfwSetWindowMaximizeCallback(CORE.Window.handle, WindowMaximizeCallback);
-// HERE 12 //#endif
     glfwSetWindowIconifyCallback(CORE.Window.handle, WindowIconifyCallback);
     glfwSetWindowFocusCallback(CORE.Window.handle, WindowFocusCallback);
     glfwSetDropCallback(CORE.Window.handle, WindowDropCallback);
@@ -630,43 +554,12 @@ static bool InitGraphicsDevice(int width, int height)
 
     glfwMakeContextCurrent(CORE.Window.handle);
 
-// HERE 13 //#if !defined(PLATFORM_WEB)
-// HERE 13 //    glfwSetInputMode(CORE.Window.handle, GLFW_LOCK_KEY_MODS, GLFW_TRUE); // Enable lock keys modifiers (CAPS, NUM)
-// HERE 13 //
-// HERE 13 //    glfwSwapInterval(0); // No V-Sync by default
-// HERE 13 //#endif
-
     // Try to enable GPU V-Sync, so frames are limited to screen refresh rate (60Hz -> 60 FPS)
     // NOTE: V-Sync can be enabled by graphic driver configuration, it doesn't need
     // to be activated on web platforms since VSync is enforced there.
-// HERE 14 //#if !defined(PLATFORM_WEB)
-// HERE 14 //    if (CORE.Window.flags & FLAG_VSYNC_HINT)
-// HERE 14 //    {
-// HERE 14 //        // WARNING: It seems to hit a critical render path in Intel HD Graphics
-// HERE 14 //        glfwSwapInterval(1);
-// HERE 14 //        TRACELOG(LOG_INFO, "DISPLAY: Trying to enable VSYNC");
-// HERE 14 //    }
-// HERE 14 //#endif
 
     int fbWidth = CORE.Window.screen.width;
     int fbHeight = CORE.Window.screen.height;
-
-// HERE 15 //#if defined(PLATFORM_DESKTOP)
-// HERE 15 //    if ((CORE.Window.flags & FLAG_WINDOW_HIGHDPI) > 0)
-// HERE 15 //    {
-// HERE 15 //        // NOTE: On APPLE platforms system should manage window/input scaling and also framebuffer scaling.
-// HERE 15 //        // Framebuffer scaling should be activated with: glfwWindowHint(GLFW_COCOA_RETINA_FRAMEBUFFER, GLFW_TRUE);
-// HERE 15 //#if !defined(__APPLE__)
-// HERE 15 //        glfwGetFramebufferSize(CORE.Window.handle, &fbWidth, &fbHeight);
-// HERE 15 //
-// HERE 15 //        // Screen scaling matrix is required in case desired screen area is different from display area
-// HERE 15 //        CORE.Window.screenScale = MatrixScale((float)fbWidth / CORE.Window.screen.width, (float)fbHeight / CORE.Window.screen.height, 1.0f);
-// HERE 15 //
-// HERE 15 //        // Mouse input scaling for the new screen size
-// HERE 15 //        SetMouseScale((float)CORE.Window.screen.width / fbWidth, (float)CORE.Window.screen.height / fbHeight);
-// HERE 15 //#endif
-// HERE 15 //    }
-// HERE 15 //#endif
 
     CORE.Window.render.width = fbWidth;
     CORE.Window.render.height = fbHeight;
@@ -679,377 +572,9 @@ static bool InitGraphicsDevice(int width, int height)
     TRACELOG(LOG_INFO, "    > Render size:  %i x %i", CORE.Window.render.width, CORE.Window.render.height);
     TRACELOG(LOG_INFO, "    > Viewport offsets: %i, %i", CORE.Window.renderOffset.x, CORE.Window.renderOffset.y);
 
-// HERE 1 //#endif // PLATFORM_DESKTOP || PLATFORM_WEB
-
-// HERE 16 //#if defined(PLATFORM_ANDROID) || defined(PLATFORM_DRM)
-// HERE 16 //    CORE.Window.fullscreen = true;
-// HERE 16 //    CORE.Window.flags |= FLAG_FULLSCREEN_MODE;
-// HERE 16 //
-// HERE 16 //#if defined(PLATFORM_DRM)
-// HERE 16 //    CORE.Window.fd = -1;
-// HERE 16 //    CORE.Window.connector = NULL;
-// HERE 16 //    CORE.Window.modeIndex = -1;
-// HERE 16 //    CORE.Window.crtc = NULL;
-// HERE 16 //    CORE.Window.gbmDevice = NULL;
-// HERE 16 //    CORE.Window.gbmSurface = NULL;
-// HERE 16 //    CORE.Window.prevBO = NULL;
-// HERE 16 //    CORE.Window.prevFB = 0;
-// HERE 16 //
-// HERE 16 //#if defined(DEFAULT_GRAPHIC_DEVICE_DRM)
-// HERE 16 //    CORE.Window.fd = open(DEFAULT_GRAPHIC_DEVICE_DRM, O_RDWR);
-// HERE 16 //#else
-// HERE 16 //    TRACELOG(LOG_INFO, "DISPLAY: No graphic card set, trying platform-gpu-card");
-// HERE 16 //    CORE.Window.fd = open("/dev/dri/by-path/platform-gpu-card", O_RDWR); // VideoCore VI (Raspberry Pi 4)
-// HERE 16 //
-// HERE 16 //    if ((-1 == CORE.Window.fd) || (drmModeGetResources(CORE.Window.fd) == NULL))
-// HERE 16 //    {
-// HERE 16 //        TRACELOG(LOG_INFO, "DISPLAY: Failed to open platform-gpu-card, trying card1");
-// HERE 16 //        CORE.Window.fd = open("/dev/dri/card1", O_RDWR); // Other Embedded
-// HERE 16 //    }
-// HERE 16 //
-// HERE 16 //    if ((-1 == CORE.Window.fd) || (drmModeGetResources(CORE.Window.fd) == NULL))
-// HERE 16 //    {
-// HERE 16 //        TRACELOG(LOG_INFO, "DISPLAY: Failed to open graphic card1, trying card0");
-// HERE 16 //        CORE.Window.fd = open("/dev/dri/card0", O_RDWR); // VideoCore IV (Raspberry Pi 1-3)
-// HERE 16 //    }
-// HERE 16 //#endif
-// HERE 16 //    if (-1 == CORE.Window.fd)
-// HERE 16 //    {
-// HERE 16 //        TRACELOG(LOG_WARNING, "DISPLAY: Failed to open graphic card");
-// HERE 16 //        return false;
-// HERE 16 //    }
-// HERE 16 //
-// HERE 16 //    drmModeRes *res = drmModeGetResources(CORE.Window.fd);
-// HERE 16 //    if (!res)
-// HERE 16 //    {
-// HERE 16 //        TRACELOG(LOG_WARNING, "DISPLAY: Failed get DRM resources");
-// HERE 16 //        return false;
-// HERE 16 //    }
-// HERE 16 //
-// HERE 16 //    TRACELOG(LOG_TRACE, "DISPLAY: Connectors found: %i", res->count_connectors);
-// HERE 16 //    for (size_t i = 0; i < res->count_connectors; i++)
-// HERE 16 //    {
-// HERE 16 //        TRACELOG(LOG_TRACE, "DISPLAY: Connector index %i", i);
-// HERE 16 //        drmModeConnector *con = drmModeGetConnector(CORE.Window.fd, res->connectors[i]);
-// HERE 16 //        TRACELOG(LOG_TRACE, "DISPLAY: Connector modes detected: %i", con->count_modes);
-// HERE 16 //        if ((con->connection == DRM_MODE_CONNECTED) && (con->encoder_id))
-// HERE 16 //        {
-// HERE 16 //            TRACELOG(LOG_TRACE, "DISPLAY: DRM mode connected");
-// HERE 16 //            CORE.Window.connector = con;
-// HERE 16 //            break;
-// HERE 16 //        }
-// HERE 16 //        else
-// HERE 16 //        {
-// HERE 16 //            TRACELOG(LOG_TRACE, "DISPLAY: DRM mode NOT connected (deleting)");
-// HERE 16 //            drmModeFreeConnector(con);
-// HERE 16 //        }
-// HERE 16 //    }
-// HERE 16 //
-// HERE 16 //    if (!CORE.Window.connector)
-// HERE 16 //    {
-// HERE 16 //        TRACELOG(LOG_WARNING, "DISPLAY: No suitable DRM connector found");
-// HERE 16 //        drmModeFreeResources(res);
-// HERE 16 //        return false;
-// HERE 16 //    }
-// HERE 16 //
-// HERE 16 //    drmModeEncoder *enc = drmModeGetEncoder(CORE.Window.fd, CORE.Window.connector->encoder_id);
-// HERE 16 //    if (!enc)
-// HERE 16 //    {
-// HERE 16 //        TRACELOG(LOG_WARNING, "DISPLAY: Failed to get DRM mode encoder");
-// HERE 16 //        drmModeFreeResources(res);
-// HERE 16 //        return false;
-// HERE 16 //    }
-// HERE 16 //
-// HERE 16 //    CORE.Window.crtc = drmModeGetCrtc(CORE.Window.fd, enc->crtc_id);
-// HERE 16 //    if (!CORE.Window.crtc)
-// HERE 16 //    {
-// HERE 16 //        TRACELOG(LOG_WARNING, "DISPLAY: Failed to get DRM mode crtc");
-// HERE 16 //        drmModeFreeEncoder(enc);
-// HERE 16 //        drmModeFreeResources(res);
-// HERE 16 //        return false;
-// HERE 16 //    }
-// HERE 16 //
-// HERE 16 //    // If InitWindow should use the current mode find it in the connector's mode list
-// HERE 16 //    if ((CORE.Window.screen.width <= 0) || (CORE.Window.screen.height <= 0))
-// HERE 16 //    {
-// HERE 16 //        TRACELOG(LOG_TRACE, "DISPLAY: Selecting DRM connector mode for current used mode...");
-// HERE 16 //
-// HERE 16 //        CORE.Window.modeIndex = FindMatchingConnectorMode(CORE.Window.connector, &CORE.Window.crtc->mode);
-// HERE 16 //
-// HERE 16 //        if (CORE.Window.modeIndex < 0)
-// HERE 16 //        {
-// HERE 16 //            TRACELOG(LOG_WARNING, "DISPLAY: No matching DRM connector mode found");
-// HERE 16 //            drmModeFreeEncoder(enc);
-// HERE 16 //            drmModeFreeResources(res);
-// HERE 16 //            return false;
-// HERE 16 //        }
-// HERE 16 //
-// HERE 16 //        CORE.Window.screen.width = CORE.Window.display.width;
-// HERE 16 //        CORE.Window.screen.height = CORE.Window.display.height;
-// HERE 16 //    }
-// HERE 16 //
-// HERE 16 //    const bool allowInterlaced = CORE.Window.flags & FLAG_INTERLACED_HINT;
-// HERE 16 //    const int fps = (CORE.Time.target > 0) ? (1.0 / CORE.Time.target) : 60;
-// HERE 16 //
-// HERE 16 //    // Try to find an exact matching mode
-// HERE 16 //    CORE.Window.modeIndex = FindExactConnectorMode(CORE.Window.connector, CORE.Window.screen.width, CORE.Window.screen.height, fps, allowInterlaced);
-// HERE 16 //
-// HERE 16 //    // If nothing found, try to find a nearly matching mode
-// HERE 16 //    if (CORE.Window.modeIndex < 0) CORE.Window.modeIndex = FindNearestConnectorMode(CORE.Window.connector, CORE.Window.screen.width, CORE.Window.screen.height, fps, allowInterlaced);
-// HERE 16 //
-// HERE 16 //    // If nothing found, try to find an exactly matching mode including interlaced
-// HERE 16 //    if (CORE.Window.modeIndex < 0) CORE.Window.modeIndex = FindExactConnectorMode(CORE.Window.connector, CORE.Window.screen.width, CORE.Window.screen.height, fps, true);
-// HERE 16 //
-// HERE 16 //    // If nothing found, try to find a nearly matching mode including interlaced
-// HERE 16 //    if (CORE.Window.modeIndex < 0) CORE.Window.modeIndex = FindNearestConnectorMode(CORE.Window.connector, CORE.Window.screen.width, CORE.Window.screen.height, fps, true);
-// HERE 16 //
-// HERE 16 //    // If nothing found, there is no suitable mode
-// HERE 16 //    if (CORE.Window.modeIndex < 0)
-// HERE 16 //    {
-// HERE 16 //        TRACELOG(LOG_WARNING, "DISPLAY: Failed to find a suitable DRM connector mode");
-// HERE 16 //        drmModeFreeEncoder(enc);
-// HERE 16 //        drmModeFreeResources(res);
-// HERE 16 //        return false;
-// HERE 16 //    }
-// HERE 16 //
-// HERE 16 //    CORE.Window.display.width = CORE.Window.connector->modes[CORE.Window.modeIndex].hdisplay;
-// HERE 16 //    CORE.Window.display.height = CORE.Window.connector->modes[CORE.Window.modeIndex].vdisplay;
-// HERE 16 //
-// HERE 16 //    TRACELOG(LOG_INFO, "DISPLAY: Selected DRM connector mode %s (%ux%u%c@%u)", CORE.Window.connector->modes[CORE.Window.modeIndex].name,
-// HERE 16 //             CORE.Window.connector->modes[CORE.Window.modeIndex].hdisplay, CORE.Window.connector->modes[CORE.Window.modeIndex].vdisplay,
-// HERE 16 //             (CORE.Window.connector->modes[CORE.Window.modeIndex].flags & DRM_MODE_FLAG_INTERLACE) ? 'i' : 'p',
-// HERE 16 //             CORE.Window.connector->modes[CORE.Window.modeIndex].vrefresh);
-// HERE 16 //
-// HERE 16 //    // Use the width and height of the surface for render
-// HERE 16 //    CORE.Window.render.width = CORE.Window.screen.width;
-// HERE 16 //    CORE.Window.render.height = CORE.Window.screen.height;
-// HERE 16 //
-// HERE 16 //    drmModeFreeEncoder(enc);
-// HERE 16 //    enc = NULL;
-// HERE 16 //
-// HERE 16 //    drmModeFreeResources(res);
-// HERE 16 //    res = NULL;
-// HERE 16 //
-// HERE 16 //    CORE.Window.gbmDevice = gbm_create_device(CORE.Window.fd);
-// HERE 16 //    if (!CORE.Window.gbmDevice)
-// HERE 16 //    {
-// HERE 16 //        TRACELOG(LOG_WARNING, "DISPLAY: Failed to create GBM device");
-// HERE 16 //        return false;
-// HERE 16 //    }
-// HERE 16 //
-// HERE 16 //    CORE.Window.gbmSurface = gbm_surface_create(CORE.Window.gbmDevice, CORE.Window.connector->modes[CORE.Window.modeIndex].hdisplay,
-// HERE 16 //                                                CORE.Window.connector->modes[CORE.Window.modeIndex].vdisplay, GBM_FORMAT_ARGB8888, GBM_BO_USE_SCANOUT | GBM_BO_USE_RENDERING);
-// HERE 16 //    if (!CORE.Window.gbmSurface)
-// HERE 16 //    {
-// HERE 16 //        TRACELOG(LOG_WARNING, "DISPLAY: Failed to create GBM surface");
-// HERE 16 //        return false;
-// HERE 16 //    }
-// HERE 16 //#endif
-// HERE 16 //
-// HERE 16 //    EGLint samples = 0;
-// HERE 16 //    EGLint sampleBuffer = 0;
-// HERE 16 //    if (CORE.Window.flags & FLAG_MSAA_4X_HINT)
-// HERE 16 //    {
-// HERE 16 //        samples = 4;
-// HERE 16 //        sampleBuffer = 1;
-// HERE 16 //        TRACELOG(LOG_INFO, "DISPLAY: Trying to enable MSAA x4");
-// HERE 16 //    }
-// HERE 16 //
-// HERE 16 //    const EGLint framebufferAttribs[] =
-// HERE 16 //    {
-// HERE 16 //        EGL_RENDERABLE_TYPE,
-// HERE 16 //        (rlGetVersion() == RL_OPENGL_ES_30) ? EGL_OPENGL_ES3_BIT : EGL_OPENGL_ES2_BIT, // Type of context support
-// HERE 16 //#if defined(PLATFORM_DRM)
-// HERE 16 //        EGL_SURFACE_TYPE,
-// HERE 16 //        EGL_WINDOW_BIT, // Don't use it on Android!
-// HERE 16 //#endif
-// HERE 16 //        EGL_RED_SIZE,
-// HERE 16 //        8, // RED color bit depth (alternative: 5)
-// HERE 16 //        EGL_GREEN_SIZE,
-// HERE 16 //        8, // GREEN color bit depth (alternative: 6)
-// HERE 16 //        EGL_BLUE_SIZE,
-// HERE 16 //        8, // BLUE color bit depth (alternative: 5)
-// HERE 16 //#if defined(PLATFORM_DRM)
-// HERE 16 //        EGL_ALPHA_SIZE,
-// HERE 16 //        8, // ALPHA bit depth (required for transparent framebuffer)
-// HERE 16 //#endif
-// HERE 16 //        // EGL_TRANSPARENT_TYPE, EGL_NONE, // Request transparent framebuffer (EGL_TRANSPARENT_RGB does not work on RPI)
-// HERE 16 //        EGL_DEPTH_SIZE,
-// HERE 16 //        16, // Depth buffer size (Required to use Depth testing!)
-// HERE 16 //        // EGL_STENCIL_SIZE, 8,      // Stencil buffer size
-// HERE 16 //        EGL_SAMPLE_BUFFERS,
-// HERE 16 //        sampleBuffer, // Activate MSAA
-// HERE 16 //        EGL_SAMPLES,
-// HERE 16 //        samples, // 4x Antialiasing if activated (Free on MALI GPUs)
-// HERE 16 //        EGL_NONE
-// HERE 16 //    };
-// HERE 16 //
-// HERE 16 //    const EGLint contextAttribs[] =
-// HERE 16 //        {
-// HERE 16 //            EGL_CONTEXT_CLIENT_VERSION, 2,
-// HERE 16 //            EGL_NONE};
-// HERE 16 //
-// HERE 16 //#if defined(PLATFORM_ANDROID) || defined(PLATFORM_DRM)
-// HERE 16 //    EGLint numConfigs = 0;
-// HERE 16 //
-// HERE 16 //    // Get an EGL device connection
-// HERE 16 //#if defined(PLATFORM_DRM)
-// HERE 16 //    CORE.Window.device = eglGetDisplay((EGLNativeDisplayType)CORE.Window.gbmDevice);
-// HERE 16 //#else
-// HERE 16 //    CORE.Window.device = eglGetDisplay(EGL_DEFAULT_DISPLAY);
-// HERE 16 //#endif
-// HERE 16 //    if (CORE.Window.device == EGL_NO_DISPLAY)
-// HERE 16 //    {
-// HERE 16 //        TRACELOG(LOG_WARNING, "DISPLAY: Failed to initialize EGL device");
-// HERE 16 //        return false;
-// HERE 16 //    }
-// HERE 16 //
-// HERE 16 //    // Initialize the EGL device connection
-// HERE 16 //    if (eglInitialize(CORE.Window.device, NULL, NULL) == EGL_FALSE)
-// HERE 16 //    {
-// HERE 16 //        // If all of the calls to eglInitialize returned EGL_FALSE then an error has occurred.
-// HERE 16 //        TRACELOG(LOG_WARNING, "DISPLAY: Failed to initialize EGL device");
-// HERE 16 //        return false;
-// HERE 16 //    }
-// HERE 16 //
-// HERE 16 //#if defined(PLATFORM_DRM)
-// HERE 16 //    if (!eglChooseConfig(CORE.Window.device, NULL, NULL, 0, &numConfigs))
-// HERE 16 //    {
-// HERE 16 //        TRACELOG(LOG_WARNING, "DISPLAY: Failed to get EGL config count: 0x%x", eglGetError());
-// HERE 16 //        return false;
-// HERE 16 //    }
-// HERE 16 //
-// HERE 16 //    TRACELOG(LOG_TRACE, "DISPLAY: EGL configs available: %d", numConfigs);
-// HERE 16 //
-// HERE 16 //    EGLConfig *configs = RL_CALLOC(numConfigs, sizeof(*configs));
-// HERE 16 //    if (!configs)
-// HERE 16 //    {
-// HERE 16 //        TRACELOG(LOG_WARNING, "DISPLAY: Failed to get memory for EGL configs");
-// HERE 16 //        return false;
-// HERE 16 //    }
-// HERE 16 //
-// HERE 16 //    EGLint matchingNumConfigs = 0;
-// HERE 16 //    if (!eglChooseConfig(CORE.Window.device, framebufferAttribs, configs, numConfigs, &matchingNumConfigs))
-// HERE 16 //    {
-// HERE 16 //        TRACELOG(LOG_WARNING, "DISPLAY: Failed to choose EGL config: 0x%x", eglGetError());
-// HERE 16 //        free(configs);
-// HERE 16 //        return false;
-// HERE 16 //    }
-// HERE 16 //
-// HERE 16 //    TRACELOG(LOG_TRACE, "DISPLAY: EGL matching configs available: %d", matchingNumConfigs);
-// HERE 16 //
-// HERE 16 //    // find the EGL config that matches the previously setup GBM format
-// HERE 16 //    int found = 0;
-// HERE 16 //    for (EGLint i = 0; i < matchingNumConfigs; ++i)
-// HERE 16 //    {
-// HERE 16 //        EGLint id = 0;
-// HERE 16 //        if (!eglGetConfigAttrib(CORE.Window.device, configs[i], EGL_NATIVE_VISUAL_ID, &id))
-// HERE 16 //        {
-// HERE 16 //            TRACELOG(LOG_WARNING, "DISPLAY: Failed to get EGL config attribute: 0x%x", eglGetError());
-// HERE 16 //            continue;
-// HERE 16 //        }
-// HERE 16 //
-// HERE 16 //        if (GBM_FORMAT_ARGB8888 == id)
-// HERE 16 //        {
-// HERE 16 //            TRACELOG(LOG_TRACE, "DISPLAY: Using EGL config: %d", i);
-// HERE 16 //            CORE.Window.config = configs[i];
-// HERE 16 //            found = 1;
-// HERE 16 //            break;
-// HERE 16 //        }
-// HERE 16 //    }
-// HERE 16 //
-// HERE 16 //    RL_FREE(configs);
-// HERE 16 //
-// HERE 16 //    if (!found)
-// HERE 16 //    {
-// HERE 16 //        TRACELOG(LOG_WARNING, "DISPLAY: Failed to find a suitable EGL config");
-// HERE 16 //        return false;
-// HERE 16 //    }
-// HERE 16 //#else
-// HERE 16 //    // Get an appropriate EGL framebuffer configuration
-// HERE 16 //    eglChooseConfig(CORE.Window.device, framebufferAttribs, &CORE.Window.config, 1, &numConfigs);
-// HERE 16 //#endif
-// HERE 16 //
-// HERE 16 //    // Set rendering API
-// HERE 16 //    eglBindAPI(EGL_OPENGL_ES_API);
-// HERE 16 //
-// HERE 16 //    // Create an EGL rendering context
-// HERE 16 //    CORE.Window.context = eglCreateContext(CORE.Window.device, CORE.Window.config, EGL_NO_CONTEXT, contextAttribs);
-// HERE 16 //    if (CORE.Window.context == EGL_NO_CONTEXT)
-// HERE 16 //    {
-// HERE 16 //        TRACELOG(LOG_WARNING, "DISPLAY: Failed to create EGL context");
-// HERE 16 //        return false;
-// HERE 16 //    }
-// HERE 16 //#endif
-// HERE 16 //
-// HERE 16 //    // Create an EGL window surface
-// HERE 16 //    //---------------------------------------------------------------------------------
-// HERE 16 //#if defined(PLATFORM_ANDROID)
-// HERE 16 //    EGLint displayFormat = 0;
-// HERE 16 //
-// HERE 16 //    // EGL_NATIVE_VISUAL_ID is an attribute of the EGLConfig that is guaranteed to be accepted by ANativeWindow_setBuffersGeometry()
-// HERE 16 //    // As soon as we picked a EGLConfig, we can safely reconfigure the ANativeWindow buffers to match, using EGL_NATIVE_VISUAL_ID
-// HERE 16 //    eglGetConfigAttrib(CORE.Window.device, CORE.Window.config, EGL_NATIVE_VISUAL_ID, &displayFormat);
-// HERE 16 //
-// HERE 16 //    // At this point we need to manage render size vs screen size
-// HERE 16 //    // NOTE: This function use and modify global module variables:
-// HERE 16 //    //  -> CORE.Window.screen.width/CORE.Window.screen.height
-// HERE 16 //    //  -> CORE.Window.render.width/CORE.Window.render.height
-// HERE 16 //    //  -> CORE.Window.screenScale
-// HERE 16 //    SetupFramebuffer(CORE.Window.display.width, CORE.Window.display.height);
-// HERE 16 //
-// HERE 16 //    ANativeWindow_setBuffersGeometry(CORE.Android.app->window, CORE.Window.render.width, CORE.Window.render.height, displayFormat);
-// HERE 16 //    // ANativeWindow_setBuffersGeometry(CORE.Android.app->window, 0, 0, displayFormat);       // Force use of native display size
-// HERE 16 //
-// HERE 16 //    CORE.Window.surface = eglCreateWindowSurface(CORE.Window.device, CORE.Window.config, CORE.Android.app->window, NULL);
-// HERE 16 //#endif // PLATFORM_ANDROID
-// HERE 16 //
-// HERE 16 //#if defined(PLATFORM_DRM)
-// HERE 16 //    CORE.Window.surface = eglCreateWindowSurface(CORE.Window.device, CORE.Window.config, (EGLNativeWindowType)CORE.Window.gbmSurface, NULL);
-// HERE 16 //    if (EGL_NO_SURFACE == CORE.Window.surface)
-// HERE 16 //    {
-// HERE 16 //        TRACELOG(LOG_WARNING, "DISPLAY: Failed to create EGL window surface: 0x%04x", eglGetError());
-// HERE 16 //        return false;
-// HERE 16 //    }
-// HERE 16 //
-// HERE 16 //    // At this point we need to manage render size vs screen size
-// HERE 16 //    // NOTE: This function use and modify global module variables:
-// HERE 16 //    //  -> CORE.Window.screen.width/CORE.Window.screen.height
-// HERE 16 //    //  -> CORE.Window.render.width/CORE.Window.render.height
-// HERE 16 //    //  -> CORE.Window.screenScale
-// HERE 16 //    SetupFramebuffer(CORE.Window.display.width, CORE.Window.display.height);
-// HERE 16 //#endif // PLATFORM_DRM
-// HERE 16 //
-// HERE 16 //    // There must be at least one frame displayed before the buffers are swapped
-// HERE 16 //    // eglSwapInterval(CORE.Window.device, 1);
-// HERE 16 //
-// HERE 16 //    if (eglMakeCurrent(CORE.Window.device, CORE.Window.surface, CORE.Window.surface, CORE.Window.context) == EGL_FALSE)
-// HERE 16 //    {
-// HERE 16 //        TRACELOG(LOG_WARNING, "DISPLAY: Failed to attach EGL rendering context to EGL surface");
-// HERE 16 //        return false;
-// HERE 16 //    }
-// HERE 16 //    else
-// HERE 16 //    {
-// HERE 16 //        CORE.Window.render.width = CORE.Window.screen.width;
-// HERE 16 //        CORE.Window.render.height = CORE.Window.screen.height;
-// HERE 16 //        CORE.Window.currentFbo.width = CORE.Window.render.width;
-// HERE 16 //        CORE.Window.currentFbo.height = CORE.Window.render.height;
-// HERE 16 //
-// HERE 16 //        TRACELOG(LOG_INFO, "DISPLAY: Device initialized successfully");
-// HERE 16 //        TRACELOG(LOG_INFO, "    > Display size: %i x %i", CORE.Window.display.width, CORE.Window.display.height);
-// HERE 16 //        TRACELOG(LOG_INFO, "    > Screen size:  %i x %i", CORE.Window.screen.width, CORE.Window.screen.height);
-// HERE 16 //        TRACELOG(LOG_INFO, "    > Render size:  %i x %i", CORE.Window.render.width, CORE.Window.render.height);
-// HERE 16 //        TRACELOG(LOG_INFO, "    > Viewport offsets: %i, %i", CORE.Window.renderOffset.x, CORE.Window.renderOffset.y);
-// HERE 16 //    }
-// HERE 16 //#endif // PLATFORM_ANDROID || PLATFORM_DRM
-
     // Load OpenGL extensions
     // NOTE: GL procedures address loader is required to load extensions
-// HERE 17 //#if defined(PLATFORM_DESKTOP) || defined(PLATFORM_WEB)
     rlLoadExtensions(glfwGetProcAddress);
-// HERE 17 //#else
-// HERE 17 //    rlLoadExtensions(eglGetProcAddress);
-// HERE 17 //#endif
 
     // Initialize OpenGL context (states and resources)
     // NOTE: CORE.Window.currentFbo.width and CORE.Window.currentFbo.height not used, just stored as globals in rlgl
@@ -1058,10 +583,6 @@ static bool InitGraphicsDevice(int width, int height)
     // Setup default viewport
     // NOTE: It updated CORE.Window.render.width and CORE.Window.render.height
     SetupViewport(CORE.Window.currentFbo.width, CORE.Window.currentFbo.height);
-
-// HERE 18 //#if defined(PLATFORM_ANDROID)
-// HERE 18 //    CORE.Window.ready = true;
-// HERE 18 //#endif
 
     if ((CORE.Window.flags & FLAG_WINDOW_MINIMIZED) > 0) MinimizeWindow();
 

--- a/src/rcore_web.c
+++ b/src/rcore_web.c
@@ -1111,13 +1111,35 @@ float GetMouseWheelMove(void)
     return result;
 }
 
+// Get touch position X for touch point 0 (relative to screen size)
+int GetTouchX(void)
+{
+    return (int)CORE.Input.Touch.position[0].x;
+}
+
+// Get touch position Y for touch point 0 (relative to screen size)
+int GetTouchY(void)
+{
+    return (int)CORE.Input.Touch.position[0].y;
+}
+
+// Get touch position XY for a touch point index (relative to screen size)
+// TODO: Touch position should be scaled depending on display size and render size
+Vector2 GetTouchPosition(int index)
+{
+    Vector2 position = { -1.0f, -1.0f };
+
+    if (index < MAX_TOUCH_POINTS) position = CORE.Input.Touch.position[index];
+    else TRACELOG(LOG_WARNING, "INPUT: Required touch point out of range (Max touch points: %i)", MAX_TOUCH_POINTS);
+
+    return position;
+}
 
 // Swap back buffer with front buffer (screen drawing)
 void SwapScreenBuffer(void)
 {
     glfwSwapBuffers(CORE.Window.handle);
 }
-
 
 // Register all input events
 void PollInputEvents(void)

--- a/src/rcore_web.c
+++ b/src/rcore_web.c
@@ -350,7 +350,7 @@ static bool InitGraphicsDevice(int width, int height)
     // NOTE: Framebuffer (render area - CORE.Window.render.width, CORE.Window.render.height) could include black bars...
     // ...in top-down or left-right to match display aspect ratio (no weird scaling)
 
-#if defined(PLATFORM_DESKTOP) || defined(PLATFORM_WEB)
+// HERE 1 //#if defined(PLATFORM_DESKTOP) || defined(PLATFORM_WEB)
     glfwSetErrorCallback(ErrorCallback);
 /*
     // TODO: Setup GLFW custom allocators to match raylib ones
@@ -363,9 +363,9 @@ static bool InitGraphicsDevice(int width, int height)
 
     glfwInitAllocator(&allocator);
 */
-#if defined(__APPLE__)
-    glfwInitHint(GLFW_COCOA_CHDIR_RESOURCES, GLFW_FALSE);
-#endif
+// HERE 2 //#if defined(__APPLE__)
+// HERE 2 //    glfwInitHint(GLFW_COCOA_CHDIR_RESOURCES, GLFW_FALSE);
+// HERE 2 //#endif
 
     if (!glfwInit())
     {
@@ -408,26 +408,26 @@ static bool InitGraphicsDevice(int width, int height)
     else glfwWindowHint(GLFW_FLOATING, GLFW_FALSE);
 
         // NOTE: Some GLFW flags are not supported on HTML5
-#if defined(PLATFORM_DESKTOP)
-    if ((CORE.Window.flags & FLAG_WINDOW_TRANSPARENT) > 0) glfwWindowHint(GLFW_TRANSPARENT_FRAMEBUFFER, GLFW_TRUE); // Transparent framebuffer
-    else glfwWindowHint(GLFW_TRANSPARENT_FRAMEBUFFER, GLFW_FALSE); // Opaque framebuffer
-
-    if ((CORE.Window.flags & FLAG_WINDOW_HIGHDPI) > 0)
-    {
-        // Resize window content area based on the monitor content scale.
-        // NOTE: This hint only has an effect on platforms where screen coordinates and pixels always map 1:1 such as Windows and X11.
-        // On platforms like macOS the resolution of the framebuffer is changed independently of the window size.
-        glfwWindowHint(GLFW_SCALE_TO_MONITOR, GLFW_TRUE); // Scale content area based on the monitor content scale where window is placed on
-#if defined(__APPLE__)
-        glfwWindowHint(GLFW_COCOA_RETINA_FRAMEBUFFER, GLFW_TRUE);
-#endif
-    }
-    else glfwWindowHint(GLFW_SCALE_TO_MONITOR, GLFW_FALSE);
-
-    // Mouse passthrough
-    if ((CORE.Window.flags & FLAG_WINDOW_MOUSE_PASSTHROUGH) > 0) glfwWindowHint(GLFW_MOUSE_PASSTHROUGH, GLFW_TRUE);
-    else glfwWindowHint(GLFW_MOUSE_PASSTHROUGH, GLFW_FALSE);
-#endif
+// HERE 3 //#if defined(PLATFORM_DESKTOP)
+// HERE 3 //    if ((CORE.Window.flags & FLAG_WINDOW_TRANSPARENT) > 0) glfwWindowHint(GLFW_TRANSPARENT_FRAMEBUFFER, GLFW_TRUE); // Transparent framebuffer
+// HERE 3 //    else glfwWindowHint(GLFW_TRANSPARENT_FRAMEBUFFER, GLFW_FALSE); // Opaque framebuffer
+// HERE 3 //
+// HERE 3 //    if ((CORE.Window.flags & FLAG_WINDOW_HIGHDPI) > 0)
+// HERE 3 //    {
+// HERE 3 //        // Resize window content area based on the monitor content scale.
+// HERE 3 //        // NOTE: This hint only has an effect on platforms where screen coordinates and pixels always map 1:1 such as Windows and X11.
+// HERE 3 //        // On platforms like macOS the resolution of the framebuffer is changed independently of the window size.
+// HERE 3 //        glfwWindowHint(GLFW_SCALE_TO_MONITOR, GLFW_TRUE); // Scale content area based on the monitor content scale where window is placed on
+// HERE 3 //#if defined(__APPLE__)
+// HERE 3 //        glfwWindowHint(GLFW_COCOA_RETINA_FRAMEBUFFER, GLFW_TRUE);
+// HERE 3 //#endif
+// HERE 3 //    }
+// HERE 3 //    else glfwWindowHint(GLFW_SCALE_TO_MONITOR, GLFW_FALSE);
+// HERE 3 //
+// HERE 3 //    // Mouse passthrough
+// HERE 3 //    if ((CORE.Window.flags & FLAG_WINDOW_MOUSE_PASSTHROUGH) > 0) glfwWindowHint(GLFW_MOUSE_PASSTHROUGH, GLFW_TRUE);
+// HERE 3 //    else glfwWindowHint(GLFW_MOUSE_PASSTHROUGH, GLFW_FALSE);
+// HERE 3 //#endif
 
     if (CORE.Window.flags & FLAG_MSAA_4X_HINT)
     {
@@ -452,11 +452,11 @@ static bool InitGraphicsDevice(int width, int height)
         glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);                 // Choose OpenGL minor version (just hint)
         glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE); // Profiles Hint: Only 3.3 and above!
                                                                        // Values: GLFW_OPENGL_CORE_PROFILE, GLFW_OPENGL_ANY_PROFILE, GLFW_OPENGL_COMPAT_PROFILE
-#if defined(__APPLE__)
-        glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GLFW_TRUE); // OSX Requires forward compatibility
-#else
+// HERE 4 //#if defined(__APPLE__)
+// HERE 4 //        glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GLFW_TRUE); // OSX Requires forward compatibility
+// HERE 4 //#else
         glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GLFW_FALSE); // Forward Compatibility Hint: Only 3.3 and above!
-#endif
+// HERE 4 //#endif
         // glfwWindowHint(GLFW_OPENGL_DEBUG_CONTEXT, GLFW_TRUE); // Request OpenGL DEBUG context
     }
     else if (rlGetVersion() == RL_OPENGL_43)
@@ -474,56 +474,56 @@ static bool InitGraphicsDevice(int width, int height)
         glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 2);
         glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 0);
         glfwWindowHint(GLFW_CLIENT_API, GLFW_OPENGL_ES_API);
-#if defined(PLATFORM_DESKTOP)
-        glfwWindowHint(GLFW_CONTEXT_CREATION_API, GLFW_EGL_CONTEXT_API);
-#else
+// HERE 5 //#if defined(PLATFORM_DESKTOP)
+// HERE 5 //        glfwWindowHint(GLFW_CONTEXT_CREATION_API, GLFW_EGL_CONTEXT_API);
+// HERE 5 //#else
         glfwWindowHint(GLFW_CONTEXT_CREATION_API, GLFW_NATIVE_CONTEXT_API);
-#endif
+// HERE 5 //#endif
     }
     else if (rlGetVersion() == RL_OPENGL_ES_30) // Request OpenGL ES 3.0 context
     {
         glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
         glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 0);
         glfwWindowHint(GLFW_CLIENT_API, GLFW_OPENGL_ES_API);
-#if defined(PLATFORM_DESKTOP)
-        glfwWindowHint(GLFW_CONTEXT_CREATION_API, GLFW_EGL_CONTEXT_API);
-#else
+// HERE 6 //#if defined(PLATFORM_DESKTOP)
+// HERE 6 //        glfwWindowHint(GLFW_CONTEXT_CREATION_API, GLFW_EGL_CONTEXT_API);
+// HERE 6 //#else
         glfwWindowHint(GLFW_CONTEXT_CREATION_API, GLFW_NATIVE_CONTEXT_API);
-#endif
+// HERE 6 //#endif
     }
 
-#if defined(PLATFORM_DESKTOP)
-    // NOTE: GLFW 3.4+ defers initialization of the Joystick subsystem on the first call to any Joystick related functions.
-    // Forcing this initialization here avoids doing it on PollInputEvents() called by EndDrawing() after first frame has been just drawn.
-    // The initialization will still happen and possible delays still occur, but before the window is shown, which is a nicer experience.
-    // REF: https://github.com/raysan5/raylib/issues/1554
-    if (MAX_GAMEPADS > 0) glfwSetJoystickCallback(NULL);
-#endif
+// HERE 7 //#if defined(PLATFORM_DESKTOP)
+// HERE 7 //    // NOTE: GLFW 3.4+ defers initialization of the Joystick subsystem on the first call to any Joystick related functions.
+// HERE 7 //    // Forcing this initialization here avoids doing it on PollInputEvents() called by EndDrawing() after first frame has been just drawn.
+// HERE 7 //    // The initialization will still happen and possible delays still occur, but before the window is shown, which is a nicer experience.
+// HERE 7 //    // REF: https://github.com/raysan5/raylib/issues/1554
+// HERE 7 //    if (MAX_GAMEPADS > 0) glfwSetJoystickCallback(NULL);
+// HERE 7 //#endif
 
-#if defined(PLATFORM_DESKTOP)
-    // Find monitor resolution
-    GLFWmonitor *monitor = glfwGetPrimaryMonitor();
-    if (!monitor)
-    {
-        TRACELOG(LOG_WARNING, "GLFW: Failed to get primary monitor");
-        return false;
-    }
+// HERE 8 //#if defined(PLATFORM_DESKTOP)
+// HERE 8 //    // Find monitor resolution
+// HERE 8 //    GLFWmonitor *monitor = glfwGetPrimaryMonitor();
+// HERE 8 //    if (!monitor)
+// HERE 8 //    {
+// HERE 8 //        TRACELOG(LOG_WARNING, "GLFW: Failed to get primary monitor");
+// HERE 8 //        return false;
+// HERE 8 //    }
+// HERE 8 //
+// HERE 8 //    const GLFWvidmode *mode = glfwGetVideoMode(monitor);
+// HERE 8 //
+// HERE 8 //    CORE.Window.display.width = mode->width;
+// HERE 8 //    CORE.Window.display.height = mode->height;
+// HERE 8 //
+// HERE 8 //    // Set screen width/height to the display width/height if they are 0
+// HERE 8 //    if (CORE.Window.screen.width == 0) CORE.Window.screen.width = CORE.Window.display.width;
+// HERE 8 //    if (CORE.Window.screen.height == 0) CORE.Window.screen.height = CORE.Window.display.height;
+// HERE 8 //#endif // PLATFORM_DESKTOP
 
-    const GLFWvidmode *mode = glfwGetVideoMode(monitor);
-
-    CORE.Window.display.width = mode->width;
-    CORE.Window.display.height = mode->height;
-
-    // Set screen width/height to the display width/height if they are 0
-    if (CORE.Window.screen.width == 0) CORE.Window.screen.width = CORE.Window.display.width;
-    if (CORE.Window.screen.height == 0) CORE.Window.screen.height = CORE.Window.display.height;
-#endif // PLATFORM_DESKTOP
-
-#if defined(PLATFORM_WEB)
+// HERE 9 //#if defined(PLATFORM_WEB)
     // NOTE: Getting video modes is not implemented in emscripten GLFW3 version
     CORE.Window.display.width = CORE.Window.screen.width;
     CORE.Window.display.height = CORE.Window.screen.height;
-#endif // PLATFORM_WEB
+// HERE 9 //#endif // PLATFORM_WEB
 
     if (CORE.Window.fullscreen)
     {
@@ -582,13 +582,13 @@ static bool InitGraphicsDevice(int width, int height)
     }
     else
     {
-#if defined(PLATFORM_DESKTOP)
-        // If we are windowed fullscreen, ensures that window does not minimize when focus is lost
-        if ((CORE.Window.screen.height == CORE.Window.display.height) && (CORE.Window.screen.width == CORE.Window.display.width))
-        {
-            glfwWindowHint(GLFW_AUTO_ICONIFY, 0);
-        }
-#endif
+// HERE 10 //#if defined(PLATFORM_DESKTOP)
+// HERE 10 //        // If we are windowed fullscreen, ensures that window does not minimize when focus is lost
+// HERE 10 //        if ((CORE.Window.screen.height == CORE.Window.display.height) && (CORE.Window.screen.width == CORE.Window.display.width))
+// HERE 10 //        {
+// HERE 10 //            glfwWindowHint(GLFW_AUTO_ICONIFY, 0);
+// HERE 10 //        }
+// HERE 10 //#endif
         // No-fullscreen window creation
         CORE.Window.handle = glfwCreateWindow(CORE.Window.screen.width, CORE.Window.screen.height, (CORE.Window.title != 0) ? CORE.Window.title : " ", NULL, NULL);
 
@@ -607,15 +607,15 @@ static bool InitGraphicsDevice(int width, int height)
     }
 
 // glfwCreateWindow title doesn't work with emscripten.
-#if defined(PLATFORM_WEB)
+// HERE 11 //#if defined(PLATFORM_WEB)
     emscripten_set_window_title((CORE.Window.title != 0) ? CORE.Window.title : " ");
-#endif
+// HERE 11 //#endif
 
     // Set window callback events
     glfwSetWindowSizeCallback(CORE.Window.handle, WindowSizeCallback); // NOTE: Resizing not allowed by default!
-#if !defined(PLATFORM_WEB)
-    glfwSetWindowMaximizeCallback(CORE.Window.handle, WindowMaximizeCallback);
-#endif
+// HERE 12 //#if !defined(PLATFORM_WEB)
+// HERE 12 //    glfwSetWindowMaximizeCallback(CORE.Window.handle, WindowMaximizeCallback);
+// HERE 12 //#endif
     glfwSetWindowIconifyCallback(CORE.Window.handle, WindowIconifyCallback);
     glfwSetWindowFocusCallback(CORE.Window.handle, WindowFocusCallback);
     glfwSetDropCallback(CORE.Window.handle, WindowDropCallback);
@@ -630,43 +630,43 @@ static bool InitGraphicsDevice(int width, int height)
 
     glfwMakeContextCurrent(CORE.Window.handle);
 
-#if !defined(PLATFORM_WEB)
-    glfwSetInputMode(CORE.Window.handle, GLFW_LOCK_KEY_MODS, GLFW_TRUE); // Enable lock keys modifiers (CAPS, NUM)
-
-    glfwSwapInterval(0); // No V-Sync by default
-#endif
+// HERE 13 //#if !defined(PLATFORM_WEB)
+// HERE 13 //    glfwSetInputMode(CORE.Window.handle, GLFW_LOCK_KEY_MODS, GLFW_TRUE); // Enable lock keys modifiers (CAPS, NUM)
+// HERE 13 //
+// HERE 13 //    glfwSwapInterval(0); // No V-Sync by default
+// HERE 13 //#endif
 
     // Try to enable GPU V-Sync, so frames are limited to screen refresh rate (60Hz -> 60 FPS)
     // NOTE: V-Sync can be enabled by graphic driver configuration, it doesn't need
     // to be activated on web platforms since VSync is enforced there.
-#if !defined(PLATFORM_WEB)
-    if (CORE.Window.flags & FLAG_VSYNC_HINT)
-    {
-        // WARNING: It seems to hit a critical render path in Intel HD Graphics
-        glfwSwapInterval(1);
-        TRACELOG(LOG_INFO, "DISPLAY: Trying to enable VSYNC");
-    }
-#endif
+// HERE 14 //#if !defined(PLATFORM_WEB)
+// HERE 14 //    if (CORE.Window.flags & FLAG_VSYNC_HINT)
+// HERE 14 //    {
+// HERE 14 //        // WARNING: It seems to hit a critical render path in Intel HD Graphics
+// HERE 14 //        glfwSwapInterval(1);
+// HERE 14 //        TRACELOG(LOG_INFO, "DISPLAY: Trying to enable VSYNC");
+// HERE 14 //    }
+// HERE 14 //#endif
 
     int fbWidth = CORE.Window.screen.width;
     int fbHeight = CORE.Window.screen.height;
 
-#if defined(PLATFORM_DESKTOP)
-    if ((CORE.Window.flags & FLAG_WINDOW_HIGHDPI) > 0)
-    {
-        // NOTE: On APPLE platforms system should manage window/input scaling and also framebuffer scaling.
-        // Framebuffer scaling should be activated with: glfwWindowHint(GLFW_COCOA_RETINA_FRAMEBUFFER, GLFW_TRUE);
-#if !defined(__APPLE__)
-        glfwGetFramebufferSize(CORE.Window.handle, &fbWidth, &fbHeight);
-
-        // Screen scaling matrix is required in case desired screen area is different from display area
-        CORE.Window.screenScale = MatrixScale((float)fbWidth / CORE.Window.screen.width, (float)fbHeight / CORE.Window.screen.height, 1.0f);
-
-        // Mouse input scaling for the new screen size
-        SetMouseScale((float)CORE.Window.screen.width / fbWidth, (float)CORE.Window.screen.height / fbHeight);
-#endif
-    }
-#endif
+// HERE 15 //#if defined(PLATFORM_DESKTOP)
+// HERE 15 //    if ((CORE.Window.flags & FLAG_WINDOW_HIGHDPI) > 0)
+// HERE 15 //    {
+// HERE 15 //        // NOTE: On APPLE platforms system should manage window/input scaling and also framebuffer scaling.
+// HERE 15 //        // Framebuffer scaling should be activated with: glfwWindowHint(GLFW_COCOA_RETINA_FRAMEBUFFER, GLFW_TRUE);
+// HERE 15 //#if !defined(__APPLE__)
+// HERE 15 //        glfwGetFramebufferSize(CORE.Window.handle, &fbWidth, &fbHeight);
+// HERE 15 //
+// HERE 15 //        // Screen scaling matrix is required in case desired screen area is different from display area
+// HERE 15 //        CORE.Window.screenScale = MatrixScale((float)fbWidth / CORE.Window.screen.width, (float)fbHeight / CORE.Window.screen.height, 1.0f);
+// HERE 15 //
+// HERE 15 //        // Mouse input scaling for the new screen size
+// HERE 15 //        SetMouseScale((float)CORE.Window.screen.width / fbWidth, (float)CORE.Window.screen.height / fbHeight);
+// HERE 15 //#endif
+// HERE 15 //    }
+// HERE 15 //#endif
 
     CORE.Window.render.width = fbWidth;
     CORE.Window.render.height = fbHeight;
@@ -679,377 +679,377 @@ static bool InitGraphicsDevice(int width, int height)
     TRACELOG(LOG_INFO, "    > Render size:  %i x %i", CORE.Window.render.width, CORE.Window.render.height);
     TRACELOG(LOG_INFO, "    > Viewport offsets: %i, %i", CORE.Window.renderOffset.x, CORE.Window.renderOffset.y);
 
-#endif // PLATFORM_DESKTOP || PLATFORM_WEB
+// HERE 1 //#endif // PLATFORM_DESKTOP || PLATFORM_WEB
 
-#if defined(PLATFORM_ANDROID) || defined(PLATFORM_DRM)
-    CORE.Window.fullscreen = true;
-    CORE.Window.flags |= FLAG_FULLSCREEN_MODE;
-
-#if defined(PLATFORM_DRM)
-    CORE.Window.fd = -1;
-    CORE.Window.connector = NULL;
-    CORE.Window.modeIndex = -1;
-    CORE.Window.crtc = NULL;
-    CORE.Window.gbmDevice = NULL;
-    CORE.Window.gbmSurface = NULL;
-    CORE.Window.prevBO = NULL;
-    CORE.Window.prevFB = 0;
-
-#if defined(DEFAULT_GRAPHIC_DEVICE_DRM)
-    CORE.Window.fd = open(DEFAULT_GRAPHIC_DEVICE_DRM, O_RDWR);
-#else
-    TRACELOG(LOG_INFO, "DISPLAY: No graphic card set, trying platform-gpu-card");
-    CORE.Window.fd = open("/dev/dri/by-path/platform-gpu-card", O_RDWR); // VideoCore VI (Raspberry Pi 4)
-
-    if ((-1 == CORE.Window.fd) || (drmModeGetResources(CORE.Window.fd) == NULL))
-    {
-        TRACELOG(LOG_INFO, "DISPLAY: Failed to open platform-gpu-card, trying card1");
-        CORE.Window.fd = open("/dev/dri/card1", O_RDWR); // Other Embedded
-    }
-
-    if ((-1 == CORE.Window.fd) || (drmModeGetResources(CORE.Window.fd) == NULL))
-    {
-        TRACELOG(LOG_INFO, "DISPLAY: Failed to open graphic card1, trying card0");
-        CORE.Window.fd = open("/dev/dri/card0", O_RDWR); // VideoCore IV (Raspberry Pi 1-3)
-    }
-#endif
-    if (-1 == CORE.Window.fd)
-    {
-        TRACELOG(LOG_WARNING, "DISPLAY: Failed to open graphic card");
-        return false;
-    }
-
-    drmModeRes *res = drmModeGetResources(CORE.Window.fd);
-    if (!res)
-    {
-        TRACELOG(LOG_WARNING, "DISPLAY: Failed get DRM resources");
-        return false;
-    }
-
-    TRACELOG(LOG_TRACE, "DISPLAY: Connectors found: %i", res->count_connectors);
-    for (size_t i = 0; i < res->count_connectors; i++)
-    {
-        TRACELOG(LOG_TRACE, "DISPLAY: Connector index %i", i);
-        drmModeConnector *con = drmModeGetConnector(CORE.Window.fd, res->connectors[i]);
-        TRACELOG(LOG_TRACE, "DISPLAY: Connector modes detected: %i", con->count_modes);
-        if ((con->connection == DRM_MODE_CONNECTED) && (con->encoder_id))
-        {
-            TRACELOG(LOG_TRACE, "DISPLAY: DRM mode connected");
-            CORE.Window.connector = con;
-            break;
-        }
-        else
-        {
-            TRACELOG(LOG_TRACE, "DISPLAY: DRM mode NOT connected (deleting)");
-            drmModeFreeConnector(con);
-        }
-    }
-
-    if (!CORE.Window.connector)
-    {
-        TRACELOG(LOG_WARNING, "DISPLAY: No suitable DRM connector found");
-        drmModeFreeResources(res);
-        return false;
-    }
-
-    drmModeEncoder *enc = drmModeGetEncoder(CORE.Window.fd, CORE.Window.connector->encoder_id);
-    if (!enc)
-    {
-        TRACELOG(LOG_WARNING, "DISPLAY: Failed to get DRM mode encoder");
-        drmModeFreeResources(res);
-        return false;
-    }
-
-    CORE.Window.crtc = drmModeGetCrtc(CORE.Window.fd, enc->crtc_id);
-    if (!CORE.Window.crtc)
-    {
-        TRACELOG(LOG_WARNING, "DISPLAY: Failed to get DRM mode crtc");
-        drmModeFreeEncoder(enc);
-        drmModeFreeResources(res);
-        return false;
-    }
-
-    // If InitWindow should use the current mode find it in the connector's mode list
-    if ((CORE.Window.screen.width <= 0) || (CORE.Window.screen.height <= 0))
-    {
-        TRACELOG(LOG_TRACE, "DISPLAY: Selecting DRM connector mode for current used mode...");
-
-        CORE.Window.modeIndex = FindMatchingConnectorMode(CORE.Window.connector, &CORE.Window.crtc->mode);
-
-        if (CORE.Window.modeIndex < 0)
-        {
-            TRACELOG(LOG_WARNING, "DISPLAY: No matching DRM connector mode found");
-            drmModeFreeEncoder(enc);
-            drmModeFreeResources(res);
-            return false;
-        }
-
-        CORE.Window.screen.width = CORE.Window.display.width;
-        CORE.Window.screen.height = CORE.Window.display.height;
-    }
-
-    const bool allowInterlaced = CORE.Window.flags & FLAG_INTERLACED_HINT;
-    const int fps = (CORE.Time.target > 0) ? (1.0 / CORE.Time.target) : 60;
-
-    // Try to find an exact matching mode
-    CORE.Window.modeIndex = FindExactConnectorMode(CORE.Window.connector, CORE.Window.screen.width, CORE.Window.screen.height, fps, allowInterlaced);
-
-    // If nothing found, try to find a nearly matching mode
-    if (CORE.Window.modeIndex < 0) CORE.Window.modeIndex = FindNearestConnectorMode(CORE.Window.connector, CORE.Window.screen.width, CORE.Window.screen.height, fps, allowInterlaced);
-
-    // If nothing found, try to find an exactly matching mode including interlaced
-    if (CORE.Window.modeIndex < 0) CORE.Window.modeIndex = FindExactConnectorMode(CORE.Window.connector, CORE.Window.screen.width, CORE.Window.screen.height, fps, true);
-
-    // If nothing found, try to find a nearly matching mode including interlaced
-    if (CORE.Window.modeIndex < 0) CORE.Window.modeIndex = FindNearestConnectorMode(CORE.Window.connector, CORE.Window.screen.width, CORE.Window.screen.height, fps, true);
-
-    // If nothing found, there is no suitable mode
-    if (CORE.Window.modeIndex < 0)
-    {
-        TRACELOG(LOG_WARNING, "DISPLAY: Failed to find a suitable DRM connector mode");
-        drmModeFreeEncoder(enc);
-        drmModeFreeResources(res);
-        return false;
-    }
-
-    CORE.Window.display.width = CORE.Window.connector->modes[CORE.Window.modeIndex].hdisplay;
-    CORE.Window.display.height = CORE.Window.connector->modes[CORE.Window.modeIndex].vdisplay;
-
-    TRACELOG(LOG_INFO, "DISPLAY: Selected DRM connector mode %s (%ux%u%c@%u)", CORE.Window.connector->modes[CORE.Window.modeIndex].name,
-             CORE.Window.connector->modes[CORE.Window.modeIndex].hdisplay, CORE.Window.connector->modes[CORE.Window.modeIndex].vdisplay,
-             (CORE.Window.connector->modes[CORE.Window.modeIndex].flags & DRM_MODE_FLAG_INTERLACE) ? 'i' : 'p',
-             CORE.Window.connector->modes[CORE.Window.modeIndex].vrefresh);
-
-    // Use the width and height of the surface for render
-    CORE.Window.render.width = CORE.Window.screen.width;
-    CORE.Window.render.height = CORE.Window.screen.height;
-
-    drmModeFreeEncoder(enc);
-    enc = NULL;
-
-    drmModeFreeResources(res);
-    res = NULL;
-
-    CORE.Window.gbmDevice = gbm_create_device(CORE.Window.fd);
-    if (!CORE.Window.gbmDevice)
-    {
-        TRACELOG(LOG_WARNING, "DISPLAY: Failed to create GBM device");
-        return false;
-    }
-
-    CORE.Window.gbmSurface = gbm_surface_create(CORE.Window.gbmDevice, CORE.Window.connector->modes[CORE.Window.modeIndex].hdisplay,
-                                                CORE.Window.connector->modes[CORE.Window.modeIndex].vdisplay, GBM_FORMAT_ARGB8888, GBM_BO_USE_SCANOUT | GBM_BO_USE_RENDERING);
-    if (!CORE.Window.gbmSurface)
-    {
-        TRACELOG(LOG_WARNING, "DISPLAY: Failed to create GBM surface");
-        return false;
-    }
-#endif
-
-    EGLint samples = 0;
-    EGLint sampleBuffer = 0;
-    if (CORE.Window.flags & FLAG_MSAA_4X_HINT)
-    {
-        samples = 4;
-        sampleBuffer = 1;
-        TRACELOG(LOG_INFO, "DISPLAY: Trying to enable MSAA x4");
-    }
-
-    const EGLint framebufferAttribs[] =
-    {
-        EGL_RENDERABLE_TYPE,
-        (rlGetVersion() == RL_OPENGL_ES_30) ? EGL_OPENGL_ES3_BIT : EGL_OPENGL_ES2_BIT, // Type of context support
-#if defined(PLATFORM_DRM)
-        EGL_SURFACE_TYPE,
-        EGL_WINDOW_BIT, // Don't use it on Android!
-#endif
-        EGL_RED_SIZE,
-        8, // RED color bit depth (alternative: 5)
-        EGL_GREEN_SIZE,
-        8, // GREEN color bit depth (alternative: 6)
-        EGL_BLUE_SIZE,
-        8, // BLUE color bit depth (alternative: 5)
-#if defined(PLATFORM_DRM)
-        EGL_ALPHA_SIZE,
-        8, // ALPHA bit depth (required for transparent framebuffer)
-#endif
-        // EGL_TRANSPARENT_TYPE, EGL_NONE, // Request transparent framebuffer (EGL_TRANSPARENT_RGB does not work on RPI)
-        EGL_DEPTH_SIZE,
-        16, // Depth buffer size (Required to use Depth testing!)
-        // EGL_STENCIL_SIZE, 8,      // Stencil buffer size
-        EGL_SAMPLE_BUFFERS,
-        sampleBuffer, // Activate MSAA
-        EGL_SAMPLES,
-        samples, // 4x Antialiasing if activated (Free on MALI GPUs)
-        EGL_NONE
-    };
-
-    const EGLint contextAttribs[] =
-        {
-            EGL_CONTEXT_CLIENT_VERSION, 2,
-            EGL_NONE};
-
-#if defined(PLATFORM_ANDROID) || defined(PLATFORM_DRM)
-    EGLint numConfigs = 0;
-
-    // Get an EGL device connection
-#if defined(PLATFORM_DRM)
-    CORE.Window.device = eglGetDisplay((EGLNativeDisplayType)CORE.Window.gbmDevice);
-#else
-    CORE.Window.device = eglGetDisplay(EGL_DEFAULT_DISPLAY);
-#endif
-    if (CORE.Window.device == EGL_NO_DISPLAY)
-    {
-        TRACELOG(LOG_WARNING, "DISPLAY: Failed to initialize EGL device");
-        return false;
-    }
-
-    // Initialize the EGL device connection
-    if (eglInitialize(CORE.Window.device, NULL, NULL) == EGL_FALSE)
-    {
-        // If all of the calls to eglInitialize returned EGL_FALSE then an error has occurred.
-        TRACELOG(LOG_WARNING, "DISPLAY: Failed to initialize EGL device");
-        return false;
-    }
-
-#if defined(PLATFORM_DRM)
-    if (!eglChooseConfig(CORE.Window.device, NULL, NULL, 0, &numConfigs))
-    {
-        TRACELOG(LOG_WARNING, "DISPLAY: Failed to get EGL config count: 0x%x", eglGetError());
-        return false;
-    }
-
-    TRACELOG(LOG_TRACE, "DISPLAY: EGL configs available: %d", numConfigs);
-
-    EGLConfig *configs = RL_CALLOC(numConfigs, sizeof(*configs));
-    if (!configs)
-    {
-        TRACELOG(LOG_WARNING, "DISPLAY: Failed to get memory for EGL configs");
-        return false;
-    }
-
-    EGLint matchingNumConfigs = 0;
-    if (!eglChooseConfig(CORE.Window.device, framebufferAttribs, configs, numConfigs, &matchingNumConfigs))
-    {
-        TRACELOG(LOG_WARNING, "DISPLAY: Failed to choose EGL config: 0x%x", eglGetError());
-        free(configs);
-        return false;
-    }
-
-    TRACELOG(LOG_TRACE, "DISPLAY: EGL matching configs available: %d", matchingNumConfigs);
-
-    // find the EGL config that matches the previously setup GBM format
-    int found = 0;
-    for (EGLint i = 0; i < matchingNumConfigs; ++i)
-    {
-        EGLint id = 0;
-        if (!eglGetConfigAttrib(CORE.Window.device, configs[i], EGL_NATIVE_VISUAL_ID, &id))
-        {
-            TRACELOG(LOG_WARNING, "DISPLAY: Failed to get EGL config attribute: 0x%x", eglGetError());
-            continue;
-        }
-
-        if (GBM_FORMAT_ARGB8888 == id)
-        {
-            TRACELOG(LOG_TRACE, "DISPLAY: Using EGL config: %d", i);
-            CORE.Window.config = configs[i];
-            found = 1;
-            break;
-        }
-    }
-
-    RL_FREE(configs);
-
-    if (!found)
-    {
-        TRACELOG(LOG_WARNING, "DISPLAY: Failed to find a suitable EGL config");
-        return false;
-    }
-#else
-    // Get an appropriate EGL framebuffer configuration
-    eglChooseConfig(CORE.Window.device, framebufferAttribs, &CORE.Window.config, 1, &numConfigs);
-#endif
-
-    // Set rendering API
-    eglBindAPI(EGL_OPENGL_ES_API);
-
-    // Create an EGL rendering context
-    CORE.Window.context = eglCreateContext(CORE.Window.device, CORE.Window.config, EGL_NO_CONTEXT, contextAttribs);
-    if (CORE.Window.context == EGL_NO_CONTEXT)
-    {
-        TRACELOG(LOG_WARNING, "DISPLAY: Failed to create EGL context");
-        return false;
-    }
-#endif
-
-    // Create an EGL window surface
-    //---------------------------------------------------------------------------------
-#if defined(PLATFORM_ANDROID)
-    EGLint displayFormat = 0;
-
-    // EGL_NATIVE_VISUAL_ID is an attribute of the EGLConfig that is guaranteed to be accepted by ANativeWindow_setBuffersGeometry()
-    // As soon as we picked a EGLConfig, we can safely reconfigure the ANativeWindow buffers to match, using EGL_NATIVE_VISUAL_ID
-    eglGetConfigAttrib(CORE.Window.device, CORE.Window.config, EGL_NATIVE_VISUAL_ID, &displayFormat);
-
-    // At this point we need to manage render size vs screen size
-    // NOTE: This function use and modify global module variables:
-    //  -> CORE.Window.screen.width/CORE.Window.screen.height
-    //  -> CORE.Window.render.width/CORE.Window.render.height
-    //  -> CORE.Window.screenScale
-    SetupFramebuffer(CORE.Window.display.width, CORE.Window.display.height);
-
-    ANativeWindow_setBuffersGeometry(CORE.Android.app->window, CORE.Window.render.width, CORE.Window.render.height, displayFormat);
-    // ANativeWindow_setBuffersGeometry(CORE.Android.app->window, 0, 0, displayFormat);       // Force use of native display size
-
-    CORE.Window.surface = eglCreateWindowSurface(CORE.Window.device, CORE.Window.config, CORE.Android.app->window, NULL);
-#endif // PLATFORM_ANDROID
-
-#if defined(PLATFORM_DRM)
-    CORE.Window.surface = eglCreateWindowSurface(CORE.Window.device, CORE.Window.config, (EGLNativeWindowType)CORE.Window.gbmSurface, NULL);
-    if (EGL_NO_SURFACE == CORE.Window.surface)
-    {
-        TRACELOG(LOG_WARNING, "DISPLAY: Failed to create EGL window surface: 0x%04x", eglGetError());
-        return false;
-    }
-
-    // At this point we need to manage render size vs screen size
-    // NOTE: This function use and modify global module variables:
-    //  -> CORE.Window.screen.width/CORE.Window.screen.height
-    //  -> CORE.Window.render.width/CORE.Window.render.height
-    //  -> CORE.Window.screenScale
-    SetupFramebuffer(CORE.Window.display.width, CORE.Window.display.height);
-#endif // PLATFORM_DRM
-
-    // There must be at least one frame displayed before the buffers are swapped
-    // eglSwapInterval(CORE.Window.device, 1);
-
-    if (eglMakeCurrent(CORE.Window.device, CORE.Window.surface, CORE.Window.surface, CORE.Window.context) == EGL_FALSE)
-    {
-        TRACELOG(LOG_WARNING, "DISPLAY: Failed to attach EGL rendering context to EGL surface");
-        return false;
-    }
-    else
-    {
-        CORE.Window.render.width = CORE.Window.screen.width;
-        CORE.Window.render.height = CORE.Window.screen.height;
-        CORE.Window.currentFbo.width = CORE.Window.render.width;
-        CORE.Window.currentFbo.height = CORE.Window.render.height;
-
-        TRACELOG(LOG_INFO, "DISPLAY: Device initialized successfully");
-        TRACELOG(LOG_INFO, "    > Display size: %i x %i", CORE.Window.display.width, CORE.Window.display.height);
-        TRACELOG(LOG_INFO, "    > Screen size:  %i x %i", CORE.Window.screen.width, CORE.Window.screen.height);
-        TRACELOG(LOG_INFO, "    > Render size:  %i x %i", CORE.Window.render.width, CORE.Window.render.height);
-        TRACELOG(LOG_INFO, "    > Viewport offsets: %i, %i", CORE.Window.renderOffset.x, CORE.Window.renderOffset.y);
-    }
-#endif // PLATFORM_ANDROID || PLATFORM_DRM
+// HERE 16 //#if defined(PLATFORM_ANDROID) || defined(PLATFORM_DRM)
+// HERE 16 //    CORE.Window.fullscreen = true;
+// HERE 16 //    CORE.Window.flags |= FLAG_FULLSCREEN_MODE;
+// HERE 16 //
+// HERE 16 //#if defined(PLATFORM_DRM)
+// HERE 16 //    CORE.Window.fd = -1;
+// HERE 16 //    CORE.Window.connector = NULL;
+// HERE 16 //    CORE.Window.modeIndex = -1;
+// HERE 16 //    CORE.Window.crtc = NULL;
+// HERE 16 //    CORE.Window.gbmDevice = NULL;
+// HERE 16 //    CORE.Window.gbmSurface = NULL;
+// HERE 16 //    CORE.Window.prevBO = NULL;
+// HERE 16 //    CORE.Window.prevFB = 0;
+// HERE 16 //
+// HERE 16 //#if defined(DEFAULT_GRAPHIC_DEVICE_DRM)
+// HERE 16 //    CORE.Window.fd = open(DEFAULT_GRAPHIC_DEVICE_DRM, O_RDWR);
+// HERE 16 //#else
+// HERE 16 //    TRACELOG(LOG_INFO, "DISPLAY: No graphic card set, trying platform-gpu-card");
+// HERE 16 //    CORE.Window.fd = open("/dev/dri/by-path/platform-gpu-card", O_RDWR); // VideoCore VI (Raspberry Pi 4)
+// HERE 16 //
+// HERE 16 //    if ((-1 == CORE.Window.fd) || (drmModeGetResources(CORE.Window.fd) == NULL))
+// HERE 16 //    {
+// HERE 16 //        TRACELOG(LOG_INFO, "DISPLAY: Failed to open platform-gpu-card, trying card1");
+// HERE 16 //        CORE.Window.fd = open("/dev/dri/card1", O_RDWR); // Other Embedded
+// HERE 16 //    }
+// HERE 16 //
+// HERE 16 //    if ((-1 == CORE.Window.fd) || (drmModeGetResources(CORE.Window.fd) == NULL))
+// HERE 16 //    {
+// HERE 16 //        TRACELOG(LOG_INFO, "DISPLAY: Failed to open graphic card1, trying card0");
+// HERE 16 //        CORE.Window.fd = open("/dev/dri/card0", O_RDWR); // VideoCore IV (Raspberry Pi 1-3)
+// HERE 16 //    }
+// HERE 16 //#endif
+// HERE 16 //    if (-1 == CORE.Window.fd)
+// HERE 16 //    {
+// HERE 16 //        TRACELOG(LOG_WARNING, "DISPLAY: Failed to open graphic card");
+// HERE 16 //        return false;
+// HERE 16 //    }
+// HERE 16 //
+// HERE 16 //    drmModeRes *res = drmModeGetResources(CORE.Window.fd);
+// HERE 16 //    if (!res)
+// HERE 16 //    {
+// HERE 16 //        TRACELOG(LOG_WARNING, "DISPLAY: Failed get DRM resources");
+// HERE 16 //        return false;
+// HERE 16 //    }
+// HERE 16 //
+// HERE 16 //    TRACELOG(LOG_TRACE, "DISPLAY: Connectors found: %i", res->count_connectors);
+// HERE 16 //    for (size_t i = 0; i < res->count_connectors; i++)
+// HERE 16 //    {
+// HERE 16 //        TRACELOG(LOG_TRACE, "DISPLAY: Connector index %i", i);
+// HERE 16 //        drmModeConnector *con = drmModeGetConnector(CORE.Window.fd, res->connectors[i]);
+// HERE 16 //        TRACELOG(LOG_TRACE, "DISPLAY: Connector modes detected: %i", con->count_modes);
+// HERE 16 //        if ((con->connection == DRM_MODE_CONNECTED) && (con->encoder_id))
+// HERE 16 //        {
+// HERE 16 //            TRACELOG(LOG_TRACE, "DISPLAY: DRM mode connected");
+// HERE 16 //            CORE.Window.connector = con;
+// HERE 16 //            break;
+// HERE 16 //        }
+// HERE 16 //        else
+// HERE 16 //        {
+// HERE 16 //            TRACELOG(LOG_TRACE, "DISPLAY: DRM mode NOT connected (deleting)");
+// HERE 16 //            drmModeFreeConnector(con);
+// HERE 16 //        }
+// HERE 16 //    }
+// HERE 16 //
+// HERE 16 //    if (!CORE.Window.connector)
+// HERE 16 //    {
+// HERE 16 //        TRACELOG(LOG_WARNING, "DISPLAY: No suitable DRM connector found");
+// HERE 16 //        drmModeFreeResources(res);
+// HERE 16 //        return false;
+// HERE 16 //    }
+// HERE 16 //
+// HERE 16 //    drmModeEncoder *enc = drmModeGetEncoder(CORE.Window.fd, CORE.Window.connector->encoder_id);
+// HERE 16 //    if (!enc)
+// HERE 16 //    {
+// HERE 16 //        TRACELOG(LOG_WARNING, "DISPLAY: Failed to get DRM mode encoder");
+// HERE 16 //        drmModeFreeResources(res);
+// HERE 16 //        return false;
+// HERE 16 //    }
+// HERE 16 //
+// HERE 16 //    CORE.Window.crtc = drmModeGetCrtc(CORE.Window.fd, enc->crtc_id);
+// HERE 16 //    if (!CORE.Window.crtc)
+// HERE 16 //    {
+// HERE 16 //        TRACELOG(LOG_WARNING, "DISPLAY: Failed to get DRM mode crtc");
+// HERE 16 //        drmModeFreeEncoder(enc);
+// HERE 16 //        drmModeFreeResources(res);
+// HERE 16 //        return false;
+// HERE 16 //    }
+// HERE 16 //
+// HERE 16 //    // If InitWindow should use the current mode find it in the connector's mode list
+// HERE 16 //    if ((CORE.Window.screen.width <= 0) || (CORE.Window.screen.height <= 0))
+// HERE 16 //    {
+// HERE 16 //        TRACELOG(LOG_TRACE, "DISPLAY: Selecting DRM connector mode for current used mode...");
+// HERE 16 //
+// HERE 16 //        CORE.Window.modeIndex = FindMatchingConnectorMode(CORE.Window.connector, &CORE.Window.crtc->mode);
+// HERE 16 //
+// HERE 16 //        if (CORE.Window.modeIndex < 0)
+// HERE 16 //        {
+// HERE 16 //            TRACELOG(LOG_WARNING, "DISPLAY: No matching DRM connector mode found");
+// HERE 16 //            drmModeFreeEncoder(enc);
+// HERE 16 //            drmModeFreeResources(res);
+// HERE 16 //            return false;
+// HERE 16 //        }
+// HERE 16 //
+// HERE 16 //        CORE.Window.screen.width = CORE.Window.display.width;
+// HERE 16 //        CORE.Window.screen.height = CORE.Window.display.height;
+// HERE 16 //    }
+// HERE 16 //
+// HERE 16 //    const bool allowInterlaced = CORE.Window.flags & FLAG_INTERLACED_HINT;
+// HERE 16 //    const int fps = (CORE.Time.target > 0) ? (1.0 / CORE.Time.target) : 60;
+// HERE 16 //
+// HERE 16 //    // Try to find an exact matching mode
+// HERE 16 //    CORE.Window.modeIndex = FindExactConnectorMode(CORE.Window.connector, CORE.Window.screen.width, CORE.Window.screen.height, fps, allowInterlaced);
+// HERE 16 //
+// HERE 16 //    // If nothing found, try to find a nearly matching mode
+// HERE 16 //    if (CORE.Window.modeIndex < 0) CORE.Window.modeIndex = FindNearestConnectorMode(CORE.Window.connector, CORE.Window.screen.width, CORE.Window.screen.height, fps, allowInterlaced);
+// HERE 16 //
+// HERE 16 //    // If nothing found, try to find an exactly matching mode including interlaced
+// HERE 16 //    if (CORE.Window.modeIndex < 0) CORE.Window.modeIndex = FindExactConnectorMode(CORE.Window.connector, CORE.Window.screen.width, CORE.Window.screen.height, fps, true);
+// HERE 16 //
+// HERE 16 //    // If nothing found, try to find a nearly matching mode including interlaced
+// HERE 16 //    if (CORE.Window.modeIndex < 0) CORE.Window.modeIndex = FindNearestConnectorMode(CORE.Window.connector, CORE.Window.screen.width, CORE.Window.screen.height, fps, true);
+// HERE 16 //
+// HERE 16 //    // If nothing found, there is no suitable mode
+// HERE 16 //    if (CORE.Window.modeIndex < 0)
+// HERE 16 //    {
+// HERE 16 //        TRACELOG(LOG_WARNING, "DISPLAY: Failed to find a suitable DRM connector mode");
+// HERE 16 //        drmModeFreeEncoder(enc);
+// HERE 16 //        drmModeFreeResources(res);
+// HERE 16 //        return false;
+// HERE 16 //    }
+// HERE 16 //
+// HERE 16 //    CORE.Window.display.width = CORE.Window.connector->modes[CORE.Window.modeIndex].hdisplay;
+// HERE 16 //    CORE.Window.display.height = CORE.Window.connector->modes[CORE.Window.modeIndex].vdisplay;
+// HERE 16 //
+// HERE 16 //    TRACELOG(LOG_INFO, "DISPLAY: Selected DRM connector mode %s (%ux%u%c@%u)", CORE.Window.connector->modes[CORE.Window.modeIndex].name,
+// HERE 16 //             CORE.Window.connector->modes[CORE.Window.modeIndex].hdisplay, CORE.Window.connector->modes[CORE.Window.modeIndex].vdisplay,
+// HERE 16 //             (CORE.Window.connector->modes[CORE.Window.modeIndex].flags & DRM_MODE_FLAG_INTERLACE) ? 'i' : 'p',
+// HERE 16 //             CORE.Window.connector->modes[CORE.Window.modeIndex].vrefresh);
+// HERE 16 //
+// HERE 16 //    // Use the width and height of the surface for render
+// HERE 16 //    CORE.Window.render.width = CORE.Window.screen.width;
+// HERE 16 //    CORE.Window.render.height = CORE.Window.screen.height;
+// HERE 16 //
+// HERE 16 //    drmModeFreeEncoder(enc);
+// HERE 16 //    enc = NULL;
+// HERE 16 //
+// HERE 16 //    drmModeFreeResources(res);
+// HERE 16 //    res = NULL;
+// HERE 16 //
+// HERE 16 //    CORE.Window.gbmDevice = gbm_create_device(CORE.Window.fd);
+// HERE 16 //    if (!CORE.Window.gbmDevice)
+// HERE 16 //    {
+// HERE 16 //        TRACELOG(LOG_WARNING, "DISPLAY: Failed to create GBM device");
+// HERE 16 //        return false;
+// HERE 16 //    }
+// HERE 16 //
+// HERE 16 //    CORE.Window.gbmSurface = gbm_surface_create(CORE.Window.gbmDevice, CORE.Window.connector->modes[CORE.Window.modeIndex].hdisplay,
+// HERE 16 //                                                CORE.Window.connector->modes[CORE.Window.modeIndex].vdisplay, GBM_FORMAT_ARGB8888, GBM_BO_USE_SCANOUT | GBM_BO_USE_RENDERING);
+// HERE 16 //    if (!CORE.Window.gbmSurface)
+// HERE 16 //    {
+// HERE 16 //        TRACELOG(LOG_WARNING, "DISPLAY: Failed to create GBM surface");
+// HERE 16 //        return false;
+// HERE 16 //    }
+// HERE 16 //#endif
+// HERE 16 //
+// HERE 16 //    EGLint samples = 0;
+// HERE 16 //    EGLint sampleBuffer = 0;
+// HERE 16 //    if (CORE.Window.flags & FLAG_MSAA_4X_HINT)
+// HERE 16 //    {
+// HERE 16 //        samples = 4;
+// HERE 16 //        sampleBuffer = 1;
+// HERE 16 //        TRACELOG(LOG_INFO, "DISPLAY: Trying to enable MSAA x4");
+// HERE 16 //    }
+// HERE 16 //
+// HERE 16 //    const EGLint framebufferAttribs[] =
+// HERE 16 //    {
+// HERE 16 //        EGL_RENDERABLE_TYPE,
+// HERE 16 //        (rlGetVersion() == RL_OPENGL_ES_30) ? EGL_OPENGL_ES3_BIT : EGL_OPENGL_ES2_BIT, // Type of context support
+// HERE 16 //#if defined(PLATFORM_DRM)
+// HERE 16 //        EGL_SURFACE_TYPE,
+// HERE 16 //        EGL_WINDOW_BIT, // Don't use it on Android!
+// HERE 16 //#endif
+// HERE 16 //        EGL_RED_SIZE,
+// HERE 16 //        8, // RED color bit depth (alternative: 5)
+// HERE 16 //        EGL_GREEN_SIZE,
+// HERE 16 //        8, // GREEN color bit depth (alternative: 6)
+// HERE 16 //        EGL_BLUE_SIZE,
+// HERE 16 //        8, // BLUE color bit depth (alternative: 5)
+// HERE 16 //#if defined(PLATFORM_DRM)
+// HERE 16 //        EGL_ALPHA_SIZE,
+// HERE 16 //        8, // ALPHA bit depth (required for transparent framebuffer)
+// HERE 16 //#endif
+// HERE 16 //        // EGL_TRANSPARENT_TYPE, EGL_NONE, // Request transparent framebuffer (EGL_TRANSPARENT_RGB does not work on RPI)
+// HERE 16 //        EGL_DEPTH_SIZE,
+// HERE 16 //        16, // Depth buffer size (Required to use Depth testing!)
+// HERE 16 //        // EGL_STENCIL_SIZE, 8,      // Stencil buffer size
+// HERE 16 //        EGL_SAMPLE_BUFFERS,
+// HERE 16 //        sampleBuffer, // Activate MSAA
+// HERE 16 //        EGL_SAMPLES,
+// HERE 16 //        samples, // 4x Antialiasing if activated (Free on MALI GPUs)
+// HERE 16 //        EGL_NONE
+// HERE 16 //    };
+// HERE 16 //
+// HERE 16 //    const EGLint contextAttribs[] =
+// HERE 16 //        {
+// HERE 16 //            EGL_CONTEXT_CLIENT_VERSION, 2,
+// HERE 16 //            EGL_NONE};
+// HERE 16 //
+// HERE 16 //#if defined(PLATFORM_ANDROID) || defined(PLATFORM_DRM)
+// HERE 16 //    EGLint numConfigs = 0;
+// HERE 16 //
+// HERE 16 //    // Get an EGL device connection
+// HERE 16 //#if defined(PLATFORM_DRM)
+// HERE 16 //    CORE.Window.device = eglGetDisplay((EGLNativeDisplayType)CORE.Window.gbmDevice);
+// HERE 16 //#else
+// HERE 16 //    CORE.Window.device = eglGetDisplay(EGL_DEFAULT_DISPLAY);
+// HERE 16 //#endif
+// HERE 16 //    if (CORE.Window.device == EGL_NO_DISPLAY)
+// HERE 16 //    {
+// HERE 16 //        TRACELOG(LOG_WARNING, "DISPLAY: Failed to initialize EGL device");
+// HERE 16 //        return false;
+// HERE 16 //    }
+// HERE 16 //
+// HERE 16 //    // Initialize the EGL device connection
+// HERE 16 //    if (eglInitialize(CORE.Window.device, NULL, NULL) == EGL_FALSE)
+// HERE 16 //    {
+// HERE 16 //        // If all of the calls to eglInitialize returned EGL_FALSE then an error has occurred.
+// HERE 16 //        TRACELOG(LOG_WARNING, "DISPLAY: Failed to initialize EGL device");
+// HERE 16 //        return false;
+// HERE 16 //    }
+// HERE 16 //
+// HERE 16 //#if defined(PLATFORM_DRM)
+// HERE 16 //    if (!eglChooseConfig(CORE.Window.device, NULL, NULL, 0, &numConfigs))
+// HERE 16 //    {
+// HERE 16 //        TRACELOG(LOG_WARNING, "DISPLAY: Failed to get EGL config count: 0x%x", eglGetError());
+// HERE 16 //        return false;
+// HERE 16 //    }
+// HERE 16 //
+// HERE 16 //    TRACELOG(LOG_TRACE, "DISPLAY: EGL configs available: %d", numConfigs);
+// HERE 16 //
+// HERE 16 //    EGLConfig *configs = RL_CALLOC(numConfigs, sizeof(*configs));
+// HERE 16 //    if (!configs)
+// HERE 16 //    {
+// HERE 16 //        TRACELOG(LOG_WARNING, "DISPLAY: Failed to get memory for EGL configs");
+// HERE 16 //        return false;
+// HERE 16 //    }
+// HERE 16 //
+// HERE 16 //    EGLint matchingNumConfigs = 0;
+// HERE 16 //    if (!eglChooseConfig(CORE.Window.device, framebufferAttribs, configs, numConfigs, &matchingNumConfigs))
+// HERE 16 //    {
+// HERE 16 //        TRACELOG(LOG_WARNING, "DISPLAY: Failed to choose EGL config: 0x%x", eglGetError());
+// HERE 16 //        free(configs);
+// HERE 16 //        return false;
+// HERE 16 //    }
+// HERE 16 //
+// HERE 16 //    TRACELOG(LOG_TRACE, "DISPLAY: EGL matching configs available: %d", matchingNumConfigs);
+// HERE 16 //
+// HERE 16 //    // find the EGL config that matches the previously setup GBM format
+// HERE 16 //    int found = 0;
+// HERE 16 //    for (EGLint i = 0; i < matchingNumConfigs; ++i)
+// HERE 16 //    {
+// HERE 16 //        EGLint id = 0;
+// HERE 16 //        if (!eglGetConfigAttrib(CORE.Window.device, configs[i], EGL_NATIVE_VISUAL_ID, &id))
+// HERE 16 //        {
+// HERE 16 //            TRACELOG(LOG_WARNING, "DISPLAY: Failed to get EGL config attribute: 0x%x", eglGetError());
+// HERE 16 //            continue;
+// HERE 16 //        }
+// HERE 16 //
+// HERE 16 //        if (GBM_FORMAT_ARGB8888 == id)
+// HERE 16 //        {
+// HERE 16 //            TRACELOG(LOG_TRACE, "DISPLAY: Using EGL config: %d", i);
+// HERE 16 //            CORE.Window.config = configs[i];
+// HERE 16 //            found = 1;
+// HERE 16 //            break;
+// HERE 16 //        }
+// HERE 16 //    }
+// HERE 16 //
+// HERE 16 //    RL_FREE(configs);
+// HERE 16 //
+// HERE 16 //    if (!found)
+// HERE 16 //    {
+// HERE 16 //        TRACELOG(LOG_WARNING, "DISPLAY: Failed to find a suitable EGL config");
+// HERE 16 //        return false;
+// HERE 16 //    }
+// HERE 16 //#else
+// HERE 16 //    // Get an appropriate EGL framebuffer configuration
+// HERE 16 //    eglChooseConfig(CORE.Window.device, framebufferAttribs, &CORE.Window.config, 1, &numConfigs);
+// HERE 16 //#endif
+// HERE 16 //
+// HERE 16 //    // Set rendering API
+// HERE 16 //    eglBindAPI(EGL_OPENGL_ES_API);
+// HERE 16 //
+// HERE 16 //    // Create an EGL rendering context
+// HERE 16 //    CORE.Window.context = eglCreateContext(CORE.Window.device, CORE.Window.config, EGL_NO_CONTEXT, contextAttribs);
+// HERE 16 //    if (CORE.Window.context == EGL_NO_CONTEXT)
+// HERE 16 //    {
+// HERE 16 //        TRACELOG(LOG_WARNING, "DISPLAY: Failed to create EGL context");
+// HERE 16 //        return false;
+// HERE 16 //    }
+// HERE 16 //#endif
+// HERE 16 //
+// HERE 16 //    // Create an EGL window surface
+// HERE 16 //    //---------------------------------------------------------------------------------
+// HERE 16 //#if defined(PLATFORM_ANDROID)
+// HERE 16 //    EGLint displayFormat = 0;
+// HERE 16 //
+// HERE 16 //    // EGL_NATIVE_VISUAL_ID is an attribute of the EGLConfig that is guaranteed to be accepted by ANativeWindow_setBuffersGeometry()
+// HERE 16 //    // As soon as we picked a EGLConfig, we can safely reconfigure the ANativeWindow buffers to match, using EGL_NATIVE_VISUAL_ID
+// HERE 16 //    eglGetConfigAttrib(CORE.Window.device, CORE.Window.config, EGL_NATIVE_VISUAL_ID, &displayFormat);
+// HERE 16 //
+// HERE 16 //    // At this point we need to manage render size vs screen size
+// HERE 16 //    // NOTE: This function use and modify global module variables:
+// HERE 16 //    //  -> CORE.Window.screen.width/CORE.Window.screen.height
+// HERE 16 //    //  -> CORE.Window.render.width/CORE.Window.render.height
+// HERE 16 //    //  -> CORE.Window.screenScale
+// HERE 16 //    SetupFramebuffer(CORE.Window.display.width, CORE.Window.display.height);
+// HERE 16 //
+// HERE 16 //    ANativeWindow_setBuffersGeometry(CORE.Android.app->window, CORE.Window.render.width, CORE.Window.render.height, displayFormat);
+// HERE 16 //    // ANativeWindow_setBuffersGeometry(CORE.Android.app->window, 0, 0, displayFormat);       // Force use of native display size
+// HERE 16 //
+// HERE 16 //    CORE.Window.surface = eglCreateWindowSurface(CORE.Window.device, CORE.Window.config, CORE.Android.app->window, NULL);
+// HERE 16 //#endif // PLATFORM_ANDROID
+// HERE 16 //
+// HERE 16 //#if defined(PLATFORM_DRM)
+// HERE 16 //    CORE.Window.surface = eglCreateWindowSurface(CORE.Window.device, CORE.Window.config, (EGLNativeWindowType)CORE.Window.gbmSurface, NULL);
+// HERE 16 //    if (EGL_NO_SURFACE == CORE.Window.surface)
+// HERE 16 //    {
+// HERE 16 //        TRACELOG(LOG_WARNING, "DISPLAY: Failed to create EGL window surface: 0x%04x", eglGetError());
+// HERE 16 //        return false;
+// HERE 16 //    }
+// HERE 16 //
+// HERE 16 //    // At this point we need to manage render size vs screen size
+// HERE 16 //    // NOTE: This function use and modify global module variables:
+// HERE 16 //    //  -> CORE.Window.screen.width/CORE.Window.screen.height
+// HERE 16 //    //  -> CORE.Window.render.width/CORE.Window.render.height
+// HERE 16 //    //  -> CORE.Window.screenScale
+// HERE 16 //    SetupFramebuffer(CORE.Window.display.width, CORE.Window.display.height);
+// HERE 16 //#endif // PLATFORM_DRM
+// HERE 16 //
+// HERE 16 //    // There must be at least one frame displayed before the buffers are swapped
+// HERE 16 //    // eglSwapInterval(CORE.Window.device, 1);
+// HERE 16 //
+// HERE 16 //    if (eglMakeCurrent(CORE.Window.device, CORE.Window.surface, CORE.Window.surface, CORE.Window.context) == EGL_FALSE)
+// HERE 16 //    {
+// HERE 16 //        TRACELOG(LOG_WARNING, "DISPLAY: Failed to attach EGL rendering context to EGL surface");
+// HERE 16 //        return false;
+// HERE 16 //    }
+// HERE 16 //    else
+// HERE 16 //    {
+// HERE 16 //        CORE.Window.render.width = CORE.Window.screen.width;
+// HERE 16 //        CORE.Window.render.height = CORE.Window.screen.height;
+// HERE 16 //        CORE.Window.currentFbo.width = CORE.Window.render.width;
+// HERE 16 //        CORE.Window.currentFbo.height = CORE.Window.render.height;
+// HERE 16 //
+// HERE 16 //        TRACELOG(LOG_INFO, "DISPLAY: Device initialized successfully");
+// HERE 16 //        TRACELOG(LOG_INFO, "    > Display size: %i x %i", CORE.Window.display.width, CORE.Window.display.height);
+// HERE 16 //        TRACELOG(LOG_INFO, "    > Screen size:  %i x %i", CORE.Window.screen.width, CORE.Window.screen.height);
+// HERE 16 //        TRACELOG(LOG_INFO, "    > Render size:  %i x %i", CORE.Window.render.width, CORE.Window.render.height);
+// HERE 16 //        TRACELOG(LOG_INFO, "    > Viewport offsets: %i, %i", CORE.Window.renderOffset.x, CORE.Window.renderOffset.y);
+// HERE 16 //    }
+// HERE 16 //#endif // PLATFORM_ANDROID || PLATFORM_DRM
 
     // Load OpenGL extensions
     // NOTE: GL procedures address loader is required to load extensions
-#if defined(PLATFORM_DESKTOP) || defined(PLATFORM_WEB)
+// HERE 17 //#if defined(PLATFORM_DESKTOP) || defined(PLATFORM_WEB)
     rlLoadExtensions(glfwGetProcAddress);
-#else
-    rlLoadExtensions(eglGetProcAddress);
-#endif
+// HERE 17 //#else
+// HERE 17 //    rlLoadExtensions(eglGetProcAddress);
+// HERE 17 //#endif
 
     // Initialize OpenGL context (states and resources)
     // NOTE: CORE.Window.currentFbo.width and CORE.Window.currentFbo.height not used, just stored as globals in rlgl
@@ -1059,9 +1059,9 @@ static bool InitGraphicsDevice(int width, int height)
     // NOTE: It updated CORE.Window.render.width and CORE.Window.render.height
     SetupViewport(CORE.Window.currentFbo.width, CORE.Window.currentFbo.height);
 
-#if defined(PLATFORM_ANDROID)
-    CORE.Window.ready = true;
-#endif
+// HERE 18 //#if defined(PLATFORM_ANDROID)
+// HERE 18 //    CORE.Window.ready = true;
+// HERE 18 //#endif
 
     if ((CORE.Window.flags & FLAG_WINDOW_MINIMIZED) > 0) MinimizeWindow();
 


### PR DESCRIPTION
### PR changes
1. First pass to remove unneeded platform macros for `PLATFORM_WEB`.
On `rcore_web.c`: [R353](https://github.com/raysan5/raylib/pull/3338/commits/b36a838e287dec2d3fe616d2150798b8f51e1ed5#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdR353), [R366-R368](https://github.com/raysan5/raylib/pull/3338/commits/b36a838e287dec2d3fe616d2150798b8f51e1ed5#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdR366-R368), [R411-R430](https://github.com/raysan5/raylib/pull/3338/commits/b36a838e287dec2d3fe616d2150798b8f51e1ed5#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdR411-R430), [R455-R457](https://github.com/raysan5/raylib/pull/3338/commits/b36a838e287dec2d3fe616d2150798b8f51e1ed5#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdR455-R457), [R459](https://github.com/raysan5/raylib/pull/3338/commits/b36a838e287dec2d3fe616d2150798b8f51e1ed5#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdR459), [R477-R479](https://github.com/raysan5/raylib/pull/3338/commits/b36a838e287dec2d3fe616d2150798b8f51e1ed5#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdR477-R479), [R481](https://github.com/raysan5/raylib/pull/3338/commits/b36a838e287dec2d3fe616d2150798b8f51e1ed5#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdR481), [R488-R490](https://github.com/raysan5/raylib/pull/3338/commits/b36a838e287dec2d3fe616d2150798b8f51e1ed5#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdR488-R490), [R492](https://github.com/raysan5/raylib/pull/3338/commits/b36a838e287dec2d3fe616d2150798b8f51e1ed5#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdR492), [R495-R501](https://github.com/raysan5/raylib/pull/3338/commits/b36a838e287dec2d3fe616d2150798b8f51e1ed5#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdR495-R501), [R503-R520](https://github.com/raysan5/raylib/pull/3338/commits/b36a838e287dec2d3fe616d2150798b8f51e1ed5#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdR503-R520), [R522](https://github.com/raysan5/raylib/pull/3338/commits/b36a838e287dec2d3fe616d2150798b8f51e1ed5#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdR522), [R526](https://github.com/raysan5/raylib/pull/3338/commits/b36a838e287dec2d3fe616d2150798b8f51e1ed5#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdR526), [R585-R591](https://github.com/raysan5/raylib/pull/3338/commits/b36a838e287dec2d3fe616d2150798b8f51e1ed5#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdR585-R591), [R610](https://github.com/raysan5/raylib/pull/3338/commits/b36a838e287dec2d3fe616d2150798b8f51e1ed5#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdR610), [R612](https://github.com/raysan5/raylib/pull/3338/commits/b36a838e287dec2d3fe616d2150798b8f51e1ed5#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdR612), [R616-R618](https://github.com/raysan5/raylib/pull/3338/commits/b36a838e287dec2d3fe616d2150798b8f51e1ed5#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdR616-R618), [R633-R637](https://github.com/raysan5/raylib/pull/3338/commits/b36a838e287dec2d3fe616d2150798b8f51e1ed5#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdR633-R637), [R642-R649](https://github.com/raysan5/raylib/pull/3338/commits/b36a838e287dec2d3fe616d2150798b8f51e1ed5#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdR642-R649), [R654-R669](https://github.com/raysan5/raylib/pull/3338/commits/b36a838e287dec2d3fe616d2150798b8f51e1ed5#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdR654-R669), [R682](https://github.com/raysan5/raylib/pull/3338/commits/b36a838e287dec2d3fe616d2150798b8f51e1ed5#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdR682), [R684-R1044](https://github.com/raysan5/raylib/pull/3338/commits/b36a838e287dec2d3fe616d2150798b8f51e1ed5#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdR684-R1044), [R1048](https://github.com/raysan5/raylib/pull/3338/commits/b36a838e287dec2d3fe616d2150798b8f51e1ed5#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdR1048), [R1050-R1052](https://github.com/raysan5/raylib/pull/3338/commits/b36a838e287dec2d3fe616d2150798b8f51e1ed5#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdR1050-R1052), [R1062-R1064](https://github.com/raysan5/raylib/pull/3338/commits/b36a838e287dec2d3fe616d2150798b8f51e1ed5#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdR1062-R1064).

2. Second pass to remove unneeded platform macros for `PLATFORM_WEB`.
On `rcore_web.c`: [L353](https://github.com/raysan5/raylib/pull/3338/files#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdL353), [L366-L368](https://github.com/raysan5/raylib/pull/3338/files#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdL366-L368), [L411-L430](https://github.com/raysan5/raylib/pull/3338/files#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdL411-L430), [L455-L457](https://github.com/raysan5/raylib/pull/3338/files#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdL455-L457), [L459](https://github.com/raysan5/raylib/pull/3338/files#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdL459), [L477-L479](https://github.com/raysan5/raylib/pull/3338/files#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdL477-L479), [L481](https://github.com/raysan5/raylib/pull/3338/files#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdL481), [L488-L490](https://github.com/raysan5/raylib/pull/3338/files#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdL488-L490), [L492-L509](https://github.com/raysan5/raylib/pull/3338/files#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdL492-L509), [L512-L522](https://github.com/raysan5/raylib/pull/3338/files#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdL512-L522), [L526](https://github.com/raysan5/raylib/pull/3338/files#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdL526), [L585-L591](https://github.com/raysan5/raylib/pull/3338/files#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdL585-L591), [L610](https://github.com/raysan5/raylib/pull/3338/files#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdL610), [L612](https://github.com/raysan5/raylib/pull/3338/files#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdL612), [L616-L618](https://github.com/raysan5/raylib/pull/3338/files#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdL616-L618), [L633-L637](https://github.com/raysan5/raylib/pull/3338/files#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdL633-L637), [L642-L649](https://github.com/raysan5/raylib/pull/3338/files#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdL642-L649), [L654-L670](https://github.com/raysan5/raylib/pull/3338/files#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdL654-L670), [L682-L1045](https://github.com/raysan5/raylib/pull/3338/files#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdL682-L1045), [L1048](https://github.com/raysan5/raylib/pull/3338/files#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdL1048), [L1050-L1052](https://github.com/raysan5/raylib/pull/3338/files#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdL1050-L1052), [L1062-L1064](https://github.com/raysan5/raylib/pull/3338/files#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdL1062-L1064).

3. Move `GetTouchX()`, `GetTouchY()`, `GetTouchPosition()` from `rcore.c` ([R2124-R2162](https://github.com/raysan5/raylib/pull/3338/files#diff-39fea0e3daa23741e81daf967717f35c7842426aab26a0bc3f525d6a2f03e339R2124-R2162)) to `rcore_web.c` ([R1114-R1136](https://github.com/raysan5/raylib/pull/3338/files#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdR1114-R1136)), `rcore_desktop.c` ([R1582-R1606](https://github.com/raysan5/raylib/pull/3338/files#diff-10e13300b4588e538a0c2c603707242b63d716e3ab2b80b81db9a54c308ca3acR1582-R1606)), `rcore_android.c` ([R1686-R1708](https://github.com/raysan5/raylib/pull/3338/files#diff-df7f2529f920b22e7f3b28d8c53b9042fe9ba3e0c4be0a421ac8d9e0c3bde72dR1686-R1708)). **Note:** instead of deleting them from `rcore.c` just commented them to keep as reference. Will clean up later.

4. Move `SetMouseCursor` from `rcore.c`([R2109-R2122](https://github.com/raysan5/raylib/pull/3338/files#diff-39fea0e3daa23741e81daf967717f35c7842426aab26a0bc3f525d6a2f03e339R2109-R2122)) to `rcore_android.c` ([R1686-R1691](https://github.com/raysan5/raylib/pull/3338/files#diff-df7f2529f920b22e7f3b28d8c53b9042fe9ba3e0c4be0a421ac8d9e0c3bde72dR1686-R1691)), `rcore_desktop.c` ([R1582-R1593](https://github.com/raysan5/raylib/pull/3338/files#diff-10e13300b4588e538a0c2c603707242b63d716e3ab2b80b81db9a54c308ca3acR1582-R1593)), `rcore_web.c` ([R1113-R1118](https://github.com/raysan5/raylib/pull/3338/files#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdR1113-R1118)). **Note:** instead of deleting it from `rcore.c` just commented it to keep as reference. Will clean up later.

### Status
- #3339

### Environment
- Compiled with `emscripten/emsdk` on Linux (Mint 21.1 64-bit).
- Tested on Firefox (115.1.0esr 64-bit) and Chromium (115.0.5790.170 64-bit) both running on Linux Mint (21.1 64-bit).

**Edit 1:** added second pass; added line marks.
**Edit 2:** added note C about models_skybox; formatting.
**Edit 3:** moved status to separate issue.
**Edit 4, 5:** added moved functions.