### PR TITLE
Update zig build system to zig version 0.11.0

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1,7 +1,0 @@
-const std = @import("std");
-const raylib = @import("src/build.zig");
-
-// This has been tested to work with zig master branch as of commit 87de821 or May 14 2023
-pub fn build(b: *std.Build) void {
-    raylib.build(b);
-}

--- a/examples/build.zig
+++ b/examples/build.zig
@@ -27,10 +27,10 @@ fn add_module(comptime module: []const u8, b: *std.Build, target: std.zig.CrossT
         exe.addCSourceFile(.{ .file = .{ .path = path }, .flags = &.{} });
         exe.linkLibC();
         exe.addObjectFile(switch (target.getOsTag()) {
-            .windows => .{ .path = "../zig-out/lib/raylib.lib" },
-            .linux => .{ .path = "../zig-out/lib/libraylib.a" },
-            .macos => .{ .path = "../zig-out/lib/libraylib.a" },
-            .emscripten => .{ .path = "../zig-out/lib/libraylib.a" },
+            .windows => .{ .path = "../src/zig-out/lib/raylib.lib" },
+            .linux => .{ .path = "../src/zig-out/lib/libraylib.a" },
+            .macos => .{ .path = "../src/zig-out/lib/libraylib.a" },
+            .emscripten => .{ .path = "../src/zig-out/lib/libraylib.a" },
             else => @panic("Unsupported OS"),
         });
 

--- a/examples/build.zig
+++ b/examples/build.zig
@@ -71,11 +71,15 @@ fn add_module(comptime module: []const u8, b: *std.Build, target: std.zig.CrossT
             },
         }
 
-        b.installArtifact(exe);
-        var run = b.addRunArtifact(exe);
-        run.cwd = module;
-        b.step(name, name).dependOn(&run.step);
-        all.dependOn(&exe.step);
+        const install_cmd = b.addInstallArtifact(exe, .{});
+
+        const run_cmd = b.addRunArtifact(exe);
+        run_cmd.step.dependOn(&install_cmd.step);
+
+        const run_step = b.step(name, name);
+        run_step.dependOn(&run_cmd.step);
+
+        all.dependOn(&install_cmd.step);
     }
     return all;
 }

--- a/examples/build.zig
+++ b/examples/build.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const builtin = @import("builtin");
 
-// This has been tested to work with zig master branch as of commit 87de821 or May 14 2023
+// This has been tested to work with zig 0.11.0 (67709b6, Aug 4 2023)
 fn add_module(comptime module: []const u8, b: *std.Build, target: std.zig.CrossTarget, optimize: std.builtin.OptimizeMode) !*std.Build.Step {
     if (target.getOsTag() == .emscripten) {
         @panic("Emscripten building via Zig unsupported");

--- a/examples/build.zig
+++ b/examples/build.zig
@@ -11,7 +11,7 @@ fn add_module(comptime module: []const u8, b: *std.Build, target: std.zig.CrossT
     const dir = try std.fs.cwd().openIterableDir(module, .{});
     var iter = dir.iterate();
     while (try iter.next()) |entry| {
-        if (entry.kind != .File) continue;
+        if (entry.kind != .file) continue;
         const extension_idx = std.mem.lastIndexOf(u8, entry.name, ".c") orelse continue;
         const name = entry.name[0..extension_idx];
         const path = try std.fs.path.join(b.allocator, &.{ module, entry.name });
@@ -24,26 +24,26 @@ fn add_module(comptime module: []const u8, b: *std.Build, target: std.zig.CrossT
             .target = target,
             .optimize = optimize,
         });
-        exe.addCSourceFile(path, &[_][]const u8{});
+        exe.addCSourceFile(.{ .file = .{ .path = path }, .flags = &.{} });
         exe.linkLibC();
         exe.addObjectFile(switch (target.getOsTag()) {
-            .windows => "../src/zig-out/lib/raylib.lib",
-            .linux => "../src/zig-out/lib/libraylib.a",
-            .macos => "../src/zig-out/lib/libraylib.a",
-            .emscripten => "../src/zig-out/lib/libraylib.a",
+            .windows => .{ .path = "../zig-out/lib/raylib.lib" },
+            .linux => .{ .path = "../zig-out/lib/libraylib.a" },
+            .macos => .{ .path = "../zig-out/lib/libraylib.a" },
+            .emscripten => .{ .path = "../zig-out/lib/libraylib.a" },
             else => @panic("Unsupported OS"),
         });
 
-        exe.addIncludePath("../src");
-        exe.addIncludePath("../src/external");
-        exe.addIncludePath("../src/external/glfw/include");
+        exe.addIncludePath(.{ .path = "../src" });
+        exe.addIncludePath(.{ .path = "../src/external" });
+        exe.addIncludePath(.{ .path = "../src/external/glfw/include" });
 
         switch (target.getOsTag()) {
             .windows => {
                 exe.linkSystemLibrary("winmm");
                 exe.linkSystemLibrary("gdi32");
                 exe.linkSystemLibrary("opengl32");
-                exe.addIncludePath("external/glfw/deps/mingw");
+                exe.addIncludePath(.{ .path = "external/glfw/deps/mingw" });
 
                 exe.defineCMacro("PLATFORM_DESKTOP", null);
             },

--- a/src/build.zig
+++ b/src/build.zig
@@ -192,12 +192,12 @@ pub fn build(b: *std.Build) void {
 
     const lib = addRaylib(b, target, optimize, options);
 
-    lib.installHeader("src/raylib.h", "raylib.h");
-    lib.installHeader("src/raymath.h", "raymath.h");
-    lib.installHeader("src/rlgl.h", "rlgl.h");
+    lib.installHeader("raylib.h", "raylib.h");
+    lib.installHeader("raymath.h", "raymath.h");
+    lib.installHeader("rlgl.h", "rlgl.h");
 
     if (options.raygui) {
-        lib.installHeader("../raygui/src/raygui.h", "raygui.h");
+        lib.installHeader("../../raygui/src/raygui.h", "raygui.h");
     }
 
     b.installArtifact(lib);

--- a/src/build.zig
+++ b/src/build.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 
-// This has been tested to work with zig master branch as of commit 87de821 or May 14 2023
+// This has been tested to work with zig 0.11.0 (67709b6, Aug 4 2023)
 pub fn addRaylib(b: *std.Build, target: std.zig.CrossTarget, optimize: std.builtin.OptimizeMode, options: Options) *std.Build.CompileStep {
     const raylib_flags = &[_][]const u8{
         "-std=gnu99",


### PR DESCRIPTION
Discard `build.zig` and use `src/build.zig` only, bc by default these two output in different directories.

build command: cd to `src` then `zig build`.

Close #3386