### PR TITLE
[split] `rcore`, `web`, `desktop`, `android` changes (batch 4)

### DIFF
--- a/src/rcore_android.c
+++ b/src/rcore_android.c
@@ -145,501 +145,8 @@ static bool InitGraphicsDevice(int width, int height)
     // NOTE: Framebuffer (render area - CORE.Window.render.width, CORE.Window.render.height) could include black bars...
     // ...in top-down or left-right to match display aspect ratio (no weird scaling)
 
-// HERE 1 //#if defined(PLATFORM_DESKTOP) || defined(PLATFORM_WEB)
-// HERE 1 //    glfwSetErrorCallback(ErrorCallback);
-// HERE 1 ///*
-// HERE 1 //    // TODO: Setup GLFW custom allocators to match raylib ones
-// HERE 1 //    const GLFWallocator allocator = {
-// HERE 1 //        .allocate = MemAlloc,
-// HERE 1 //        .deallocate = MemFree,
-// HERE 1 //        .reallocate = MemRealloc,
-// HERE 1 //        .user = NULL
-// HERE 1 //    };
-// HERE 1 //
-// HERE 1 //    glfwInitAllocator(&allocator);
-// HERE 1 //*/
-// HERE 1 //#if defined(__APPLE__)
-// HERE 1 //    glfwInitHint(GLFW_COCOA_CHDIR_RESOURCES, GLFW_FALSE);
-// HERE 1 //#endif
-// HERE 1 //
-// HERE 1 //    if (!glfwInit())
-// HERE 1 //    {
-// HERE 1 //        TRACELOG(LOG_WARNING, "GLFW: Failed to initialize GLFW");
-// HERE 1 //        return false;
-// HERE 1 //    }
-// HERE 1 //
-// HERE 1 //    glfwDefaultWindowHints();                       // Set default windows hints
-// HERE 1 //    //glfwWindowHint(GLFW_RED_BITS, 8);             // Framebuffer red color component bits
-// HERE 1 //    //glfwWindowHint(GLFW_GREEN_BITS, 8);           // Framebuffer green color component bits
-// HERE 1 //    //glfwWindowHint(GLFW_BLUE_BITS, 8);            // Framebuffer blue color component bits
-// HERE 1 //    //glfwWindowHint(GLFW_ALPHA_BITS, 8);           // Framebuffer alpha color component bits
-// HERE 1 //    //glfwWindowHint(GLFW_DEPTH_BITS, 24);          // Depthbuffer bits
-// HERE 1 //    //glfwWindowHint(GLFW_REFRESH_RATE, 0);         // Refresh rate for fullscreen window
-// HERE 1 //    //glfwWindowHint(GLFW_CLIENT_API, GLFW_OPENGL_API); // OpenGL API to use. Alternative: GLFW_OPENGL_ES_API
-// HERE 1 //    //glfwWindowHint(GLFW_AUX_BUFFERS, 0);          // Number of auxiliar buffers
-// HERE 1 //
-// HERE 1 //    // Check window creation flags
-// HERE 1 //    if ((CORE.Window.flags & FLAG_FULLSCREEN_MODE) > 0) CORE.Window.fullscreen = true;
-// HERE 1 //
-// HERE 1 //    if ((CORE.Window.flags & FLAG_WINDOW_HIDDEN) > 0) glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE); // Visible window
-// HERE 1 //    else glfwWindowHint(GLFW_VISIBLE, GLFW_TRUE);     // Window initially hidden
-// HERE 1 //
-// HERE 1 //    if ((CORE.Window.flags & FLAG_WINDOW_UNDECORATED) > 0) glfwWindowHint(GLFW_DECORATED, GLFW_FALSE); // Border and buttons on Window
-// HERE 1 //    else glfwWindowHint(GLFW_DECORATED, GLFW_TRUE);   // Decorated window
-// HERE 1 //
-// HERE 1 //    if ((CORE.Window.flags & FLAG_WINDOW_RESIZABLE) > 0) glfwWindowHint(GLFW_RESIZABLE, GLFW_TRUE); // Resizable window
-// HERE 1 //    else glfwWindowHint(GLFW_RESIZABLE, GLFW_FALSE);  // Avoid window being resizable
-// HERE 1 //
-// HERE 1 //    // Disable FLAG_WINDOW_MINIMIZED, not supported on initialization
-// HERE 1 //    if ((CORE.Window.flags & FLAG_WINDOW_MINIMIZED) > 0) CORE.Window.flags &= ~FLAG_WINDOW_MINIMIZED;
-// HERE 1 //
-// HERE 1 //    // Disable FLAG_WINDOW_MAXIMIZED, not supported on initialization
-// HERE 1 //    if ((CORE.Window.flags & FLAG_WINDOW_MAXIMIZED) > 0) CORE.Window.flags &= ~FLAG_WINDOW_MAXIMIZED;
-// HERE 1 //
-// HERE 1 //    if ((CORE.Window.flags & FLAG_WINDOW_UNFOCUSED) > 0) glfwWindowHint(GLFW_FOCUSED, GLFW_FALSE);
-// HERE 1 //    else glfwWindowHint(GLFW_FOCUSED, GLFW_TRUE);
-// HERE 1 //
-// HERE 1 //    if ((CORE.Window.flags & FLAG_WINDOW_TOPMOST) > 0) glfwWindowHint(GLFW_FLOATING, GLFW_TRUE);
-// HERE 1 //    else glfwWindowHint(GLFW_FLOATING, GLFW_FALSE);
-// HERE 1 //
-// HERE 1 //    // NOTE: Some GLFW flags are not supported on HTML5
-// HERE 1 //#if defined(PLATFORM_DESKTOP)
-// HERE 1 //    if ((CORE.Window.flags & FLAG_WINDOW_TRANSPARENT) > 0) glfwWindowHint(GLFW_TRANSPARENT_FRAMEBUFFER, GLFW_TRUE);     // Transparent framebuffer
-// HERE 1 //    else glfwWindowHint(GLFW_TRANSPARENT_FRAMEBUFFER, GLFW_FALSE);  // Opaque framebuffer
-// HERE 1 //
-// HERE 1 //    if ((CORE.Window.flags & FLAG_WINDOW_HIGHDPI) > 0)
-// HERE 1 //    {
-// HERE 1 //        // Resize window content area based on the monitor content scale.
-// HERE 1 //        // NOTE: This hint only has an effect on platforms where screen coordinates and pixels always map 1:1 such as Windows and X11.
-// HERE 1 //        // On platforms like macOS the resolution of the framebuffer is changed independently of the window size.
-// HERE 1 //        glfwWindowHint(GLFW_SCALE_TO_MONITOR, GLFW_TRUE);   // Scale content area based on the monitor content scale where window is placed on
-// HERE 1 //    #if defined(__APPLE__)
-// HERE 1 //        glfwWindowHint(GLFW_COCOA_RETINA_FRAMEBUFFER, GLFW_TRUE);
-// HERE 1 //    #endif
-// HERE 1 //    }
-// HERE 1 //    else glfwWindowHint(GLFW_SCALE_TO_MONITOR, GLFW_FALSE);
-// HERE 1 //
-// HERE 1 //    // Mouse passthrough
-// HERE 1 //    if ((CORE.Window.flags & FLAG_WINDOW_MOUSE_PASSTHROUGH) > 0) glfwWindowHint(GLFW_MOUSE_PASSTHROUGH, GLFW_TRUE);
-// HERE 1 //    else glfwWindowHint(GLFW_MOUSE_PASSTHROUGH, GLFW_FALSE);
-// HERE 1 //#endif
-// HERE 1 //
-// HERE 1 //    if (CORE.Window.flags & FLAG_MSAA_4X_HINT)
-// HERE 1 //    {
-// HERE 1 //        // NOTE: MSAA is only enabled for main framebuffer, not user-created FBOs
-// HERE 1 //        TRACELOG(LOG_INFO, "DISPLAY: Trying to enable MSAA x4");
-// HERE 1 //        glfwWindowHint(GLFW_SAMPLES, 4);   // Tries to enable multisampling x4 (MSAA), default is 0
-// HERE 1 //    }
-// HERE 1 //
-// HERE 1 //    // NOTE: When asking for an OpenGL context version, most drivers provide the highest supported version
-// HERE 1 //    // with backward compatibility to older OpenGL versions.
-// HERE 1 //    // For example, if using OpenGL 1.1, driver can provide a 4.3 backwards compatible context.
-// HERE 1 //
-// HERE 1 //    // Check selection OpenGL version
-// HERE 1 //    if (rlGetVersion() == RL_OPENGL_21)
-// HERE 1 //    {
-// HERE 1 //        glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 2);          // Choose OpenGL major version (just hint)
-// HERE 1 //        glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 1);          // Choose OpenGL minor version (just hint)
-// HERE 1 //    }
-// HERE 1 //    else if (rlGetVersion() == RL_OPENGL_33)
-// HERE 1 //    {
-// HERE 1 //        glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);          // Choose OpenGL major version (just hint)
-// HERE 1 //        glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);          // Choose OpenGL minor version (just hint)
-// HERE 1 //        glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE); // Profiles Hint: Only 3.3 and above!
-// HERE 1 //                                                                       // Values: GLFW_OPENGL_CORE_PROFILE, GLFW_OPENGL_ANY_PROFILE, GLFW_OPENGL_COMPAT_PROFILE
-// HERE 1 //#if defined(__APPLE__)
-// HERE 1 //        glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GLFW_TRUE);  // OSX Requires forward compatibility
-// HERE 1 //#else
-// HERE 1 //        glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GLFW_FALSE); // Forward Compatibility Hint: Only 3.3 and above!
-// HERE 1 //#endif
-// HERE 1 //        //glfwWindowHint(GLFW_OPENGL_DEBUG_CONTEXT, GLFW_TRUE); // Request OpenGL DEBUG context
-// HERE 1 //    }
-// HERE 1 //    else if (rlGetVersion() == RL_OPENGL_43)
-// HERE 1 //    {
-// HERE 1 //        glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 4);          // Choose OpenGL major version (just hint)
-// HERE 1 //        glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);          // Choose OpenGL minor version (just hint)
-// HERE 1 //        glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
-// HERE 1 //        glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GLFW_FALSE);
-// HERE 1 //#if defined(RLGL_ENABLE_OPENGL_DEBUG_CONTEXT)
-// HERE 1 //        glfwWindowHint(GLFW_OPENGL_DEBUG_CONTEXT, GLFW_TRUE);   // Enable OpenGL Debug Context
-// HERE 1 //#endif
-// HERE 1 //    }
-// HERE 1 //    else if (rlGetVersion() == RL_OPENGL_ES_20)                 // Request OpenGL ES 2.0 context
-// HERE 1 //    {
-// HERE 1 //        glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 2);
-// HERE 1 //        glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 0);
-// HERE 1 //        glfwWindowHint(GLFW_CLIENT_API, GLFW_OPENGL_ES_API);
-// HERE 1 //#if defined(PLATFORM_DESKTOP)
-// HERE 1 //        glfwWindowHint(GLFW_CONTEXT_CREATION_API, GLFW_EGL_CONTEXT_API);
-// HERE 1 //#else
-// HERE 1 //        glfwWindowHint(GLFW_CONTEXT_CREATION_API, GLFW_NATIVE_CONTEXT_API);
-// HERE 1 //#endif
-// HERE 1 //    }
-// HERE 1 //    else if (rlGetVersion() == RL_OPENGL_ES_30)                 // Request OpenGL ES 3.0 context
-// HERE 1 //    {
-// HERE 1 //        glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
-// HERE 1 //        glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 0);
-// HERE 1 //        glfwWindowHint(GLFW_CLIENT_API, GLFW_OPENGL_ES_API);
-// HERE 1 //#if defined(PLATFORM_DESKTOP)
-// HERE 1 //        glfwWindowHint(GLFW_CONTEXT_CREATION_API, GLFW_EGL_CONTEXT_API);
-// HERE 1 //#else
-// HERE 1 //        glfwWindowHint(GLFW_CONTEXT_CREATION_API, GLFW_NATIVE_CONTEXT_API);
-// HERE 1 //#endif
-// HERE 1 //    }
-// HERE 1 //
-// HERE 1 //#if defined(PLATFORM_DESKTOP)
-// HERE 1 //    // NOTE: GLFW 3.4+ defers initialization of the Joystick subsystem on the first call to any Joystick related functions.
-// HERE 1 //    // Forcing this initialization here avoids doing it on PollInputEvents() called by EndDrawing() after first frame has been just drawn.
-// HERE 1 //    // The initialization will still happen and possible delays still occur, but before the window is shown, which is a nicer experience.
-// HERE 1 //    // REF: https://github.com/raysan5/raylib/issues/1554
-// HERE 1 //    if (MAX_GAMEPADS > 0) glfwSetJoystickCallback(NULL);
-// HERE 1 //#endif
-// HERE 1 //
-// HERE 1 //#if defined(PLATFORM_DESKTOP)
-// HERE 1 //    // Find monitor resolution
-// HERE 1 //    GLFWmonitor *monitor = glfwGetPrimaryMonitor();
-// HERE 1 //    if (!monitor)
-// HERE 1 //    {
-// HERE 1 //        TRACELOG(LOG_WARNING, "GLFW: Failed to get primary monitor");
-// HERE 1 //        return false;
-// HERE 1 //    }
-// HERE 1 //
-// HERE 1 //    const GLFWvidmode *mode = glfwGetVideoMode(monitor);
-// HERE 1 //
-// HERE 1 //    CORE.Window.display.width = mode->width;
-// HERE 1 //    CORE.Window.display.height = mode->height;
-// HERE 1 //
-// HERE 1 //    // Set screen width/height to the display width/height if they are 0
-// HERE 1 //    if (CORE.Window.screen.width == 0) CORE.Window.screen.width = CORE.Window.display.width;
-// HERE 1 //    if (CORE.Window.screen.height == 0) CORE.Window.screen.height = CORE.Window.display.height;
-// HERE 1 //#endif  // PLATFORM_DESKTOP
-// HERE 1 //
-// HERE 1 //#if defined(PLATFORM_WEB)
-// HERE 1 //    // NOTE: Getting video modes is not implemented in emscripten GLFW3 version
-// HERE 1 //    CORE.Window.display.width = CORE.Window.screen.width;
-// HERE 1 //    CORE.Window.display.height = CORE.Window.screen.height;
-// HERE 1 //#endif  // PLATFORM_WEB
-// HERE 1 //
-// HERE 1 //    if (CORE.Window.fullscreen)
-// HERE 1 //    {
-// HERE 1 //        // remember center for switchinging from fullscreen to window
-// HERE 1 //        if ((CORE.Window.screen.height == CORE.Window.display.height) && (CORE.Window.screen.width == CORE.Window.display.width))
-// HERE 1 //        {
-// HERE 1 //            // If screen width/height equal to the display, we can't calculate the window pos for toggling full-screened/windowed.
-// HERE 1 //            // Toggling full-screened/windowed with pos(0, 0) can cause problems in some platforms, such as X11.
-// HERE 1 //            CORE.Window.position.x = CORE.Window.display.width/4;
-// HERE 1 //            CORE.Window.position.y = CORE.Window.display.height/4;
-// HERE 1 //        }
-// HERE 1 //        else
-// HERE 1 //        {
-// HERE 1 //            CORE.Window.position.x = CORE.Window.display.width/2 - CORE.Window.screen.width/2;
-// HERE 1 //            CORE.Window.position.y = CORE.Window.display.height/2 - CORE.Window.screen.height/2;
-// HERE 1 //        }
-// HERE 1 //
-// HERE 1 //        if (CORE.Window.position.x < 0) CORE.Window.position.x = 0;
-// HERE 1 //        if (CORE.Window.position.y < 0) CORE.Window.position.y = 0;
-// HERE 1 //
-// HERE 1 //        // Obtain recommended CORE.Window.display.width/CORE.Window.display.height from a valid videomode for the monitor
-// HERE 1 //        int count = 0;
-// HERE 1 //        const GLFWvidmode *modes = glfwGetVideoModes(glfwGetPrimaryMonitor(), &count);
-// HERE 1 //
-// HERE 1 //        // Get closest video mode to desired CORE.Window.screen.width/CORE.Window.screen.height
-// HERE 1 //        for (int i = 0; i < count; i++)
-// HERE 1 //        {
-// HERE 1 //            if ((unsigned int)modes[i].width >= CORE.Window.screen.width)
-// HERE 1 //            {
-// HERE 1 //                if ((unsigned int)modes[i].height >= CORE.Window.screen.height)
-// HERE 1 //                {
-// HERE 1 //                    CORE.Window.display.width = modes[i].width;
-// HERE 1 //                    CORE.Window.display.height = modes[i].height;
-// HERE 1 //                    break;
-// HERE 1 //                }
-// HERE 1 //            }
-// HERE 1 //        }
-// HERE 1 //        TRACELOG(LOG_WARNING, "SYSTEM: Closest fullscreen videomode: %i x %i", CORE.Window.display.width, CORE.Window.display.height);
-// HERE 1 //
-// HERE 1 //        // NOTE: ISSUE: Closest videomode could not match monitor aspect-ratio, for example,
-// HERE 1 //        // for a desired screen size of 800x450 (16:9), closest supported videomode is 800x600 (4:3),
-// HERE 1 //        // framebuffer is rendered correctly but once displayed on a 16:9 monitor, it gets stretched
-// HERE 1 //        // by the sides to fit all monitor space...
-// HERE 1 //
-// HERE 1 //        // Try to setup the most appropriate fullscreen framebuffer for the requested screenWidth/screenHeight
-// HERE 1 //        // It considers device display resolution mode and setups a framebuffer with black bars if required (render size/offset)
-// HERE 1 //        // Modified global variables: CORE.Window.screen.width/CORE.Window.screen.height - CORE.Window.render.width/CORE.Window.render.height - CORE.Window.renderOffset.x/CORE.Window.renderOffset.y - CORE.Window.screenScale
-// HERE 1 //        // TODO: It is a quite cumbersome solution to display size vs requested size, it should be reviewed or removed...
-// HERE 1 //        // HighDPI monitors are properly considered in a following similar function: SetupViewport()
-// HERE 1 //        SetupFramebuffer(CORE.Window.display.width, CORE.Window.display.height);
-// HERE 1 //
-// HERE 1 //        CORE.Window.handle = glfwCreateWindow(CORE.Window.display.width, CORE.Window.display.height, (CORE.Window.title != 0)? CORE.Window.title : " ", glfwGetPrimaryMonitor(), NULL);
-// HERE 1 //
-// HERE 1 //        // NOTE: Full-screen change, not working properly...
-// HERE 1 //        //glfwSetWindowMonitor(CORE.Window.handle, glfwGetPrimaryMonitor(), 0, 0, CORE.Window.screen.width, CORE.Window.screen.height, GLFW_DONT_CARE);
-// HERE 1 //    }
-// HERE 1 //    else
-// HERE 1 //    {
-// HERE 1 //#if defined(PLATFORM_DESKTOP)
-// HERE 1 //        // If we are windowed fullscreen, ensures that window does not minimize when focus is lost
-// HERE 1 //        if ((CORE.Window.screen.height == CORE.Window.display.height) && (CORE.Window.screen.width == CORE.Window.display.width))
-// HERE 1 //        {
-// HERE 1 //            glfwWindowHint(GLFW_AUTO_ICONIFY, 0);
-// HERE 1 //        }
-// HERE 1 //#endif
-// HERE 1 //        // No-fullscreen window creation
-// HERE 1 //        CORE.Window.handle = glfwCreateWindow(CORE.Window.screen.width, CORE.Window.screen.height, (CORE.Window.title != 0)? CORE.Window.title : " ", NULL, NULL);
-// HERE 1 //
-// HERE 1 //        if (CORE.Window.handle)
-// HERE 1 //        {
-// HERE 1 //            CORE.Window.render.width = CORE.Window.screen.width;
-// HERE 1 //            CORE.Window.render.height = CORE.Window.screen.height;
-// HERE 1 //        }
-// HERE 1 //    }
-// HERE 1 //
-// HERE 1 //    if (!CORE.Window.handle)
-// HERE 1 //    {
-// HERE 1 //        glfwTerminate();
-// HERE 1 //        TRACELOG(LOG_WARNING, "GLFW: Failed to initialize Window");
-// HERE 1 //        return false;
-// HERE 1 //    }
-// HERE 1 //
-// HERE 1 //// glfwCreateWindow title doesn't work with emscripten.
-// HERE 1 //#if defined(PLATFORM_WEB)
-// HERE 1 //    emscripten_set_window_title((CORE.Window.title != 0)? CORE.Window.title : " ");
-// HERE 1 //#endif
-// HERE 1 //
-// HERE 1 //    // Set window callback events
-// HERE 1 //    glfwSetWindowSizeCallback(CORE.Window.handle, WindowSizeCallback);      // NOTE: Resizing not allowed by default!
-// HERE 1 //#if !defined(PLATFORM_WEB)
-// HERE 1 //    glfwSetWindowMaximizeCallback(CORE.Window.handle, WindowMaximizeCallback);
-// HERE 1 //#endif
-// HERE 1 //    glfwSetWindowIconifyCallback(CORE.Window.handle, WindowIconifyCallback);
-// HERE 1 //    glfwSetWindowFocusCallback(CORE.Window.handle, WindowFocusCallback);
-// HERE 1 //    glfwSetDropCallback(CORE.Window.handle, WindowDropCallback);
-// HERE 1 //
-// HERE 1 //    // Set input callback events
-// HERE 1 //    glfwSetKeyCallback(CORE.Window.handle, KeyCallback);
-// HERE 1 //    glfwSetCharCallback(CORE.Window.handle, CharCallback);
-// HERE 1 //    glfwSetMouseButtonCallback(CORE.Window.handle, MouseButtonCallback);
-// HERE 1 //    glfwSetCursorPosCallback(CORE.Window.handle, MouseCursorPosCallback);   // Track mouse position changes
-// HERE 1 //    glfwSetScrollCallback(CORE.Window.handle, MouseScrollCallback);
-// HERE 1 //    glfwSetCursorEnterCallback(CORE.Window.handle, CursorEnterCallback);
-// HERE 1 //
-// HERE 1 //    glfwMakeContextCurrent(CORE.Window.handle);
-// HERE 1 //
-// HERE 1 //#if !defined(PLATFORM_WEB)
-// HERE 1 //    glfwSetInputMode(CORE.Window.handle, GLFW_LOCK_KEY_MODS, GLFW_TRUE);    // Enable lock keys modifiers (CAPS, NUM)
-// HERE 1 //
-// HERE 1 //    glfwSwapInterval(0);        // No V-Sync by default
-// HERE 1 //#endif
-// HERE 1 //
-// HERE 1 //    // Try to enable GPU V-Sync, so frames are limited to screen refresh rate (60Hz -> 60 FPS)
-// HERE 1 //    // NOTE: V-Sync can be enabled by graphic driver configuration, it doesn't need
-// HERE 1 //    // to be activated on web platforms since VSync is enforced there.
-// HERE 1 //#if !defined(PLATFORM_WEB)
-// HERE 1 //    if (CORE.Window.flags & FLAG_VSYNC_HINT)
-// HERE 1 //    {
-// HERE 1 //        // WARNING: It seems to hit a critical render path in Intel HD Graphics
-// HERE 1 //        glfwSwapInterval(1);
-// HERE 1 //        TRACELOG(LOG_INFO, "DISPLAY: Trying to enable VSYNC");
-// HERE 1 //    }
-// HERE 1 //#endif
-// HERE 1 //
-// HERE 1 //    int fbWidth = CORE.Window.screen.width;
-// HERE 1 //    int fbHeight = CORE.Window.screen.height;
-// HERE 1 //
-// HERE 1 //#if defined(PLATFORM_DESKTOP)
-// HERE 1 //    if ((CORE.Window.flags & FLAG_WINDOW_HIGHDPI) > 0)
-// HERE 1 //    {
-// HERE 1 //        // NOTE: On APPLE platforms system should manage window/input scaling and also framebuffer scaling.
-// HERE 1 //        // Framebuffer scaling should be activated with: glfwWindowHint(GLFW_COCOA_RETINA_FRAMEBUFFER, GLFW_TRUE);
-// HERE 1 //    #if !defined(__APPLE__)
-// HERE 1 //        glfwGetFramebufferSize(CORE.Window.handle, &fbWidth, &fbHeight);
-// HERE 1 //
-// HERE 1 //        // Screen scaling matrix is required in case desired screen area is different from display area
-// HERE 1 //        CORE.Window.screenScale = MatrixScale((float)fbWidth/CORE.Window.screen.width, (float)fbHeight/CORE.Window.screen.height, 1.0f);
-// HERE 1 //
-// HERE 1 //        // Mouse input scaling for the new screen size
-// HERE 1 //        SetMouseScale((float)CORE.Window.screen.width/fbWidth, (float)CORE.Window.screen.height/fbHeight);
-// HERE 1 //    #endif
-// HERE 1 //    }
-// HERE 1 //#endif
-// HERE 1 //
-// HERE 1 //    CORE.Window.render.width = fbWidth;
-// HERE 1 //    CORE.Window.render.height = fbHeight;
-// HERE 1 //    CORE.Window.currentFbo.width = fbWidth;
-// HERE 1 //    CORE.Window.currentFbo.height = fbHeight;
-// HERE 1 //
-// HERE 1 //    TRACELOG(LOG_INFO, "DISPLAY: Device initialized successfully");
-// HERE 1 //    TRACELOG(LOG_INFO, "    > Display size: %i x %i", CORE.Window.display.width, CORE.Window.display.height);
-// HERE 1 //    TRACELOG(LOG_INFO, "    > Screen size:  %i x %i", CORE.Window.screen.width, CORE.Window.screen.height);
-// HERE 1 //    TRACELOG(LOG_INFO, "    > Render size:  %i x %i", CORE.Window.render.width, CORE.Window.render.height);
-// HERE 1 //    TRACELOG(LOG_INFO, "    > Viewport offsets: %i, %i", CORE.Window.renderOffset.x, CORE.Window.renderOffset.y);
-// HERE 1 //
-// HERE 1 //#endif  // PLATFORM_DESKTOP || PLATFORM_WEB
-
-// HERE 2 //#if defined(PLATFORM_ANDROID) || defined(PLATFORM_DRM)
     CORE.Window.fullscreen = true;
     CORE.Window.flags |= FLAG_FULLSCREEN_MODE;
