### PR TITLE
[split] `rcore`, `web`, `desktop`, `android` changes (batch 5)

### DIFF
--- a/src/rcore.c
+++ b/src/rcore.c
@@ -1937,14 +1937,14 @@ int GetCharPressed(void)
     return value;
 }
 
-// Set a custom key to exit program
-// NOTE: default exitKey is ESCAPE
-void SetExitKey(int key)
-{
-#if !defined(PLATFORM_ANDROID)
-    CORE.Input.Keyboard.exitKey = key;
-#endif
-}
+//// Set a custom key to exit program
+//// NOTE: default exitKey is ESCAPE
+//void SetExitKey(int key)
+//{
+//#if !defined(PLATFORM_ANDROID)
+//    CORE.Input.Keyboard.exitKey = key;
+//#endif
+//}
 
 // NOTE: Gamepad support not implemented in emscripten GLFW3 (PLATFORM_WEB)
 

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -828,7 +828,7 @@ VrStereoConfig LoadVrStereoConfig(VrDeviceInfo device)
 // Unload VR stereo config properties
 void UnloadVrStereoConfig(VrStereoConfig config)
 {
-    //...
+    TRACELOG(LOG_INFO, "UnloadVrStereoConfig not implemented in rcore.c");
 }
 
 // Load shader from files and bind default locations

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -2446,279 +2446,279 @@ static void ScanDirectoryFilesRecursively(const char *basePath, FilePathList *fi
     else TRACELOG(LOG_WARNING, "FILEIO: Directory cannot be opened (%s)", basePath);
 }
 
-#if defined(PLATFORM_DESKTOP) || defined(PLATFORM_WEB)
-
-// GLFW3 WindowSize Callback, runs when window is resizedLastFrame
-// NOTE: Window resizing not allowed by default
-static void WindowSizeCallback(GLFWwindow *window, int width, int height)
-{
-    // Reset viewport and projection matrix for new size
-    SetupViewport(width, height);
-
-    CORE.Window.currentFbo.width = width;
-    CORE.Window.currentFbo.height = height;
-    CORE.Window.resizedLastFrame = true;
-
-    if (IsWindowFullscreen()) return;
-
-    // Set current screen size
-#if defined(__APPLE__)
-    CORE.Window.screen.width = width;
-    CORE.Window.screen.height = height;
-#else
-    if ((CORE.Window.flags & FLAG_WINDOW_HIGHDPI) > 0)
-    {
-        Vector2 windowScaleDPI = GetWindowScaleDPI();
-
-        CORE.Window.screen.width = (unsigned int)(width/windowScaleDPI.x);
-        CORE.Window.screen.height = (unsigned int)(height/windowScaleDPI.y);
-    }
-    else
-    {
-        CORE.Window.screen.width = width;
-        CORE.Window.screen.height = height;
-    }
-#endif
-
-    // NOTE: Postprocessing texture is not scaled to new size
-}
-
-// GLFW3 WindowIconify Callback, runs when window is minimized/restored
-static void WindowIconifyCallback(GLFWwindow *window, int iconified)
-{
-    if (iconified) CORE.Window.flags |= FLAG_WINDOW_MINIMIZED;  // The window was iconified
-    else CORE.Window.flags &= ~FLAG_WINDOW_MINIMIZED;           // The window was restored
-}
-
-// GLFW3 WindowFocus Callback, runs when window get/lose focus
-static void WindowFocusCallback(GLFWwindow *window, int focused)
-{
-    if (focused) CORE.Window.flags &= ~FLAG_WINDOW_UNFOCUSED;   // The window was focused
-    else CORE.Window.flags |= FLAG_WINDOW_UNFOCUSED;            // The window lost focus
-}
-
-// GLFW3 Keyboard Callback, runs on key pressed
-static void KeyCallback(GLFWwindow *window, int key, int scancode, int action, int mods)
-{
-    if (key < 0) return;    // Security check, macOS fn key generates -1
-
-    // WARNING: GLFW could return GLFW_REPEAT, we need to consider it as 1
-    // to work properly with our implementation (IsKeyDown/IsKeyUp checks)
-    if (action == GLFW_RELEASE) CORE.Input.Keyboard.currentKeyState[key] = 0;
-    else if(action == GLFW_PRESS) CORE.Input.Keyboard.currentKeyState[key] = 1;
-    else if(action == GLFW_REPEAT) CORE.Input.Keyboard.keyRepeatInFrame[key] = 1;
-
-#if !defined(PLATFORM_WEB)
-    // WARNING: Check if CAPS/NUM key modifiers are enabled and force down state for those keys
-    if (((key == KEY_CAPS_LOCK) && ((mods & GLFW_MOD_CAPS_LOCK) > 0)) ||
-        ((key == KEY_NUM_LOCK) && ((mods & GLFW_MOD_NUM_LOCK) > 0))) CORE.Input.Keyboard.currentKeyState[key] = 1;
-#endif
-
-    // Check if there is space available in the key queue
-    if ((CORE.Input.Keyboard.keyPressedQueueCount < MAX_KEY_PRESSED_QUEUE) && (action == GLFW_PRESS))
-    {
-        // Add character to the queue
-        CORE.Input.Keyboard.keyPressedQueue[CORE.Input.Keyboard.keyPressedQueueCount] = key;
-        CORE.Input.Keyboard.keyPressedQueueCount++;
-    }
-
-    // Check the exit key to set close window
-    if ((key == CORE.Input.Keyboard.exitKey) && (action == GLFW_PRESS)) glfwSetWindowShouldClose(CORE.Window.handle, GLFW_TRUE);
-
-#if defined(SUPPORT_SCREEN_CAPTURE)
-    if ((key == GLFW_KEY_F12) && (action == GLFW_PRESS))
-    {
-#if defined(SUPPORT_GIF_RECORDING)
-        if (mods & GLFW_MOD_CONTROL)
-        {
-            if (gifRecording)
-            {
-                gifRecording = false;
-
-                MsfGifResult result = msf_gif_end(&gifState);
-
-                SaveFileData(TextFormat("%s/screenrec%03i.gif", CORE.Storage.basePath, screenshotCounter), result.data, (unsigned int)result.dataSize);
-                msf_gif_free(result);
-
-            #if defined(PLATFORM_WEB)
-                // Download file from MEMFS (emscripten memory filesystem)
-                // saveFileFromMEMFSToDisk() function is defined in raylib/templates/web_shel/shell.html
-                emscripten_run_script(TextFormat("saveFileFromMEMFSToDisk('%s','%s')", TextFormat("screenrec%03i.gif", screenshotCounter - 1), TextFormat("screenrec%03i.gif", screenshotCounter - 1)));
-            #endif
-
-                TRACELOG(LOG_INFO, "SYSTEM: Finish animated GIF recording");
-            }
-            else
-            {
-                gifRecording = true;
-                gifFrameCounter = 0;
-
-                Vector2 scale = GetWindowScaleDPI();
-                msf_gif_begin(&gifState, (int)((float)CORE.Window.render.width*scale.x), (int)((float)CORE.Window.render.height*scale.y));
-                screenshotCounter++;
-
-                TRACELOG(LOG_INFO, "SYSTEM: Start animated GIF recording: %s", TextFormat("screenrec%03i.gif", screenshotCounter));
-            }
-        }
-        else
-#endif  // SUPPORT_GIF_RECORDING
-        {
-            TakeScreenshot(TextFormat("screenshot%03i.png", screenshotCounter));
-            screenshotCounter++;
-        }
-    }
-#endif  // SUPPORT_SCREEN_CAPTURE
-
-#if defined(SUPPORT_EVENTS_AUTOMATION)
-    if ((key == GLFW_KEY_F11) && (action == GLFW_PRESS))
-    {
-        eventsRecording = !eventsRecording;
-
-        // On finish recording, we export events into a file
-        if (!eventsRecording) ExportAutomationEvents("eventsrec.rep");
-    }
-    else if ((key == GLFW_KEY_F9) && (action == GLFW_PRESS))
-    {
-        LoadAutomationEvents("eventsrec.rep");
-        eventsPlaying = true;
-
-        TRACELOG(LOG_WARNING, "eventsPlaying enabled!");
-    }
-#endif
-}
-
-// GLFW3 Char Key Callback, runs on key down (gets equivalent unicode char value)
-static void CharCallback(GLFWwindow *window, unsigned int key)
-{
-    //TRACELOG(LOG_DEBUG, "Char Callback: KEY:%i(%c)", key, key);
-
-    // NOTE: Registers any key down considering OS keyboard layout but
-    // does not detect action events, those should be managed by user...
-    // Ref: https://github.com/glfw/glfw/issues/668#issuecomment-166794907
-    // Ref: https://www.glfw.org/docs/latest/input_guide.html#input_char
-
-    // Check if there is space available in the queue
-    if (CORE.Input.Keyboard.charPressedQueueCount < MAX_CHAR_PRESSED_QUEUE)
-    {
-        // Add character to the queue
-        CORE.Input.Keyboard.charPressedQueue[CORE.Input.Keyboard.charPressedQueueCount] = key;
-        CORE.Input.Keyboard.charPressedQueueCount++;
-    }
-}
-
-// GLFW3 Mouse Button Callback, runs on mouse button pressed
-static void MouseButtonCallback(GLFWwindow *window, int button, int action, int mods)
-{
-    // WARNING: GLFW could only return GLFW_PRESS (1) or GLFW_RELEASE (0) for now,
-    // but future releases may add more actions (i.e. GLFW_REPEAT)
-    CORE.Input.Mouse.currentButtonState[button] = action;
-
-#if defined(SUPPORT_GESTURES_SYSTEM) && defined(SUPPORT_MOUSE_GESTURES)         // PLATFORM_DESKTOP
-    // Process mouse events as touches to be able to use mouse-gestures
-    GestureEvent gestureEvent = { 0 };
-
-    // Register touch actions
-    if ((CORE.Input.Mouse.currentButtonState[button] == 1) && (CORE.Input.Mouse.previousButtonState[button] == 0)) gestureEvent.touchAction = TOUCH_ACTION_DOWN;
-    else if ((CORE.Input.Mouse.currentButtonState[button] == 0) && (CORE.Input.Mouse.previousButtonState[button] == 1)) gestureEvent.touchAction = TOUCH_ACTION_UP;
-
-    // NOTE: TOUCH_ACTION_MOVE event is registered in MouseCursorPosCallback()
-
-    // Assign a pointer ID
-    gestureEvent.pointId[0] = 0;
-
-    // Register touch points count
-    gestureEvent.pointCount = 1;
-
-    // Register touch points position, only one point registered
-    gestureEvent.position[0] = GetMousePosition();
-
-    // Normalize gestureEvent.position[0] for CORE.Window.screen.width and CORE.Window.screen.height
-    gestureEvent.position[0].x /= (float)GetScreenWidth();
-    gestureEvent.position[0].y /= (float)GetScreenHeight();
-
-    // Gesture data is sent to gestures-system for processing
-#if defined(PLATFORM_WEB)
-    // Prevent calling ProcessGestureEvent() when Emscripten is present and there's a touch gesture, so EmscriptenTouchCallback() can handle it itself
-    if (GetMouseX() != 0 || GetMouseY() != 0) ProcessGestureEvent(gestureEvent);
-#else
-    ProcessGestureEvent(gestureEvent);
-#endif
-
-#endif
-}
-
-// GLFW3 Cursor Position Callback, runs on mouse move
-static void MouseCursorPosCallback(GLFWwindow *window, double x, double y)
-{
-    CORE.Input.Mouse.currentPosition.x = (float)x;
-    CORE.Input.Mouse.currentPosition.y = (float)y;
-    CORE.Input.Touch.position[0] = CORE.Input.Mouse.currentPosition;
-
-#if defined(SUPPORT_GESTURES_SYSTEM) && defined(SUPPORT_MOUSE_GESTURES)         // PLATFORM_DESKTOP
-    // Process mouse events as touches to be able to use mouse-gestures
-    GestureEvent gestureEvent = { 0 };
-
-    gestureEvent.touchAction = TOUCH_ACTION_MOVE;
-
-    // Assign a pointer ID
-    gestureEvent.pointId[0] = 0;
-
-    // Register touch points count
-    gestureEvent.pointCount = 1;
-
-    // Register touch points position, only one point registered
-    gestureEvent.position[0] = CORE.Input.Touch.position[0];
-
-    // Normalize gestureEvent.position[0] for CORE.Window.screen.width and CORE.Window.screen.height
-    gestureEvent.position[0].x /= (float)GetScreenWidth();
-    gestureEvent.position[0].y /= (float)GetScreenHeight();
-
-    // Gesture data is sent to gestures-system for processing
-    ProcessGestureEvent(gestureEvent);
-#endif
-}
-
-// GLFW3 Scrolling Callback, runs on mouse wheel
-static void MouseScrollCallback(GLFWwindow *window, double xoffset, double yoffset)
-{
-    CORE.Input.Mouse.currentWheelMove = (Vector2){ (float)xoffset, (float)yoffset };
-}
-
-// GLFW3 CursorEnter Callback, when cursor enters the window
-static void CursorEnterCallback(GLFWwindow *window, int enter)
-{
-    if (enter == true) CORE.Input.Mouse.cursorOnScreen = true;
-    else CORE.Input.Mouse.cursorOnScreen = false;
-}
-
-// GLFW3 Window Drop Callback, runs when drop files into window
-static void WindowDropCallback(GLFWwindow *window, int count, const char **paths)
-{
-    if (count > 0)
-    {
-        // In case previous dropped filepaths have not been freed, we free them
-        if (CORE.Window.dropFileCount > 0)
-        {
-            for (unsigned int i = 0; i < CORE.Window.dropFileCount; i++) RL_FREE(CORE.Window.dropFilepaths[i]);
-
-            RL_FREE(CORE.Window.dropFilepaths);
-
-            CORE.Window.dropFileCount = 0;
-            CORE.Window.dropFilepaths = NULL;
-        }
-
-        // WARNING: Paths are freed by GLFW when the callback returns, we must keep an internal copy
-        CORE.Window.dropFileCount = count;
-        CORE.Window.dropFilepaths = (char **)RL_CALLOC(CORE.Window.dropFileCount, sizeof(char *));
-
-        for (unsigned int i = 0; i < CORE.Window.dropFileCount; i++)
-        {
-            CORE.Window.dropFilepaths[i] = (char *)RL_CALLOC(MAX_FILEPATH_LENGTH, sizeof(char));
-            strcpy(CORE.Window.dropFilepaths[i], paths[i]);
-        }
-    }
-}
-#endif
+//#if defined(PLATFORM_DESKTOP) || defined(PLATFORM_WEB)
+//
+//// GLFW3 WindowSize Callback, runs when window is resizedLastFrame
+//// NOTE: Window resizing not allowed by default
+//static void WindowSizeCallback(GLFWwindow *window, int width, int height)
+//{
+//    // Reset viewport and projection matrix for new size
+//    SetupViewport(width, height);
+//
+//    CORE.Window.currentFbo.width = width;
+//    CORE.Window.currentFbo.height = height;
+//    CORE.Window.resizedLastFrame = true;
+//
+//    if (IsWindowFullscreen()) return;
+//
+//    // Set current screen size
+//#if defined(__APPLE__)
+//    CORE.Window.screen.width = width;
+//    CORE.Window.screen.height = height;
+//#else
+//    if ((CORE.Window.flags & FLAG_WINDOW_HIGHDPI) > 0)
+//    {
+//        Vector2 windowScaleDPI = GetWindowScaleDPI();
+//
+//        CORE.Window.screen.width = (unsigned int)(width/windowScaleDPI.x);
+//        CORE.Window.screen.height = (unsigned int)(height/windowScaleDPI.y);
+//    }
+//    else
+//    {
+//        CORE.Window.screen.width = width;
+//        CORE.Window.screen.height = height;
+//    }
+//#endif
+//
+//    // NOTE: Postprocessing texture is not scaled to new size
+//}
+//
+//// GLFW3 WindowIconify Callback, runs when window is minimized/restored
+//static void WindowIconifyCallback(GLFWwindow *window, int iconified)
+//{
+//    if (iconified) CORE.Window.flags |= FLAG_WINDOW_MINIMIZED;  // The window was iconified
+//    else CORE.Window.flags &= ~FLAG_WINDOW_MINIMIZED;           // The window was restored
+//}
+//
+//// GLFW3 WindowFocus Callback, runs when window get/lose focus
+//static void WindowFocusCallback(GLFWwindow *window, int focused)
+//{
+//    if (focused) CORE.Window.flags &= ~FLAG_WINDOW_UNFOCUSED;   // The window was focused
+//    else CORE.Window.flags |= FLAG_WINDOW_UNFOCUSED;            // The window lost focus
+//}
+//
+//// GLFW3 Keyboard Callback, runs on key pressed
+//static void KeyCallback(GLFWwindow *window, int key, int scancode, int action, int mods)
+//{
+//    if (key < 0) return;    // Security check, macOS fn key generates -1
+//
+//    // WARNING: GLFW could return GLFW_REPEAT, we need to consider it as 1
+//    // to work properly with our implementation (IsKeyDown/IsKeyUp checks)
+//    if (action == GLFW_RELEASE) CORE.Input.Keyboard.currentKeyState[key] = 0;
+//    else if(action == GLFW_PRESS) CORE.Input.Keyboard.currentKeyState[key] = 1;
+//    else if(action == GLFW_REPEAT) CORE.Input.Keyboard.keyRepeatInFrame[key] = 1;
+//
+//#if !defined(PLATFORM_WEB)
+//    // WARNING: Check if CAPS/NUM key modifiers are enabled and force down state for those keys
+//    if (((key == KEY_CAPS_LOCK) && ((mods & GLFW_MOD_CAPS_LOCK) > 0)) ||
+//        ((key == KEY_NUM_LOCK) && ((mods & GLFW_MOD_NUM_LOCK) > 0))) CORE.Input.Keyboard.currentKeyState[key] = 1;
+//#endif
+//
+//    // Check if there is space available in the key queue
+//    if ((CORE.Input.Keyboard.keyPressedQueueCount < MAX_KEY_PRESSED_QUEUE) && (action == GLFW_PRESS))
+//    {
+//        // Add character to the queue
+//        CORE.Input.Keyboard.keyPressedQueue[CORE.Input.Keyboard.keyPressedQueueCount] = key;
+//        CORE.Input.Keyboard.keyPressedQueueCount++;
+//    }
+//
+//    // Check the exit key to set close window
+//    if ((key == CORE.Input.Keyboard.exitKey) && (action == GLFW_PRESS)) glfwSetWindowShouldClose(CORE.Window.handle, GLFW_TRUE);
+//
+//#if defined(SUPPORT_SCREEN_CAPTURE)
+//    if ((key == GLFW_KEY_F12) && (action == GLFW_PRESS))
+//    {
+//#if defined(SUPPORT_GIF_RECORDING)
+//        if (mods & GLFW_MOD_CONTROL)
+//        {
+//            if (gifRecording)
+//            {
+//                gifRecording = false;
+//
+//                MsfGifResult result = msf_gif_end(&gifState);
+//
+//                SaveFileData(TextFormat("%s/screenrec%03i.gif", CORE.Storage.basePath, screenshotCounter), result.data, (unsigned int)result.dataSize);
+//                msf_gif_free(result);
+//
+//            #if defined(PLATFORM_WEB)
+//                // Download file from MEMFS (emscripten memory filesystem)
+//                // saveFileFromMEMFSToDisk() function is defined in raylib/templates/web_shel/shell.html
+//                emscripten_run_script(TextFormat("saveFileFromMEMFSToDisk('%s','%s')", TextFormat("screenrec%03i.gif", screenshotCounter - 1), TextFormat("screenrec%03i.gif", screenshotCounter - 1)));
+//            #endif
+//
+//                TRACELOG(LOG_INFO, "SYSTEM: Finish animated GIF recording");
+//            }
+//            else
+//            {
+//                gifRecording = true;
+//                gifFrameCounter = 0;
+//
+//                Vector2 scale = GetWindowScaleDPI();
+//                msf_gif_begin(&gifState, (int)((float)CORE.Window.render.width*scale.x), (int)((float)CORE.Window.render.height*scale.y));
+//                screenshotCounter++;
+//
+//                TRACELOG(LOG_INFO, "SYSTEM: Start animated GIF recording: %s", TextFormat("screenrec%03i.gif", screenshotCounter));
+//            }
+//        }
+//        else
+//#endif  // SUPPORT_GIF_RECORDING
+//        {
+//            TakeScreenshot(TextFormat("screenshot%03i.png", screenshotCounter));
+//            screenshotCounter++;
+//        }
+//    }
+//#endif  // SUPPORT_SCREEN_CAPTURE
+//
+//#if defined(SUPPORT_EVENTS_AUTOMATION)
+//    if ((key == GLFW_KEY_F11) && (action == GLFW_PRESS))
+//    {
+//        eventsRecording = !eventsRecording;
+//
+//        // On finish recording, we export events into a file
+//        if (!eventsRecording) ExportAutomationEvents("eventsrec.rep");
+//    }
+//    else if ((key == GLFW_KEY_F9) && (action == GLFW_PRESS))
+//    {
+//        LoadAutomationEvents("eventsrec.rep");
+//        eventsPlaying = true;
+//
+//        TRACELOG(LOG_WARNING, "eventsPlaying enabled!");
+//    }
+//#endif
+//}
+//
+//// GLFW3 Char Key Callback, runs on key down (gets equivalent unicode char value)
+//static void CharCallback(GLFWwindow *window, unsigned int key)
+//{
+//    //TRACELOG(LOG_DEBUG, "Char Callback: KEY:%i(%c)", key, key);
+//
+//    // NOTE: Registers any key down considering OS keyboard layout but
+//    // does not detect action events, those should be managed by user...
+//    // Ref: https://github.com/glfw/glfw/issues/668#issuecomment-166794907
+//    // Ref: https://www.glfw.org/docs/latest/input_guide.html#input_char
+//
+//    // Check if there is space available in the queue
+//    if (CORE.Input.Keyboard.charPressedQueueCount < MAX_CHAR_PRESSED_QUEUE)
+//    {
+//        // Add character to the queue
+//        CORE.Input.Keyboard.charPressedQueue[CORE.Input.Keyboard.charPressedQueueCount] = key;
+//        CORE.Input.Keyboard.charPressedQueueCount++;
+//    }
+//}
+//
+//// GLFW3 Mouse Button Callback, runs on mouse button pressed
+//static void MouseButtonCallback(GLFWwindow *window, int button, int action, int mods)
+//{
+//    // WARNING: GLFW could only return GLFW_PRESS (1) or GLFW_RELEASE (0) for now,
+//    // but future releases may add more actions (i.e. GLFW_REPEAT)
+//    CORE.Input.Mouse.currentButtonState[button] = action;
+//
+//#if defined(SUPPORT_GESTURES_SYSTEM) && defined(SUPPORT_MOUSE_GESTURES)         // PLATFORM_DESKTOP
+//    // Process mouse events as touches to be able to use mouse-gestures
+//    GestureEvent gestureEvent = { 0 };
+//
+//    // Register touch actions
+//    if ((CORE.Input.Mouse.currentButtonState[button] == 1) && (CORE.Input.Mouse.previousButtonState[button] == 0)) gestureEvent.touchAction = TOUCH_ACTION_DOWN;
+//    else if ((CORE.Input.Mouse.currentButtonState[button] == 0) && (CORE.Input.Mouse.previousButtonState[button] == 1)) gestureEvent.touchAction = TOUCH_ACTION_UP;
+//
+//    // NOTE: TOUCH_ACTION_MOVE event is registered in MouseCursorPosCallback()
+//
+//    // Assign a pointer ID
+//    gestureEvent.pointId[0] = 0;
+//
+//    // Register touch points count
+//    gestureEvent.pointCount = 1;
+//
+//    // Register touch points position, only one point registered
+//    gestureEvent.position[0] = GetMousePosition();
+//
+//    // Normalize gestureEvent.position[0] for CORE.Window.screen.width and CORE.Window.screen.height
+//    gestureEvent.position[0].x /= (float)GetScreenWidth();
+//    gestureEvent.position[0].y /= (float)GetScreenHeight();
+//
+//    // Gesture data is sent to gestures-system for processing
+//#if defined(PLATFORM_WEB)
+//    // Prevent calling ProcessGestureEvent() when Emscripten is present and there's a touch gesture, so EmscriptenTouchCallback() can handle it itself
+//    if (GetMouseX() != 0 || GetMouseY() != 0) ProcessGestureEvent(gestureEvent);
+//#else
+//    ProcessGestureEvent(gestureEvent);
+//#endif
+//
+//#endif
+//}
+//
+//// GLFW3 Cursor Position Callback, runs on mouse move
+//static void MouseCursorPosCallback(GLFWwindow *window, double x, double y)
+//{
+//    CORE.Input.Mouse.currentPosition.x = (float)x;
+//    CORE.Input.Mouse.currentPosition.y = (float)y;
+//    CORE.Input.Touch.position[0] = CORE.Input.Mouse.currentPosition;
+//
+//#if defined(SUPPORT_GESTURES_SYSTEM) && defined(SUPPORT_MOUSE_GESTURES)         // PLATFORM_DESKTOP
+//    // Process mouse events as touches to be able to use mouse-gestures
+//    GestureEvent gestureEvent = { 0 };
+//
+//    gestureEvent.touchAction = TOUCH_ACTION_MOVE;
+//
+//    // Assign a pointer ID
+//    gestureEvent.pointId[0] = 0;
+//
+//    // Register touch points count
+//    gestureEvent.pointCount = 1;
+//
+//    // Register touch points position, only one point registered
+//    gestureEvent.position[0] = CORE.Input.Touch.position[0];
+//
+//    // Normalize gestureEvent.position[0] for CORE.Window.screen.width and CORE.Window.screen.height
+//    gestureEvent.position[0].x /= (float)GetScreenWidth();
+//    gestureEvent.position[0].y /= (float)GetScreenHeight();
+//
+//    // Gesture data is sent to gestures-system for processing
+//    ProcessGestureEvent(gestureEvent);
+//#endif
+//}
+//
+//// GLFW3 Scrolling Callback, runs on mouse wheel
+//static void MouseScrollCallback(GLFWwindow *window, double xoffset, double yoffset)
+//{
+//    CORE.Input.Mouse.currentWheelMove = (Vector2){ (float)xoffset, (float)yoffset };
+//}
+//
+//// GLFW3 CursorEnter Callback, when cursor enters the window
+//static void CursorEnterCallback(GLFWwindow *window, int enter)
+//{
+//    if (enter == true) CORE.Input.Mouse.cursorOnScreen = true;
+//    else CORE.Input.Mouse.cursorOnScreen = false;
+//}
+//
+//// GLFW3 Window Drop Callback, runs when drop files into window
+//static void WindowDropCallback(GLFWwindow *window, int count, const char **paths)
+//{
+//    if (count > 0)
+//    {
+//        // In case previous dropped filepaths have not been freed, we free them
+//        if (CORE.Window.dropFileCount > 0)
+//        {
+//            for (unsigned int i = 0; i < CORE.Window.dropFileCount; i++) RL_FREE(CORE.Window.dropFilepaths[i]);
+//
+//            RL_FREE(CORE.Window.dropFilepaths);
+//
+//            CORE.Window.dropFileCount = 0;
+//            CORE.Window.dropFilepaths = NULL;
+//        }
+//
+//        // WARNING: Paths are freed by GLFW when the callback returns, we must keep an internal copy
+//        CORE.Window.dropFileCount = count;
+//        CORE.Window.dropFilepaths = (char **)RL_CALLOC(CORE.Window.dropFileCount, sizeof(char *));
+//
+//        for (unsigned int i = 0; i < CORE.Window.dropFileCount; i++)
+//        {
+//            CORE.Window.dropFilepaths[i] = (char *)RL_CALLOC(MAX_FILEPATH_LENGTH, sizeof(char));
+//            strcpy(CORE.Window.dropFilepaths[i], paths[i]);
+//        }
+//    }
+//}
+//#endif
 
 #if defined(PLATFORM_DRM)
 // Initialize Keyboard system (using standard input)

