### PR TITLE
Fix `windowMin/Max` to `screenMin/Max` for `android`, `drm`, `template`

### DIFF
--- a/src/rcore.h
+++ b/src/rcore.h
@@ -127,8 +127,6 @@ typedef struct CoreData {
         Point renderOffset;                 // Offset from render area (must be divided by 2)
         Size screenMin;                     // Screen minimum width and height (for resizable window)
         Size screenMax;                     // Screen maximum width and height (for resizable window)
-        Size windowMin;                     // Window minimum width and height
-        Size windowMax;                     // Window maximum width and height
         Matrix screenScale;                 // Matrix to scale screen (framebuffer rendering)
 
         char **dropFilepaths;               // Store dropped files paths pointers (provided by GLFW)

--- a/src/rcore_android.c
+++ b/src/rcore_android.c
@@ -416,15 +416,15 @@ void SetWindowMonitor(int monitor)
 // Set window minimum dimensions (FLAG_WINDOW_RESIZABLE)
 void SetWindowMinSize(int width, int height)
 {
-    CORE.Window.windowMin.width = width;
-    CORE.Window.windowMin.height = height;
+    CORE.Window.screenMin.width = width;
+    CORE.Window.screenMin.height = height;
 }
 
 // Set window maximum dimensions (FLAG_WINDOW_RESIZABLE)
 void SetWindowMaxSize(int width, int height)
 {
-    CORE.Window.windowMax.width = width;
-    CORE.Window.windowMax.height = height;
+    CORE.Window.screenMax.width = width;
+    CORE.Window.screenMax.height = height;
 }
 
 // Set window dimensions
@@ -1198,7 +1198,7 @@ static int32_t AndroidInputCallback(struct android_app *app, AInputEvent *event)
 
     if (CORE.Input.Touch.pointCount > 0) CORE.Input.Touch.currentTouchState[MOUSE_BUTTON_LEFT] = 1;
     else CORE.Input.Touch.currentTouchState[MOUSE_BUTTON_LEFT] = 0;
-    
+
     // Map touch[0] as mouse input for convenience
     CORE.Input.Mouse.currentPosition = CORE.Input.Touch.position[0];
     CORE.Input.Mouse.currentWheelMove = (Vector2){ 0.0f, 0.0f };

--- a/src/rcore_drm.c
+++ b/src/rcore_drm.c
@@ -281,7 +281,7 @@ void InitWindow(int width, int height, const char *title)
     InitGamepad();    // Gamepad init
     InitKeyboard();   // Keyboard init (stdin)
     //--------------------------------------------------------------
-    
+
     TRACELOG(LOG_INFO, "PLATFORM: DRM: Application initialized successfully");
 }
 
@@ -517,15 +517,15 @@ void SetWindowMonitor(int monitor)
 // Set window minimum dimensions (FLAG_WINDOW_RESIZABLE)
 void SetWindowMinSize(int width, int height)
 {
-    CORE.Window.windowMin.width = width;
-    CORE.Window.windowMin.height = height;
+    CORE.Window.screenMin.width = width;
+    CORE.Window.screenMin.height = height;
 }
 
 // Set window maximum dimensions (FLAG_WINDOW_RESIZABLE)
 void SetWindowMaxSize(int width, int height)
 {
-    CORE.Window.windowMax.width = width;
-    CORE.Window.windowMax.height = height;
+    CORE.Window.screenMax.width = width;
+    CORE.Window.screenMax.height = height;
 }
 
 // Set window dimensions
@@ -841,10 +841,10 @@ static bool InitGraphicsDevice(int width, int height)
     CORE.Window.screenScale = MatrixIdentity();  // No draw scaling required by default
 
     // Set the window minimum and maximum default values to 0