-
-// HERE 3 //#if defined(PLATFORM_DRM)
-// HERE 3 //    CORE.Window.fd = -1;
-// HERE 3 //    CORE.Window.connector = NULL;
-// HERE 3 //    CORE.Window.modeIndex = -1;
-// HERE 3 //    CORE.Window.crtc = NULL;
-// HERE 3 //    CORE.Window.gbmDevice = NULL;
-// HERE 3 //    CORE.Window.gbmSurface = NULL;
-// HERE 3 //    CORE.Window.prevBO = NULL;
-// HERE 3 //    CORE.Window.prevFB = 0;
-// HERE 3 //
-// HERE 3 //#if defined(DEFAULT_GRAPHIC_DEVICE_DRM)
-// HERE 3 //    CORE.Window.fd = open(DEFAULT_GRAPHIC_DEVICE_DRM, O_RDWR);
-// HERE 3 //#else
-// HERE 3 //    TRACELOG(LOG_INFO, "DISPLAY: No graphic card set, trying platform-gpu-card");
-// HERE 3 //    CORE.Window.fd = open("/dev/dri/by-path/platform-gpu-card",  O_RDWR); // VideoCore VI (Raspberry Pi 4)
-// HERE 3 //
-// HERE 3 //    if ((-1 == CORE.Window.fd) || (drmModeGetResources(CORE.Window.fd) == NULL))
-// HERE 3 //    {
-// HERE 3 //        TRACELOG(LOG_INFO, "DISPLAY: Failed to open platform-gpu-card, trying card1");
-// HERE 3 //        CORE.Window.fd = open("/dev/dri/card1", O_RDWR); // Other Embedded
-// HERE 3 //    }
-// HERE 3 //
-// HERE 3 //    if ((-1 == CORE.Window.fd) || (drmModeGetResources(CORE.Window.fd) == NULL))
-// HERE 3 //    {
-// HERE 3 //        TRACELOG(LOG_INFO, "DISPLAY: Failed to open graphic card1, trying card0");
-// HERE 3 //        CORE.Window.fd = open("/dev/dri/card0", O_RDWR); // VideoCore IV (Raspberry Pi 1-3)
-// HERE 3 //    }
-// HERE 3 //#endif
-// HERE 3 //    if (-1 == CORE.Window.fd)
-// HERE 3 //    {
-// HERE 3 //        TRACELOG(LOG_WARNING, "DISPLAY: Failed to open graphic card");
-// HERE 3 //        return false;
-// HERE 3 //    }
-// HERE 3 //
-// HERE 3 //    drmModeRes *res = drmModeGetResources(CORE.Window.fd);
-// HERE 3 //    if (!res)
-// HERE 3 //    {
-// HERE 3 //        TRACELOG(LOG_WARNING, "DISPLAY: Failed get DRM resources");
-// HERE 3 //        return false;
-// HERE 3 //    }
-// HERE 3 //
-// HERE 3 //    TRACELOG(LOG_TRACE, "DISPLAY: Connectors found: %i", res->count_connectors);
-// HERE 3 //    for (size_t i = 0; i < res->count_connectors; i++)
-// HERE 3 //    {
-// HERE 3 //        TRACELOG(LOG_TRACE, "DISPLAY: Connector index %i", i);
-// HERE 3 //        drmModeConnector *con = drmModeGetConnector(CORE.Window.fd, res->connectors[i]);
-// HERE 3 //        TRACELOG(LOG_TRACE, "DISPLAY: Connector modes detected: %i", con->count_modes);
-// HERE 3 //        if ((con->connection == DRM_MODE_CONNECTED) && (con->encoder_id))
-// HERE 3 //        {
-// HERE 3 //            TRACELOG(LOG_TRACE, "DISPLAY: DRM mode connected");
-// HERE 3 //            CORE.Window.connector = con;
-// HERE 3 //            break;
-// HERE 3 //        }
-// HERE 3 //        else
-// HERE 3 //        {
-// HERE 3 //            TRACELOG(LOG_TRACE, "DISPLAY: DRM mode NOT connected (deleting)");
-// HERE 3 //            drmModeFreeConnector(con);
-// HERE 3 //        }
-// HERE 3 //    }
-// HERE 3 //
-// HERE 3 //    if (!CORE.Window.connector)
-// HERE 3 //    {
-// HERE 3 //        TRACELOG(LOG_WARNING, "DISPLAY: No suitable DRM connector found");
-// HERE 3 //        drmModeFreeResources(res);
-// HERE 3 //        return false;
-// HERE 3 //    }
-// HERE 3 //
-// HERE 3 //    drmModeEncoder *enc = drmModeGetEncoder(CORE.Window.fd, CORE.Window.connector->encoder_id);
-// HERE 3 //    if (!enc)
-// HERE 3 //    {
-// HERE 3 //        TRACELOG(LOG_WARNING, "DISPLAY: Failed to get DRM mode encoder");
-// HERE 3 //        drmModeFreeResources(res);
-// HERE 3 //        return false;
-// HERE 3 //    }
-// HERE 3 //
-// HERE 3 //    CORE.Window.crtc = drmModeGetCrtc(CORE.Window.fd, enc->crtc_id);
-// HERE 3 //    if (!CORE.Window.crtc)
-// HERE 3 //    {
-// HERE 3 //        TRACELOG(LOG_WARNING, "DISPLAY: Failed to get DRM mode crtc");
-// HERE 3 //        drmModeFreeEncoder(enc);
-// HERE 3 //        drmModeFreeResources(res);
-// HERE 3 //        return false;
-// HERE 3 //    }
-// HERE 3 //
-// HERE 3 //    // If InitWindow should use the current mode find it in the connector's mode list
-// HERE 3 //    if ((CORE.Window.screen.width <= 0) || (CORE.Window.screen.height <= 0))
-// HERE 3 //    {
-// HERE 3 //        TRACELOG(LOG_TRACE, "DISPLAY: Selecting DRM connector mode for current used mode...");
-// HERE 3 //
-// HERE 3 //        CORE.Window.modeIndex = FindMatchingConnectorMode(CORE.Window.connector, &CORE.Window.crtc->mode);
-// HERE 3 //
-// HERE 3 //        if (CORE.Window.modeIndex < 0)
-// HERE 3 //        {
-// HERE 3 //            TRACELOG(LOG_WARNING, "DISPLAY: No matching DRM connector mode found");
-// HERE 3 //            drmModeFreeEncoder(enc);
-// HERE 3 //            drmModeFreeResources(res);
-// HERE 3 //            return false;
-// HERE 3 //        }
-// HERE 3 //
-// HERE 3 //        CORE.Window.screen.width = CORE.Window.display.width;
-// HERE 3 //        CORE.Window.screen.height = CORE.Window.display.height;
-// HERE 3 //    }
-// HERE 3 //
-// HERE 3 //    const bool allowInterlaced = CORE.Window.flags & FLAG_INTERLACED_HINT;
-// HERE 3 //    const int fps = (CORE.Time.target > 0) ? (1.0/CORE.Time.target) : 60;
-// HERE 3 //
-// HERE 3 //    // Try to find an exact matching mode
-// HERE 3 //    CORE.Window.modeIndex = FindExactConnectorMode(CORE.Window.connector, CORE.Window.screen.width, CORE.Window.screen.height, fps, allowInterlaced);
-// HERE 3 //
-// HERE 3 //    // If nothing found, try to find a nearly matching mode
-// HERE 3 //    if (CORE.Window.modeIndex < 0) CORE.Window.modeIndex = FindNearestConnectorMode(CORE.Window.connector, CORE.Window.screen.width, CORE.Window.screen.height, fps, allowInterlaced);
-// HERE 3 //
-// HERE 3 //    // If nothing found, try to find an exactly matching mode including interlaced
-// HERE 3 //    if (CORE.Window.modeIndex < 0) CORE.Window.modeIndex = FindExactConnectorMode(CORE.Window.connector, CORE.Window.screen.width, CORE.Window.screen.height, fps, true);
-// HERE 3 //
-// HERE 3 //    // If nothing found, try to find a nearly matching mode including interlaced
-// HERE 3 //    if (CORE.Window.modeIndex < 0) CORE.Window.modeIndex = FindNearestConnectorMode(CORE.Window.connector, CORE.Window.screen.width, CORE.Window.screen.height, fps, true);
-// HERE 3 //
-// HERE 3 //    // If nothing found, there is no suitable mode
-// HERE 3 //    if (CORE.Window.modeIndex < 0)
-// HERE 3 //    {
-// HERE 3 //        TRACELOG(LOG_WARNING, "DISPLAY: Failed to find a suitable DRM connector mode");
-// HERE 3 //        drmModeFreeEncoder(enc);
-// HERE 3 //        drmModeFreeResources(res);
-// HERE 3 //        return false;
-// HERE 3 //    }
-// HERE 3 //
-// HERE 3 //    CORE.Window.display.width = CORE.Window.connector->modes[CORE.Window.modeIndex].hdisplay;
-// HERE 3 //    CORE.Window.display.height = CORE.Window.connector->modes[CORE.Window.modeIndex].vdisplay;
-// HERE 3 //
-// HERE 3 //    TRACELOG(LOG_INFO, "DISPLAY: Selected DRM connector mode %s (%ux%u%c@%u)", CORE.Window.connector->modes[CORE.Window.modeIndex].name,
-// HERE 3 //        CORE.Window.connector->modes[CORE.Window.modeIndex].hdisplay, CORE.Window.connector->modes[CORE.Window.modeIndex].vdisplay,
-// HERE 3 //        (CORE.Window.connector->modes[CORE.Window.modeIndex].flags & DRM_MODE_FLAG_INTERLACE) ? 'i' : 'p',
-// HERE 3 //        CORE.Window.connector->modes[CORE.Window.modeIndex].vrefresh);
-// HERE 3 //
-// HERE 3 //    // Use the width and height of the surface for render
-// HERE 3 //    CORE.Window.render.width = CORE.Window.screen.width;
-// HERE 3 //    CORE.Window.render.height = CORE.Window.screen.height;
-// HERE 3 //
-// HERE 3 //    drmModeFreeEncoder(enc);
-// HERE 3 //    enc = NULL;
-// HERE 3 //
-// HERE 3 //    drmModeFreeResources(res);
-// HERE 3 //    res = NULL;
-// HERE 3 //
-// HERE 3 //    CORE.Window.gbmDevice = gbm_create_device(CORE.Window.fd);
-// HERE 3 //    if (!CORE.Window.gbmDevice)
-// HERE 3 //    {
-// HERE 3 //        TRACELOG(LOG_WARNING, "DISPLAY: Failed to create GBM device");
-// HERE 3 //        return false;
-// HERE 3 //    }
-// HERE 3 //
-// HERE 3 //    CORE.Window.gbmSurface = gbm_surface_create(CORE.Window.gbmDevice, CORE.Window.connector->modes[CORE.Window.modeIndex].hdisplay,
-// HERE 3 //        CORE.Window.connector->modes[CORE.Window.modeIndex].vdisplay, GBM_FORMAT_ARGB8888, GBM_BO_USE_SCANOUT | GBM_BO_USE_RENDERING);
-// HERE 3 //    if (!CORE.Window.gbmSurface)
-// HERE 3 //    {
-// HERE 3 //        TRACELOG(LOG_WARNING, "DISPLAY: Failed to create GBM surface");
-// HERE 3 //        return false;
-// HERE 3 //    }
-// HERE 3 //#endif
 
     EGLint samples = 0;
     EGLint sampleBuffer = 0;