--- a/src/rcore_android.c
+++ b/src/rcore_android.c
@@ -270,6 +270,350 @@ static bool InitGraphicsDevice(int width, int height)
     return true;
 }
 
+// ANDROID: Process activity lifecycle commands
+static void AndroidCommandCallback(struct android_app *app, int32_t cmd)
+{
+    switch (cmd)
+    {
+        case APP_CMD_START:
+        {
+            //rendering = true;
+        } break;
+        case APP_CMD_RESUME: break;
+        case APP_CMD_INIT_WINDOW:
+        {
+            if (app->window != NULL)
+            {
+                if (CORE.Android.contextRebindRequired)
+                {
+                    // Reset screen scaling to full display size
+                    EGLint displayFormat = 0;
+                    eglGetConfigAttrib(CORE.Window.device, CORE.Window.config, EGL_NATIVE_VISUAL_ID, &displayFormat);
+
+                    // Adding renderOffset here feels rather hackish, but the viewport scaling is wrong after the
+                    // context rebinding if the screen is scaled unless offsets are added. There's probably a more
+                    // appropriate way to fix this
+                    ANativeWindow_setBuffersGeometry(app->window,
+                        CORE.Window.render.width + CORE.Window.renderOffset.x,
+                        CORE.Window.render.height + CORE.Window.renderOffset.y,
+                        displayFormat);
+
+                    // Recreate display surface and re-attach OpenGL context
+                    CORE.Window.surface = eglCreateWindowSurface(CORE.Window.device, CORE.Window.config, app->window, NULL);
+                    eglMakeCurrent(CORE.Window.device, CORE.Window.surface, CORE.Window.surface, CORE.Window.context);
+
+                    CORE.Android.contextRebindRequired = false;
+                }
+                else
+                {
+                    CORE.Window.display.width = ANativeWindow_getWidth(CORE.Android.app->window);
+                    CORE.Window.display.height = ANativeWindow_getHeight(CORE.Android.app->window);
+
+                    // Initialize graphics device (display device and OpenGL context)
+                    InitGraphicsDevice(CORE.Window.screen.width, CORE.Window.screen.height);
+
+                    // Initialize hi-res timer
+                    InitTimer();
+
+                    // Initialize random seed
+                    srand((unsigned int)time(NULL));
+
+                #if defined(SUPPORT_MODULE_RTEXT) && defined(SUPPORT_DEFAULT_FONT)
+                    // Load default font
+                    // WARNING: External function: Module required: rtext
+                    LoadFontDefault();
+                    Rectangle rec = GetFontDefault().recs[95];
+                    // NOTE: We setup a 1px padding on char rectangle to avoid pixel bleeding on MSAA filtering
+                    #if defined(SUPPORT_MODULE_RSHAPES)
+                    SetShapesTexture(GetFontDefault().texture, (Rectangle){ rec.x + 1, rec.y + 1, rec.width - 2, rec.height - 2 });  // WARNING: Module required: rshapes
+                    #endif
+                #endif
+
+                    // TODO: GPU assets reload in case of lost focus (lost context)
+                    // NOTE: This problem has been solved just unbinding and rebinding context from display
+                    /*
+                    if (assetsReloadRequired)
+                    {
+                        for (int i = 0; i < assetCount; i++)
+                        {
+                            // TODO: Unload old asset if required
+
+                            // Load texture again to pointed texture
+                            (*textureAsset + i) = LoadTexture(assetPath[i]);
+                        }
+                    }
+                    */
+                }
+            }
+        } break;
+        case APP_CMD_GAINED_FOCUS:
+        {
+            CORE.Android.appEnabled = true;
+            //ResumeMusicStream();
+        } break;
+        case APP_CMD_PAUSE: break;
+        case APP_CMD_LOST_FOCUS:
+        {
+            CORE.Android.appEnabled = false;
+            //PauseMusicStream();
+        } break;
+        case APP_CMD_TERM_WINDOW:
+        {
+            // Detach OpenGL context and destroy display surface
+            // NOTE 1: This case is used when the user exits the app without closing it. We detach the context to ensure everything is recoverable upon resuming.
+            // NOTE 2: Detaching context before destroying display surface avoids losing our resources (textures, shaders, VBOs...)
+            // NOTE 3: In some cases (too many context loaded), OS could unload context automatically... :(
+            if (CORE.Window.device != EGL_NO_DISPLAY)
+            {
+                eglMakeCurrent(CORE.Window.device, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
+
+                if (CORE.Window.surface != EGL_NO_SURFACE)
+                {
+                    eglDestroySurface(CORE.Window.device, CORE.Window.surface);
+                    CORE.Window.surface = EGL_NO_SURFACE;
+                }
+
+                CORE.Android.contextRebindRequired = true;
+            }
+            // If 'CORE.Window.device' is already set to 'EGL_NO_DISPLAY'
+            // this means that the user has already called 'CloseWindow()'
+
+        } break;
+        case APP_CMD_SAVE_STATE: break;
+        case APP_CMD_STOP: break;
+        case APP_CMD_DESTROY: break;
+        case APP_CMD_CONFIG_CHANGED:
+        {
+            //AConfiguration_fromAssetManager(CORE.Android.app->config, CORE.Android.app->activity->assetManager);
+            //print_cur_config(CORE.Android.app);
+
+            // Check screen orientation here!
+        } break;
+        default: break;
+    }
+}
+
+static GamepadButton AndroidTranslateGamepadButton(int button)
+{
+    switch (button)
+    {
+        case AKEYCODE_BUTTON_A: return GAMEPAD_BUTTON_RIGHT_FACE_DOWN;
+        case AKEYCODE_BUTTON_B: return GAMEPAD_BUTTON_RIGHT_FACE_RIGHT;
+        case AKEYCODE_BUTTON_X: return GAMEPAD_BUTTON_RIGHT_FACE_LEFT;
+        case AKEYCODE_BUTTON_Y: return GAMEPAD_BUTTON_RIGHT_FACE_UP;
+        case AKEYCODE_BUTTON_L1: return GAMEPAD_BUTTON_LEFT_TRIGGER_1;
+        case AKEYCODE_BUTTON_R1: return GAMEPAD_BUTTON_RIGHT_TRIGGER_1;
+        case AKEYCODE_BUTTON_L2: return GAMEPAD_BUTTON_LEFT_TRIGGER_2;
+        case AKEYCODE_BUTTON_R2: return GAMEPAD_BUTTON_RIGHT_TRIGGER_2;
+        case AKEYCODE_BUTTON_THUMBL: return GAMEPAD_BUTTON_LEFT_THUMB;
+        case AKEYCODE_BUTTON_THUMBR: return GAMEPAD_BUTTON_RIGHT_THUMB;
+        case AKEYCODE_BUTTON_START: return GAMEPAD_BUTTON_MIDDLE_RIGHT;
+        case AKEYCODE_BUTTON_SELECT: return GAMEPAD_BUTTON_MIDDLE_LEFT;
+        case AKEYCODE_BUTTON_MODE: return GAMEPAD_BUTTON_MIDDLE;
+        // On some (most?) gamepads dpad events are reported as axis motion instead
+        case AKEYCODE_DPAD_DOWN: return GAMEPAD_BUTTON_LEFT_FACE_DOWN;
+        case AKEYCODE_DPAD_RIGHT: return GAMEPAD_BUTTON_LEFT_FACE_RIGHT;
+        case AKEYCODE_DPAD_LEFT: return GAMEPAD_BUTTON_LEFT_FACE_LEFT;
+        case AKEYCODE_DPAD_UP: return GAMEPAD_BUTTON_LEFT_FACE_UP;
+        default: return GAMEPAD_BUTTON_UNKNOWN;
+    }
+}
+
+// ANDROID: Get input events
+static int32_t AndroidInputCallback(struct android_app *app, AInputEvent *event)
+{
+    // If additional inputs are required check:
+    // https://developer.android.com/ndk/reference/group/input
+    // https://developer.android.com/training/game-controllers/controller-input
+
+    int type = AInputEvent_getType(event);
+    int source = AInputEvent_getSource(event);
+
+    if (type == AINPUT_EVENT_TYPE_MOTION)
+    {
+        if (((source & AINPUT_SOURCE_JOYSTICK) == AINPUT_SOURCE_JOYSTICK) ||
+            ((source & AINPUT_SOURCE_GAMEPAD) == AINPUT_SOURCE_GAMEPAD))
+        {
+            // For now we'll assume a single gamepad which we "detect" on its input event
+            CORE.Input.Gamepad.ready[0] = true;
+
+            CORE.Input.Gamepad.axisState[0][GAMEPAD_AXIS_LEFT_X] = AMotionEvent_getAxisValue(
+                    event, AMOTION_EVENT_AXIS_X, 0);
+            CORE.Input.Gamepad.axisState[0][GAMEPAD_AXIS_LEFT_Y] = AMotionEvent_getAxisValue(
+                    event, AMOTION_EVENT_AXIS_Y, 0);
+            CORE.Input.Gamepad.axisState[0][GAMEPAD_AXIS_RIGHT_X] = AMotionEvent_getAxisValue(
+                    event, AMOTION_EVENT_AXIS_Z, 0);
+            CORE.Input.Gamepad.axisState[0][GAMEPAD_AXIS_RIGHT_Y] = AMotionEvent_getAxisValue(
+                    event, AMOTION_EVENT_AXIS_RZ, 0);
+            CORE.Input.Gamepad.axisState[0][GAMEPAD_AXIS_LEFT_TRIGGER] = AMotionEvent_getAxisValue(
+                    event, AMOTION_EVENT_AXIS_BRAKE, 0) * 2.0f - 1.0f;
+            CORE.Input.Gamepad.axisState[0][GAMEPAD_AXIS_RIGHT_TRIGGER] = AMotionEvent_getAxisValue(
+                    event, AMOTION_EVENT_AXIS_GAS, 0) * 2.0f - 1.0f;
+
+            // dpad is reported as an axis on android
+            float dpadX = AMotionEvent_getAxisValue(event, AMOTION_EVENT_AXIS_HAT_X, 0);
+            float dpadY = AMotionEvent_getAxisValue(event, AMOTION_EVENT_AXIS_HAT_Y, 0);
+
+            if (dpadX == 1.0f)
+            {
+                CORE.Input.Gamepad.currentButtonState[0][GAMEPAD_BUTTON_LEFT_FACE_RIGHT] = 1;
+                CORE.Input.Gamepad.currentButtonState[0][GAMEPAD_BUTTON_LEFT_FACE_LEFT] = 0;
+            }
+            else if (dpadX == -1.0f)
+            {
+                CORE.Input.Gamepad.currentButtonState[0][GAMEPAD_BUTTON_LEFT_FACE_RIGHT] = 0;
+                CORE.Input.Gamepad.currentButtonState[0][GAMEPAD_BUTTON_LEFT_FACE_LEFT] = 1;
+            }
+            else
+            {
+                CORE.Input.Gamepad.currentButtonState[0][GAMEPAD_BUTTON_LEFT_FACE_RIGHT] = 0;
+                CORE.Input.Gamepad.currentButtonState[0][GAMEPAD_BUTTON_LEFT_FACE_LEFT] = 0;
+            }
+
+            if (dpadY == 1.0f)
+            {
+                CORE.Input.Gamepad.currentButtonState[0][GAMEPAD_BUTTON_LEFT_FACE_DOWN] = 1;
+                CORE.Input.Gamepad.currentButtonState[0][GAMEPAD_BUTTON_LEFT_FACE_UP] = 0;
+            }
+            else if (dpadY == -1.0f)
+            {
+                CORE.Input.Gamepad.currentButtonState[0][GAMEPAD_BUTTON_LEFT_FACE_DOWN] = 0;
+                CORE.Input.Gamepad.currentButtonState[0][GAMEPAD_BUTTON_LEFT_FACE_UP] = 1;
+            }
+            else
+            {
+                CORE.Input.Gamepad.currentButtonState[0][GAMEPAD_BUTTON_LEFT_FACE_DOWN] = 0;
+                CORE.Input.Gamepad.currentButtonState[0][GAMEPAD_BUTTON_LEFT_FACE_UP] = 0;
+            }
+
+            return 1; // Handled gamepad axis motion
+        }
+    }
+    else if (type == AINPUT_EVENT_TYPE_KEY)
+    {
+        int32_t keycode = AKeyEvent_getKeyCode(event);
+        //int32_t AKeyEvent_getMetaState(event);
+
+        // Handle gamepad button presses and releases
+        if (((source & AINPUT_SOURCE_JOYSTICK) == AINPUT_SOURCE_JOYSTICK) ||
+            ((source & AINPUT_SOURCE_GAMEPAD) == AINPUT_SOURCE_GAMEPAD))
+        {
+            // For now we'll assume a single gamepad which we "detect" on its input event
+            CORE.Input.Gamepad.ready[0] = true;
+
+            GamepadButton button = AndroidTranslateGamepadButton(keycode);
+
+            if (button == GAMEPAD_BUTTON_UNKNOWN) return 1;
+
+            if (AKeyEvent_getAction(event) == AKEY_EVENT_ACTION_DOWN)
+            {
+                CORE.Input.Gamepad.currentButtonState[0][button] = 1;
+            }
+            else CORE.Input.Gamepad.currentButtonState[0][button] = 0;  // Key up
+
+            return 1; // Handled gamepad button
+        }
+
+        // Save current button and its state
+        // NOTE: Android key action is 0 for down and 1 for up
+        if (AKeyEvent_getAction(event) == AKEY_EVENT_ACTION_DOWN)
+        {
+            CORE.Input.Keyboard.currentKeyState[keycode] = 1;   // Key down
+
+            CORE.Input.Keyboard.keyPressedQueue[CORE.Input.Keyboard.keyPressedQueueCount] = keycode;
+            CORE.Input.Keyboard.keyPressedQueueCount++;
+        }
+        else if (AKeyEvent_getAction(event) == AKEY_EVENT_ACTION_MULTIPLE) CORE.Input.Keyboard.keyRepeatInFrame[keycode] = 1;
+        else CORE.Input.Keyboard.currentKeyState[keycode] = 0;  // Key up
+
+        if (keycode == AKEYCODE_POWER)
+        {
+            // Let the OS handle input to avoid app stuck. Behaviour: CMD_PAUSE -> CMD_SAVE_STATE -> CMD_STOP -> CMD_CONFIG_CHANGED -> CMD_LOST_FOCUS
+            // Resuming Behaviour: CMD_START -> CMD_RESUME -> CMD_CONFIG_CHANGED -> CMD_CONFIG_CHANGED -> CMD_GAINED_FOCUS
+            // It seems like locking mobile, screen size (CMD_CONFIG_CHANGED) is affected.
+            // NOTE: AndroidManifest.xml must have <activity android:configChanges="orientation|keyboardHidden|screenSize" >
+            // Before that change, activity was calling CMD_TERM_WINDOW and CMD_DESTROY when locking mobile, so that was not a normal behaviour
+            return 0;
+        }
+        else if ((keycode == AKEYCODE_BACK) || (keycode == AKEYCODE_MENU))
+        {
+            // Eat BACK_BUTTON and AKEYCODE_MENU, just do nothing... and don't let to be handled by OS!
+            return 1;
+        }
+        else if ((keycode == AKEYCODE_VOLUME_UP) || (keycode == AKEYCODE_VOLUME_DOWN))
+        {
+            // Set default OS behaviour
+            return 0;
+        }
+
+        return 0;
+    }
+
+    // Register touch points count
+    CORE.Input.Touch.pointCount = AMotionEvent_getPointerCount(event);
+
+    for (int i = 0; (i < CORE.Input.Touch.pointCount) && (i < MAX_TOUCH_POINTS); i++)
+    {
+        // Register touch points id
+        CORE.Input.Touch.pointId[i] = AMotionEvent_getPointerId(event, i);
+
+        // Register touch points position
+        CORE.Input.Touch.position[i] = (Vector2){ AMotionEvent_getX(event, i), AMotionEvent_getY(event, i) };
+
+        // Normalize CORE.Input.Touch.position[i] for CORE.Window.screen.width and CORE.Window.screen.height
+        float widthRatio = (float)(CORE.Window.screen.width + CORE.Window.renderOffset.x) / (float)CORE.Window.display.width;
+        float heightRatio = (float)(CORE.Window.screen.height + CORE.Window.renderOffset.y) / (float)CORE.Window.display.height;
+        CORE.Input.Touch.position[i].x = CORE.Input.Touch.position[i].x * widthRatio - (float)CORE.Window.renderOffset.x / 2;
+        CORE.Input.Touch.position[i].y = CORE.Input.Touch.position[i].y * heightRatio - (float)CORE.Window.renderOffset.y / 2;
+    }
+
+    int32_t action = AMotionEvent_getAction(event);
+    unsigned int flags = action & AMOTION_EVENT_ACTION_MASK;
+
+#if defined(SUPPORT_GESTURES_SYSTEM)        // PLATFORM_ANDROID
+    GestureEvent gestureEvent = { 0 };
+
+    gestureEvent.pointCount = CORE.Input.Touch.pointCount;
+
+    // Register touch actions
+    if (flags == AMOTION_EVENT_ACTION_DOWN) gestureEvent.touchAction = TOUCH_ACTION_DOWN;
+    else if (flags == AMOTION_EVENT_ACTION_UP) gestureEvent.touchAction = TOUCH_ACTION_UP;
+    else if (flags == AMOTION_EVENT_ACTION_MOVE) gestureEvent.touchAction = TOUCH_ACTION_MOVE;
+    else if (flags == AMOTION_EVENT_ACTION_CANCEL) gestureEvent.touchAction = TOUCH_ACTION_CANCEL;
+
+    for (int i = 0; (i < gestureEvent.pointCount) && (i < MAX_TOUCH_POINTS); i++)
+    {
+        gestureEvent.pointId[i] = CORE.Input.Touch.pointId[i];
+        gestureEvent.position[i] = CORE.Input.Touch.position[i];
+    }
+
+    // Gesture data is sent to gestures system for processing
+    ProcessGestureEvent(gestureEvent);
+#endif
+
+    int32_t pointerIndex = (action & AMOTION_EVENT_ACTION_POINTER_INDEX_MASK) >> AMOTION_EVENT_ACTION_POINTER_INDEX_SHIFT;
+
+    if (flags == AMOTION_EVENT_ACTION_POINTER_UP || flags == AMOTION_EVENT_ACTION_UP)
+    {
+        // One of the touchpoints is released, remove it from touch point arrays
+        for (int i = pointerIndex; (i < CORE.Input.Touch.pointCount - 1) && (i < MAX_TOUCH_POINTS); i++)
+        {
+            CORE.Input.Touch.pointId[i] = CORE.Input.Touch.pointId[i+1];
+            CORE.Input.Touch.position[i] = CORE.Input.Touch.position[i+1];
+        }
+
+        CORE.Input.Touch.pointCount--;
+    }
+
+    // When all touchpoints are tapped and released really quickly, this event is generated
+    if (flags == AMOTION_EVENT_ACTION_CANCEL) CORE.Input.Touch.pointCount = 0;
+
+    if (CORE.Input.Touch.pointCount > 0) CORE.Input.Touch.currentTouchState[MOUSE_BUTTON_LEFT] = 1;
+    else CORE.Input.Touch.currentTouchState[MOUSE_BUTTON_LEFT] = 0;
+
+    return 0;
+}
+
 // To allow easier porting to android, we allow the user to define a
 // main function which we call from android_main, defined by ourselves
 extern int main(int argc, char *argv[]);
@@ -855,348 +1199,4 @@ void PollInputEvents(void)
             //ANativeActivity_finish(CORE.Android.app->activity);
         }
     }
