### PR TITLE
[split] `rcore`, `android` changes (batch 2)

### DIFF
--- a/src/rcore.c
+++ b/src/rcore.c
@@ -332,7 +332,7 @@ const char *TextFormat(const char *text, ...);       // Formatting of text with 
     #include "rcore_web.c"
 #elif defined(PLATFORM_DRM)
     #include "rcore_drm.c"
-#elif defined(PLATFOM_ANDROID)
+#elif defined(PLATFORM_ANDROID)
     #include "rcore_android.c"
 #else
     // Software rendering backend, user needs to provide buffer ;)


### PR DESCRIPTION
### PR changes
1. Fixes the `PLATFORM_ANDROID` build by fixing the typo on the `rcore.c` preprocessor define ([R335](https://github.com/raysan5/raylib/pull/3364/files#diff-39fea0e3daa23741e81daf967717f35c7842426aab26a0bc3f525d6a2f03e339R335)).

### Status
- #3371

### Environment
- Compiled following [these wiki instructions](https://github.com/raysan5/raylib/wiki/Working-for-Android-(on-Linux)) (for `android-29`) on Linux Mint (21.1 64-bit).

### Edits
- **1:** added line marks.