@@ -653,15 +160,9 @@ static bool InitGraphicsDevice(int width, int height)
     const EGLint framebufferAttribs[] =
     {
         EGL_RENDERABLE_TYPE, (rlGetVersion() == RL_OPENGL_ES_30)? EGL_OPENGL_ES3_BIT : EGL_OPENGL_ES2_BIT,      // Type of context support
-// HERE 4 //#if defined(PLATFORM_DRM)
-// HERE 4 //        EGL_SURFACE_TYPE, EGL_WINDOW_BIT,          // Don't use it on Android!
-// HERE 4 //#endif
         EGL_RED_SIZE, 8,            // RED color bit depth (alternative: 5)
         EGL_GREEN_SIZE, 8,          // GREEN color bit depth (alternative: 6)
         EGL_BLUE_SIZE, 8,           // BLUE color bit depth (alternative: 5)
-// HERE 5 //#if defined(PLATFORM_DRM)
-// HERE 5 //        EGL_ALPHA_SIZE, 8,        // ALPHA bit depth (required for transparent framebuffer)
-// HERE 5 //#endif
         //EGL_TRANSPARENT_TYPE, EGL_NONE, // Request transparent framebuffer (EGL_TRANSPARENT_RGB does not work on RPI)
         EGL_DEPTH_SIZE, 16,         // Depth buffer size (Required to use Depth testing!)
         //EGL_STENCIL_SIZE, 8,      // Stencil buffer size
@@ -676,15 +177,10 @@ static bool InitGraphicsDevice(int width, int height)
         EGL_NONE
     };
 
-// HERE 6 //#if defined(PLATFORM_ANDROID) || defined(PLATFORM_DRM)
     EGLint numConfigs = 0;
 
     // Get an EGL device connection
-// HERE 7 //#if defined(PLATFORM_DRM)
-// HERE 7 //    CORE.Window.device = eglGetDisplay((EGLNativeDisplayType)CORE.Window.gbmDevice);
-// HERE 7 //#else
     CORE.Window.device = eglGetDisplay(EGL_DEFAULT_DISPLAY);
-// HERE 7 //#endif
     if (CORE.Window.device == EGL_NO_DISPLAY)
     {
         TRACELOG(LOG_WARNING, "DISPLAY: Failed to initialize EGL device");
@@ -699,63 +195,8 @@ static bool InitGraphicsDevice(int width, int height)
         return false;
     }
 
-// HERE 8 //#if defined(PLATFORM_DRM)
-// HERE 8 //    if (!eglChooseConfig(CORE.Window.device, NULL, NULL, 0, &numConfigs))
-// HERE 8 //    {
-// HERE 8 //        TRACELOG(LOG_WARNING, "DISPLAY: Failed to get EGL config count: 0x%x", eglGetError());
-// HERE 8 //        return false;
-// HERE 8 //    }
-// HERE 8 //
-// HERE 8 //    TRACELOG(LOG_TRACE, "DISPLAY: EGL configs available: %d", numConfigs);
-// HERE 8 //
-// HERE 8 //    EGLConfig *configs = RL_CALLOC(numConfigs, sizeof(*configs));
-// HERE 8 //    if (!configs)
-// HERE 8 //    {
-// HERE 8 //        TRACELOG(LOG_WARNING, "DISPLAY: Failed to get memory for EGL configs");
-// HERE 8 //        return false;
-// HERE 8 //    }
-// HERE 8 //
-// HERE 8 //    EGLint matchingNumConfigs = 0;
-// HERE 8 //    if (!eglChooseConfig(CORE.Window.device, framebufferAttribs, configs, numConfigs, &matchingNumConfigs))
-// HERE 8 //    {
-// HERE 8 //        TRACELOG(LOG_WARNING, "DISPLAY: Failed to choose EGL config: 0x%x", eglGetError());
-// HERE 8 //        free(configs);
-// HERE 8 //        return false;
-// HERE 8 //    }
-// HERE 8 //
-// HERE 8 //    TRACELOG(LOG_TRACE, "DISPLAY: EGL matching configs available: %d", matchingNumConfigs);
-// HERE 8 //
-// HERE 8 //    // find the EGL config that matches the previously setup GBM format
-// HERE 8 //    int found = 0;
-// HERE 8 //    for (EGLint i = 0; i < matchingNumConfigs; ++i)
-// HERE 8 //    {
-// HERE 8 //        EGLint id = 0;
-// HERE 8 //        if (!eglGetConfigAttrib(CORE.Window.device, configs[i], EGL_NATIVE_VISUAL_ID, &id))
-// HERE 8 //        {
-// HERE 8 //            TRACELOG(LOG_WARNING, "DISPLAY: Failed to get EGL config attribute: 0x%x", eglGetError());
-// HERE 8 //            continue;
-// HERE 8 //        }
-// HERE 8 //
-// HERE 8 //        if (GBM_FORMAT_ARGB8888 == id)
-// HERE 8 //        {
-// HERE 8 //            TRACELOG(LOG_TRACE, "DISPLAY: Using EGL config: %d", i);
-// HERE 8 //            CORE.Window.config = configs[i];
-// HERE 8 //            found = 1;
-// HERE 8 //            break;
-// HERE 8 //        }
-// HERE 8 //    }
-// HERE 8 //
-// HERE 8 //    RL_FREE(configs);
-// HERE 8 //
-// HERE 8 //    if (!found)
-// HERE 8 //    {
-// HERE 8 //        TRACELOG(LOG_WARNING, "DISPLAY: Failed to find a suitable EGL config");
-// HERE 8 //        return false;
-// HERE 8 //    }
-// HERE 8 //#else
     // Get an appropriate EGL framebuffer configuration
     eglChooseConfig(CORE.Window.device, framebufferAttribs, &CORE.Window.config, 1, &numConfigs);
-// HERE 8 //#endif
 
     // Set rendering API
     eglBindAPI(EGL_OPENGL_ES_API);
@@ -767,11 +208,9 @@ static bool InitGraphicsDevice(int width, int height)
         TRACELOG(LOG_WARNING, "DISPLAY: Failed to create EGL context");
         return false;
     }
-// HERE 6 //#endif
 
     // Create an EGL window surface
     //---------------------------------------------------------------------------------
-// HERE 9 //#if defined(PLATFORM_ANDROID)
     EGLint displayFormat = 0;
 
     // EGL_NATIVE_VISUAL_ID is an attribute of the EGLConfig that is guaranteed to be accepted by ANativeWindow_setBuffersGeometry()
@@ -789,23 +228,6 @@ static bool InitGraphicsDevice(int width, int height)
     //ANativeWindow_setBuffersGeometry(CORE.Android.app->window, 0, 0, displayFormat);       // Force use of native display size
 
     CORE.Window.surface = eglCreateWindowSurface(CORE.Window.device, CORE.Window.config, CORE.Android.app->window, NULL);
-// HERE 9 //#endif  // PLATFORM_ANDROID
-
-// HERE 10 //#if defined(PLATFORM_DRM)
-// HERE 10 //    CORE.Window.surface = eglCreateWindowSurface(CORE.Window.device, CORE.Window.config, (EGLNativeWindowType)CORE.Window.gbmSurface, NULL);
-// HERE 10 //    if (EGL_NO_SURFACE == CORE.Window.surface)
-// HERE 10 //    {
-// HERE 10 //        TRACELOG(LOG_WARNING, "DISPLAY: Failed to create EGL window surface: 0x%04x", eglGetError());
-// HERE 10 //        return false;
-// HERE 10 //    }
-// HERE 10 //
-// HERE 10 //    // At this point we need to manage render size vs screen size
-// HERE 10 //    // NOTE: This function use and modify global module variables:
-// HERE 10 //    //  -> CORE.Window.screen.width/CORE.Window.screen.height
-// HERE 10 //    //  -> CORE.Window.render.width/CORE.Window.render.height
-// HERE 10 //    //  -> CORE.Window.screenScale
-// HERE 10 //    SetupFramebuffer(CORE.Window.display.width, CORE.Window.display.height);
-// HERE 10 //#endif  // PLATFORM_DRM
 
     // There must be at least one frame displayed before the buffers are swapped
     //eglSwapInterval(CORE.Window.device, 1);
@@ -828,15 +250,10 @@ static bool InitGraphicsDevice(int width, int height)
         TRACELOG(LOG_INFO, "    > Render size:  %i x %i", CORE.Window.render.width, CORE.Window.render.height);
         TRACELOG(LOG_INFO, "    > Viewport offsets: %i, %i", CORE.Window.renderOffset.x, CORE.Window.renderOffset.y);
     }
-// HERE 2 //#endif  // PLATFORM_ANDROID || PLATFORM_DRM
 
     // Load OpenGL extensions
     // NOTE: GL procedures address loader is required to load extensions
-// HERE 11 //#if defined(PLATFORM_DESKTOP) || defined(PLATFORM_WEB)
-// HERE 11 //    rlLoadExtensions(glfwGetProcAddress);
-// HERE 11 //#else
     rlLoadExtensions(eglGetProcAddress);
-// HERE 11 //#endif
 
     // Initialize OpenGL context (states and resources)
     // NOTE: CORE.Window.currentFbo.width and CORE.Window.currentFbo.height not used, just stored as globals in rlgl
@@ -846,9 +263,7 @@ static bool InitGraphicsDevice(int width, int height)
     // NOTE: It updated CORE.Window.render.width and CORE.Window.render.height
     SetupViewport(CORE.Window.currentFbo.width, CORE.Window.currentFbo.height);
 
-// HERE 12 //#if defined(PLATFORM_ANDROID)
     CORE.Window.ready = true;
-// HERE 12 //#endif
 
     if ((CORE.Window.flags & FLAG_WINDOW_MINIMIZED) > 0) MinimizeWindow();
 

--- a/src/rcore_android.c
+++ b/src/rcore_android.c
@@ -1043,16 +1043,18 @@ void OpenURL(const char *url)
     }
 }
 
-// Get gamepad internal name id
-const char *GetGamepadName(int gamepad)
-{
-    return NULL;
-}
-
 // Get selected monitor physical width in millimetres
 int GetMonitorPhysicalWidth(int monitor)
 {
     return 0;
+}
+
+// Get gamepad internal name id
+const char *GetGamepadName(int gamepad)
+{
+    TRACELOG(LOG_INFO, "GetGamepadName not implemented in rcore_android.c");
+
+    return NULL;
 }
 
 // Get gamepad axis count
@@ -1064,6 +1066,8 @@ int GetGamepadAxisCount(int gamepad)
 // Set internal gamepad mappings
 int SetGamepadMappings(const char *mappings)
 {
+    TRACELOG(LOG_INFO, "SetGamepadMappings not implemented in rcore_android.c");
+
     return 0;
 }
 

--- a/src/rcore_android.c
+++ b/src/rcore_android.c
@@ -145,501 +145,501 @@ static bool InitGraphicsDevice(int width, int height)
     // NOTE: Framebuffer (render area - CORE.Window.render.width, CORE.Window.render.height) could include black bars...
     // ...in top-down or left-right to match display aspect ratio (no weird scaling)
 