-}
-
-// ANDROID: Process activity lifecycle commands
-static void AndroidCommandCallback(struct android_app *app, int32_t cmd)
-{
-    switch (cmd)
-    {
-        case APP_CMD_START:
-        {
-            //rendering = true;
-        } break;
-        case APP_CMD_RESUME: break;
-        case APP_CMD_INIT_WINDOW:
-        {
-            if (app->window != NULL)
-            {
-                if (CORE.Android.contextRebindRequired)
-                {
-                    // Reset screen scaling to full display size
-                    EGLint displayFormat = 0;
-                    eglGetConfigAttrib(CORE.Window.device, CORE.Window.config, EGL_NATIVE_VISUAL_ID, &displayFormat);
-
-                    // Adding renderOffset here feels rather hackish, but the viewport scaling is wrong after the
-                    // context rebinding if the screen is scaled unless offsets are added. There's probably a more
-                    // appropriate way to fix this
-                    ANativeWindow_setBuffersGeometry(app->window,
-                        CORE.Window.render.width + CORE.Window.renderOffset.x,
-                        CORE.Window.render.height + CORE.Window.renderOffset.y,
-                        displayFormat);
-
-                    // Recreate display surface and re-attach OpenGL context
-                    CORE.Window.surface = eglCreateWindowSurface(CORE.Window.device, CORE.Window.config, app->window, NULL);
-                    eglMakeCurrent(CORE.Window.device, CORE.Window.surface, CORE.Window.surface, CORE.Window.context);
-
-                    CORE.Android.contextRebindRequired = false;
-                }
-                else
-                {
-                    CORE.Window.display.width = ANativeWindow_getWidth(CORE.Android.app->window);
-                    CORE.Window.display.height = ANativeWindow_getHeight(CORE.Android.app->window);
-
-                    // Initialize graphics device (display device and OpenGL context)
-                    InitGraphicsDevice(CORE.Window.screen.width, CORE.Window.screen.height);
-
-                    // Initialize hi-res timer
-                    InitTimer();
-
-                    // Initialize random seed
-                    srand((unsigned int)time(NULL));
-
-                #if defined(SUPPORT_MODULE_RTEXT) && defined(SUPPORT_DEFAULT_FONT)
-                    // Load default font
-                    // WARNING: External function: Module required: rtext
-                    LoadFontDefault();
-                    Rectangle rec = GetFontDefault().recs[95];
-                    // NOTE: We setup a 1px padding on char rectangle to avoid pixel bleeding on MSAA filtering
-                    #if defined(SUPPORT_MODULE_RSHAPES)
-                    SetShapesTexture(GetFontDefault().texture, (Rectangle){ rec.x + 1, rec.y + 1, rec.width - 2, rec.height - 2 });  // WARNING: Module required: rshapes
-                    #endif
-                #endif
-
-                    // TODO: GPU assets reload in case of lost focus (lost context)
-                    // NOTE: This problem has been solved just unbinding and rebinding context from display
-                    /*
-                    if (assetsReloadRequired)
-                    {
-                        for (int i = 0; i < assetCount; i++)
-                        {
-                            // TODO: Unload old asset if required
-
-                            // Load texture again to pointed texture
-                            (*textureAsset + i) = LoadTexture(assetPath[i]);
-                        }
-                    }
-                    */
-                }
-            }
-        } break;
-        case APP_CMD_GAINED_FOCUS:
-        {
-            CORE.Android.appEnabled = true;
-            //ResumeMusicStream();
-        } break;
-        case APP_CMD_PAUSE: break;
-        case APP_CMD_LOST_FOCUS:
-        {
-            CORE.Android.appEnabled = false;
-            //PauseMusicStream();
-        } break;
-        case APP_CMD_TERM_WINDOW:
-        {
-            // Detach OpenGL context and destroy display surface
-            // NOTE 1: This case is used when the user exits the app without closing it. We detach the context to ensure everything is recoverable upon resuming.
-            // NOTE 2: Detaching context before destroying display surface avoids losing our resources (textures, shaders, VBOs...)
-            // NOTE 3: In some cases (too many context loaded), OS could unload context automatically... :(
-            if (CORE.Window.device != EGL_NO_DISPLAY)
-            {
-                eglMakeCurrent(CORE.Window.device, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
-
-                if (CORE.Window.surface != EGL_NO_SURFACE)
-                {
-                    eglDestroySurface(CORE.Window.device, CORE.Window.surface);
-                    CORE.Window.surface = EGL_NO_SURFACE;
-                }
-
-                CORE.Android.contextRebindRequired = true;
-            }
-            // If 'CORE.Window.device' is already set to 'EGL_NO_DISPLAY'
-            // this means that the user has already called 'CloseWindow()'
-
-        } break;
-        case APP_CMD_SAVE_STATE: break;
-        case APP_CMD_STOP: break;
-        case APP_CMD_DESTROY: break;
-        case APP_CMD_CONFIG_CHANGED:
-        {
-            //AConfiguration_fromAssetManager(CORE.Android.app->config, CORE.Android.app->activity->assetManager);
-            //print_cur_config(CORE.Android.app);
-
-            // Check screen orientation here!
-        } break;
-        default: break;
-    }
-}
-
-static GamepadButton AndroidTranslateGamepadButton(int button)
-{
-    switch (button)
-    {
-        case AKEYCODE_BUTTON_A: return GAMEPAD_BUTTON_RIGHT_FACE_DOWN;
-        case AKEYCODE_BUTTON_B: return GAMEPAD_BUTTON_RIGHT_FACE_RIGHT;
-        case AKEYCODE_BUTTON_X: return GAMEPAD_BUTTON_RIGHT_FACE_LEFT;
-        case AKEYCODE_BUTTON_Y: return GAMEPAD_BUTTON_RIGHT_FACE_UP;
-        case AKEYCODE_BUTTON_L1: return GAMEPAD_BUTTON_LEFT_TRIGGER_1;
-        case AKEYCODE_BUTTON_R1: return GAMEPAD_BUTTON_RIGHT_TRIGGER_1;
-        case AKEYCODE_BUTTON_L2: return GAMEPAD_BUTTON_LEFT_TRIGGER_2;
-        case AKEYCODE_BUTTON_R2: return GAMEPAD_BUTTON_RIGHT_TRIGGER_2;
-        case AKEYCODE_BUTTON_THUMBL: return GAMEPAD_BUTTON_LEFT_THUMB;
-        case AKEYCODE_BUTTON_THUMBR: return GAMEPAD_BUTTON_RIGHT_THUMB;
-        case AKEYCODE_BUTTON_START: return GAMEPAD_BUTTON_MIDDLE_RIGHT;
-        case AKEYCODE_BUTTON_SELECT: return GAMEPAD_BUTTON_MIDDLE_LEFT;
-        case AKEYCODE_BUTTON_MODE: return GAMEPAD_BUTTON_MIDDLE;
-        // On some (most?) gamepads dpad events are reported as axis motion instead
-        case AKEYCODE_DPAD_DOWN: return GAMEPAD_BUTTON_LEFT_FACE_DOWN;
-        case AKEYCODE_DPAD_RIGHT: return GAMEPAD_BUTTON_LEFT_FACE_RIGHT;
-        case AKEYCODE_DPAD_LEFT: return GAMEPAD_BUTTON_LEFT_FACE_LEFT;
-        case AKEYCODE_DPAD_UP: return GAMEPAD_BUTTON_LEFT_FACE_UP;
-        default: return GAMEPAD_BUTTON_UNKNOWN;
-    }
-}
-
-// ANDROID: Get input events
-static int32_t AndroidInputCallback(struct android_app *app, AInputEvent *event)
-{
-    // If additional inputs are required check:
-    // https://developer.android.com/ndk/reference/group/input
-    // https://developer.android.com/training/game-controllers/controller-input
-
-    int type = AInputEvent_getType(event);
-    int source = AInputEvent_getSource(event);
-
-    if (type == AINPUT_EVENT_TYPE_MOTION)
-    {
-        if (((source & AINPUT_SOURCE_JOYSTICK) == AINPUT_SOURCE_JOYSTICK) ||
-            ((source & AINPUT_SOURCE_GAMEPAD) == AINPUT_SOURCE_GAMEPAD))
-        {
-            // For now we'll assume a single gamepad which we "detect" on its input event
-            CORE.Input.Gamepad.ready[0] = true;
-
-            CORE.Input.Gamepad.axisState[0][GAMEPAD_AXIS_LEFT_X] = AMotionEvent_getAxisValue(
-                    event, AMOTION_EVENT_AXIS_X, 0);
-            CORE.Input.Gamepad.axisState[0][GAMEPAD_AXIS_LEFT_Y] = AMotionEvent_getAxisValue(
-                    event, AMOTION_EVENT_AXIS_Y, 0);
-            CORE.Input.Gamepad.axisState[0][GAMEPAD_AXIS_RIGHT_X] = AMotionEvent_getAxisValue(
-                    event, AMOTION_EVENT_AXIS_Z, 0);
-            CORE.Input.Gamepad.axisState[0][GAMEPAD_AXIS_RIGHT_Y] = AMotionEvent_getAxisValue(
-                    event, AMOTION_EVENT_AXIS_RZ, 0);
-            CORE.Input.Gamepad.axisState[0][GAMEPAD_AXIS_LEFT_TRIGGER] = AMotionEvent_getAxisValue(
-                    event, AMOTION_EVENT_AXIS_BRAKE, 0) * 2.0f - 1.0f;
-            CORE.Input.Gamepad.axisState[0][GAMEPAD_AXIS_RIGHT_TRIGGER] = AMotionEvent_getAxisValue(
-                    event, AMOTION_EVENT_AXIS_GAS, 0) * 2.0f - 1.0f;
-
-            // dpad is reported as an axis on android
-            float dpadX = AMotionEvent_getAxisValue(event, AMOTION_EVENT_AXIS_HAT_X, 0);
-            float dpadY = AMotionEvent_getAxisValue(event, AMOTION_EVENT_AXIS_HAT_Y, 0);
-
-            if (dpadX == 1.0f)
-            {
-                CORE.Input.Gamepad.currentButtonState[0][GAMEPAD_BUTTON_LEFT_FACE_RIGHT] = 1;
-                CORE.Input.Gamepad.currentButtonState[0][GAMEPAD_BUTTON_LEFT_FACE_LEFT] = 0;
-            }
-            else if (dpadX == -1.0f)
-            {
-                CORE.Input.Gamepad.currentButtonState[0][GAMEPAD_BUTTON_LEFT_FACE_RIGHT] = 0;
-                CORE.Input.Gamepad.currentButtonState[0][GAMEPAD_BUTTON_LEFT_FACE_LEFT] = 1;
-            }
-            else
-            {
-                CORE.Input.Gamepad.currentButtonState[0][GAMEPAD_BUTTON_LEFT_FACE_RIGHT] = 0;
-                CORE.Input.Gamepad.currentButtonState[0][GAMEPAD_BUTTON_LEFT_FACE_LEFT] = 0;
-            }
-
-            if (dpadY == 1.0f)
-            {
-                CORE.Input.Gamepad.currentButtonState[0][GAMEPAD_BUTTON_LEFT_FACE_DOWN] = 1;
-                CORE.Input.Gamepad.currentButtonState[0][GAMEPAD_BUTTON_LEFT_FACE_UP] = 0;
-            }
-            else if (dpadY == -1.0f)
-            {
-                CORE.Input.Gamepad.currentButtonState[0][GAMEPAD_BUTTON_LEFT_FACE_DOWN] = 0;
-                CORE.Input.Gamepad.currentButtonState[0][GAMEPAD_BUTTON_LEFT_FACE_UP] = 1;
-            }
-            else
-            {
-                CORE.Input.Gamepad.currentButtonState[0][GAMEPAD_BUTTON_LEFT_FACE_DOWN] = 0;
-                CORE.Input.Gamepad.currentButtonState[0][GAMEPAD_BUTTON_LEFT_FACE_UP] = 0;
-            }
-
-            return 1; // Handled gamepad axis motion
-        }
-    }
-    else if (type == AINPUT_EVENT_TYPE_KEY)
-    {
-        int32_t keycode = AKeyEvent_getKeyCode(event);
-        //int32_t AKeyEvent_getMetaState(event);
-
-        // Handle gamepad button presses and releases
-        if (((source & AINPUT_SOURCE_JOYSTICK) == AINPUT_SOURCE_JOYSTICK) ||
-            ((source & AINPUT_SOURCE_GAMEPAD) == AINPUT_SOURCE_GAMEPAD))
-        {
-            // For now we'll assume a single gamepad which we "detect" on its input event
-            CORE.Input.Gamepad.ready[0] = true;
-
-            GamepadButton button = AndroidTranslateGamepadButton(keycode);
-
-            if (button == GAMEPAD_BUTTON_UNKNOWN) return 1;
-
-            if (AKeyEvent_getAction(event) == AKEY_EVENT_ACTION_DOWN)
-            {
-                CORE.Input.Gamepad.currentButtonState[0][button] = 1;
-            }
-            else CORE.Input.Gamepad.currentButtonState[0][button] = 0;  // Key up
-
-            return 1; // Handled gamepad button
-        }
-
-        // Save current button and its state
-        // NOTE: Android key action is 0 for down and 1 for up
-        if (AKeyEvent_getAction(event) == AKEY_EVENT_ACTION_DOWN)
-        {
-            CORE.Input.Keyboard.currentKeyState[keycode] = 1;   // Key down
-
-            CORE.Input.Keyboard.keyPressedQueue[CORE.Input.Keyboard.keyPressedQueueCount] = keycode;
-            CORE.Input.Keyboard.keyPressedQueueCount++;
-        }
-        else if (AKeyEvent_getAction(event) == AKEY_EVENT_ACTION_MULTIPLE) CORE.Input.Keyboard.keyRepeatInFrame[keycode] = 1;
-        else CORE.Input.Keyboard.currentKeyState[keycode] = 0;  // Key up
-
-        if (keycode == AKEYCODE_POWER)
-        {
-            // Let the OS handle input to avoid app stuck. Behaviour: CMD_PAUSE -> CMD_SAVE_STATE -> CMD_STOP -> CMD_CONFIG_CHANGED -> CMD_LOST_FOCUS
-            // Resuming Behaviour: CMD_START -> CMD_RESUME -> CMD_CONFIG_CHANGED -> CMD_CONFIG_CHANGED -> CMD_GAINED_FOCUS
-            // It seems like locking mobile, screen size (CMD_CONFIG_CHANGED) is affected.
-            // NOTE: AndroidManifest.xml must have <activity android:configChanges="orientation|keyboardHidden|screenSize" >
-            // Before that change, activity was calling CMD_TERM_WINDOW and CMD_DESTROY when locking mobile, so that was not a normal behaviour
-            return 0;
-        }
-        else if ((keycode == AKEYCODE_BACK) || (keycode == AKEYCODE_MENU))
-        {
-            // Eat BACK_BUTTON and AKEYCODE_MENU, just do nothing... and don't let to be handled by OS!
-            return 1;
-        }
-        else if ((keycode == AKEYCODE_VOLUME_UP) || (keycode == AKEYCODE_VOLUME_DOWN))
-        {
-            // Set default OS behaviour
-            return 0;
-        }
-
-        return 0;
-    }
-
-    // Register touch points count
-    CORE.Input.Touch.pointCount = AMotionEvent_getPointerCount(event);
-
-    for (int i = 0; (i < CORE.Input.Touch.pointCount) && (i < MAX_TOUCH_POINTS); i++)
-    {
-        // Register touch points id
-        CORE.Input.Touch.pointId[i] = AMotionEvent_getPointerId(event, i);
-
-        // Register touch points position
-        CORE.Input.Touch.position[i] = (Vector2){ AMotionEvent_getX(event, i), AMotionEvent_getY(event, i) };
-
-        // Normalize CORE.Input.Touch.position[i] for CORE.Window.screen.width and CORE.Window.screen.height
-        float widthRatio = (float)(CORE.Window.screen.width + CORE.Window.renderOffset.x) / (float)CORE.Window.display.width;
-        float heightRatio = (float)(CORE.Window.screen.height + CORE.Window.renderOffset.y) / (float)CORE.Window.display.height;
-        CORE.Input.Touch.position[i].x = CORE.Input.Touch.position[i].x * widthRatio - (float)CORE.Window.renderOffset.x / 2;
-        CORE.Input.Touch.position[i].y = CORE.Input.Touch.position[i].y * heightRatio - (float)CORE.Window.renderOffset.y / 2;
-    }
-
-    int32_t action = AMotionEvent_getAction(event);
-    unsigned int flags = action & AMOTION_EVENT_ACTION_MASK;
-
-#if defined(SUPPORT_GESTURES_SYSTEM)        // PLATFORM_ANDROID
-    GestureEvent gestureEvent = { 0 };
-
-    gestureEvent.pointCount = CORE.Input.Touch.pointCount;
-
-    // Register touch actions
-    if (flags == AMOTION_EVENT_ACTION_DOWN) gestureEvent.touchAction = TOUCH_ACTION_DOWN;
-    else if (flags == AMOTION_EVENT_ACTION_UP) gestureEvent.touchAction = TOUCH_ACTION_UP;
-    else if (flags == AMOTION_EVENT_ACTION_MOVE) gestureEvent.touchAction = TOUCH_ACTION_MOVE;
-    else if (flags == AMOTION_EVENT_ACTION_CANCEL) gestureEvent.touchAction = TOUCH_ACTION_CANCEL;
-
-    for (int i = 0; (i < gestureEvent.pointCount) && (i < MAX_TOUCH_POINTS); i++)
-    {
-        gestureEvent.pointId[i] = CORE.Input.Touch.pointId[i];
-        gestureEvent.position[i] = CORE.Input.Touch.position[i];
-    }
-
-    // Gesture data is sent to gestures system for processing
-    ProcessGestureEvent(gestureEvent);
-#endif
-
-    int32_t pointerIndex = (action & AMOTION_EVENT_ACTION_POINTER_INDEX_MASK) >> AMOTION_EVENT_ACTION_POINTER_INDEX_SHIFT;
-
-    if (flags == AMOTION_EVENT_ACTION_POINTER_UP || flags == AMOTION_EVENT_ACTION_UP)
-    {
-        // One of the touchpoints is released, remove it from touch point arrays
-        for (int i = pointerIndex; (i < CORE.Input.Touch.pointCount - 1) && (i < MAX_TOUCH_POINTS); i++)
-        {
-            CORE.Input.Touch.pointId[i] = CORE.Input.Touch.pointId[i+1];
-            CORE.Input.Touch.position[i] = CORE.Input.Touch.position[i+1];
-        }
-
-        CORE.Input.Touch.pointCount--;
-    }
-
-    // When all touchpoints are tapped and released really quickly, this event is generated
-    if (flags == AMOTION_EVENT_ACTION_CANCEL) CORE.Input.Touch.pointCount = 0;
-
-    if (CORE.Input.Touch.pointCount > 0) CORE.Input.Touch.currentTouchState[MOUSE_BUTTON_LEFT] = 1;
-    else CORE.Input.Touch.currentTouchState[MOUSE_BUTTON_LEFT] = 0;
-
-    return 0;
 }

--- a/src/rcore_android.c
+++ b/src/rcore_android.c
@@ -928,6 +928,7 @@ const char *GetMonitorName(int monitor)
 // Set clipboard text content
 void SetClipboardText(const char *text)
 {
+    TRACELOG(LOG_INFO, "SetClipboardText not implemented in rcore_android.c");
 }
 
 

--- a/src/rcore_android.c
+++ b/src/rcore_android.c
@@ -136,11 +136,11 @@ static bool InitGraphicsDevice(int width, int height)
     CORE.Window.screen.height = height;          // User desired height
     CORE.Window.screenScale = MatrixIdentity();  // No draw scaling required by default
 
-    // Set the window minimum and maximum default values to 0
-    CORE.Window.windowMin.width  = 0;
-    CORE.Window.windowMin.height = 0;
-    CORE.Window.windowMax.width  = 0;
-    CORE.Window.windowMax.height = 0;
+    // Set the screen minimum and maximum default values to 0
+    CORE.Window.screenMin.width  = 0;
+    CORE.Window.screenMin.height = 0;
+    CORE.Window.screenMax.width  = 0;
+    CORE.Window.screenMax.height = 0;
 
     // NOTE: Framebuffer (render area - CORE.Window.render.width, CORE.Window.render.height) could include black bars...
     // ...in top-down or left-right to match display aspect ratio (no weird scaling)

--- a/src/rcore_android.c
+++ b/src/rcore_android.c
@@ -270,350 +270,6 @@ static bool InitGraphicsDevice(int width, int height)
     return true;
 }
 
