### PR TITLE
Optimize m3d mesh creation

### DIFF
--- a/src/rmodels.c
+++ b/src/rmodels.c
@@ -5623,7 +5623,7 @@ static Model LoadM3D(const char *fileName)
         // We always need a default material, so we add +1
         model.materialCount++;
 
-        // Sort faces by material.
+        // failsafe, model should already have faces grouped by material
         qsort(m3d->face, m3d->numface, sizeof(m3df_t), m3d_compare_faces);
 
         model.meshes = (Mesh *)RL_CALLOC(model.meshCount, sizeof(Mesh));

--- a/src/rmodels.c
+++ b/src/rmodels.c
@@ -5567,6 +5567,15 @@ static Model LoadVOX(const char *fileName)
 unsigned char *m3d_loaderhook(char *fn, unsigned int *len) { return LoadFileData((const char *)fn, (int *)len); }
 void m3d_freehook(void *data) { UnloadFileData((unsigned char *)data); }
 
+// Comparison function for qsort
+static int m3d_compare_faces(const void *a, const void *b)
+{
+  m3df_t *fa = (m3df_t *)a;
+  m3df_t *fb = (m3df_t *)b;
+
+  return (fa->materialid - fb->materialid);
+}
+
 // Load M3D mesh data
 static Model LoadM3D(const char *fileName)
 {
@@ -5614,19 +5623,8 @@ static Model LoadM3D(const char *fileName)
         // We always need a default material, so we add +1
         model.materialCount++;
 
-        // Sort faces by material (insertion)
-        for (i = 1; i < m3d->numface; i++)
-        {
-          m3df_t key = m3d->face[i];
-          j = i - 1;
-    
-          while (j >= 0 && m3d->face[j].materialid > key.materialid)
-          {
-            m3d->face[j+1] = m3d->face[j];
-            j = j - 1;
-          }
-          m3d->face[j+1] = key;
-        }
+        // Sort faces by material.
+        qsort(m3d->face, m3d->numface, sizeof(m3df_t), m3d_compare_faces);
 
         model.meshes = (Mesh *)RL_CALLOC(model.meshCount, sizeof(Mesh));
         model.meshMaterial = (int *)RL_CALLOC(model.meshCount, sizeof(int));

--- a/src/rmodels.c
+++ b/src/rmodels.c
@@ -5567,15 +5567,6 @@ static Model LoadVOX(const char *fileName)
 unsigned char *m3d_loaderhook(char *fn, unsigned int *len) { return LoadFileData((const char *)fn, (int *)len); }
 void m3d_freehook(void *data) { UnloadFileData((unsigned char *)data); }
 
-// Comparison function for qsort
-static int m3d_compare_faces(const void *a, const void *b)
-{
-  m3df_t *fa = (m3df_t *)a;
-  m3df_t *fb = (m3df_t *)b;
-
-  return (fa->materialid - fb->materialid);
-}
-
 // Load M3D mesh data
 static Model LoadM3D(const char *fileName)
 {
@@ -5623,8 +5614,19 @@ static Model LoadM3D(const char *fileName)
         // We always need a default material, so we add +1
         model.materialCount++;
 
-        // Sort faces by material.
-        qsort(m3d->face, m3d->numface, sizeof(m3df_t), m3d_compare_faces);
+        // Sort faces by material (insertion)
+        for (i = 1; i < m3d->numface; i++)
+        {
+          m3df_t key = m3d->face[i];
+          j = i - 1;
+    
+          while (j >= 0 && m3d->face[j].materialid > key.materialid)
+          {
+            m3d->face[j+1] = m3d->face[j];
+            j = j - 1;
+          }
+          m3d->face[j+1] = key;
+        }
 
         model.meshes = (Mesh *)RL_CALLOC(model.meshCount, sizeof(Mesh));
         model.meshMaterial = (int *)RL_CALLOC(model.meshCount, sizeof(int));

--- a/src/rmodels.c
+++ b/src/rmodels.c
@@ -5567,6 +5567,15 @@ static Model LoadVOX(const char *fileName)
 unsigned char *m3d_loaderhook(char *fn, unsigned int *len) { return LoadFileData((const char *)fn, (int *)len); }
 void m3d_freehook(void *data) { UnloadFileData((unsigned char *)data); }
 
+// Comparison function for qsort
+static int m3d_compare_faces(const void *a, const void *b)
+{
+  m3df_t *fa = (m3df_t *)a;
+  m3df_t *fb = (m3df_t *)b;
+
+  return (fa->materialid - fb->materialid);
+}
+
 // Load M3D mesh data
 static Model LoadM3D(const char *fileName)
 {
@@ -5613,6 +5622,9 @@ static Model LoadM3D(const char *fileName)
 
         // We always need a default material, so we add +1
         model.materialCount++;
+
+        // Sort faces by material.
+        qsort(m3d->face, m3d->numface, sizeof(m3df_t), m3d_compare_faces);
 
         model.meshes = (Mesh *)RL_CALLOC(model.meshCount, sizeof(Mesh));
         model.meshMaterial = (int *)RL_CALLOC(model.meshCount, sizeof(int));


### PR DESCRIPTION
Hello, I've changed the m3d loader to sort faces by material. The old code assumes the faces are already grouped together by material, which may not be the case for every model. 

This will reduce the number of meshes being created and uploaded to the gpu for those cases