-#if defined(PLATFORM_DESKTOP) || defined(PLATFORM_WEB)
-    glfwSetErrorCallback(ErrorCallback);
-/*
-    // TODO: Setup GLFW custom allocators to match raylib ones
-    const GLFWallocator allocator = {
-        .allocate = MemAlloc,
-        .deallocate = MemFree,
-        .reallocate = MemRealloc,
-        .user = NULL
-    };
+// HERE 1 //#if defined(PLATFORM_DESKTOP) || defined(PLATFORM_WEB)
+// HERE 1 //    glfwSetErrorCallback(ErrorCallback);
+// HERE 1 ///*
+// HERE 1 //    // TODO: Setup GLFW custom allocators to match raylib ones
+// HERE 1 //    const GLFWallocator allocator = {
+// HERE 1 //        .allocate = MemAlloc,
+// HERE 1 //        .deallocate = MemFree,
+// HERE 1 //        .reallocate = MemRealloc,
+// HERE 1 //        .user = NULL
+// HERE 1 //    };
+// HERE 1 //
+// HERE 1 //    glfwInitAllocator(&allocator);
+// HERE 1 //*/
+// HERE 1 //#if defined(__APPLE__)
+// HERE 1 //    glfwInitHint(GLFW_COCOA_CHDIR_RESOURCES, GLFW_FALSE);
+// HERE 1 //#endif
+// HERE 1 //
+// HERE 1 //    if (!glfwInit())
+// HERE 1 //    {
+// HERE 1 //        TRACELOG(LOG_WARNING, "GLFW: Failed to initialize GLFW");
+// HERE 1 //        return false;
+// HERE 1 //    }
+// HERE 1 //
+// HERE 1 //    glfwDefaultWindowHints();                       // Set default windows hints
+// HERE 1 //    //glfwWindowHint(GLFW_RED_BITS, 8);             // Framebuffer red color component bits
+// HERE 1 //    //glfwWindowHint(GLFW_GREEN_BITS, 8);           // Framebuffer green color component bits
+// HERE 1 //    //glfwWindowHint(GLFW_BLUE_BITS, 8);            // Framebuffer blue color component bits
+// HERE 1 //    //glfwWindowHint(GLFW_ALPHA_BITS, 8);           // Framebuffer alpha color component bits
+// HERE 1 //    //glfwWindowHint(GLFW_DEPTH_BITS, 24);          // Depthbuffer bits
+// HERE 1 //    //glfwWindowHint(GLFW_REFRESH_RATE, 0);         // Refresh rate for fullscreen window
+// HERE 1 //    //glfwWindowHint(GLFW_CLIENT_API, GLFW_OPENGL_API); // OpenGL API to use. Alternative: GLFW_OPENGL_ES_API
+// HERE 1 //    //glfwWindowHint(GLFW_AUX_BUFFERS, 0);          // Number of auxiliar buffers
+// HERE 1 //
+// HERE 1 //    // Check window creation flags
+// HERE 1 //    if ((CORE.Window.flags & FLAG_FULLSCREEN_MODE) > 0) CORE.Window.fullscreen = true;
+// HERE 1 //
+// HERE 1 //    if ((CORE.Window.flags & FLAG_WINDOW_HIDDEN) > 0) glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE); // Visible window
+// HERE 1 //    else glfwWindowHint(GLFW_VISIBLE, GLFW_TRUE);     // Window initially hidden
+// HERE 1 //
+// HERE 1 //    if ((CORE.Window.flags & FLAG_WINDOW_UNDECORATED) > 0) glfwWindowHint(GLFW_DECORATED, GLFW_FALSE); // Border and buttons on Window
+// HERE 1 //    else glfwWindowHint(GLFW_DECORATED, GLFW_TRUE);   // Decorated window
+// HERE 1 //
+// HERE 1 //    if ((CORE.Window.flags & FLAG_WINDOW_RESIZABLE) > 0) glfwWindowHint(GLFW_RESIZABLE, GLFW_TRUE); // Resizable window
+// HERE 1 //    else glfwWindowHint(GLFW_RESIZABLE, GLFW_FALSE);  // Avoid window being resizable
+// HERE 1 //
+// HERE 1 //    // Disable FLAG_WINDOW_MINIMIZED, not supported on initialization
+// HERE 1 //    if ((CORE.Window.flags & FLAG_WINDOW_MINIMIZED) > 0) CORE.Window.flags &= ~FLAG_WINDOW_MINIMIZED;
+// HERE 1 //
+// HERE 1 //    // Disable FLAG_WINDOW_MAXIMIZED, not supported on initialization
+// HERE 1 //    if ((CORE.Window.flags & FLAG_WINDOW_MAXIMIZED) > 0) CORE.Window.flags &= ~FLAG_WINDOW_MAXIMIZED;
+// HERE 1 //
+// HERE 1 //    if ((CORE.Window.flags & FLAG_WINDOW_UNFOCUSED) > 0) glfwWindowHint(GLFW_FOCUSED, GLFW_FALSE);
+// HERE 1 //    else glfwWindowHint(GLFW_FOCUSED, GLFW_TRUE);
+// HERE 1 //
+// HERE 1 //    if ((CORE.Window.flags & FLAG_WINDOW_TOPMOST) > 0) glfwWindowHint(GLFW_FLOATING, GLFW_TRUE);
+// HERE 1 //    else glfwWindowHint(GLFW_FLOATING, GLFW_FALSE);
+// HERE 1 //
+// HERE 1 //    // NOTE: Some GLFW flags are not supported on HTML5
+// HERE 1 //#if defined(PLATFORM_DESKTOP)
+// HERE 1 //    if ((CORE.Window.flags & FLAG_WINDOW_TRANSPARENT) > 0) glfwWindowHint(GLFW_TRANSPARENT_FRAMEBUFFER, GLFW_TRUE);     // Transparent framebuffer
+// HERE 1 //    else glfwWindowHint(GLFW_TRANSPARENT_FRAMEBUFFER, GLFW_FALSE);  // Opaque framebuffer
+// HERE 1 //
+// HERE 1 //    if ((CORE.Window.flags & FLAG_WINDOW_HIGHDPI) > 0)
+// HERE 1 //    {
+// HERE 1 //        // Resize window content area based on the monitor content scale.
+// HERE 1 //        // NOTE: This hint only has an effect on platforms where screen coordinates and pixels always map 1:1 such as Windows and X11.
+// HERE 1 //        // On platforms like macOS the resolution of the framebuffer is changed independently of the window size.
+// HERE 1 //        glfwWindowHint(GLFW_SCALE_TO_MONITOR, GLFW_TRUE);   // Scale content area based on the monitor content scale where window is placed on
+// HERE 1 //    #if defined(__APPLE__)
+// HERE 1 //        glfwWindowHint(GLFW_COCOA_RETINA_FRAMEBUFFER, GLFW_TRUE);
+// HERE 1 //    #endif
+// HERE 1 //    }
+// HERE 1 //    else glfwWindowHint(GLFW_SCALE_TO_MONITOR, GLFW_FALSE);
+// HERE 1 //
+// HERE 1 //    // Mouse passthrough
+// HERE 1 //    if ((CORE.Window.flags & FLAG_WINDOW_MOUSE_PASSTHROUGH) > 0) glfwWindowHint(GLFW_MOUSE_PASSTHROUGH, GLFW_TRUE);
+// HERE 1 //    else glfwWindowHint(GLFW_MOUSE_PASSTHROUGH, GLFW_FALSE);
+// HERE 1 //#endif
+// HERE 1 //
+// HERE 1 //    if (CORE.Window.flags & FLAG_MSAA_4X_HINT)
+// HERE 1 //    {
+// HERE 1 //        // NOTE: MSAA is only enabled for main framebuffer, not user-created FBOs
+// HERE 1 //        TRACELOG(LOG_INFO, "DISPLAY: Trying to enable MSAA x4");
+// HERE 1 //        glfwWindowHint(GLFW_SAMPLES, 4);   // Tries to enable multisampling x4 (MSAA), default is 0
+// HERE 1 //    }
+// HERE 1 //
+// HERE 1 //    // NOTE: When asking for an OpenGL context version, most drivers provide the highest supported version
+// HERE 1 //    // with backward compatibility to older OpenGL versions.
+// HERE 1 //    // For example, if using OpenGL 1.1, driver can provide a 4.3 backwards compatible context.
+// HERE 1 //
+// HERE 1 //    // Check selection OpenGL version
+// HERE 1 //    if (rlGetVersion() == RL_OPENGL_21)
+// HERE 1 //    {
+// HERE 1 //        glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 2);          // Choose OpenGL major version (just hint)
+// HERE 1 //        glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 1);          // Choose OpenGL minor version (just hint)
+// HERE 1 //    }
+// HERE 1 //    else if (rlGetVersion() == RL_OPENGL_33)
+// HERE 1 //    {
+// HERE 1 //        glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);          // Choose OpenGL major version (just hint)
+// HERE 1 //        glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);          // Choose OpenGL minor version (just hint)
+// HERE 1 //        glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE); // Profiles Hint: Only 3.3 and above!
+// HERE 1 //                                                                       // Values: GLFW_OPENGL_CORE_PROFILE, GLFW_OPENGL_ANY_PROFILE, GLFW_OPENGL_COMPAT_PROFILE
+// HERE 1 //#if defined(__APPLE__)
+// HERE 1 //        glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GLFW_TRUE);  // OSX Requires forward compatibility
+// HERE 1 //#else
+// HERE 1 //        glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GLFW_FALSE); // Forward Compatibility Hint: Only 3.3 and above!
+// HERE 1 //#endif
+// HERE 1 //        //glfwWindowHint(GLFW_OPENGL_DEBUG_CONTEXT, GLFW_TRUE); // Request OpenGL DEBUG context
+// HERE 1 //    }
+// HERE 1 //    else if (rlGetVersion() == RL_OPENGL_43)
+// HERE 1 //    {
+// HERE 1 //        glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 4);          // Choose OpenGL major version (just hint)
+// HERE 1 //        glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);          // Choose OpenGL minor version (just hint)
+// HERE 1 //        glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
+// HERE 1 //        glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GLFW_FALSE);
+// HERE 1 //#if defined(RLGL_ENABLE_OPENGL_DEBUG_CONTEXT)
+// HERE 1 //        glfwWindowHint(GLFW_OPENGL_DEBUG_CONTEXT, GLFW_TRUE);   // Enable OpenGL Debug Context
+// HERE 1 //#endif
+// HERE 1 //    }
+// HERE 1 //    else if (rlGetVersion() == RL_OPENGL_ES_20)                 // Request OpenGL ES 2.0 context
+// HERE 1 //    {
+// HERE 1 //        glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 2);
+// HERE 1 //        glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 0);
+// HERE 1 //        glfwWindowHint(GLFW_CLIENT_API, GLFW_OPENGL_ES_API);
+// HERE 1 //#if defined(PLATFORM_DESKTOP)
+// HERE 1 //        glfwWindowHint(GLFW_CONTEXT_CREATION_API, GLFW_EGL_CONTEXT_API);
+// HERE 1 //#else
+// HERE 1 //        glfwWindowHint(GLFW_CONTEXT_CREATION_API, GLFW_NATIVE_CONTEXT_API);
+// HERE 1 //#endif
+// HERE 1 //    }
+// HERE 1 //    else if (rlGetVersion() == RL_OPENGL_ES_30)                 // Request OpenGL ES 3.0 context
+// HERE 1 //    {
+// HERE 1 //        glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
+// HERE 1 //        glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 0);
+// HERE 1 //        glfwWindowHint(GLFW_CLIENT_API, GLFW_OPENGL_ES_API);
+// HERE 1 //#if defined(PLATFORM_DESKTOP)
+// HERE 1 //        glfwWindowHint(GLFW_CONTEXT_CREATION_API, GLFW_EGL_CONTEXT_API);
+// HERE 1 //#else
+// HERE 1 //        glfwWindowHint(GLFW_CONTEXT_CREATION_API, GLFW_NATIVE_CONTEXT_API);
+// HERE 1 //#endif
+// HERE 1 //    }
+// HERE 1 //
+// HERE 1 //#if defined(PLATFORM_DESKTOP)
+// HERE 1 //    // NOTE: GLFW 3.4+ defers initialization of the Joystick subsystem on the first call to any Joystick related functions.
+// HERE 1 //    // Forcing this initialization here avoids doing it on PollInputEvents() called by EndDrawing() after first frame has been just drawn.
+// HERE 1 //    // The initialization will still happen and possible delays still occur, but before the window is shown, which is a nicer experience.
+// HERE 1 //    // REF: https://github.com/raysan5/raylib/issues/1554
+// HERE 1 //    if (MAX_GAMEPADS > 0) glfwSetJoystickCallback(NULL);
+// HERE 1 //#endif
+// HERE 1 //
+// HERE 1 //#if defined(PLATFORM_DESKTOP)
+// HERE 1 //    // Find monitor resolution
+// HERE 1 //    GLFWmonitor *monitor = glfwGetPrimaryMonitor();
+// HERE 1 //    if (!monitor)
+// HERE 1 //    {
+// HERE 1 //        TRACELOG(LOG_WARNING, "GLFW: Failed to get primary monitor");
+// HERE 1 //        return false;
+// HERE 1 //    }
+// HERE 1 //
+// HERE 1 //    const GLFWvidmode *mode = glfwGetVideoMode(monitor);
+// HERE 1 //
+// HERE 1 //    CORE.Window.display.width = mode->width;
+// HERE 1 //    CORE.Window.display.height = mode->height;
+// HERE 1 //
+// HERE 1 //    // Set screen width/height to the display width/height if they are 0
+// HERE 1 //    if (CORE.Window.screen.width == 0) CORE.Window.screen.width = CORE.Window.display.width;
+// HERE 1 //    if (CORE.Window.screen.height == 0) CORE.Window.screen.height = CORE.Window.display.height;
+// HERE 1 //#endif  // PLATFORM_DESKTOP
+// HERE 1 //
+// HERE 1 //#if defined(PLATFORM_WEB)
+// HERE 1 //    // NOTE: Getting video modes is not implemented in emscripten GLFW3 version
+// HERE 1 //    CORE.Window.display.width = CORE.Window.screen.width;
+// HERE 1 //    CORE.Window.display.height = CORE.Window.screen.height;
+// HERE 1 //#endif  // PLATFORM_WEB
+// HERE 1 //
+// HERE 1 //    if (CORE.Window.fullscreen)
+// HERE 1 //    {
+// HERE 1 //        // remember center for switchinging from fullscreen to window
+// HERE 1 //        if ((CORE.Window.screen.height == CORE.Window.display.height) && (CORE.Window.screen.width == CORE.Window.display.width))
+// HERE 1 //        {
+// HERE 1 //            // If screen width/height equal to the display, we can't calculate the window pos for toggling full-screened/windowed.
+// HERE 1 //            // Toggling full-screened/windowed with pos(0, 0) can cause problems in some platforms, such as X11.
+// HERE 1 //            CORE.Window.position.x = CORE.Window.display.width/4;
+// HERE 1 //            CORE.Window.position.y = CORE.Window.display.height/4;
+// HERE 1 //        }
+// HERE 1 //        else
+// HERE 1 //        {
+// HERE 1 //            CORE.Window.position.x = CORE.Window.display.width/2 - CORE.Window.screen.width/2;
+// HERE 1 //            CORE.Window.position.y = CORE.Window.display.height/2 - CORE.Window.screen.height/2;
+// HERE 1 //        }
+// HERE 1 //
+// HERE 1 //        if (CORE.Window.position.x < 0) CORE.Window.position.x = 0;
+// HERE 1 //        if (CORE.Window.position.y < 0) CORE.Window.position.y = 0;
+// HERE 1 //
+// HERE 1 //        // Obtain recommended CORE.Window.display.width/CORE.Window.display.height from a valid videomode for the monitor
+// HERE 1 //        int count = 0;
+// HERE 1 //        const GLFWvidmode *modes = glfwGetVideoModes(glfwGetPrimaryMonitor(), &count);
+// HERE 1 //
+// HERE 1 //        // Get closest video mode to desired CORE.Window.screen.width/CORE.Window.screen.height
+// HERE 1 //        for (int i = 0; i < count; i++)
+// HERE 1 //        {
+// HERE 1 //            if ((unsigned int)modes[i].width >= CORE.Window.screen.width)
+// HERE 1 //            {
+// HERE 1 //                if ((unsigned int)modes[i].height >= CORE.Window.screen.height)
+// HERE 1 //                {
+// HERE 1 //                    CORE.Window.display.width = modes[i].width;
+// HERE 1 //                    CORE.Window.display.height = modes[i].height;
+// HERE 1 //                    break;
+// HERE 1 //                }
+// HERE 1 //            }
+// HERE 1 //        }
+// HERE 1 //        TRACELOG(LOG_WARNING, "SYSTEM: Closest fullscreen videomode: %i x %i", CORE.Window.display.width, CORE.Window.display.height);
+// HERE 1 //
+// HERE 1 //        // NOTE: ISSUE: Closest videomode could not match monitor aspect-ratio, for example,
+// HERE 1 //        // for a desired screen size of 800x450 (16:9), closest supported videomode is 800x600 (4:3),
+// HERE 1 //        // framebuffer is rendered correctly but once displayed on a 16:9 monitor, it gets stretched
+// HERE 1 //        // by the sides to fit all monitor space...
+// HERE 1 //
+// HERE 1 //        // Try to setup the most appropriate fullscreen framebuffer for the requested screenWidth/screenHeight
+// HERE 1 //        // It considers device display resolution mode and setups a framebuffer with black bars if required (render size/offset)
+// HERE 1 //        // Modified global variables: CORE.Window.screen.width/CORE.Window.screen.height - CORE.Window.render.width/CORE.Window.render.height - CORE.Window.renderOffset.x/CORE.Window.renderOffset.y - CORE.Window.screenScale
+// HERE 1 //        // TODO: It is a quite cumbersome solution to display size vs requested size, it should be reviewed or removed...
+// HERE 1 //        // HighDPI monitors are properly considered in a following similar function: SetupViewport()
+// HERE 1 //        SetupFramebuffer(CORE.Window.display.width, CORE.Window.display.height);
+// HERE 1 //
+// HERE 1 //        CORE.Window.handle = glfwCreateWindow(CORE.Window.display.width, CORE.Window.display.height, (CORE.Window.title != 0)? CORE.Window.title : " ", glfwGetPrimaryMonitor(), NULL);
+// HERE 1 //
+// HERE 1 //        // NOTE: Full-screen change, not working properly...
+// HERE 1 //        //glfwSetWindowMonitor(CORE.Window.handle, glfwGetPrimaryMonitor(), 0, 0, CORE.Window.screen.width, CORE.Window.screen.height, GLFW_DONT_CARE);
+// HERE 1 //    }
+// HERE 1 //    else
+// HERE 1 //    {
+// HERE 1 //#if defined(PLATFORM_DESKTOP)
+// HERE 1 //        // If we are windowed fullscreen, ensures that window does not minimize when focus is lost
+// HERE 1 //        if ((CORE.Window.screen.height == CORE.Window.display.height) && (CORE.Window.screen.width == CORE.Window.display.width))
+// HERE 1 //        {
+// HERE 1 //            glfwWindowHint(GLFW_AUTO_ICONIFY, 0);
+// HERE 1 //        }
+// HERE 1 //#endif
+// HERE 1 //        // No-fullscreen window creation
+// HERE 1 //        CORE.Window.handle = glfwCreateWindow(CORE.Window.screen.width, CORE.Window.screen.height, (CORE.Window.title != 0)? CORE.Window.title : " ", NULL, NULL);
+// HERE 1 //
+// HERE 1 //        if (CORE.Window.handle)
+// HERE 1 //        {
+// HERE 1 //            CORE.Window.render.width = CORE.Window.screen.width;
+// HERE 1 //            CORE.Window.render.height = CORE.Window.screen.height;
+// HERE 1 //        }
+// HERE 1 //    }
+// HERE 1 //
+// HERE 1 //    if (!CORE.Window.handle)
+// HERE 1 //    {
+// HERE 1 //        glfwTerminate();
+// HERE 1 //        TRACELOG(LOG_WARNING, "GLFW: Failed to initialize Window");
+// HERE 1 //        return false;
+// HERE 1 //    }
+// HERE 1 //
+// HERE 1 //// glfwCreateWindow title doesn't work with emscripten.
+// HERE 1 //#if defined(PLATFORM_WEB)
+// HERE 1 //    emscripten_set_window_title((CORE.Window.title != 0)? CORE.Window.title : " ");
+// HERE 1 //#endif
+// HERE 1 //
+// HERE 1 //    // Set window callback events
+// HERE 1 //    glfwSetWindowSizeCallback(CORE.Window.handle, WindowSizeCallback);      // NOTE: Resizing not allowed by default!
+// HERE 1 //#if !defined(PLATFORM_WEB)
+// HERE 1 //    glfwSetWindowMaximizeCallback(CORE.Window.handle, WindowMaximizeCallback);
+// HERE 1 //#endif
+// HERE 1 //    glfwSetWindowIconifyCallback(CORE.Window.handle, WindowIconifyCallback);
+// HERE 1 //    glfwSetWindowFocusCallback(CORE.Window.handle, WindowFocusCallback);
+// HERE 1 //    glfwSetDropCallback(CORE.Window.handle, WindowDropCallback);
+// HERE 1 //
+// HERE 1 //    // Set input callback events
+// HERE 1 //    glfwSetKeyCallback(CORE.Window.handle, KeyCallback);
+// HERE 1 //    glfwSetCharCallback(CORE.Window.handle, CharCallback);
+// HERE 1 //    glfwSetMouseButtonCallback(CORE.Window.handle, MouseButtonCallback);
+// HERE 1 //    glfwSetCursorPosCallback(CORE.Window.handle, MouseCursorPosCallback);   // Track mouse position changes
+// HERE 1 //    glfwSetScrollCallback(CORE.Window.handle, MouseScrollCallback);
+// HERE 1 //    glfwSetCursorEnterCallback(CORE.Window.handle, CursorEnterCallback);
+// HERE 1 //
+// HERE 1 //    glfwMakeContextCurrent(CORE.Window.handle);
+// HERE 1 //
+// HERE 1 //#if !defined(PLATFORM_WEB)
+// HERE 1 //    glfwSetInputMode(CORE.Window.handle, GLFW_LOCK_KEY_MODS, GLFW_TRUE);    // Enable lock keys modifiers (CAPS, NUM)
+// HERE 1 //
+// HERE 1 //    glfwSwapInterval(0);        // No V-Sync by default
+// HERE 1 //#endif
+// HERE 1 //
+// HERE 1 //    // Try to enable GPU V-Sync, so frames are limited to screen refresh rate (60Hz -> 60 FPS)
+// HERE 1 //    // NOTE: V-Sync can be enabled by graphic driver configuration, it doesn't need
+// HERE 1 //    // to be activated on web platforms since VSync is enforced there.
+// HERE 1 //#if !defined(PLATFORM_WEB)
+// HERE 1 //    if (CORE.Window.flags & FLAG_VSYNC_HINT)
+// HERE 1 //    {
+// HERE 1 //        // WARNING: It seems to hit a critical render path in Intel HD Graphics
+// HERE 1 //        glfwSwapInterval(1);
+// HERE 1 //        TRACELOG(LOG_INFO, "DISPLAY: Trying to enable VSYNC");
+// HERE 1 //    }
+// HERE 1 //#endif
+// HERE 1 //
+// HERE 1 //    int fbWidth = CORE.Window.screen.width;
+// HERE 1 //    int fbHeight = CORE.Window.screen.height;
+// HERE 1 //
+// HERE 1 //#if defined(PLATFORM_DESKTOP)
+// HERE 1 //    if ((CORE.Window.flags & FLAG_WINDOW_HIGHDPI) > 0)
+// HERE 1 //    {
+// HERE 1 //        // NOTE: On APPLE platforms system should manage window/input scaling and also framebuffer scaling.
+// HERE 1 //        // Framebuffer scaling should be activated with: glfwWindowHint(GLFW_COCOA_RETINA_FRAMEBUFFER, GLFW_TRUE);
+// HERE 1 //    #if !defined(__APPLE__)
+// HERE 1 //        glfwGetFramebufferSize(CORE.Window.handle, &fbWidth, &fbHeight);
+// HERE 1 //
+// HERE 1 //        // Screen scaling matrix is required in case desired screen area is different from display area
+// HERE 1 //        CORE.Window.screenScale = MatrixScale((float)fbWidth/CORE.Window.screen.width, (float)fbHeight/CORE.Window.screen.height, 1.0f);
+// HERE 1 //
+// HERE 1 //        // Mouse input scaling for the new screen size
+// HERE 1 //        SetMouseScale((float)CORE.Window.screen.width/fbWidth, (float)CORE.Window.screen.height/fbHeight);
+// HERE 1 //    #endif
+// HERE 1 //    }
+// HERE 1 //#endif
+// HERE 1 //
+// HERE 1 //    CORE.Window.render.width = fbWidth;
+// HERE 1 //    CORE.Window.render.height = fbHeight;
+// HERE 1 //    CORE.Window.currentFbo.width = fbWidth;
+// HERE 1 //    CORE.Window.currentFbo.height = fbHeight;
+// HERE 1 //
+// HERE 1 //    TRACELOG(LOG_INFO, "DISPLAY: Device initialized successfully");
+// HERE 1 //    TRACELOG(LOG_INFO, "    > Display size: %i x %i", CORE.Window.display.width, CORE.Window.display.height);
+// HERE 1 //    TRACELOG(LOG_INFO, "    > Screen size:  %i x %i", CORE.Window.screen.width, CORE.Window.screen.height);
+// HERE 1 //    TRACELOG(LOG_INFO, "    > Render size:  %i x %i", CORE.Window.render.width, CORE.Window.render.height);
+// HERE 1 //    TRACELOG(LOG_INFO, "    > Viewport offsets: %i, %i", CORE.Window.renderOffset.x, CORE.Window.renderOffset.y);
+// HERE 1 //
+// HERE 1 //#endif  // PLATFORM_DESKTOP || PLATFORM_WEB
 