-// ANDROID: Process activity lifecycle commands
-static void AndroidCommandCallback(struct android_app *app, int32_t cmd)
-{
-    switch (cmd)
-    {
-        case APP_CMD_START:
-        {
-            //rendering = true;
-        } break;
-        case APP_CMD_RESUME: break;
-        case APP_CMD_INIT_WINDOW:
-        {
-            if (app->window != NULL)
-            {
-                if (CORE.Android.contextRebindRequired)
-                {
-                    // Reset screen scaling to full display size
-                    EGLint displayFormat = 0;
-                    eglGetConfigAttrib(CORE.Window.device, CORE.Window.config, EGL_NATIVE_VISUAL_ID, &displayFormat);
-
-                    // Adding renderOffset here feels rather hackish, but the viewport scaling is wrong after the
-                    // context rebinding if the screen is scaled unless offsets are added. There's probably a more
-                    // appropriate way to fix this
-                    ANativeWindow_setBuffersGeometry(app->window,
-                        CORE.Window.render.width + CORE.Window.renderOffset.x,
-                        CORE.Window.render.height + CORE.Window.renderOffset.y,
-                        displayFormat);
-
-                    // Recreate display surface and re-attach OpenGL context
-                    CORE.Window.surface = eglCreateWindowSurface(CORE.Window.device, CORE.Window.config, app->window, NULL);
-                    eglMakeCurrent(CORE.Window.device, CORE.Window.surface, CORE.Window.surface, CORE.Window.context);
-
-                    CORE.Android.contextRebindRequired = false;
-                }
-                else
-                {
-                    CORE.Window.display.width = ANativeWindow_getWidth(CORE.Android.app->window);
-                    CORE.Window.display.height = ANativeWindow_getHeight(CORE.Android.app->window);
-
-                    // Initialize graphics device (display device and OpenGL context)
-                    InitGraphicsDevice(CORE.Window.screen.width, CORE.Window.screen.height);
-
-                    // Initialize hi-res timer
-                    InitTimer();
-
-                    // Initialize random seed
-                    srand((unsigned int)time(NULL));
-
-                #if defined(SUPPORT_MODULE_RTEXT) && defined(SUPPORT_DEFAULT_FONT)
-                    // Load default font
-                    // WARNING: External function: Module required: rtext
-                    LoadFontDefault();
-                    Rectangle rec = GetFontDefault().recs[95];
-                    // NOTE: We setup a 1px padding on char rectangle to avoid pixel bleeding on MSAA filtering
-                    #if defined(SUPPORT_MODULE_RSHAPES)
-                    SetShapesTexture(GetFontDefault().texture, (Rectangle){ rec.x + 1, rec.y + 1, rec.width - 2, rec.height - 2 });  // WARNING: Module required: rshapes
-                    #endif
-                #endif
-
-                    // TODO: GPU assets reload in case of lost focus (lost context)
-                    // NOTE: This problem has been solved just unbinding and rebinding context from display
-                    /*
-                    if (assetsReloadRequired)
-                    {
-                        for (int i = 0; i < assetCount; i++)
-                        {
-                            // TODO: Unload old asset if required
-
-                            // Load texture again to pointed texture
-                            (*textureAsset + i) = LoadTexture(assetPath[i]);
-                        }
-                    }
-                    */
-                }
-            }
-        } break;
-        case APP_CMD_GAINED_FOCUS:
-        {
-            CORE.Android.appEnabled = true;
-            //ResumeMusicStream();
-        } break;
-        case APP_CMD_PAUSE: break;
-        case APP_CMD_LOST_FOCUS:
-        {
-            CORE.Android.appEnabled = false;
-            //PauseMusicStream();
-        } break;
-        case APP_CMD_TERM_WINDOW:
-        {
-            // Detach OpenGL context and destroy display surface
-            // NOTE 1: This case is used when the user exits the app without closing it. We detach the context to ensure everything is recoverable upon resuming.
-            // NOTE 2: Detaching context before destroying display surface avoids losing our resources (textures, shaders, VBOs...)
-            // NOTE 3: In some cases (too many context loaded), OS could unload context automatically... :(
-            if (CORE.Window.device != EGL_NO_DISPLAY)
-            {
-                eglMakeCurrent(CORE.Window.device, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
-
-                if (CORE.Window.surface != EGL_NO_SURFACE)
-                {
-                    eglDestroySurface(CORE.Window.device, CORE.Window.surface);
-                    CORE.Window.surface = EGL_NO_SURFACE;
-                }
-
-                CORE.Android.contextRebindRequired = true;
-            }
-            // If 'CORE.Window.device' is already set to 'EGL_NO_DISPLAY'
-            // this means that the user has already called 'CloseWindow()'
-
-        } break;
-        case APP_CMD_SAVE_STATE: break;
-        case APP_CMD_STOP: break;
-        case APP_CMD_DESTROY: break;
-        case APP_CMD_CONFIG_CHANGED:
-        {
-            //AConfiguration_fromAssetManager(CORE.Android.app->config, CORE.Android.app->activity->assetManager);
-            //print_cur_config(CORE.Android.app);
-
-            // Check screen orientation here!
-        } break;
-        default: break;
-    }
-}
-
-static GamepadButton AndroidTranslateGamepadButton(int button)
-{
-    switch (button)
-    {
-        case AKEYCODE_BUTTON_A: return GAMEPAD_BUTTON_RIGHT_FACE_DOWN;
-        case AKEYCODE_BUTTON_B: return GAMEPAD_BUTTON_RIGHT_FACE_RIGHT;
-        case AKEYCODE_BUTTON_X: return GAMEPAD_BUTTON_RIGHT_FACE_LEFT;
-        case AKEYCODE_BUTTON_Y: return GAMEPAD_BUTTON_RIGHT_FACE_UP;
-        case AKEYCODE_BUTTON_L1: return GAMEPAD_BUTTON_LEFT_TRIGGER_1;
-        case AKEYCODE_BUTTON_R1: return GAMEPAD_BUTTON_RIGHT_TRIGGER_1;
-        case AKEYCODE_BUTTON_L2: return GAMEPAD_BUTTON_LEFT_TRIGGER_2;
-        case AKEYCODE_BUTTON_R2: return GAMEPAD_BUTTON_RIGHT_TRIGGER_2;
-        case AKEYCODE_BUTTON_THUMBL: return GAMEPAD_BUTTON_LEFT_THUMB;
-        case AKEYCODE_BUTTON_THUMBR: return GAMEPAD_BUTTON_RIGHT_THUMB;
-        case AKEYCODE_BUTTON_START: return GAMEPAD_BUTTON_MIDDLE_RIGHT;
-        case AKEYCODE_BUTTON_SELECT: return GAMEPAD_BUTTON_MIDDLE_LEFT;
-        case AKEYCODE_BUTTON_MODE: return GAMEPAD_BUTTON_MIDDLE;
-        // On some (most?) gamepads dpad events are reported as axis motion instead
-        case AKEYCODE_DPAD_DOWN: return GAMEPAD_BUTTON_LEFT_FACE_DOWN;
-        case AKEYCODE_DPAD_RIGHT: return GAMEPAD_BUTTON_LEFT_FACE_RIGHT;
-        case AKEYCODE_DPAD_LEFT: return GAMEPAD_BUTTON_LEFT_FACE_LEFT;
-        case AKEYCODE_DPAD_UP: return GAMEPAD_BUTTON_LEFT_FACE_UP;
-        default: return GAMEPAD_BUTTON_UNKNOWN;
-    }
-}
-
-// ANDROID: Get input events
-static int32_t AndroidInputCallback(struct android_app *app, AInputEvent *event)
-{
-    // If additional inputs are required check:
-    // https://developer.android.com/ndk/reference/group/input
-    // https://developer.android.com/training/game-controllers/controller-input
-
-    int type = AInputEvent_getType(event);
-    int source = AInputEvent_getSource(event);
-
-    if (type == AINPUT_EVENT_TYPE_MOTION)
-    {
-        if (((source & AINPUT_SOURCE_JOYSTICK) == AINPUT_SOURCE_JOYSTICK) ||
-            ((source & AINPUT_SOURCE_GAMEPAD) == AINPUT_SOURCE_GAMEPAD))
-        {
-            // For now we'll assume a single gamepad which we "detect" on its input event
-            CORE.Input.Gamepad.ready[0] = true;
-
-            CORE.Input.Gamepad.axisState[0][GAMEPAD_AXIS_LEFT_X] = AMotionEvent_getAxisValue(
-                    event, AMOTION_EVENT_AXIS_X, 0);
-            CORE.Input.Gamepad.axisState[0][GAMEPAD_AXIS_LEFT_Y] = AMotionEvent_getAxisValue(
-                    event, AMOTION_EVENT_AXIS_Y, 0);
-            CORE.Input.Gamepad.axisState[0][GAMEPAD_AXIS_RIGHT_X] = AMotionEvent_getAxisValue(
-                    event, AMOTION_EVENT_AXIS_Z, 0);
-            CORE.Input.Gamepad.axisState[0][GAMEPAD_AXIS_RIGHT_Y] = AMotionEvent_getAxisValue(
-                    event, AMOTION_EVENT_AXIS_RZ, 0);
-            CORE.Input.Gamepad.axisState[0][GAMEPAD_AXIS_LEFT_TRIGGER] = AMotionEvent_getAxisValue(
-                    event, AMOTION_EVENT_AXIS_BRAKE, 0) * 2.0f - 1.0f;
-            CORE.Input.Gamepad.axisState[0][GAMEPAD_AXIS_RIGHT_TRIGGER] = AMotionEvent_getAxisValue(
-                    event, AMOTION_EVENT_AXIS_GAS, 0) * 2.0f - 1.0f;
-
-            // dpad is reported as an axis on android
-            float dpadX = AMotionEvent_getAxisValue(event, AMOTION_EVENT_AXIS_HAT_X, 0);
-            float dpadY = AMotionEvent_getAxisValue(event, AMOTION_EVENT_AXIS_HAT_Y, 0);
-
-            if (dpadX == 1.0f)
-            {
-                CORE.Input.Gamepad.currentButtonState[0][GAMEPAD_BUTTON_LEFT_FACE_RIGHT] = 1;
-                CORE.Input.Gamepad.currentButtonState[0][GAMEPAD_BUTTON_LEFT_FACE_LEFT] = 0;
-            }
-            else if (dpadX == -1.0f)
-            {
-                CORE.Input.Gamepad.currentButtonState[0][GAMEPAD_BUTTON_LEFT_FACE_RIGHT] = 0;
-                CORE.Input.Gamepad.currentButtonState[0][GAMEPAD_BUTTON_LEFT_FACE_LEFT] = 1;
-            }
-            else
-            {
-                CORE.Input.Gamepad.currentButtonState[0][GAMEPAD_BUTTON_LEFT_FACE_RIGHT] = 0;
-                CORE.Input.Gamepad.currentButtonState[0][GAMEPAD_BUTTON_LEFT_FACE_LEFT] = 0;
-            }
-
-            if (dpadY == 1.0f)
-            {
-                CORE.Input.Gamepad.currentButtonState[0][GAMEPAD_BUTTON_LEFT_FACE_DOWN] = 1;
-                CORE.Input.Gamepad.currentButtonState[0][GAMEPAD_BUTTON_LEFT_FACE_UP] = 0;
-            }
-            else if (dpadY == -1.0f)
-            {
-                CORE.Input.Gamepad.currentButtonState[0][GAMEPAD_BUTTON_LEFT_FACE_DOWN] = 0;
-                CORE.Input.Gamepad.currentButtonState[0][GAMEPAD_BUTTON_LEFT_FACE_UP] = 1;
-            }
-            else
-            {
-                CORE.Input.Gamepad.currentButtonState[0][GAMEPAD_BUTTON_LEFT_FACE_DOWN] = 0;
-                CORE.Input.Gamepad.currentButtonState[0][GAMEPAD_BUTTON_LEFT_FACE_UP] = 0;
-            }
-
-            return 1; // Handled gamepad axis motion
-        }
-    }
-    else if (type == AINPUT_EVENT_TYPE_KEY)
-    {
-        int32_t keycode = AKeyEvent_getKeyCode(event);
-        //int32_t AKeyEvent_getMetaState(event);
-
-        // Handle gamepad button presses and releases
-        if (((source & AINPUT_SOURCE_JOYSTICK) == AINPUT_SOURCE_JOYSTICK) ||
-            ((source & AINPUT_SOURCE_GAMEPAD) == AINPUT_SOURCE_GAMEPAD))
-        {
-            // For now we'll assume a single gamepad which we "detect" on its input event
-            CORE.Input.Gamepad.ready[0] = true;
-
-            GamepadButton button = AndroidTranslateGamepadButton(keycode);
-
-            if (button == GAMEPAD_BUTTON_UNKNOWN) return 1;
-
-            if (AKeyEvent_getAction(event) == AKEY_EVENT_ACTION_DOWN)
-            {
-                CORE.Input.Gamepad.currentButtonState[0][button] = 1;
-            }
-            else CORE.Input.Gamepad.currentButtonState[0][button] = 0;  // Key up
-
-            return 1; // Handled gamepad button
-        }
-
-        // Save current button and its state
-        // NOTE: Android key action is 0 for down and 1 for up
-        if (AKeyEvent_getAction(event) == AKEY_EVENT_ACTION_DOWN)
-        {
-            CORE.Input.Keyboard.currentKeyState[keycode] = 1;   // Key down
-
-            CORE.Input.Keyboard.keyPressedQueue[CORE.Input.Keyboard.keyPressedQueueCount] = keycode;
-            CORE.Input.Keyboard.keyPressedQueueCount++;
-        }
-        else if (AKeyEvent_getAction(event) == AKEY_EVENT_ACTION_MULTIPLE) CORE.Input.Keyboard.keyRepeatInFrame[keycode] = 1;
-        else CORE.Input.Keyboard.currentKeyState[keycode] = 0;  // Key up
-
-        if (keycode == AKEYCODE_POWER)
-        {
-            // Let the OS handle input to avoid app stuck. Behaviour: CMD_PAUSE -> CMD_SAVE_STATE -> CMD_STOP -> CMD_CONFIG_CHANGED -> CMD_LOST_FOCUS
-            // Resuming Behaviour: CMD_START -> CMD_RESUME -> CMD_CONFIG_CHANGED -> CMD_CONFIG_CHANGED -> CMD_GAINED_FOCUS
-            // It seems like locking mobile, screen size (CMD_CONFIG_CHANGED) is affected.
-            // NOTE: AndroidManifest.xml must have <activity android:configChanges="orientation|keyboardHidden|screenSize" >
-            // Before that change, activity was calling CMD_TERM_WINDOW and CMD_DESTROY when locking mobile, so that was not a normal behaviour
-            return 0;
-        }
-        else if ((keycode == AKEYCODE_BACK) || (keycode == AKEYCODE_MENU))
-        {
-            // Eat BACK_BUTTON and AKEYCODE_MENU, just do nothing... and don't let to be handled by OS!
-            return 1;
-        }
-        else if ((keycode == AKEYCODE_VOLUME_UP) || (keycode == AKEYCODE_VOLUME_DOWN))
-        {
-            // Set default OS behaviour
-            return 0;
-        }
-
-        return 0;
-    }
-
-    // Register touch points count
-    CORE.Input.Touch.pointCount = AMotionEvent_getPointerCount(event);
-
-    for (int i = 0; (i < CORE.Input.Touch.pointCount) && (i < MAX_TOUCH_POINTS); i++)
-    {
-        // Register touch points id
-        CORE.Input.Touch.pointId[i] = AMotionEvent_getPointerId(event, i);
-
-        // Register touch points position
-        CORE.Input.Touch.position[i] = (Vector2){ AMotionEvent_getX(event, i), AMotionEvent_getY(event, i) };
-
-        // Normalize CORE.Input.Touch.position[i] for CORE.Window.screen.width and CORE.Window.screen.height
-        float widthRatio = (float)(CORE.Window.screen.width + CORE.Window.renderOffset.x) / (float)CORE.Window.display.width;
-        float heightRatio = (float)(CORE.Window.screen.height + CORE.Window.renderOffset.y) / (float)CORE.Window.display.height;
-        CORE.Input.Touch.position[i].x = CORE.Input.Touch.position[i].x * widthRatio - (float)CORE.Window.renderOffset.x / 2;
-        CORE.Input.Touch.position[i].y = CORE.Input.Touch.position[i].y * heightRatio - (float)CORE.Window.renderOffset.y / 2;
-    }
-
-    int32_t action = AMotionEvent_getAction(event);
-    unsigned int flags = action & AMOTION_EVENT_ACTION_MASK;
-
-#if defined(SUPPORT_GESTURES_SYSTEM)        // PLATFORM_ANDROID
-    GestureEvent gestureEvent = { 0 };
-
-    gestureEvent.pointCount = CORE.Input.Touch.pointCount;
-
-    // Register touch actions
-    if (flags == AMOTION_EVENT_ACTION_DOWN) gestureEvent.touchAction = TOUCH_ACTION_DOWN;
-    else if (flags == AMOTION_EVENT_ACTION_UP) gestureEvent.touchAction = TOUCH_ACTION_UP;
-    else if (flags == AMOTION_EVENT_ACTION_MOVE) gestureEvent.touchAction = TOUCH_ACTION_MOVE;
-    else if (flags == AMOTION_EVENT_ACTION_CANCEL) gestureEvent.touchAction = TOUCH_ACTION_CANCEL;
-
-    for (int i = 0; (i < gestureEvent.pointCount) && (i < MAX_TOUCH_POINTS); i++)
-    {
-        gestureEvent.pointId[i] = CORE.Input.Touch.pointId[i];
-        gestureEvent.position[i] = CORE.Input.Touch.position[i];
-    }
-
-    // Gesture data is sent to gestures system for processing
-    ProcessGestureEvent(gestureEvent);
-#endif
-
-    int32_t pointerIndex = (action & AMOTION_EVENT_ACTION_POINTER_INDEX_MASK) >> AMOTION_EVENT_ACTION_POINTER_INDEX_SHIFT;
-
-    if (flags == AMOTION_EVENT_ACTION_POINTER_UP || flags == AMOTION_EVENT_ACTION_UP)
-    {
-        // One of the touchpoints is released, remove it from touch point arrays
-        for (int i = pointerIndex; (i < CORE.Input.Touch.pointCount - 1) && (i < MAX_TOUCH_POINTS); i++)
-        {
-            CORE.Input.Touch.pointId[i] = CORE.Input.Touch.pointId[i+1];
-            CORE.Input.Touch.position[i] = CORE.Input.Touch.position[i+1];
-        }
-
-        CORE.Input.Touch.pointCount--;
-    }
-
-    // When all touchpoints are tapped and released really quickly, this event is generated
-    if (flags == AMOTION_EVENT_ACTION_CANCEL) CORE.Input.Touch.pointCount = 0;
-
-    if (CORE.Input.Touch.pointCount > 0) CORE.Input.Touch.currentTouchState[MOUSE_BUTTON_LEFT] = 1;
-    else CORE.Input.Touch.currentTouchState[MOUSE_BUTTON_LEFT] = 0;
-
-    return 0;
-}
-
 // To allow easier porting to android, we allow the user to define a
 // main function which we call from android_main, defined by ourselves
 extern int main(int argc, char *argv[]);
@@ -1199,4 +855,348 @@ void PollInputEvents(void)
             //ANativeActivity_finish(CORE.Android.app->activity);
         }
     }
