### PR TITLE
[split] `rcore`, `android` changes

### DIFF
--- a/src/rcore.h
+++ b/src/rcore.h
@@ -16,6 +16,11 @@
                                     // NOTE: GLFW3 already includes gl.h (OpenGL) headers
 #endif
 
+#if defined(PLATFORM_ANDROID)
+    #include <EGL/egl.h>            // Native platform windowing system interface
+    //#include <GLES2/gl2.h>        // OpenGL ES 2.0 library (not required in this module, only in rlgl)
+#endif
+
 #if defined(PLATFORM_DRM)
 
     #include <fcntl.h>   // POSIX file control definitions - open(), creat(), fcntl()
@@ -49,7 +54,7 @@
         bool isKeyboard;    // True if device has letter keycodes
         bool isGamepad;     // True if device has gamepad buttons
     } InputEventWorker;
-    
+
 #endif
 
 // PROVIDE A HEADER TO BE USED BY ALL THE rcore_* IMPLEMENTATIONS.

--- a/src/rcore_android.c
+++ b/src/rcore_android.c
@@ -7,9 +7,6 @@
 #include <android_native_app_glue.h>    // Required for: android_app struct and activity management
 #include <jni.h>                        // Required for: JNIEnv and JavaVM [Used in OpenURL()]
 
-#include <EGL/egl.h>                    // Native platform windowing system interface
-//#include <GLES2/gl2.h>                // OpenGL ES 2.0 library (not required in this module, only in rlgl)
-
 static bool InitGraphicsDevice(int width, int height);                                     // Initialize graphics device
 static void AndroidCommandCallback(struct android_app *app, int32_t cmd);                  // Process Android activity lifecycle commands
 static int32_t AndroidInputCallback(struct android_app *app, AInputEvent *event);          // Process Android inputs


### PR DESCRIPTION
### PR changes
1. Fixes the `android` compilation by moving `#include <EGL/egl.h>` from `rcore_android.c` ([L10-L11](https://github.com/raysan5/raylib/pull/3360/files#diff-df7f2529f920b22e7f3b28d8c53b9042fe9ba3e0c4be0a421ac8d9e0c3bde72dL10-L11)) to `rcore.h` ([R19-R22](https://github.com/raysan5/raylib/pull/3360/files#diff-7341b65fe444443a67b5c67d194f97dd0c919b63c579f15ce018de206cf84864R19-R22)). This was necessary because the `CORE.Window` EGL members ([R164-R167](https://github.com/raysan5/raylib/pull/3360/files#diff-7341b65fe444443a67b5c67d194f97dd0c919b63c579f15ce018de206cf84864R164-R167)) need it.

### Environment
- Compiled following [these wiki instructions](https://github.com/raysan5/raylib/wiki/Working-for-Android-(on-Linux)) (for `android-29`) on Linux Mint (21.1 64-bit).

### Edits
- **1:** added line marks.