-    glfwInitAllocator(&allocator);
-*/
-#if defined(__APPLE__)
-    glfwInitHint(GLFW_COCOA_CHDIR_RESOURCES, GLFW_FALSE);
-#endif
-
-    if (!glfwInit())
-    {
-        TRACELOG(LOG_WARNING, "GLFW: Failed to initialize GLFW");
-        return false;
-    }
-
-    glfwDefaultWindowHints();                       // Set default windows hints
-    //glfwWindowHint(GLFW_RED_BITS, 8);             // Framebuffer red color component bits
-    //glfwWindowHint(GLFW_GREEN_BITS, 8);           // Framebuffer green color component bits
-    //glfwWindowHint(GLFW_BLUE_BITS, 8);            // Framebuffer blue color component bits
-    //glfwWindowHint(GLFW_ALPHA_BITS, 8);           // Framebuffer alpha color component bits
-    //glfwWindowHint(GLFW_DEPTH_BITS, 24);          // Depthbuffer bits
-    //glfwWindowHint(GLFW_REFRESH_RATE, 0);         // Refresh rate for fullscreen window
-    //glfwWindowHint(GLFW_CLIENT_API, GLFW_OPENGL_API); // OpenGL API to use. Alternative: GLFW_OPENGL_ES_API
-    //glfwWindowHint(GLFW_AUX_BUFFERS, 0);          // Number of auxiliar buffers
-
-    // Check window creation flags
-    if ((CORE.Window.flags & FLAG_FULLSCREEN_MODE) > 0) CORE.Window.fullscreen = true;
-
-    if ((CORE.Window.flags & FLAG_WINDOW_HIDDEN) > 0) glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE); // Visible window
-    else glfwWindowHint(GLFW_VISIBLE, GLFW_TRUE);     // Window initially hidden
-
-    if ((CORE.Window.flags & FLAG_WINDOW_UNDECORATED) > 0) glfwWindowHint(GLFW_DECORATED, GLFW_FALSE); // Border and buttons on Window
-    else glfwWindowHint(GLFW_DECORATED, GLFW_TRUE);   // Decorated window
-
-    if ((CORE.Window.flags & FLAG_WINDOW_RESIZABLE) > 0) glfwWindowHint(GLFW_RESIZABLE, GLFW_TRUE); // Resizable window
-    else glfwWindowHint(GLFW_RESIZABLE, GLFW_FALSE);  // Avoid window being resizable
-
-    // Disable FLAG_WINDOW_MINIMIZED, not supported on initialization
-    if ((CORE.Window.flags & FLAG_WINDOW_MINIMIZED) > 0) CORE.Window.flags &= ~FLAG_WINDOW_MINIMIZED;
-
-    // Disable FLAG_WINDOW_MAXIMIZED, not supported on initialization
-    if ((CORE.Window.flags & FLAG_WINDOW_MAXIMIZED) > 0) CORE.Window.flags &= ~FLAG_WINDOW_MAXIMIZED;
-
-    if ((CORE.Window.flags & FLAG_WINDOW_UNFOCUSED) > 0) glfwWindowHint(GLFW_FOCUSED, GLFW_FALSE);
-    else glfwWindowHint(GLFW_FOCUSED, GLFW_TRUE);
-
-    if ((CORE.Window.flags & FLAG_WINDOW_TOPMOST) > 0) glfwWindowHint(GLFW_FLOATING, GLFW_TRUE);
-    else glfwWindowHint(GLFW_FLOATING, GLFW_FALSE);
-
-    // NOTE: Some GLFW flags are not supported on HTML5
-#if defined(PLATFORM_DESKTOP)
-    if ((CORE.Window.flags & FLAG_WINDOW_TRANSPARENT) > 0) glfwWindowHint(GLFW_TRANSPARENT_FRAMEBUFFER, GLFW_TRUE);     // Transparent framebuffer
-    else glfwWindowHint(GLFW_TRANSPARENT_FRAMEBUFFER, GLFW_FALSE);  // Opaque framebuffer
-
-    if ((CORE.Window.flags & FLAG_WINDOW_HIGHDPI) > 0)
-    {
-        // Resize window content area based on the monitor content scale.
-        // NOTE: This hint only has an effect on platforms where screen coordinates and pixels always map 1:1 such as Windows and X11.
-        // On platforms like macOS the resolution of the framebuffer is changed independently of the window size.
-        glfwWindowHint(GLFW_SCALE_TO_MONITOR, GLFW_TRUE);   // Scale content area based on the monitor content scale where window is placed on
-    #if defined(__APPLE__)
-        glfwWindowHint(GLFW_COCOA_RETINA_FRAMEBUFFER, GLFW_TRUE);
-    #endif
-    }
-    else glfwWindowHint(GLFW_SCALE_TO_MONITOR, GLFW_FALSE);
-
-    // Mouse passthrough
-    if ((CORE.Window.flags & FLAG_WINDOW_MOUSE_PASSTHROUGH) > 0) glfwWindowHint(GLFW_MOUSE_PASSTHROUGH, GLFW_TRUE);
-    else glfwWindowHint(GLFW_MOUSE_PASSTHROUGH, GLFW_FALSE);
-#endif
-
-    if (CORE.Window.flags & FLAG_MSAA_4X_HINT)
-    {
-        // NOTE: MSAA is only enabled for main framebuffer, not user-created FBOs
-        TRACELOG(LOG_INFO, "DISPLAY: Trying to enable MSAA x4");
-        glfwWindowHint(GLFW_SAMPLES, 4);   // Tries to enable multisampling x4 (MSAA), default is 0
-    }
-
-    // NOTE: When asking for an OpenGL context version, most drivers provide the highest supported version
-    // with backward compatibility to older OpenGL versions.
-    // For example, if using OpenGL 1.1, driver can provide a 4.3 backwards compatible context.
-
-    // Check selection OpenGL version
-    if (rlGetVersion() == RL_OPENGL_21)
-    {
-        glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 2);          // Choose OpenGL major version (just hint)
-        glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 1);          // Choose OpenGL minor version (just hint)
-    }
-    else if (rlGetVersion() == RL_OPENGL_33)
-    {
-        glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);          // Choose OpenGL major version (just hint)
-        glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);          // Choose OpenGL minor version (just hint)
-        glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE); // Profiles Hint: Only 3.3 and above!
-                                                                       // Values: GLFW_OPENGL_CORE_PROFILE, GLFW_OPENGL_ANY_PROFILE, GLFW_OPENGL_COMPAT_PROFILE
-#if defined(__APPLE__)
-        glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GLFW_TRUE);  // OSX Requires forward compatibility
-#else
-        glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GLFW_FALSE); // Forward Compatibility Hint: Only 3.3 and above!
-#endif
-        //glfwWindowHint(GLFW_OPENGL_DEBUG_CONTEXT, GLFW_TRUE); // Request OpenGL DEBUG context
-    }
-    else if (rlGetVersion() == RL_OPENGL_43)
-    {
-        glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 4);          // Choose OpenGL major version (just hint)
-        glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);          // Choose OpenGL minor version (just hint)
-        glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
-        glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GLFW_FALSE);
-#if defined(RLGL_ENABLE_OPENGL_DEBUG_CONTEXT)
-        glfwWindowHint(GLFW_OPENGL_DEBUG_CONTEXT, GLFW_TRUE);   // Enable OpenGL Debug Context
-#endif
-    }
-    else if (rlGetVersion() == RL_OPENGL_ES_20)                 // Request OpenGL ES 2.0 context
-    {
-        glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 2);
-        glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 0);
-        glfwWindowHint(GLFW_CLIENT_API, GLFW_OPENGL_ES_API);
-#if defined(PLATFORM_DESKTOP)
-        glfwWindowHint(GLFW_CONTEXT_CREATION_API, GLFW_EGL_CONTEXT_API);
-#else
-        glfwWindowHint(GLFW_CONTEXT_CREATION_API, GLFW_NATIVE_CONTEXT_API);
-#endif
-    }
-    else if (rlGetVersion() == RL_OPENGL_ES_30)                 // Request OpenGL ES 3.0 context
-    {
-        glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
-        glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 0);
-        glfwWindowHint(GLFW_CLIENT_API, GLFW_OPENGL_ES_API);
-#if defined(PLATFORM_DESKTOP)
-        glfwWindowHint(GLFW_CONTEXT_CREATION_API, GLFW_EGL_CONTEXT_API);
-#else
-        glfwWindowHint(GLFW_CONTEXT_CREATION_API, GLFW_NATIVE_CONTEXT_API);
-#endif
-    }
-
-#if defined(PLATFORM_DESKTOP)
-    // NOTE: GLFW 3.4+ defers initialization of the Joystick subsystem on the first call to any Joystick related functions.
-    // Forcing this initialization here avoids doing it on PollInputEvents() called by EndDrawing() after first frame has been just drawn.
-    // The initialization will still happen and possible delays still occur, but before the window is shown, which is a nicer experience.
-    // REF: https://github.com/raysan5/raylib/issues/1554
-    if (MAX_GAMEPADS > 0) glfwSetJoystickCallback(NULL);
-#endif
-
-#if defined(PLATFORM_DESKTOP)
-    // Find monitor resolution
-    GLFWmonitor *monitor = glfwGetPrimaryMonitor();
-    if (!monitor)
-    {
-        TRACELOG(LOG_WARNING, "GLFW: Failed to get primary monitor");
-        return false;
-    }
-
-    const GLFWvidmode *mode = glfwGetVideoMode(monitor);
-
-    CORE.Window.display.width = mode->width;
-    CORE.Window.display.height = mode->height;
-
-    // Set screen width/height to the display width/height if they are 0
-    if (CORE.Window.screen.width == 0) CORE.Window.screen.width = CORE.Window.display.width;
-    if (CORE.Window.screen.height == 0) CORE.Window.screen.height = CORE.Window.display.height;
-#endif  // PLATFORM_DESKTOP
-
-#if defined(PLATFORM_WEB)
-    // NOTE: Getting video modes is not implemented in emscripten GLFW3 version
-    CORE.Window.display.width = CORE.Window.screen.width;
-    CORE.Window.display.height = CORE.Window.screen.height;
-#endif  // PLATFORM_WEB
-
-    if (CORE.Window.fullscreen)
-    {
-        // remember center for switchinging from fullscreen to window
-        if ((CORE.Window.screen.height == CORE.Window.display.height) && (CORE.Window.screen.width == CORE.Window.display.width))
-        {
-            // If screen width/height equal to the display, we can't calculate the window pos for toggling full-screened/windowed.
-            // Toggling full-screened/windowed with pos(0, 0) can cause problems in some platforms, such as X11.
-            CORE.Window.position.x = CORE.Window.display.width/4;
-            CORE.Window.position.y = CORE.Window.display.height/4;
-        }
-        else
-        {
-            CORE.Window.position.x = CORE.Window.display.width/2 - CORE.Window.screen.width/2;
-            CORE.Window.position.y = CORE.Window.display.height/2 - CORE.Window.screen.height/2;
-        }
-
-        if (CORE.Window.position.x < 0) CORE.Window.position.x = 0;
-        if (CORE.Window.position.y < 0) CORE.Window.position.y = 0;
-
-        // Obtain recommended CORE.Window.display.width/CORE.Window.display.height from a valid videomode for the monitor
-        int count = 0;
-        const GLFWvidmode *modes = glfwGetVideoModes(glfwGetPrimaryMonitor(), &count);
-
-        // Get closest video mode to desired CORE.Window.screen.width/CORE.Window.screen.height
-        for (int i = 0; i < count; i++)
-        {
-            if ((unsigned int)modes[i].width >= CORE.Window.screen.width)
-            {
-                if ((unsigned int)modes[i].height >= CORE.Window.screen.height)
-                {
-                    CORE.Window.display.width = modes[i].width;
-                    CORE.Window.display.height = modes[i].height;
-                    break;
-                }
-            }
-        }
-        TRACELOG(LOG_WARNING, "SYSTEM: Closest fullscreen videomode: %i x %i", CORE.Window.display.width, CORE.Window.display.height);
-
-        // NOTE: ISSUE: Closest videomode could not match monitor aspect-ratio, for example,
-        // for a desired screen size of 800x450 (16:9), closest supported videomode is 800x600 (4:3),
-        // framebuffer is rendered correctly but once displayed on a 16:9 monitor, it gets stretched
-        // by the sides to fit all monitor space...
-
-        // Try to setup the most appropriate fullscreen framebuffer for the requested screenWidth/screenHeight
-        // It considers device display resolution mode and setups a framebuffer with black bars if required (render size/offset)
-        // Modified global variables: CORE.Window.screen.width/CORE.Window.screen.height - CORE.Window.render.width/CORE.Window.render.height - CORE.Window.renderOffset.x/CORE.Window.renderOffset.y - CORE.Window.screenScale
-        // TODO: It is a quite cumbersome solution to display size vs requested size, it should be reviewed or removed...
-        // HighDPI monitors are properly considered in a following similar function: SetupViewport()
-        SetupFramebuffer(CORE.Window.display.width, CORE.Window.display.height);
-
-        CORE.Window.handle = glfwCreateWindow(CORE.Window.display.width, CORE.Window.display.height, (CORE.Window.title != 0)? CORE.Window.title : " ", glfwGetPrimaryMonitor(), NULL);
-
-        // NOTE: Full-screen change, not working properly...
-        //glfwSetWindowMonitor(CORE.Window.handle, glfwGetPrimaryMonitor(), 0, 0, CORE.Window.screen.width, CORE.Window.screen.height, GLFW_DONT_CARE);
-    }
-    else
-    {
-#if defined(PLATFORM_DESKTOP)
-        // If we are windowed fullscreen, ensures that window does not minimize when focus is lost
-        if ((CORE.Window.screen.height == CORE.Window.display.height) && (CORE.Window.screen.width == CORE.Window.display.width))
-        {
-            glfwWindowHint(GLFW_AUTO_ICONIFY, 0);
-        }
-#endif
-        // No-fullscreen window creation
-        CORE.Window.handle = glfwCreateWindow(CORE.Window.screen.width, CORE.Window.screen.height, (CORE.Window.title != 0)? CORE.Window.title : " ", NULL, NULL);
-
-        if (CORE.Window.handle)
-        {
-            CORE.Window.render.width = CORE.Window.screen.width;
-            CORE.Window.render.height = CORE.Window.screen.height;
-        }
-    }
-
-    if (!CORE.Window.handle)
-    {
-        glfwTerminate();
-        TRACELOG(LOG_WARNING, "GLFW: Failed to initialize Window");
-        return false;
-    }
-
-// glfwCreateWindow title doesn't work with emscripten.
-#if defined(PLATFORM_WEB)
-    emscripten_set_window_title((CORE.Window.title != 0)? CORE.Window.title : " ");
-#endif
-
-    // Set window callback events
-    glfwSetWindowSizeCallback(CORE.Window.handle, WindowSizeCallback);      // NOTE: Resizing not allowed by default!
-#if !defined(PLATFORM_WEB)
-    glfwSetWindowMaximizeCallback(CORE.Window.handle, WindowMaximizeCallback);
-#endif
-    glfwSetWindowIconifyCallback(CORE.Window.handle, WindowIconifyCallback);
-    glfwSetWindowFocusCallback(CORE.Window.handle, WindowFocusCallback);
-    glfwSetDropCallback(CORE.Window.handle, WindowDropCallback);
-
-    // Set input callback events
-    glfwSetKeyCallback(CORE.Window.handle, KeyCallback);
-    glfwSetCharCallback(CORE.Window.handle, CharCallback);
-    glfwSetMouseButtonCallback(CORE.Window.handle, MouseButtonCallback);
-    glfwSetCursorPosCallback(CORE.Window.handle, MouseCursorPosCallback);   // Track mouse position changes
-    glfwSetScrollCallback(CORE.Window.handle, MouseScrollCallback);
-    glfwSetCursorEnterCallback(CORE.Window.handle, CursorEnterCallback);
-
-    glfwMakeContextCurrent(CORE.Window.handle);
-
-#if !defined(PLATFORM_WEB)
-    glfwSetInputMode(CORE.Window.handle, GLFW_LOCK_KEY_MODS, GLFW_TRUE);    // Enable lock keys modifiers (CAPS, NUM)
-
-    glfwSwapInterval(0);        // No V-Sync by default
-#endif
-
-    // Try to enable GPU V-Sync, so frames are limited to screen refresh rate (60Hz -> 60 FPS)
-    // NOTE: V-Sync can be enabled by graphic driver configuration, it doesn't need
-    // to be activated on web platforms since VSync is enforced there.
-#if !defined(PLATFORM_WEB)
-    if (CORE.Window.flags & FLAG_VSYNC_HINT)
-    {
-        // WARNING: It seems to hit a critical render path in Intel HD Graphics
-        glfwSwapInterval(1);
-        TRACELOG(LOG_INFO, "DISPLAY: Trying to enable VSYNC");
-    }
-#endif
-
-    int fbWidth = CORE.Window.screen.width;
-    int fbHeight = CORE.Window.screen.height;
-
-#if defined(PLATFORM_DESKTOP)
-    if ((CORE.Window.flags & FLAG_WINDOW_HIGHDPI) > 0)
-    {
-        // NOTE: On APPLE platforms system should manage window/input scaling and also framebuffer scaling.
-        // Framebuffer scaling should be activated with: glfwWindowHint(GLFW_COCOA_RETINA_FRAMEBUFFER, GLFW_TRUE);
-    #if !defined(__APPLE__)
-        glfwGetFramebufferSize(CORE.Window.handle, &fbWidth, &fbHeight);
-
-        // Screen scaling matrix is required in case desired screen area is different from display area
-        CORE.Window.screenScale = MatrixScale((float)fbWidth/CORE.Window.screen.width, (float)fbHeight/CORE.Window.screen.height, 1.0f);
-
-        // Mouse input scaling for the new screen size
-        SetMouseScale((float)CORE.Window.screen.width/fbWidth, (float)CORE.Window.screen.height/fbHeight);
-    #endif
-    }
-#endif
-
-    CORE.Window.render.width = fbWidth;
-    CORE.Window.render.height = fbHeight;
-    CORE.Window.currentFbo.width = fbWidth;
-    CORE.Window.currentFbo.height = fbHeight;
-
-    TRACELOG(LOG_INFO, "DISPLAY: Device initialized successfully");
-    TRACELOG(LOG_INFO, "    > Display size: %i x %i", CORE.Window.display.width, CORE.Window.display.height);
-    TRACELOG(LOG_INFO, "    > Screen size:  %i x %i", CORE.Window.screen.width, CORE.Window.screen.height);
-    TRACELOG(LOG_INFO, "    > Render size:  %i x %i", CORE.Window.render.width, CORE.Window.render.height);
-    TRACELOG(LOG_INFO, "    > Viewport offsets: %i, %i", CORE.Window.renderOffset.x, CORE.Window.renderOffset.y);
-
-#endif  // PLATFORM_DESKTOP || PLATFORM_WEB
-
-#if defined(PLATFORM_ANDROID) || defined(PLATFORM_DRM)
+// HERE 2 //#if defined(PLATFORM_ANDROID) || defined(PLATFORM_DRM)
     CORE.Window.fullscreen = true;
     CORE.Window.flags |= FLAG_FULLSCREEN_MODE;
 