+}
+
+// ANDROID: Process activity lifecycle commands
+static void AndroidCommandCallback(struct android_app *app, int32_t cmd)
+{
+    switch (cmd)
+    {
+        case APP_CMD_START:
+        {
+            //rendering = true;
+        } break;
+        case APP_CMD_RESUME: break;
+        case APP_CMD_INIT_WINDOW:
+        {
+            if (app->window != NULL)
+            {
+                if (CORE.Android.contextRebindRequired)
+                {
+                    // Reset screen scaling to full display size
+                    EGLint displayFormat = 0;
+                    eglGetConfigAttrib(CORE.Window.device, CORE.Window.config, EGL_NATIVE_VISUAL_ID, &displayFormat);
+
+                    // Adding renderOffset here feels rather hackish, but the viewport scaling is wrong after the
+                    // context rebinding if the screen is scaled unless offsets are added. There's probably a more
+                    // appropriate way to fix this
+                    ANativeWindow_setBuffersGeometry(app->window,
+                        CORE.Window.render.width + CORE.Window.renderOffset.x,
+                        CORE.Window.render.height + CORE.Window.renderOffset.y,
+                        displayFormat);
+
+                    // Recreate display surface and re-attach OpenGL context
+                    CORE.Window.surface = eglCreateWindowSurface(CORE.Window.device, CORE.Window.config, app->window, NULL);
+                    eglMakeCurrent(CORE.Window.device, CORE.Window.surface, CORE.Window.surface, CORE.Window.context);
+
+                    CORE.Android.contextRebindRequired = false;
+                }
+                else
+                {
+                    CORE.Window.display.width = ANativeWindow_getWidth(CORE.Android.app->window);
+                    CORE.Window.display.height = ANativeWindow_getHeight(CORE.Android.app->window);
+
+                    // Initialize graphics device (display device and OpenGL context)
+                    InitGraphicsDevice(CORE.Window.screen.width, CORE.Window.screen.height);
+
+                    // Initialize hi-res timer
+                    InitTimer();
+
+                    // Initialize random seed
+                    srand((unsigned int)time(NULL));
+
+                #if defined(SUPPORT_MODULE_RTEXT) && defined(SUPPORT_DEFAULT_FONT)
+                    // Load default font
+                    // WARNING: External function: Module required: rtext
+                    LoadFontDefault();
+                    Rectangle rec = GetFontDefault().recs[95];
+                    // NOTE: We setup a 1px padding on char rectangle to avoid pixel bleeding on MSAA filtering
+                    #if defined(SUPPORT_MODULE_RSHAPES)
+                    SetShapesTexture(GetFontDefault().texture, (Rectangle){ rec.x + 1, rec.y + 1, rec.width - 2, rec.height - 2 });  // WARNING: Module required: rshapes
+                    #endif
+                #endif
+
+                    // TODO: GPU assets reload in case of lost focus (lost context)
+                    // NOTE: This problem has been solved just unbinding and rebinding context from display
+                    /*
+                    if (assetsReloadRequired)
+                    {
+                        for (int i = 0; i < assetCount; i++)
+                        {
+                            // TODO: Unload old asset if required
+
+                            // Load texture again to pointed texture
+                            (*textureAsset + i) = LoadTexture(assetPath[i]);
+                        }
+                    }
+                    */
+                }
+            }
+        } break;
+        case APP_CMD_GAINED_FOCUS:
+        {
+            CORE.Android.appEnabled = true;
+            //ResumeMusicStream();
+        } break;
+        case APP_CMD_PAUSE: break;
+        case APP_CMD_LOST_FOCUS:
+        {
+            CORE.Android.appEnabled = false;
+            //PauseMusicStream();
+        } break;
+        case APP_CMD_TERM_WINDOW:
+        {
+            // Detach OpenGL context and destroy display surface
+            // NOTE 1: This case is used when the user exits the app without closing it. We detach the context to ensure everything is recoverable upon resuming.
+            // NOTE 2: Detaching context before destroying display surface avoids losing our resources (textures, shaders, VBOs...)
+            // NOTE 3: In some cases (too many context loaded), OS could unload context automatically... :(
+            if (CORE.Window.device != EGL_NO_DISPLAY)
+            {
+                eglMakeCurrent(CORE.Window.device, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
+
+                if (CORE.Window.surface != EGL_NO_SURFACE)
+                {
+                    eglDestroySurface(CORE.Window.device, CORE.Window.surface);
+                    CORE.Window.surface = EGL_NO_SURFACE;
+                }
+
+                CORE.Android.contextRebindRequired = true;
+            }
+            // If 'CORE.Window.device' is already set to 'EGL_NO_DISPLAY'
+            // this means that the user has already called 'CloseWindow()'
+
+        } break;
+        case APP_CMD_SAVE_STATE: break;
+        case APP_CMD_STOP: break;
+        case APP_CMD_DESTROY: break;
+        case APP_CMD_CONFIG_CHANGED:
+        {
+            //AConfiguration_fromAssetManager(CORE.Android.app->config, CORE.Android.app->activity->assetManager);
+            //print_cur_config(CORE.Android.app);
+
+            // Check screen orientation here!
+        } break;
+        default: break;
+    }
+}
+
+static GamepadButton AndroidTranslateGamepadButton(int button)
+{
+    switch (button)
+    {
+        case AKEYCODE_BUTTON_A: return GAMEPAD_BUTTON_RIGHT_FACE_DOWN;
+        case AKEYCODE_BUTTON_B: return GAMEPAD_BUTTON_RIGHT_FACE_RIGHT;
+        case AKEYCODE_BUTTON_X: return GAMEPAD_BUTTON_RIGHT_FACE_LEFT;
+        case AKEYCODE_BUTTON_Y: return GAMEPAD_BUTTON_RIGHT_FACE_UP;
+        case AKEYCODE_BUTTON_L1: return GAMEPAD_BUTTON_LEFT_TRIGGER_1;
+        case AKEYCODE_BUTTON_R1: return GAMEPAD_BUTTON_RIGHT_TRIGGER_1;
+        case AKEYCODE_BUTTON_L2: return GAMEPAD_BUTTON_LEFT_TRIGGER_2;
+        case AKEYCODE_BUTTON_R2: return GAMEPAD_BUTTON_RIGHT_TRIGGER_2;
+        case AKEYCODE_BUTTON_THUMBL: return GAMEPAD_BUTTON_LEFT_THUMB;
+        case AKEYCODE_BUTTON_THUMBR: return GAMEPAD_BUTTON_RIGHT_THUMB;
+        case AKEYCODE_BUTTON_START: return GAMEPAD_BUTTON_MIDDLE_RIGHT;
+        case AKEYCODE_BUTTON_SELECT: return GAMEPAD_BUTTON_MIDDLE_LEFT;
+        case AKEYCODE_BUTTON_MODE: return GAMEPAD_BUTTON_MIDDLE;
+        // On some (most?) gamepads dpad events are reported as axis motion instead
+        case AKEYCODE_DPAD_DOWN: return GAMEPAD_BUTTON_LEFT_FACE_DOWN;
+        case AKEYCODE_DPAD_RIGHT: return GAMEPAD_BUTTON_LEFT_FACE_RIGHT;
+        case AKEYCODE_DPAD_LEFT: return GAMEPAD_BUTTON_LEFT_FACE_LEFT;
+        case AKEYCODE_DPAD_UP: return GAMEPAD_BUTTON_LEFT_FACE_UP;
+        default: return GAMEPAD_BUTTON_UNKNOWN;
+    }
+}
+
+// ANDROID: Get input events
+static int32_t AndroidInputCallback(struct android_app *app, AInputEvent *event)
+{
+    // If additional inputs are required check:
+    // https://developer.android.com/ndk/reference/group/input
+    // https://developer.android.com/training/game-controllers/controller-input
+
+    int type = AInputEvent_getType(event);
+    int source = AInputEvent_getSource(event);
+
+    if (type == AINPUT_EVENT_TYPE_MOTION)
+    {
+        if (((source & AINPUT_SOURCE_JOYSTICK) == AINPUT_SOURCE_JOYSTICK) ||
+            ((source & AINPUT_SOURCE_GAMEPAD) == AINPUT_SOURCE_GAMEPAD))
+        {
+            // For now we'll assume a single gamepad which we "detect" on its input event
+            CORE.Input.Gamepad.ready[0] = true;
+
+            CORE.Input.Gamepad.axisState[0][GAMEPAD_AXIS_LEFT_X] = AMotionEvent_getAxisValue(
+                    event, AMOTION_EVENT_AXIS_X, 0);
+            CORE.Input.Gamepad.axisState[0][GAMEPAD_AXIS_LEFT_Y] = AMotionEvent_getAxisValue(
+                    event, AMOTION_EVENT_AXIS_Y, 0);
+            CORE.Input.Gamepad.axisState[0][GAMEPAD_AXIS_RIGHT_X] = AMotionEvent_getAxisValue(
+                    event, AMOTION_EVENT_AXIS_Z, 0);
+            CORE.Input.Gamepad.axisState[0][GAMEPAD_AXIS_RIGHT_Y] = AMotionEvent_getAxisValue(
+                    event, AMOTION_EVENT_AXIS_RZ, 0);
+            CORE.Input.Gamepad.axisState[0][GAMEPAD_AXIS_LEFT_TRIGGER] = AMotionEvent_getAxisValue(
+                    event, AMOTION_EVENT_AXIS_BRAKE, 0) * 2.0f - 1.0f;
+            CORE.Input.Gamepad.axisState[0][GAMEPAD_AXIS_RIGHT_TRIGGER] = AMotionEvent_getAxisValue(
+                    event, AMOTION_EVENT_AXIS_GAS, 0) * 2.0f - 1.0f;
+
+            // dpad is reported as an axis on android
+            float dpadX = AMotionEvent_getAxisValue(event, AMOTION_EVENT_AXIS_HAT_X, 0);
+            float dpadY = AMotionEvent_getAxisValue(event, AMOTION_EVENT_AXIS_HAT_Y, 0);
+
+            if (dpadX == 1.0f)
+            {
+                CORE.Input.Gamepad.currentButtonState[0][GAMEPAD_BUTTON_LEFT_FACE_RIGHT] = 1;
+                CORE.Input.Gamepad.currentButtonState[0][GAMEPAD_BUTTON_LEFT_FACE_LEFT] = 0;
+            }
+            else if (dpadX == -1.0f)
+            {
+                CORE.Input.Gamepad.currentButtonState[0][GAMEPAD_BUTTON_LEFT_FACE_RIGHT] = 0;
+                CORE.Input.Gamepad.currentButtonState[0][GAMEPAD_BUTTON_LEFT_FACE_LEFT] = 1;
+            }
+            else
+            {
+                CORE.Input.Gamepad.currentButtonState[0][GAMEPAD_BUTTON_LEFT_FACE_RIGHT] = 0;
+                CORE.Input.Gamepad.currentButtonState[0][GAMEPAD_BUTTON_LEFT_FACE_LEFT] = 0;
+            }
+
+            if (dpadY == 1.0f)
+            {
+                CORE.Input.Gamepad.currentButtonState[0][GAMEPAD_BUTTON_LEFT_FACE_DOWN] = 1;
+                CORE.Input.Gamepad.currentButtonState[0][GAMEPAD_BUTTON_LEFT_FACE_UP] = 0;
+            }
+            else if (dpadY == -1.0f)
+            {
+                CORE.Input.Gamepad.currentButtonState[0][GAMEPAD_BUTTON_LEFT_FACE_DOWN] = 0;
+                CORE.Input.Gamepad.currentButtonState[0][GAMEPAD_BUTTON_LEFT_FACE_UP] = 1;
+            }
+            else
+            {
+                CORE.Input.Gamepad.currentButtonState[0][GAMEPAD_BUTTON_LEFT_FACE_DOWN] = 0;
+                CORE.Input.Gamepad.currentButtonState[0][GAMEPAD_BUTTON_LEFT_FACE_UP] = 0;
+            }
+
+            return 1; // Handled gamepad axis motion
+        }
+    }
+    else if (type == AINPUT_EVENT_TYPE_KEY)
+    {
+        int32_t keycode = AKeyEvent_getKeyCode(event);
+        //int32_t AKeyEvent_getMetaState(event);
+
+        // Handle gamepad button presses and releases
+        if (((source & AINPUT_SOURCE_JOYSTICK) == AINPUT_SOURCE_JOYSTICK) ||
+            ((source & AINPUT_SOURCE_GAMEPAD) == AINPUT_SOURCE_GAMEPAD))
+        {
+            // For now we'll assume a single gamepad which we "detect" on its input event
+            CORE.Input.Gamepad.ready[0] = true;
+
+            GamepadButton button = AndroidTranslateGamepadButton(keycode);
+
+            if (button == GAMEPAD_BUTTON_UNKNOWN) return 1;
+
+            if (AKeyEvent_getAction(event) == AKEY_EVENT_ACTION_DOWN)
+            {
+                CORE.Input.Gamepad.currentButtonState[0][button] = 1;
+            }
+            else CORE.Input.Gamepad.currentButtonState[0][button] = 0;  // Key up
+
+            return 1; // Handled gamepad button
+        }
+
+        // Save current button and its state
+        // NOTE: Android key action is 0 for down and 1 for up
+        if (AKeyEvent_getAction(event) == AKEY_EVENT_ACTION_DOWN)
+        {
+            CORE.Input.Keyboard.currentKeyState[keycode] = 1;   // Key down
+
+            CORE.Input.Keyboard.keyPressedQueue[CORE.Input.Keyboard.keyPressedQueueCount] = keycode;
+            CORE.Input.Keyboard.keyPressedQueueCount++;
+        }
+        else if (AKeyEvent_getAction(event) == AKEY_EVENT_ACTION_MULTIPLE) CORE.Input.Keyboard.keyRepeatInFrame[keycode] = 1;
+        else CORE.Input.Keyboard.currentKeyState[keycode] = 0;  // Key up
+
+        if (keycode == AKEYCODE_POWER)
+        {
+            // Let the OS handle input to avoid app stuck. Behaviour: CMD_PAUSE -> CMD_SAVE_STATE -> CMD_STOP -> CMD_CONFIG_CHANGED -> CMD_LOST_FOCUS
+            // Resuming Behaviour: CMD_START -> CMD_RESUME -> CMD_CONFIG_CHANGED -> CMD_CONFIG_CHANGED -> CMD_GAINED_FOCUS
+            // It seems like locking mobile, screen size (CMD_CONFIG_CHANGED) is affected.
+            // NOTE: AndroidManifest.xml must have <activity android:configChanges="orientation|keyboardHidden|screenSize" >
+            // Before that change, activity was calling CMD_TERM_WINDOW and CMD_DESTROY when locking mobile, so that was not a normal behaviour
+            return 0;
+        }
+        else if ((keycode == AKEYCODE_BACK) || (keycode == AKEYCODE_MENU))
+        {
+            // Eat BACK_BUTTON and AKEYCODE_MENU, just do nothing... and don't let to be handled by OS!
+            return 1;
+        }
+        else if ((keycode == AKEYCODE_VOLUME_UP) || (keycode == AKEYCODE_VOLUME_DOWN))
+        {
+            // Set default OS behaviour
+            return 0;
+        }
+
+        return 0;
+    }
+
+    // Register touch points count
+    CORE.Input.Touch.pointCount = AMotionEvent_getPointerCount(event);
+
+    for (int i = 0; (i < CORE.Input.Touch.pointCount) && (i < MAX_TOUCH_POINTS); i++)
+    {
+        // Register touch points id
+        CORE.Input.Touch.pointId[i] = AMotionEvent_getPointerId(event, i);
+
+        // Register touch points position
+        CORE.Input.Touch.position[i] = (Vector2){ AMotionEvent_getX(event, i), AMotionEvent_getY(event, i) };
+
+        // Normalize CORE.Input.Touch.position[i] for CORE.Window.screen.width and CORE.Window.screen.height
+        float widthRatio = (float)(CORE.Window.screen.width + CORE.Window.renderOffset.x) / (float)CORE.Window.display.width;
+        float heightRatio = (float)(CORE.Window.screen.height + CORE.Window.renderOffset.y) / (float)CORE.Window.display.height;
+        CORE.Input.Touch.position[i].x = CORE.Input.Touch.position[i].x * widthRatio - (float)CORE.Window.renderOffset.x / 2;
+        CORE.Input.Touch.position[i].y = CORE.Input.Touch.position[i].y * heightRatio - (float)CORE.Window.renderOffset.y / 2;
+    }
+
+    int32_t action = AMotionEvent_getAction(event);
+    unsigned int flags = action & AMOTION_EVENT_ACTION_MASK;
+
+#if defined(SUPPORT_GESTURES_SYSTEM)        // PLATFORM_ANDROID
+    GestureEvent gestureEvent = { 0 };
+
+    gestureEvent.pointCount = CORE.Input.Touch.pointCount;
+
+    // Register touch actions
+    if (flags == AMOTION_EVENT_ACTION_DOWN) gestureEvent.touchAction = TOUCH_ACTION_DOWN;
+    else if (flags == AMOTION_EVENT_ACTION_UP) gestureEvent.touchAction = TOUCH_ACTION_UP;
+    else if (flags == AMOTION_EVENT_ACTION_MOVE) gestureEvent.touchAction = TOUCH_ACTION_MOVE;
+    else if (flags == AMOTION_EVENT_ACTION_CANCEL) gestureEvent.touchAction = TOUCH_ACTION_CANCEL;
+
+    for (int i = 0; (i < gestureEvent.pointCount) && (i < MAX_TOUCH_POINTS); i++)
+    {
+        gestureEvent.pointId[i] = CORE.Input.Touch.pointId[i];
+        gestureEvent.position[i] = CORE.Input.Touch.position[i];
+    }
+
+    // Gesture data is sent to gestures system for processing
+    ProcessGestureEvent(gestureEvent);
+#endif
+
+    int32_t pointerIndex = (action & AMOTION_EVENT_ACTION_POINTER_INDEX_MASK) >> AMOTION_EVENT_ACTION_POINTER_INDEX_SHIFT;
+
+    if (flags == AMOTION_EVENT_ACTION_POINTER_UP || flags == AMOTION_EVENT_ACTION_UP)
+    {
+        // One of the touchpoints is released, remove it from touch point arrays
+        for (int i = pointerIndex; (i < CORE.Input.Touch.pointCount - 1) && (i < MAX_TOUCH_POINTS); i++)
+        {
+            CORE.Input.Touch.pointId[i] = CORE.Input.Touch.pointId[i+1];
+            CORE.Input.Touch.position[i] = CORE.Input.Touch.position[i+1];
+        }
+
+        CORE.Input.Touch.pointCount--;
+    }
+
+    // When all touchpoints are tapped and released really quickly, this event is generated
+    if (flags == AMOTION_EVENT_ACTION_CANCEL) CORE.Input.Touch.pointCount = 0;
+
+    if (CORE.Input.Touch.pointCount > 0) CORE.Input.Touch.currentTouchState[MOUSE_BUTTON_LEFT] = 1;
+    else CORE.Input.Touch.currentTouchState[MOUSE_BUTTON_LEFT] = 0;
+
+    return 0;
 }

--- a/src/rcore_android.c
+++ b/src/rcore_android.c
@@ -1049,6 +1049,13 @@ int GetMonitorPhysicalWidth(int monitor)
     return 0;
 }
 