-    CORE.Window.windowMin.width  = 0;
-    CORE.Window.windowMin.height = 0;
-    CORE.Window.windowMax.width  = 0;
-    CORE.Window.windowMax.height = 0;
+    CORE.Window.screenMin.width  = 0;
+    CORE.Window.screenMin.height = 0;
+    CORE.Window.screenMax.width  = 0;
+    CORE.Window.screenMax.height = 0;
 
     // NOTE: Framebuffer (render area - CORE.Window.render.width, CORE.Window.render.height) could include black bars...
     // ...in top-down or left-right to match display aspect ratio (no weird scaling)

--- a/src/rcore_template.c
+++ b/src/rcore_template.c
@@ -141,7 +141,7 @@ void InitWindow(int width, int height, const char *title)
 
     // If graphic device is no properly initialized, we end program
     if (!CORE.Window.ready) { TRACELOG(LOG_FATAL, "PLATFORM: Failed to initialize graphic device"); return; }
-    
+
     // Initialize hi-res timer
     InitTimer();
 
@@ -150,7 +150,7 @@ void InitWindow(int width, int height, const char *title)
 
     // Initialize base path for storage
     CORE.Storage.basePath = GetWorkingDirectory();
-    
+
 #if defined(SUPPORT_MODULE_RTEXT) && defined(SUPPORT_DEFAULT_FONT)
     // Load default font
     // WARNING: External function: Module required: rtext
@@ -344,15 +344,15 @@ void SetWindowMonitor(int monitor)
 // Set window minimum dimensions (FLAG_WINDOW_RESIZABLE)
 void SetWindowMinSize(int width, int height)
 {
-    CORE.Window.windowMin.width = width;
-    CORE.Window.windowMin.height = height;
+    CORE.Window.screenMin.width = width;
+    CORE.Window.screenMin.height = height;
 }
 
 // Set window maximum dimensions (FLAG_WINDOW_RESIZABLE)
 void SetWindowMaxSize(int width, int height)
 {
-    CORE.Window.windowMax.width = width;
-    CORE.Window.windowMax.height = height;
+    CORE.Window.screenMax.width = width;
+    CORE.Window.screenMax.height = height;
 }
 
 // Set window dimensions


### PR DESCRIPTION
Fixes some `windowMin` and `windowMax` that should be `screenMin` and `screenMax` for `PLATFORM_ANDROID`, `PLATFORM_DRM` and `PLATFORM_TEMPLATE`:

- `rcore.h`: [L130-L131](https://github.com/raysan5/raylib/pull/3400/files#diff-7341b65fe444443a67b5c67d194f97dd0c919b63c579f15ce018de206cf84864L130-L131).
- `rcore_android.c`: [R419-R420](https://github.com/raysan5/raylib/pull/3400/files#diff-df7f2529f920b22e7f3b28d8c53b9042fe9ba3e0c4be0a421ac8d9e0c3bde72dR419-R420), [R426-R427](https://github.com/raysan5/raylib/pull/3400/files#diff-df7f2529f920b22e7f3b28d8c53b9042fe9ba3e0c4be0a421ac8d9e0c3bde72dR426-R427).
- `rcore_drm.c`: [R520-R521](https://github.com/raysan5/raylib/pull/3400/files#diff-ae04a2ff3974ba8bcfeb7ddfde3038688d4c2aac31d22c745f52680dcdaf1ddaR520-R521), [R527-R528](https://github.com/raysan5/raylib/pull/3400/files#diff-ae04a2ff3974ba8bcfeb7ddfde3038688d4c2aac31d22c745f52680dcdaf1ddaR527-R528), [R844-R847](https://github.com/raysan5/raylib/pull/3400/files#diff-ae04a2ff3974ba8bcfeb7ddfde3038688d4c2aac31d22c745f52680dcdaf1ddaR844-R847).
- `rcore_template.c`: [R347-R348](https://github.com/raysan5/raylib/pull/3400/files#diff-8b082901dd641b3d10f6444023946081d7a3d3d84e8ed1c89b119499a82f33d1R347-R348), [R354-R355](https://github.com/raysan5/raylib/pull/3400/files#diff-8b082901dd641b3d10f6444023946081d7a3d3d84e8ed1c89b119499a82f33d1R354-R355).

**Edit:** added line marks; editing.