-#if defined(PLATFORM_DRM)
-    CORE.Window.fd = -1;
-    CORE.Window.connector = NULL;
-    CORE.Window.modeIndex = -1;
-    CORE.Window.crtc = NULL;
-    CORE.Window.gbmDevice = NULL;
-    CORE.Window.gbmSurface = NULL;
-    CORE.Window.prevBO = NULL;
-    CORE.Window.prevFB = 0;
-
-#if defined(DEFAULT_GRAPHIC_DEVICE_DRM)
-    CORE.Window.fd = open(DEFAULT_GRAPHIC_DEVICE_DRM, O_RDWR);
-#else
-    TRACELOG(LOG_INFO, "DISPLAY: No graphic card set, trying platform-gpu-card");
-    CORE.Window.fd = open("/dev/dri/by-path/platform-gpu-card",  O_RDWR); // VideoCore VI (Raspberry Pi 4)
-
-    if ((-1 == CORE.Window.fd) || (drmModeGetResources(CORE.Window.fd) == NULL))
-    {
-        TRACELOG(LOG_INFO, "DISPLAY: Failed to open platform-gpu-card, trying card1");
-        CORE.Window.fd = open("/dev/dri/card1", O_RDWR); // Other Embedded
-    }
-
-    if ((-1 == CORE.Window.fd) || (drmModeGetResources(CORE.Window.fd) == NULL))
-    {
-        TRACELOG(LOG_INFO, "DISPLAY: Failed to open graphic card1, trying card0");
-        CORE.Window.fd = open("/dev/dri/card0", O_RDWR); // VideoCore IV (Raspberry Pi 1-3)
-    }
-#endif
-    if (-1 == CORE.Window.fd)
-    {
-        TRACELOG(LOG_WARNING, "DISPLAY: Failed to open graphic card");
-        return false;
-    }
-
-    drmModeRes *res = drmModeGetResources(CORE.Window.fd);
-    if (!res)
-    {
-        TRACELOG(LOG_WARNING, "DISPLAY: Failed get DRM resources");
-        return false;
-    }
-
-    TRACELOG(LOG_TRACE, "DISPLAY: Connectors found: %i", res->count_connectors);
-    for (size_t i = 0; i < res->count_connectors; i++)
-    {
-        TRACELOG(LOG_TRACE, "DISPLAY: Connector index %i", i);
-        drmModeConnector *con = drmModeGetConnector(CORE.Window.fd, res->connectors[i]);
-        TRACELOG(LOG_TRACE, "DISPLAY: Connector modes detected: %i", con->count_modes);
-        if ((con->connection == DRM_MODE_CONNECTED) && (con->encoder_id))
-        {
-            TRACELOG(LOG_TRACE, "DISPLAY: DRM mode connected");
-            CORE.Window.connector = con;
-            break;
-        }
-        else
-        {
-            TRACELOG(LOG_TRACE, "DISPLAY: DRM mode NOT connected (deleting)");
-            drmModeFreeConnector(con);
-        }
-    }
-
-    if (!CORE.Window.connector)
-    {
-        TRACELOG(LOG_WARNING, "DISPLAY: No suitable DRM connector found");
-        drmModeFreeResources(res);
-        return false;
-    }
-
-    drmModeEncoder *enc = drmModeGetEncoder(CORE.Window.fd, CORE.Window.connector->encoder_id);
-    if (!enc)
-    {
-        TRACELOG(LOG_WARNING, "DISPLAY: Failed to get DRM mode encoder");
-        drmModeFreeResources(res);
-        return false;
-    }
-
-    CORE.Window.crtc = drmModeGetCrtc(CORE.Window.fd, enc->crtc_id);
-    if (!CORE.Window.crtc)
-    {
-        TRACELOG(LOG_WARNING, "DISPLAY: Failed to get DRM mode crtc");
-        drmModeFreeEncoder(enc);
-        drmModeFreeResources(res);
-        return false;
-    }
-
-    // If InitWindow should use the current mode find it in the connector's mode list
-    if ((CORE.Window.screen.width <= 0) || (CORE.Window.screen.height <= 0))
-    {
-        TRACELOG(LOG_TRACE, "DISPLAY: Selecting DRM connector mode for current used mode...");
-
-        CORE.Window.modeIndex = FindMatchingConnectorMode(CORE.Window.connector, &CORE.Window.crtc->mode);
-
-        if (CORE.Window.modeIndex < 0)
-        {
-            TRACELOG(LOG_WARNING, "DISPLAY: No matching DRM connector mode found");
-            drmModeFreeEncoder(enc);
-            drmModeFreeResources(res);
-            return false;
-        }
-
-        CORE.Window.screen.width = CORE.Window.display.width;
-        CORE.Window.screen.height = CORE.Window.display.height;
-    }
-
-    const bool allowInterlaced = CORE.Window.flags & FLAG_INTERLACED_HINT;
-    const int fps = (CORE.Time.target > 0) ? (1.0/CORE.Time.target) : 60;
-
-    // Try to find an exact matching mode
-    CORE.Window.modeIndex = FindExactConnectorMode(CORE.Window.connector, CORE.Window.screen.width, CORE.Window.screen.height, fps, allowInterlaced);
-
-    // If nothing found, try to find a nearly matching mode
-    if (CORE.Window.modeIndex < 0) CORE.Window.modeIndex = FindNearestConnectorMode(CORE.Window.connector, CORE.Window.screen.width, CORE.Window.screen.height, fps, allowInterlaced);
-
-    // If nothing found, try to find an exactly matching mode including interlaced
-    if (CORE.Window.modeIndex < 0) CORE.Window.modeIndex = FindExactConnectorMode(CORE.Window.connector, CORE.Window.screen.width, CORE.Window.screen.height, fps, true);
-
-    // If nothing found, try to find a nearly matching mode including interlaced
-    if (CORE.Window.modeIndex < 0) CORE.Window.modeIndex = FindNearestConnectorMode(CORE.Window.connector, CORE.Window.screen.width, CORE.Window.screen.height, fps, true);
-
-    // If nothing found, there is no suitable mode
-    if (CORE.Window.modeIndex < 0)
-    {
-        TRACELOG(LOG_WARNING, "DISPLAY: Failed to find a suitable DRM connector mode");
-        drmModeFreeEncoder(enc);
-        drmModeFreeResources(res);
-        return false;
-    }
-
-    CORE.Window.display.width = CORE.Window.connector->modes[CORE.Window.modeIndex].hdisplay;
-    CORE.Window.display.height = CORE.Window.connector->modes[CORE.Window.modeIndex].vdisplay;
-
-    TRACELOG(LOG_INFO, "DISPLAY: Selected DRM connector mode %s (%ux%u%c@%u)", CORE.Window.connector->modes[CORE.Window.modeIndex].name,
-        CORE.Window.connector->modes[CORE.Window.modeIndex].hdisplay, CORE.Window.connector->modes[CORE.Window.modeIndex].vdisplay,
-        (CORE.Window.connector->modes[CORE.Window.modeIndex].flags & DRM_MODE_FLAG_INTERLACE) ? 'i' : 'p',
-        CORE.Window.connector->modes[CORE.Window.modeIndex].vrefresh);
-
-    // Use the width and height of the surface for render
-    CORE.Window.render.width = CORE.Window.screen.width;
-    CORE.Window.render.height = CORE.Window.screen.height;
-
-    drmModeFreeEncoder(enc);
-    enc = NULL;
-
-    drmModeFreeResources(res);
-    res = NULL;
-
-    CORE.Window.gbmDevice = gbm_create_device(CORE.Window.fd);
-    if (!CORE.Window.gbmDevice)
-    {
-        TRACELOG(LOG_WARNING, "DISPLAY: Failed to create GBM device");
-        return false;
-    }
-
-    CORE.Window.gbmSurface = gbm_surface_create(CORE.Window.gbmDevice, CORE.Window.connector->modes[CORE.Window.modeIndex].hdisplay,
-        CORE.Window.connector->modes[CORE.Window.modeIndex].vdisplay, GBM_FORMAT_ARGB8888, GBM_BO_USE_SCANOUT | GBM_BO_USE_RENDERING);
-    if (!CORE.Window.gbmSurface)
-    {
-        TRACELOG(LOG_WARNING, "DISPLAY: Failed to create GBM surface");
-        return false;
-    }
-#endif
+// HERE 3 //#if defined(PLATFORM_DRM)
+// HERE 3 //    CORE.Window.fd = -1;
+// HERE 3 //    CORE.Window.connector = NULL;
+// HERE 3 //    CORE.Window.modeIndex = -1;
+// HERE 3 //    CORE.Window.crtc = NULL;
+// HERE 3 //    CORE.Window.gbmDevice = NULL;
+// HERE 3 //    CORE.Window.gbmSurface = NULL;
+// HERE 3 //    CORE.Window.prevBO = NULL;
+// HERE 3 //    CORE.Window.prevFB = 0;
+// HERE 3 //
+// HERE 3 //#if defined(DEFAULT_GRAPHIC_DEVICE_DRM)
+// HERE 3 //    CORE.Window.fd = open(DEFAULT_GRAPHIC_DEVICE_DRM, O_RDWR);
+// HERE 3 //#else
+// HERE 3 //    TRACELOG(LOG_INFO, "DISPLAY: No graphic card set, trying platform-gpu-card");
+// HERE 3 //    CORE.Window.fd = open("/dev/dri/by-path/platform-gpu-card",  O_RDWR); // VideoCore VI (Raspberry Pi 4)
+// HERE 3 //
+// HERE 3 //    if ((-1 == CORE.Window.fd) || (drmModeGetResources(CORE.Window.fd) == NULL))
+// HERE 3 //    {
+// HERE 3 //        TRACELOG(LOG_INFO, "DISPLAY: Failed to open platform-gpu-card, trying card1");
+// HERE 3 //        CORE.Window.fd = open("/dev/dri/card1", O_RDWR); // Other Embedded
+// HERE 3 //    }
+// HERE 3 //
+// HERE 3 //    if ((-1 == CORE.Window.fd) || (drmModeGetResources(CORE.Window.fd) == NULL))
+// HERE 3 //    {
+// HERE 3 //        TRACELOG(LOG_INFO, "DISPLAY: Failed to open graphic card1, trying card0");
+// HERE 3 //        CORE.Window.fd = open("/dev/dri/card0", O_RDWR); // VideoCore IV (Raspberry Pi 1-3)
+// HERE 3 //    }
+// HERE 3 //#endif
+// HERE 3 //    if (-1 == CORE.Window.fd)
+// HERE 3 //    {
+// HERE 3 //        TRACELOG(LOG_WARNING, "DISPLAY: Failed to open graphic card");
+// HERE 3 //        return false;
+// HERE 3 //    }
+// HERE 3 //
+// HERE 3 //    drmModeRes *res = drmModeGetResources(CORE.Window.fd);
+// HERE 3 //    if (!res)
+// HERE 3 //    {
+// HERE 3 //        TRACELOG(LOG_WARNING, "DISPLAY: Failed get DRM resources");
+// HERE 3 //        return false;
+// HERE 3 //    }
+// HERE 3 //
+// HERE 3 //    TRACELOG(LOG_TRACE, "DISPLAY: Connectors found: %i", res->count_connectors);
+// HERE 3 //    for (size_t i = 0; i < res->count_connectors; i++)
+// HERE 3 //    {
+// HERE 3 //        TRACELOG(LOG_TRACE, "DISPLAY: Connector index %i", i);
+// HERE 3 //        drmModeConnector *con = drmModeGetConnector(CORE.Window.fd, res->connectors[i]);
+// HERE 3 //        TRACELOG(LOG_TRACE, "DISPLAY: Connector modes detected: %i", con->count_modes);
+// HERE 3 //        if ((con->connection == DRM_MODE_CONNECTED) && (con->encoder_id))
+// HERE 3 //        {
+// HERE 3 //            TRACELOG(LOG_TRACE, "DISPLAY: DRM mode connected");
+// HERE 3 //            CORE.Window.connector = con;
+// HERE 3 //            break;
+// HERE 3 //        }
+// HERE 3 //        else
+// HERE 3 //        {
+// HERE 3 //            TRACELOG(LOG_TRACE, "DISPLAY: DRM mode NOT connected (deleting)");
+// HERE 3 //            drmModeFreeConnector(con);
+// HERE 3 //        }
+// HERE 3 //    }
+// HERE 3 //
+// HERE 3 //    if (!CORE.Window.connector)
+// HERE 3 //    {
+// HERE 3 //        TRACELOG(LOG_WARNING, "DISPLAY: No suitable DRM connector found");
+// HERE 3 //        drmModeFreeResources(res);
+// HERE 3 //        return false;
+// HERE 3 //    }
+// HERE 3 //
+// HERE 3 //    drmModeEncoder *enc = drmModeGetEncoder(CORE.Window.fd, CORE.Window.connector->encoder_id);
+// HERE 3 //    if (!enc)
+// HERE 3 //    {
+// HERE 3 //        TRACELOG(LOG_WARNING, "DISPLAY: Failed to get DRM mode encoder");
+// HERE 3 //        drmModeFreeResources(res);
+// HERE 3 //        return false;
+// HERE 3 //    }
+// HERE 3 //
+// HERE 3 //    CORE.Window.crtc = drmModeGetCrtc(CORE.Window.fd, enc->crtc_id);
+// HERE 3 //    if (!CORE.Window.crtc)
+// HERE 3 //    {
+// HERE 3 //        TRACELOG(LOG_WARNING, "DISPLAY: Failed to get DRM mode crtc");
+// HERE 3 //        drmModeFreeEncoder(enc);
+// HERE 3 //        drmModeFreeResources(res);
+// HERE 3 //        return false;
+// HERE 3 //    }
+// HERE 3 //
+// HERE 3 //    // If InitWindow should use the current mode find it in the connector's mode list
+// HERE 3 //    if ((CORE.Window.screen.width <= 0) || (CORE.Window.screen.height <= 0))
+// HERE 3 //    {
+// HERE 3 //        TRACELOG(LOG_TRACE, "DISPLAY: Selecting DRM connector mode for current used mode...");
+// HERE 3 //
+// HERE 3 //        CORE.Window.modeIndex = FindMatchingConnectorMode(CORE.Window.connector, &CORE.Window.crtc->mode);
+// HERE 3 //
+// HERE 3 //        if (CORE.Window.modeIndex < 0)
+// HERE 3 //        {
+// HERE 3 //            TRACELOG(LOG_WARNING, "DISPLAY: No matching DRM connector mode found");
+// HERE 3 //            drmModeFreeEncoder(enc);
+// HERE 3 //            drmModeFreeResources(res);
+// HERE 3 //            return false;
+// HERE 3 //        }
+// HERE 3 //
+// HERE 3 //        CORE.Window.screen.width = CORE.Window.display.width;
+// HERE 3 //        CORE.Window.screen.height = CORE.Window.display.height;
+// HERE 3 //    }
+// HERE 3 //
+// HERE 3 //    const bool allowInterlaced = CORE.Window.flags & FLAG_INTERLACED_HINT;
+// HERE 3 //    const int fps = (CORE.Time.target > 0) ? (1.0/CORE.Time.target) : 60;
+// HERE 3 //
+// HERE 3 //    // Try to find an exact matching mode
+// HERE 3 //    CORE.Window.modeIndex = FindExactConnectorMode(CORE.Window.connector, CORE.Window.screen.width, CORE.Window.screen.height, fps, allowInterlaced);
+// HERE 3 //
+// HERE 3 //    // If nothing found, try to find a nearly matching mode
+// HERE 3 //    if (CORE.Window.modeIndex < 0) CORE.Window.modeIndex = FindNearestConnectorMode(CORE.Window.connector, CORE.Window.screen.width, CORE.Window.screen.height, fps, allowInterlaced);
+// HERE 3 //
+// HERE 3 //    // If nothing found, try to find an exactly matching mode including interlaced
+// HERE 3 //    if (CORE.Window.modeIndex < 0) CORE.Window.modeIndex = FindExactConnectorMode(CORE.Window.connector, CORE.Window.screen.width, CORE.Window.screen.height, fps, true);
+// HERE 3 //
+// HERE 3 //    // If nothing found, try to find a nearly matching mode including interlaced
+// HERE 3 //    if (CORE.Window.modeIndex < 0) CORE.Window.modeIndex = FindNearestConnectorMode(CORE.Window.connector, CORE.Window.screen.width, CORE.Window.screen.height, fps, true);
+// HERE 3 //
+// HERE 3 //    // If nothing found, there is no suitable mode
+// HERE 3 //    if (CORE.Window.modeIndex < 0)
+// HERE 3 //    {
+// HERE 3 //        TRACELOG(LOG_WARNING, "DISPLAY: Failed to find a suitable DRM connector mode");
+// HERE 3 //        drmModeFreeEncoder(enc);
+// HERE 3 //        drmModeFreeResources(res);
+// HERE 3 //        return false;
+// HERE 3 //    }
+// HERE 3 //
+// HERE 3 //    CORE.Window.display.width = CORE.Window.connector->modes[CORE.Window.modeIndex].hdisplay;
+// HERE 3 //    CORE.Window.display.height = CORE.Window.connector->modes[CORE.Window.modeIndex].vdisplay;
+// HERE 3 //
+// HERE 3 //    TRACELOG(LOG_INFO, "DISPLAY: Selected DRM connector mode %s (%ux%u%c@%u)", CORE.Window.connector->modes[CORE.Window.modeIndex].name,
+// HERE 3 //        CORE.Window.connector->modes[CORE.Window.modeIndex].hdisplay, CORE.Window.connector->modes[CORE.Window.modeIndex].vdisplay,
+// HERE 3 //        (CORE.Window.connector->modes[CORE.Window.modeIndex].flags & DRM_MODE_FLAG_INTERLACE) ? 'i' : 'p',
+// HERE 3 //        CORE.Window.connector->modes[CORE.Window.modeIndex].vrefresh);
+// HERE 3 //
+// HERE 3 //    // Use the width and height of the surface for render
+// HERE 3 //    CORE.Window.render.width = CORE.Window.screen.width;
+// HERE 3 //    CORE.Window.render.height = CORE.Window.screen.height;
+// HERE 3 //
+// HERE 3 //    drmModeFreeEncoder(enc);
+// HERE 3 //    enc = NULL;
+// HERE 3 //
+// HERE 3 //    drmModeFreeResources(res);
+// HERE 3 //    res = NULL;
+// HERE 3 //
+// HERE 3 //    CORE.Window.gbmDevice = gbm_create_device(CORE.Window.fd);
+// HERE 3 //    if (!CORE.Window.gbmDevice)
+// HERE 3 //    {
+// HERE 3 //        TRACELOG(LOG_WARNING, "DISPLAY: Failed to create GBM device");
+// HERE 3 //        return false;
+// HERE 3 //    }
+// HERE 3 //
+// HERE 3 //    CORE.Window.gbmSurface = gbm_surface_create(CORE.Window.gbmDevice, CORE.Window.connector->modes[CORE.Window.modeIndex].hdisplay,
+// HERE 3 //        CORE.Window.connector->modes[CORE.Window.modeIndex].vdisplay, GBM_FORMAT_ARGB8888, GBM_BO_USE_SCANOUT | GBM_BO_USE_RENDERING);
+// HERE 3 //    if (!CORE.Window.gbmSurface)
+// HERE 3 //    {
+// HERE 3 //        TRACELOG(LOG_WARNING, "DISPLAY: Failed to create GBM surface");
+// HERE 3 //        return false;
+// HERE 3 //    }
+// HERE 3 //#endif
 
     EGLint samples = 0;
     EGLint sampleBuffer = 0;