+// Set a custom key to exit program
+// NOTE: default exitKey is ESCAPE
+void SetExitKey(int key)
+{
+    TRACELOG(LOG_INFO, "SetExitKey not implemented in rcore_android.c");
+}
+
 // Get gamepad internal name id
 const char *GetGamepadName(int gamepad)
 {

--- a/src/rcore_desktop.c
+++ b/src/rcore_desktop.c
@@ -1512,6 +1512,13 @@ int GetMonitorPhysicalWidth(int monitor)
     return 0;
 }
 
+// Set a custom key to exit program
+// NOTE: default exitKey is ESCAPE
+void SetExitKey(int key)
+{
+    CORE.Input.Keyboard.exitKey = key;
+}
+
 // Get gamepad internal name id
 const char *GetGamepadName(int gamepad)
 {

--- a/src/rcore_web.c
+++ b/src/rcore_web.c
@@ -1041,6 +1041,13 @@ int GetMonitorPhysicalWidth(int monitor)
     return 0;
 }
 
+// Set a custom key to exit program
+// NOTE: default exitKey is ESCAPE
+void SetExitKey(int key)
+{
+    CORE.Input.Keyboard.exitKey = key;
+}
+
 // NOTE: Gamepad support not implemented in emscripten GLFW3 (PLATFORM_WEB)
 
 // Get gamepad internal name id

