### PR TITLE
Window size and fullscreen fixes

### DIFF
--- a/src/rcore_desktop.c
+++ b/src/rcore_desktop.c
@@ -854,6 +854,7 @@ void SetWindowMaxSize(int width, int height)
 void SetWindowSize(int width, int height)
 {
     glfwSetWindowSize(platform.handle, width, height);
+    WindowSizeCallback(platform.handle, width, height);
 }
 
 // Set window opacity, value opacity is between 0.0 and 1.0

--- a/src/rcore_desktop.c
+++ b/src/rcore_desktop.c
@@ -362,6 +362,7 @@ void ToggleFullscreen(void)
             int monitorHeight = GetMonitorHeight(monitorIndex);
             int refreshRate = GLFW_DONT_CARE;
 
+            //Prevent GLFW from changing the video mode if the screen is the same size as the monitor
             if (CORE.Window.screen.width == monitorWidth && CORE.Window.screen.height == monitorHeight)
             {
                 refreshRate = GetMonitorRefreshRate(refreshRate);

--- a/src/rcore_desktop.c
+++ b/src/rcore_desktop.c
@@ -358,10 +358,19 @@ void ToggleFullscreen(void)
         }
         else
         {
+            int monitorWidth = GetMonitorWidth(monitorIndex);
+            int monitorHeight = GetMonitorHeight(monitorIndex);
+            int refreshRate = GLFW_DONT_CARE;
+
+            if (CORE.Window.screen.width == monitorWidth && CORE.Window.screen.height == monitorHeight)
+            {
+                refreshRate = GetMonitorRefreshRate(refreshRate);
+            }
+
             CORE.Window.fullscreen = true;
             CORE.Window.flags |= FLAG_FULLSCREEN_MODE;
 
-            glfwSetWindowMonitor(platform.handle, monitor, 0, 0, CORE.Window.screen.width, CORE.Window.screen.height, GLFW_DONT_CARE);
+            glfwSetWindowMonitor(platform.handle, monitor, 0, 0, CORE.Window.screen.width, CORE.Window.screen.height, refreshRate);
         }
 
     }


### PR DESCRIPTION
Fixes #3390.

It also implements the first approach suggested in #3378.

### Code example ###

Note that, when changing to fullscreen, ``SetWindowSize()`` needs to be called before ``ToggleFullscreen()``, while the order needs to be reversed when changing to windowed mode.

Additionally, is does not automatically restore the previous window position when changing to windowed mode.

```C
#include <raylib.h>
#include <stdio.h>
#include <stdbool.h>

int main()
{
	char str[32];

	InitWindow(800, 600, "Test");

	while (!WindowShouldClose()) {
		if (IsKeyPressed(KEY_F)) {
			if (!IsWindowFullscreen()) {
				int monitor = GetCurrentMonitor();

				SetWindowSize(GetMonitorWidth(monitor), GetMonitorHeight(monitor));
				ToggleFullscreen();
			} else {
				ToggleFullscreen();
				SetWindowSize(800, 600);
			}
		}

		sprintf(str, "Screen: %dx%d %c (monitor: %d)",
				GetScreenWidth(), GetScreenHeight(),
				IsWindowFullscreen() ? 'F' : 'W',
				GetCurrentMonitor());

		BeginDrawing();
		ClearBackground(GRAY);
		DrawText(str, 0, 64, 32, BLACK);
		EndDrawing();
	}

	CloseWindow();

	return 0;
}

```