### PR TITLE
Factor's Raylib bindings mention being at v4.5 now.

### DIFF
--- a/BINDINGS.md
+++ b/BINDINGS.md
@@ -23,7 +23,7 @@ Some people ported raylib to other languages in form of bindings or wrappers to 
 | raylib-d           | **4.5** | [D](https://dlang.org/)              | Zlib | https://github.com/schveiguy/raylib-d        |
 | dlang_raylib       | 4.0     | [D](https://dlang.org)                  | MPL-2.0 |https://github.com/rc-05/dlang_raylib          |
 | rayex              | 3.7     | [elixir](https://elixir-lang.org/)      | Apache-2.0 | https://github.com/shiryel/rayex     |
-| raylib-factor      | 4.0     | [Factor](https://factorcode.org/)        | BSD  | https://github.com/factor/factor/blob/master/extra/raylib/raylib.factor   |
+| raylib-factor      | **4.5** | [Factor](https://factorcode.org/)        | BSD  | https://github.com/factor/factor/blob/master/extra/raylib/raylib.factor   |
 | raylib-freebasic   | **4.5** | [FreeBASIC](https://www.freebasic.net/) | MIT | https://github.com/WIITD/raylib-freebasic     |
 | fortran-raylib     | **4.5** | [Fortran](https://fortran-lang.org/) | ISC | https://github.com/interkosmos/fortran-raylib     |
 | raylib for Pascal  | **4.5** | [Object Pascal](https://en.wikipedia.org/wiki/Object_Pascal) | Modified Zlib | https://github.com/tinyBigGAMES/raylib |


### PR DESCRIPTION
I looked at the linked Factor binding page for Raylib and found that the file [summary.txt](https://github.com/factor/factor/blob/master/extra/raylib/summary.txt) has the following text in it:

```
Bindings for Raylib 4.5
```

The bindings have also been updated within the last week.

This implies that Factor's Raylib bindings are either already up to date with v4.5 or will be soon.

Thus, I have submitted this likely correction to Raylib's bindings table.

(PS: There are other Factor Raylib bindings on the internet that are less up-to-date, so don't confuse those with this.)