--- a/src/rcore_web.c
+++ b/src/rcore_web.c
@@ -1272,3 +1272,257 @@ void PollInputEvents(void)
         }
     }
 }
+
+// GLFW3 WindowSize Callback, runs when window is resizedLastFrame
+// NOTE: Window resizing not allowed by default
+static void WindowSizeCallback(GLFWwindow *window, int width, int height)
+{
+    // Reset viewport and projection matrix for new size
+    SetupViewport(width, height);
+
+    CORE.Window.currentFbo.width = width;
+    CORE.Window.currentFbo.height = height;
+    CORE.Window.resizedLastFrame = true;
+
+    if (IsWindowFullscreen()) return;
+
+    // Set current screen size
+    if ((CORE.Window.flags & FLAG_WINDOW_HIGHDPI) > 0)
+    {
+        Vector2 windowScaleDPI = GetWindowScaleDPI();
+
+        CORE.Window.screen.width = (unsigned int)(width/windowScaleDPI.x);
+        CORE.Window.screen.height = (unsigned int)(height/windowScaleDPI.y);
+    }
+    else
+    {
+        CORE.Window.screen.width = width;
+        CORE.Window.screen.height = height;
+    }
+
+    // NOTE: Postprocessing texture is not scaled to new size
+}
+
+// GLFW3 WindowIconify Callback, runs when window is minimized/restored
+static void WindowIconifyCallback(GLFWwindow *window, int iconified)
+{
+    if (iconified) CORE.Window.flags |= FLAG_WINDOW_MINIMIZED;  // The window was iconified
+    else CORE.Window.flags &= ~FLAG_WINDOW_MINIMIZED;           // The window was restored
+}
+
+// GLFW3 WindowFocus Callback, runs when window get/lose focus
+static void WindowFocusCallback(GLFWwindow *window, int focused)
+{
+    if (focused) CORE.Window.flags &= ~FLAG_WINDOW_UNFOCUSED;   // The window was focused
+    else CORE.Window.flags |= FLAG_WINDOW_UNFOCUSED;            // The window lost focus
+}
+
+// GLFW3 Keyboard Callback, runs on key pressed
+static void KeyCallback(GLFWwindow *window, int key, int scancode, int action, int mods)
+{
+    if (key < 0) return;    // Security check, macOS fn key generates -1
+
+    // WARNING: GLFW could return GLFW_REPEAT, we need to consider it as 1
+    // to work properly with our implementation (IsKeyDown/IsKeyUp checks)
+    if (action == GLFW_RELEASE) CORE.Input.Keyboard.currentKeyState[key] = 0;
+    else if(action == GLFW_PRESS) CORE.Input.Keyboard.currentKeyState[key] = 1;
+    else if(action == GLFW_REPEAT) CORE.Input.Keyboard.keyRepeatInFrame[key] = 1;
+
+    // Check if there is space available in the key queue
+    if ((CORE.Input.Keyboard.keyPressedQueueCount < MAX_KEY_PRESSED_QUEUE) && (action == GLFW_PRESS))
+    {
+        // Add character to the queue
+        CORE.Input.Keyboard.keyPressedQueue[CORE.Input.Keyboard.keyPressedQueueCount] = key;
+        CORE.Input.Keyboard.keyPressedQueueCount++;
+    }
+
+    // Check the exit key to set close window
+    if ((key == CORE.Input.Keyboard.exitKey) && (action == GLFW_PRESS)) glfwSetWindowShouldClose(CORE.Window.handle, GLFW_TRUE);
+
+#if defined(SUPPORT_SCREEN_CAPTURE)
+    if ((key == GLFW_KEY_F12) && (action == GLFW_PRESS))
+    {
+#if defined(SUPPORT_GIF_RECORDING)
+        if (mods & GLFW_MOD_CONTROL)
+        {
+            if (gifRecording)
+            {
+                gifRecording = false;
+
+                MsfGifResult result = msf_gif_end(&gifState);
+
+                SaveFileData(TextFormat("%s/screenrec%03i.gif", CORE.Storage.basePath, screenshotCounter), result.data, (unsigned int)result.dataSize);
+                msf_gif_free(result);
+
+                // Download file from MEMFS (emscripten memory filesystem)
+                // saveFileFromMEMFSToDisk() function is defined in raylib/templates/web_shel/shell.html
+                emscripten_run_script(TextFormat("saveFileFromMEMFSToDisk('%s','%s')", TextFormat("screenrec%03i.gif", screenshotCounter - 1), TextFormat("screenrec%03i.gif", screenshotCounter - 1)));
+
+                TRACELOG(LOG_INFO, "SYSTEM: Finish animated GIF recording");
+            }
+            else
+            {
+                gifRecording = true;
+                gifFrameCounter = 0;
+
+                Vector2 scale = GetWindowScaleDPI();
+                msf_gif_begin(&gifState, (int)((float)CORE.Window.render.width*scale.x), (int)((float)CORE.Window.render.height*scale.y));
+                screenshotCounter++;
+
+                TRACELOG(LOG_INFO, "SYSTEM: Start animated GIF recording: %s", TextFormat("screenrec%03i.gif", screenshotCounter));
+            }
+        }
+        else
+#endif  // SUPPORT_GIF_RECORDING
+        {
+            TakeScreenshot(TextFormat("screenshot%03i.png", screenshotCounter));
+            screenshotCounter++;
+        }
+    }
+#endif  // SUPPORT_SCREEN_CAPTURE
+
+#if defined(SUPPORT_EVENTS_AUTOMATION)
+    if ((key == GLFW_KEY_F11) && (action == GLFW_PRESS))
+    {
+        eventsRecording = !eventsRecording;
+
+        // On finish recording, we export events into a file
+        if (!eventsRecording) ExportAutomationEvents("eventsrec.rep");
+    }
+    else if ((key == GLFW_KEY_F9) && (action == GLFW_PRESS))
+    {
+        LoadAutomationEvents("eventsrec.rep");
+        eventsPlaying = true;
+
+        TRACELOG(LOG_WARNING, "eventsPlaying enabled!");
+    }
+#endif
+}
+
+// GLFW3 Char Key Callback, runs on key down (gets equivalent unicode char value)
+static void CharCallback(GLFWwindow *window, unsigned int key)
+{
+    //TRACELOG(LOG_DEBUG, "Char Callback: KEY:%i(%c)", key, key);
+
+    // NOTE: Registers any key down considering OS keyboard layout but
+    // does not detect action events, those should be managed by user...
+    // Ref: https://github.com/glfw/glfw/issues/668#issuecomment-166794907
+    // Ref: https://www.glfw.org/docs/latest/input_guide.html#input_char
+
+    // Check if there is space available in the queue
+    if (CORE.Input.Keyboard.charPressedQueueCount < MAX_CHAR_PRESSED_QUEUE)
+    {
+        // Add character to the queue
+        CORE.Input.Keyboard.charPressedQueue[CORE.Input.Keyboard.charPressedQueueCount] = key;
+        CORE.Input.Keyboard.charPressedQueueCount++;
+    }
+}
+
+// GLFW3 Mouse Button Callback, runs on mouse button pressed
+static void MouseButtonCallback(GLFWwindow *window, int button, int action, int mods)
+{
+    // WARNING: GLFW could only return GLFW_PRESS (1) or GLFW_RELEASE (0) for now,
+    // but future releases may add more actions (i.e. GLFW_REPEAT)
+    CORE.Input.Mouse.currentButtonState[button] = action;
+
+#if defined(SUPPORT_GESTURES_SYSTEM) && defined(SUPPORT_MOUSE_GESTURES)         // PLATFORM_DESKTOP
+    // Process mouse events as touches to be able to use mouse-gestures
+    GestureEvent gestureEvent = { 0 };
+
+    // Register touch actions
+    if ((CORE.Input.Mouse.currentButtonState[button] == 1) && (CORE.Input.Mouse.previousButtonState[button] == 0)) gestureEvent.touchAction = TOUCH_ACTION_DOWN;
+    else if ((CORE.Input.Mouse.currentButtonState[button] == 0) && (CORE.Input.Mouse.previousButtonState[button] == 1)) gestureEvent.touchAction = TOUCH_ACTION_UP;
+
+    // NOTE: TOUCH_ACTION_MOVE event is registered in MouseCursorPosCallback()
+
+    // Assign a pointer ID
+    gestureEvent.pointId[0] = 0;
+
+    // Register touch points count
+    gestureEvent.pointCount = 1;
+
+    // Register touch points position, only one point registered
+    gestureEvent.position[0] = GetMousePosition();
+
+    // Normalize gestureEvent.position[0] for CORE.Window.screen.width and CORE.Window.screen.height
+    gestureEvent.position[0].x /= (float)GetScreenWidth();
+    gestureEvent.position[0].y /= (float)GetScreenHeight();
+
+    // Gesture data is sent to gestures-system for processing
+    // Prevent calling ProcessGestureEvent() when Emscripten is present and there's a touch gesture, so EmscriptenTouchCallback() can handle it itself
+    if (GetMouseX() != 0 || GetMouseY() != 0) ProcessGestureEvent(gestureEvent);
+
+#endif
+}
+
+// GLFW3 Cursor Position Callback, runs on mouse move
+static void MouseCursorPosCallback(GLFWwindow *window, double x, double y)
+{
+    CORE.Input.Mouse.currentPosition.x = (float)x;
+    CORE.Input.Mouse.currentPosition.y = (float)y;
+    CORE.Input.Touch.position[0] = CORE.Input.Mouse.currentPosition;
+
+#if defined(SUPPORT_GESTURES_SYSTEM) && defined(SUPPORT_MOUSE_GESTURES)         // PLATFORM_DESKTOP
+    // Process mouse events as touches to be able to use mouse-gestures
+    GestureEvent gestureEvent = { 0 };
+
+    gestureEvent.touchAction = TOUCH_ACTION_MOVE;
+
+    // Assign a pointer ID
+    gestureEvent.pointId[0] = 0;
+
+    // Register touch points count
+    gestureEvent.pointCount = 1;
+
+    // Register touch points position, only one point registered
+    gestureEvent.position[0] = CORE.Input.Touch.position[0];
+
+    // Normalize gestureEvent.position[0] for CORE.Window.screen.width and CORE.Window.screen.height
+    gestureEvent.position[0].x /= (float)GetScreenWidth();
+    gestureEvent.position[0].y /= (float)GetScreenHeight();
+
+    // Gesture data is sent to gestures-system for processing
+    ProcessGestureEvent(gestureEvent);
+#endif
+}
+
+// GLFW3 Scrolling Callback, runs on mouse wheel
+static void MouseScrollCallback(GLFWwindow *window, double xoffset, double yoffset)
+{
+    CORE.Input.Mouse.currentWheelMove = (Vector2){ (float)xoffset, (float)yoffset };
+}
+
+// GLFW3 CursorEnter Callback, when cursor enters the window
+static void CursorEnterCallback(GLFWwindow *window, int enter)
+{
+    if (enter == true) CORE.Input.Mouse.cursorOnScreen = true;
+    else CORE.Input.Mouse.cursorOnScreen = false;
+}
+
+// GLFW3 Window Drop Callback, runs when drop files into window
+static void WindowDropCallback(GLFWwindow *window, int count, const char **paths)
+{
+    if (count > 0)
+    {
+        // In case previous dropped filepaths have not been freed, we free them
+        if (CORE.Window.dropFileCount > 0)
+        {
+            for (unsigned int i = 0; i < CORE.Window.dropFileCount; i++) RL_FREE(CORE.Window.dropFilepaths[i]);
+
+            RL_FREE(CORE.Window.dropFilepaths);
+
+            CORE.Window.dropFileCount = 0;
+            CORE.Window.dropFilepaths = NULL;
+        }
+
+        // WARNING: Paths are freed by GLFW when the callback returns, we must keep an internal copy
+        CORE.Window.dropFileCount = count;
+        CORE.Window.dropFilepaths = (char **)RL_CALLOC(CORE.Window.dropFileCount, sizeof(char *));
+
+        for (unsigned int i = 0; i < CORE.Window.dropFileCount; i++)
+        {
+            CORE.Window.dropFilepaths[i] = (char *)RL_CALLOC(MAX_FILEPATH_LENGTH, sizeof(char));
+            strcpy(CORE.Window.dropFilepaths[i], paths[i]);
+        }
+    }
+}