@@ -653,15 +653,15 @@ static bool InitGraphicsDevice(int width, int height)
     const EGLint framebufferAttribs[] =
     {
         EGL_RENDERABLE_TYPE, (rlGetVersion() == RL_OPENGL_ES_30)? EGL_OPENGL_ES3_BIT : EGL_OPENGL_ES2_BIT,      // Type of context support
-#if defined(PLATFORM_DRM)
-        EGL_SURFACE_TYPE, EGL_WINDOW_BIT,          // Don't use it on Android!
-#endif
+// HERE 4 //#if defined(PLATFORM_DRM)
+// HERE 4 //        EGL_SURFACE_TYPE, EGL_WINDOW_BIT,          // Don't use it on Android!
+// HERE 4 //#endif
         EGL_RED_SIZE, 8,            // RED color bit depth (alternative: 5)
         EGL_GREEN_SIZE, 8,          // GREEN color bit depth (alternative: 6)
         EGL_BLUE_SIZE, 8,           // BLUE color bit depth (alternative: 5)
-#if defined(PLATFORM_DRM)
-        EGL_ALPHA_SIZE, 8,        // ALPHA bit depth (required for transparent framebuffer)
-#endif
+// HERE 5 //#if defined(PLATFORM_DRM)
+// HERE 5 //        EGL_ALPHA_SIZE, 8,        // ALPHA bit depth (required for transparent framebuffer)
+// HERE 5 //#endif
         //EGL_TRANSPARENT_TYPE, EGL_NONE, // Request transparent framebuffer (EGL_TRANSPARENT_RGB does not work on RPI)
         EGL_DEPTH_SIZE, 16,         // Depth buffer size (Required to use Depth testing!)
         //EGL_STENCIL_SIZE, 8,      // Stencil buffer size
@@ -676,15 +676,15 @@ static bool InitGraphicsDevice(int width, int height)
         EGL_NONE
     };
 
-#if defined(PLATFORM_ANDROID) || defined(PLATFORM_DRM)
+// HERE 6 //#if defined(PLATFORM_ANDROID) || defined(PLATFORM_DRM)
     EGLint numConfigs = 0;
 
     // Get an EGL device connection
-#if defined(PLATFORM_DRM)
-    CORE.Window.device = eglGetDisplay((EGLNativeDisplayType)CORE.Window.gbmDevice);
-#else
+// HERE 7 //#if defined(PLATFORM_DRM)
+// HERE 7 //    CORE.Window.device = eglGetDisplay((EGLNativeDisplayType)CORE.Window.gbmDevice);
+// HERE 7 //#else
     CORE.Window.device = eglGetDisplay(EGL_DEFAULT_DISPLAY);
-#endif
+// HERE 7 //#endif
     if (CORE.Window.device == EGL_NO_DISPLAY)
     {
         TRACELOG(LOG_WARNING, "DISPLAY: Failed to initialize EGL device");
@@ -699,63 +699,63 @@ static bool InitGraphicsDevice(int width, int height)
         return false;
     }
 
-#if defined(PLATFORM_DRM)
-    if (!eglChooseConfig(CORE.Window.device, NULL, NULL, 0, &numConfigs))
-    {
-        TRACELOG(LOG_WARNING, "DISPLAY: Failed to get EGL config count: 0x%x", eglGetError());
-        return false;
-    }
-
-    TRACELOG(LOG_TRACE, "DISPLAY: EGL configs available: %d", numConfigs);
-
-    EGLConfig *configs = RL_CALLOC(numConfigs, sizeof(*configs));
-    if (!configs)
-    {
-        TRACELOG(LOG_WARNING, "DISPLAY: Failed to get memory for EGL configs");
-        return false;
-    }
-
-    EGLint matchingNumConfigs = 0;
-    if (!eglChooseConfig(CORE.Window.device, framebufferAttribs, configs, numConfigs, &matchingNumConfigs))
-    {
-        TRACELOG(LOG_WARNING, "DISPLAY: Failed to choose EGL config: 0x%x", eglGetError());
-        free(configs);
-        return false;
-    }
-
-    TRACELOG(LOG_TRACE, "DISPLAY: EGL matching configs available: %d", matchingNumConfigs);
-
-    // find the EGL config that matches the previously setup GBM format
-    int found = 0;
-    for (EGLint i = 0; i < matchingNumConfigs; ++i)
-    {
-        EGLint id = 0;
-        if (!eglGetConfigAttrib(CORE.Window.device, configs[i], EGL_NATIVE_VISUAL_ID, &id))
-        {
-            TRACELOG(LOG_WARNING, "DISPLAY: Failed to get EGL config attribute: 0x%x", eglGetError());
-            continue;
-        }
-
-        if (GBM_FORMAT_ARGB8888 == id)
-        {
-            TRACELOG(LOG_TRACE, "DISPLAY: Using EGL config: %d", i);
-            CORE.Window.config = configs[i];
-            found = 1;
-            break;
-        }
-    }
-
-    RL_FREE(configs);
-
-    if (!found)
-    {
-        TRACELOG(LOG_WARNING, "DISPLAY: Failed to find a suitable EGL config");
-        return false;
-    }
-#else
+// HERE 8 //#if defined(PLATFORM_DRM)
+// HERE 8 //    if (!eglChooseConfig(CORE.Window.device, NULL, NULL, 0, &numConfigs))
+// HERE 8 //    {
+// HERE 8 //        TRACELOG(LOG_WARNING, "DISPLAY: Failed to get EGL config count: 0x%x", eglGetError());
+// HERE 8 //        return false;
+// HERE 8 //    }
+// HERE 8 //
+// HERE 8 //    TRACELOG(LOG_TRACE, "DISPLAY: EGL configs available: %d", numConfigs);
+// HERE 8 //
+// HERE 8 //    EGLConfig *configs = RL_CALLOC(numConfigs, sizeof(*configs));
+// HERE 8 //    if (!configs)
+// HERE 8 //    {
+// HERE 8 //        TRACELOG(LOG_WARNING, "DISPLAY: Failed to get memory for EGL configs");
+// HERE 8 //        return false;
+// HERE 8 //    }
+// HERE 8 //
+// HERE 8 //    EGLint matchingNumConfigs = 0;
+// HERE 8 //    if (!eglChooseConfig(CORE.Window.device, framebufferAttribs, configs, numConfigs, &matchingNumConfigs))
+// HERE 8 //    {
+// HERE 8 //        TRACELOG(LOG_WARNING, "DISPLAY: Failed to choose EGL config: 0x%x", eglGetError());
+// HERE 8 //        free(configs);
+// HERE 8 //        return false;
+// HERE 8 //    }
+// HERE 8 //
+// HERE 8 //    TRACELOG(LOG_TRACE, "DISPLAY: EGL matching configs available: %d", matchingNumConfigs);
+// HERE 8 //
+// HERE 8 //    // find the EGL config that matches the previously setup GBM format
+// HERE 8 //    int found = 0;
+// HERE 8 //    for (EGLint i = 0; i < matchingNumConfigs; ++i)
+// HERE 8 //    {
+// HERE 8 //        EGLint id = 0;
+// HERE 8 //        if (!eglGetConfigAttrib(CORE.Window.device, configs[i], EGL_NATIVE_VISUAL_ID, &id))
+// HERE 8 //        {
+// HERE 8 //            TRACELOG(LOG_WARNING, "DISPLAY: Failed to get EGL config attribute: 0x%x", eglGetError());
+// HERE 8 //            continue;
+// HERE 8 //        }
+// HERE 8 //
+// HERE 8 //        if (GBM_FORMAT_ARGB8888 == id)
+// HERE 8 //        {
+// HERE 8 //            TRACELOG(LOG_TRACE, "DISPLAY: Using EGL config: %d", i);
+// HERE 8 //            CORE.Window.config = configs[i];
+// HERE 8 //            found = 1;
+// HERE 8 //            break;
+// HERE 8 //        }
+// HERE 8 //    }
+// HERE 8 //
+// HERE 8 //    RL_FREE(configs);
+// HERE 8 //
+// HERE 8 //    if (!found)
+// HERE 8 //    {
+// HERE 8 //        TRACELOG(LOG_WARNING, "DISPLAY: Failed to find a suitable EGL config");
+// HERE 8 //        return false;
+// HERE 8 //    }
+// HERE 8 //#else
     // Get an appropriate EGL framebuffer configuration
     eglChooseConfig(CORE.Window.device, framebufferAttribs, &CORE.Window.config, 1, &numConfigs);
