### PR TITLE
[rcamera] DLL Exports

### DIFF
--- a/src/rcamera.h
+++ b/src/rcamera.h
@@ -46,6 +46,20 @@
 // Defines and Macros
 //----------------------------------------------------------------------------------
 // Function specifiers definition
+
+// Function specifiers in case library is build/used as a shared library (Windows)
+// NOTE: Microsoft specifiers to tell compiler that symbols are imported/exported from a .dll
+#if defined(_WIN32)
+#if defined(BUILD_LIBTYPE_SHARED)
+#if defined(__TINYC__)
+#define __declspec(x) __attribute__((x))
+#endif
+#define RLAPI __declspec(dllexport)     // We are building the library as a Win32 shared library (.dll)
+#elif defined(USE_LIBTYPE_SHARED)
+#define RLAPI __declspec(dllimport)     // We are using the library as a Win32 shared library (.dll)
+#endif
+#endif
+
 #ifndef RLAPI
     #define RLAPI       // Functions defined as 'extern' by default (implicit specifiers)
 #endif


### PR DESCRIPTION
The rcamera functions were not exported to the dll, and thus are not available to users of the DLL or bindings that must link dynamically.

This PR exports them the same as other raylib modules.