### PR DESCRIPTION
### PR changes
1. Moves `SetExitKey` from `rcore.c` ([R1940-R1947](https://github.com/raysan5/raylib/pull/3345/files#diff-39fea0e3daa23741e81daf967717f35c7842426aab26a0bc3f525d6a2f03e339R1940-R1947)) to `rcore_android.c` ([R1052-R1057](https://github.com/raysan5/raylib/pull/3345/files#diff-df7f2529f920b22e7f3b28d8c53b9042fe9ba3e0c4be0a421ac8d9e0c3bde72dR1052-R1057)), `rcore_desktop.c` ([R1515-R1520](https://github.com/raysan5/raylib/pull/3345/files#diff-10e13300b4588e538a0c2c603707242b63d716e3ab2b80b81db9a54c308ca3acR1515-R1520)), `rcore_web.c` ([R1044-R1049](https://github.com/raysan5/raylib/pull/3345/files#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdR1044-R1049)). **Note:** instead of deleting it from `rcore.c` just commented it to keep as reference. Will clean up later.

2. Moves the following callback functions from `rcore.c` to `rcore_desktop.c` and `rcore_web.c` (**Note:** instead of deleting them from `rcore.c` just commented it to keep as reference. Will clean up later.):

| function | from | to | and |
| --- | --- | --- | --- |
| `WindowSizeCallback`| [L2453-L2484](https://github.com/raysan5/raylib/pull/3345/files#diff-39fea0e3daa23741e81daf967717f35c7842426aab26a0bc3f525d6a2f03e339L2453-L2484) | [R1764-R1795](https://github.com/raysan5/raylib/pull/3345/files#diff-10e13300b4588e538a0c2c603707242b63d716e3ab2b80b81db9a54c308ca3acR1764-R1795) | [R1278-R1304](https://github.com/raysan5/raylib/pull/3345/files#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdR1278-R1304) |
| `WindowIconifyCallback`| [L2487-L2491](https://github.com/raysan5/raylib/pull/3345/files#diff-39fea0e3daa23741e81daf967717f35c7842426aab26a0bc3f525d6a2f03e339L2487-L2491) | [R1798-R1802](https://github.com/raysan5/raylib/pull/3345/files#diff-10e13300b4588e538a0c2c603707242b63d716e3ab2b80b81db9a54c308ca3acR1798-R1802) | [R1307-R1311](https://github.com/raysan5/raylib/pull/3345/files#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdR1307-R1311) |
| `WindowFocusCallback`| [L2494-L2498](https://github.com/raysan5/raylib/pull/3345/files#diff-39fea0e3daa23741e81daf967717f35c7842426aab26a0bc3f525d6a2f03e339L2494-L2498) | [R1805-R1809](https://github.com/raysan5/raylib/pull/3345/files#diff-10e13300b4588e538a0c2c603707242b63d716e3ab2b80b81db9a54c308ca3acR1805-R1809) | [R1314-R1318](https://github.com/raysan5/raylib/pull/3345/files#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdR1314-R1318) |
| `KeyCallback`| [L2501-L2588](https://github.com/raysan5/raylib/pull/3345/files#diff-39fea0e3daa23741e81daf967717f35c7842426aab26a0bc3f525d6a2f03e339L2501-L2588) | [R1812-R1891](https://github.com/raysan5/raylib/pull/3345/files#diff-10e13300b4588e538a0c2c603707242b63d716e3ab2b80b81db9a54c308ca3acR1812-R1891) | [R1321-R1400](https://github.com/raysan5/raylib/pull/3345/files#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdR1321-R1400) |
| `CharCallback`| [L2591-L2607](https://github.com/raysan5/raylib/pull/3345/files#diff-39fea0e3daa23741e81daf967717f35c7842426aab26a0bc3f525d6a2f03e339L2591-L2607) | [R1894-R1910](https://github.com/raysan5/raylib/pull/3345/files#diff-10e13300b4588e538a0c2c603707242b63d716e3ab2b80b81db9a54c308ca3acR1894-R1910) | [R1403-R1419](https://github.com/raysan5/raylib/pull/3345/files#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdR1403-R1419) |
| `MouseButtonCallback`| [L2610-L2648](https://github.com/raysan5/raylib/pull/3345/files#diff-39fea0e3daa23741e81daf967717f35c7842426aab26a0bc3f525d6a2f03e339L2610-L2648) | [R1913-R1946)](https://github.com/raysan5/raylib/pull/3345/files#diff-10e13300b4588e538a0c2c603707242b63d716e3ab2b80b81db9a54c308ca3acR1913-R1946) | [R1422-R1456](https://github.com/raysan5/raylib/pull/3345/files#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdR1422-R1456) |
| `MouseCursorPosCallback`| [L2651-L2679](https://github.com/raysan5/raylib/pull/3345/files#diff-39fea0e3daa23741e81daf967717f35c7842426aab26a0bc3f525d6a2f03e339L2651-L2679) | [R1949-R1977](https://github.com/raysan5/raylib/pull/3345/files#diff-10e13300b4588e538a0c2c603707242b63d716e3ab2b80b81db9a54c308ca3acR1949-R1977) | [R1459-R1487](https://github.com/raysan5/raylib/pull/3345/files#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdR1459-R1487) |
| `MouseScrollCallback`| [L2682-L2685](https://github.com/raysan5/raylib/pull/3345/files#diff-39fea0e3daa23741e81daf967717f35c7842426aab26a0bc3f525d6a2f03e339L2682-L2685) | [R1980-R1983](https://github.com/raysan5/raylib/pull/3345/files#diff-10e13300b4588e538a0c2c603707242b63d716e3ab2b80b81db9a54c308ca3acR1980-R1983) | [R1490-R1493](https://github.com/raysan5/raylib/pull/3345/files#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdR1490-R1493) |
| `CursorEnterCallback`| [L2688-L2692](https://github.com/raysan5/raylib/pull/3345/files#diff-39fea0e3daa23741e81daf967717f35c7842426aab26a0bc3f525d6a2f03e339L2688-L2692) | [R1986-R1990](https://github.com/raysan5/raylib/pull/3345/files#diff-10e13300b4588e538a0c2c603707242b63d716e3ab2b80b81db9a54c308ca3acR1986-R1990) | [R1496-R1500](https://github.com/raysan5/raylib/pull/3345/files#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdR1496-R1500) |
| `WindowDropCallback`| [L2695-L2720](https://github.com/raysan5/raylib/pull/3345/files#diff-39fea0e3daa23741e81daf967717f35c7842426aab26a0bc3f525d6a2f03e339L2695-L2720) | [R1993-R2018](https://github.com/raysan5/raylib/pull/3345/files#diff-10e13300b4588e538a0c2c603707242b63d716e3ab2b80b81db9a54c308ca3acR1993-R2018) | [R1503-R1528](https://github.com/raysan5/raylib/pull/3345/files#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdR1503-R1528) |
<br>

3. Relocates the following emscripten callback functions inside `rcore_web.c` to their previous position on `rcore.c` to more easily track the split:

| function | from | to |
| --- | --- | --- |
| `EmscriptenFullscreenChangeCallback` | [L190-L195](https://github.com/raysan5/raylib/pull/3345/files#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdL190-L195) | [R1386-R1391](https://github.com/raysan5/raylib/pull/3345/files#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdR1386-R1391) |
| `EmscriptenWindowResizedCallback` | [L198-L203](https://github.com/raysan5/raylib/pull/3345/files#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdL198-L203) | [R1394-R1399](https://github.com/raysan5/raylib/pull/3345/files#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdR1394-R1399) |
| `EmscriptenResizeCallback` | [L205-L242](https://github.com/raysan5/raylib/pull/3345/files#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdL205-L242) | [R1401-R1438](https://github.com/raysan5/raylib/pull/3345/files#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdR1401-R1438) |
| `EmscriptenMouseCallback` | [L245-L250](https://github.com/raysan5/raylib/pull/3345/files#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdL245-L250) | [R1441-R1446](https://github.com/raysan5/raylib/pull/3345/files#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdR1441-R1446) |
| `EmscriptenGamepadCallback` | [L253-L272](https://github.com/raysan5/raylib/pull/3345/files#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdL253-L272) | [R1449-R1468](https://github.com/raysan5/raylib/pull/3345/files#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdR1449-R1468) |
| `EmscriptenTouchCallback` | [L275-L332)](https://github.com/raysan5/raylib/pull/3345/files#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdL275-L332) | [R1471-R1528](https://github.com/raysan5/raylib/pull/3345/files#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdR1471-R1528) |
<br>

4. The bbdbecc commit relocates some android callback functions from the middle of the `rcore_android.c` file to the end of the same file. That was done to more easily compare it to the original `rcore.c` which had them in the end of the file. However, Github is having trouble displaying the diff cleaning (I think it's because this PR already added a new function in the middle of `rcore_android.c` and that's making the diff display getting lost). Either way, I'd like to keep a clean log to make it easier to track and follow all changes, so I reverted this commit on this PR. I will commit it again on a future batch.

5. See item 4 above.

6. Update `UnloadVrStereoConfig` to log an error.
On `rcore.c`: [R831](https://github.com/raysan5/raylib/pull/3345/files#diff-39fea0e3daa23741e81daf967717f35c7842426aab26a0bc3f525d6a2f03e339R831).

7. Update `SetClipboardText` to log an error.
On `rcore_android.c`: [R931](https://github.com/raysan5/raylib/pull/3345/files#diff-df7f2529f920b22e7f3b28d8c53b9042fe9ba3e0c4be0a421ac8d9e0c3bde72dR931).

8. Fix `screenMin` and `screenMax` var names to set the default values.
On `rcore_android.c`: [R139-R143](https://github.com/raysan5/raylib/pull/3345/files#diff-df7f2529f920b22e7f3b28d8c53b9042fe9ba3e0c4be0a421ac8d9e0c3bde72dR139-R143).

### Status
- #3339

### Environment
- Compiled with `emscripten/emsdk` on Linux (Mint 21.1 64-bit).
- Tested on Firefox (115.1.0esr 64-bit) and Chromium (115.0.5790.170 64-bit) both running on Linux Mint (21.1 64-bit).

### Edits
**1:** added line marks.
**2:** added moved callbacks.
**3:** added relocated callbacks.
**4:** added and reverted android relocated callbacks.
**5:** added update to UnloadVrStereoConfig.
**6:** added update do SetClipboardText.
**7:** added fix for screenMin/Max.