-#endif
+// HERE 8 //#endif
 
     // Set rendering API
     eglBindAPI(EGL_OPENGL_ES_API);
@@ -767,11 +767,11 @@ static bool InitGraphicsDevice(int width, int height)
         TRACELOG(LOG_WARNING, "DISPLAY: Failed to create EGL context");
         return false;
     }
-#endif
+// HERE 6 //#endif
 
     // Create an EGL window surface
     //---------------------------------------------------------------------------------
-#if defined(PLATFORM_ANDROID)
+// HERE 9 //#if defined(PLATFORM_ANDROID)
     EGLint displayFormat = 0;
 
     // EGL_NATIVE_VISUAL_ID is an attribute of the EGLConfig that is guaranteed to be accepted by ANativeWindow_setBuffersGeometry()
@@ -789,23 +789,23 @@ static bool InitGraphicsDevice(int width, int height)
     //ANativeWindow_setBuffersGeometry(CORE.Android.app->window, 0, 0, displayFormat);       // Force use of native display size
 
     CORE.Window.surface = eglCreateWindowSurface(CORE.Window.device, CORE.Window.config, CORE.Android.app->window, NULL);
-#endif  // PLATFORM_ANDROID
+// HERE 9 //#endif  // PLATFORM_ANDROID
 
-#if defined(PLATFORM_DRM)
-    CORE.Window.surface = eglCreateWindowSurface(CORE.Window.device, CORE.Window.config, (EGLNativeWindowType)CORE.Window.gbmSurface, NULL);
-    if (EGL_NO_SURFACE == CORE.Window.surface)
-    {
-        TRACELOG(LOG_WARNING, "DISPLAY: Failed to create EGL window surface: 0x%04x", eglGetError());
-        return false;
-    }
-
-    // At this point we need to manage render size vs screen size
-    // NOTE: This function use and modify global module variables:
-    //  -> CORE.Window.screen.width/CORE.Window.screen.height
-    //  -> CORE.Window.render.width/CORE.Window.render.height
-    //  -> CORE.Window.screenScale
-    SetupFramebuffer(CORE.Window.display.width, CORE.Window.display.height);
-#endif  // PLATFORM_DRM
+// HERE 10 //#if defined(PLATFORM_DRM)
+// HERE 10 //    CORE.Window.surface = eglCreateWindowSurface(CORE.Window.device, CORE.Window.config, (EGLNativeWindowType)CORE.Window.gbmSurface, NULL);
+// HERE 10 //    if (EGL_NO_SURFACE == CORE.Window.surface)
+// HERE 10 //    {
+// HERE 10 //        TRACELOG(LOG_WARNING, "DISPLAY: Failed to create EGL window surface: 0x%04x", eglGetError());
+// HERE 10 //        return false;
+// HERE 10 //    }
+// HERE 10 //
+// HERE 10 //    // At this point we need to manage render size vs screen size
+// HERE 10 //    // NOTE: This function use and modify global module variables:
+// HERE 10 //    //  -> CORE.Window.screen.width/CORE.Window.screen.height
+// HERE 10 //    //  -> CORE.Window.render.width/CORE.Window.render.height
+// HERE 10 //    //  -> CORE.Window.screenScale
+// HERE 10 //    SetupFramebuffer(CORE.Window.display.width, CORE.Window.display.height);
+// HERE 10 //#endif  // PLATFORM_DRM
 
     // There must be at least one frame displayed before the buffers are swapped
     //eglSwapInterval(CORE.Window.device, 1);
@@ -828,15 +828,15 @@ static bool InitGraphicsDevice(int width, int height)
         TRACELOG(LOG_INFO, "    > Render size:  %i x %i", CORE.Window.render.width, CORE.Window.render.height);
         TRACELOG(LOG_INFO, "    > Viewport offsets: %i, %i", CORE.Window.renderOffset.x, CORE.Window.renderOffset.y);
     }
-#endif  // PLATFORM_ANDROID || PLATFORM_DRM
+// HERE 2 //#endif  // PLATFORM_ANDROID || PLATFORM_DRM
 
     // Load OpenGL extensions
     // NOTE: GL procedures address loader is required to load extensions
-#if defined(PLATFORM_DESKTOP) || defined(PLATFORM_WEB)
-    rlLoadExtensions(glfwGetProcAddress);
-#else
+// HERE 11 //#if defined(PLATFORM_DESKTOP) || defined(PLATFORM_WEB)
+// HERE 11 //    rlLoadExtensions(glfwGetProcAddress);
+// HERE 11 //#else
     rlLoadExtensions(eglGetProcAddress);
-#endif
+// HERE 11 //#endif
 
     // Initialize OpenGL context (states and resources)
     // NOTE: CORE.Window.currentFbo.width and CORE.Window.currentFbo.height not used, just stored as globals in rlgl
@@ -846,9 +846,9 @@ static bool InitGraphicsDevice(int width, int height)
     // NOTE: It updated CORE.Window.render.width and CORE.Window.render.height
     SetupViewport(CORE.Window.currentFbo.width, CORE.Window.currentFbo.height);
 
-#if defined(PLATFORM_ANDROID)
+// HERE 12 //#if defined(PLATFORM_ANDROID)
     CORE.Window.ready = true;
-#endif
+// HERE 12 //#endif
 
     if ((CORE.Window.flags & FLAG_WINDOW_MINIMIZED) > 0) MinimizeWindow();
 

--- a/src/rcore_desktop.c
+++ b/src/rcore_desktop.c
@@ -711,7 +711,6 @@ void ToggleBorderlessWindowed(void)
                 glfwGetMonitorPos(monitors[monitor], &monitorPosX, &monitorPosY);
                 const int monitorWidth = mode->width;
                 const int monitorHeight = mode->height;
-                glfwSetWindowSize(CORE.Window.handle, monitorWidth, monitorHeight);
 
                 // Set screen position and size
                 glfwSetWindowPos(CORE.Window.handle, monitorPosX, monitorPosY);

--- a/src/rcore_desktop.c
+++ b/src/rcore_desktop.c
@@ -1496,16 +1496,6 @@ void OpenURL(const char *url)
     }
 }
 
-// Get gamepad internal name id
-const char *GetGamepadName(int gamepad)
-{
-    const char *name = NULL;
-
-    if (CORE.Input.Gamepad.ready[gamepad]) name = glfwGetJoystickName(gamepad);
-
-    return name;
-}
-
 // Get selected monitor physical width in millimetres
 int GetMonitorPhysicalWidth(int monitor)
 {
@@ -1520,6 +1510,16 @@ int GetMonitorPhysicalWidth(int monitor)
     }
     else TRACELOG(LOG_WARNING, "GLFW: Failed to find selected monitor");
     return 0;
+}
+
+// Get gamepad internal name id
+const char *GetGamepadName(int gamepad)
+{
+    const char *name = NULL;
+
+    if (CORE.Input.Gamepad.ready[gamepad]) name = glfwGetJoystickName(gamepad);
+
+    return name;
 }
 
 // Get gamepad axis count

--- a/src/rcore_desktop.c
+++ b/src/rcore_desktop.c
@@ -1149,11 +1149,11 @@ static void ErrorCallback(int error, const char *description)
 // Get native window handle
 void *GetWindowHandle(void)
 {
-#if defined(PLATFORM_DESKTOP) && defined(_WIN32)
+#if defined(_WIN32)
     // NOTE: Returned handle is: void *HWND (windows.h)
     return glfwGetWin32Window(CORE.Window.handle);
 #endif
-#if defined(PLATFORM_DESKTOP) && defined(__linux__)
+#if defined(__linux__)
     // NOTE: Returned handle is: unsigned long Window (X.h)
     // typedef unsigned long XID;
     // typedef XID Window;

--- a/src/rcore_web.c
+++ b/src/rcore_web.c
@@ -1041,6 +1041,8 @@ int GetMonitorPhysicalWidth(int monitor)
     return 0;
 }
 
+// NOTE: Gamepad support not implemented in emscripten GLFW3 (PLATFORM_WEB)
+
 // Get gamepad internal name id
 const char *GetGamepadName(int gamepad)
 {

--- a/src/rcore_web.c
+++ b/src/rcore_web.c
@@ -1035,6 +1035,12 @@ void OpenURL(const char *url)
     }
 }
 
+// Get selected monitor physical width in millimetres
+int GetMonitorPhysicalWidth(int monitor)
+{
+    return 0;
+}
+
 // Get gamepad internal name id
 const char *GetGamepadName(int gamepad)
 {
@@ -1043,12 +1049,6 @@ const char *GetGamepadName(int gamepad)
     name = CORE.Input.Gamepad.name[gamepad];
 
     return name;
-}
-
-// Get selected monitor physical width in millimetres
-int GetMonitorPhysicalWidth(int monitor)
-{
-    return 0;
 }
 
 // Get gamepad axis count
@@ -1060,6 +1060,8 @@ int GetGamepadAxisCount(int gamepad)
 // Set internal gamepad mappings
 int SetGamepadMappings(const char *mappings)
 {
+    TRACELOG(LOG_INFO, "SetGamepadMappings not implemented in rcore_web.c");
+
     return 0;
 }
 


### PR DESCRIPTION
### PR changes
1. Fixes `ToggleBorderlessWindowed` duplicated `glfwSetWindowSize` calls as per https://github.com/raysan5/raylib/pull/3216#discussion_r1334832946.
On `rcore_desktop.c`: [L714](https://github.com/raysan5/raylib/pull/3343/files#diff-10e13300b4588e538a0c2c603707242b63d716e3ab2b80b81db9a54c308ca3acL714).

2. First and second passes to remove unneeded platform macros for `PLATFORM_ANDROID`.
On `rcore_android.c`: [L148-L477](https://github.com/raysan5/raylib/pull/3343/files#diff-df7f2529f920b22e7f3b28d8c53b9042fe9ba3e0c4be0a421ac8d9e0c3bde72dL148-L477), [L479](https://github.com/raysan5/raylib/pull/3343/files#diff-df7f2529f920b22e7f3b28d8c53b9042fe9ba3e0c4be0a421ac8d9e0c3bde72dL479), [L483-L642](https://github.com/raysan5/raylib/pull/3343/files#diff-df7f2529f920b22e7f3b28d8c53b9042fe9ba3e0c4be0a421ac8d9e0c3bde72dL483-L642), [L656-L658](https://github.com/raysan5/raylib/pull/3343/files#diff-df7f2529f920b22e7f3b28d8c53b9042fe9ba3e0c4be0a421ac8d9e0c3bde72dL656-L658), [L662-L664](https://github.com/raysan5/raylib/pull/3343/files#diff-df7f2529f920b22e7f3b28d8c53b9042fe9ba3e0c4be0a421ac8d9e0c3bde72dL662-L664), [L679](https://github.com/raysan5/raylib/pull/3343/files#diff-df7f2529f920b22e7f3b28d8c53b9042fe9ba3e0c4be0a421ac8d9e0c3bde72dL679), [L683-L685](https://github.com/raysan5/raylib/pull/3343/files#diff-df7f2529f920b22e7f3b28d8c53b9042fe9ba3e0c4be0a421ac8d9e0c3bde72dL683-L685), [L687](https://github.com/raysan5/raylib/pull/3343/files#diff-df7f2529f920b22e7f3b28d8c53b9042fe9ba3e0c4be0a421ac8d9e0c3bde72dL687), [L702-L755](https://github.com/raysan5/raylib/pull/3343/files#diff-df7f2529f920b22e7f3b28d8c53b9042fe9ba3e0c4be0a421ac8d9e0c3bde72dL702-L755), [L758](https://github.com/raysan5/raylib/pull/3343/files#diff-df7f2529f920b22e7f3b28d8c53b9042fe9ba3e0c4be0a421ac8d9e0c3bde72dL758), [L770](https://github.com/raysan5/raylib/pull/3343/files#diff-df7f2529f920b22e7f3b28d8c53b9042fe9ba3e0c4be0a421ac8d9e0c3bde72dL770), [L774](https://github.com/raysan5/raylib/pull/3343/files#diff-df7f2529f920b22e7f3b28d8c53b9042fe9ba3e0c4be0a421ac8d9e0c3bde72dL774), [L792](https://github.com/raysan5/raylib/pull/3343/files#diff-df7f2529f920b22e7f3b28d8c53b9042fe9ba3e0c4be0a421ac8d9e0c3bde72dL792), [L794-L808](https://github.com/raysan5/raylib/pull/3343/files#diff-df7f2529f920b22e7f3b28d8c53b9042fe9ba3e0c4be0a421ac8d9e0c3bde72dL794-L808), [L831](https://github.com/raysan5/raylib/pull/3343/files#diff-df7f2529f920b22e7f3b28d8c53b9042fe9ba3e0c4be0a421ac8d9e0c3bde72dL831), [L835-L837](https://github.com/raysan5/raylib/pull/3343/files#diff-df7f2529f920b22e7f3b28d8c53b9042fe9ba3e0c4be0a421ac8d9e0c3bde72dL835-L837), [L839](https://github.com/raysan5/raylib/pull/3343/files#diff-df7f2529f920b22e7f3b28d8c53b9042fe9ba3e0c4be0a421ac8d9e0c3bde72dL839), [L849](https://github.com/raysan5/raylib/pull/3343/files#diff-df7f2529f920b22e7f3b28d8c53b9042fe9ba3e0c4be0a421ac8d9e0c3bde72dL849), [L851](https://github.com/raysan5/raylib/pull/3343/files#diff-df7f2529f920b22e7f3b28d8c53b9042fe9ba3e0c4be0a421ac8d9e0c3bde72dL851).

3. See item 2 above.

4. Removes unneeded platform macros for `PLATFORM_DESKTOP`.
On `rcore_desktop.c`: [L1153](https://github.com/raysan5/raylib/pull/3343/files#diff-10e13300b4588e538a0c2c603707242b63d716e3ab2b80b81db9a54c308ca3acL1153), [L1157](https://github.com/raysan5/raylib/pull/3343/files#diff-10e13300b4588e538a0c2c603707242b63d716e3ab2b80b81db9a54c308ca3acL1157).

5. Relocate `GetGamepadName`.
On `rcore_android.c`: from [L1631-L1636](https://github.com/raysan5/raylib/pull/3343/files#diff-df7f2529f920b22e7f3b28d8c53b9042fe9ba3e0c4be0a421ac8d9e0c3bde72dL1631-L1636) to [R1052-R1058](https://github.com/raysan5/raylib/pull/3343/files#diff-df7f2529f920b22e7f3b28d8c53b9042fe9ba3e0c4be0a421ac8d9e0c3bde72dR1052-R1058).
On `rcore_desktop.c`: from [L1500-L1508](https://github.com/raysan5/raylib/pull/3343/files#diff-10e13300b4588e538a0c2c603707242b63d716e3ab2b80b81db9a54c308ca3acL1500-L1508) to [R1515-R1523](https://github.com/raysan5/raylib/pull/3343/files#diff-10e13300b4588e538a0c2c603707242b63d716e3ab2b80b81db9a54c308ca3acR1515-R1523).
On `rcore_web.c`: [R1038-L1052](https://github.com/raysan5/raylib/pull/3343/files#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdR1038-L1052).
Added tracelog error message to `GetGamepadName`.
On `rcore_android.c`: [R1055](https://github.com/raysan5/raylib/pull/3343/files#diff-df7f2529f920b22e7f3b28d8c53b9042fe9ba3e0c4be0a421ac8d9e0c3bde72dR1055).
Added tracelog error message to `SetGamepadMappings`.
On `rcore_android.c`: [R1069](https://github.com/raysan5/raylib/pull/3343/files#diff-df7f2529f920b22e7f3b28d8c53b9042fe9ba3e0c4be0a421ac8d9e0c3bde72dR1069).
On `rcore_web.c`: [R1065](https://github.com/raysan5/raylib/pull/3343/files#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdR1065).

6. Added the missing comment about gamepad on web.
On `rcore_web.c`: [R1044](https://github.com/raysan5/raylib/pull/3343/files#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdR1044).

### Status
- #3339

### Environment
- Compiled with `emscripten/emsdk` on Linux (Mint 21.1 64-bit).
- Tested on Firefox (115.1.0esr 64-bit) and Chromium (115.0.5790.170 64-bit) both running on Linux Mint (21.1 64-bit).

### Edits
**1:** added line marks.
**2:** added first pass.
**3:** added second pass; added line marks.
**4:** added removal of platform macros for desktop; editing; formatting.
**5:** added relocate and updates.
**6:** added missing comment.