### PR TITLE
Fix `GetMouseDelta()` issue for Android

### DIFF
--- a/src/rcore_android.c
+++ b/src/rcore_android.c
@@ -1178,6 +1178,16 @@ static int32_t AndroidInputCallback(struct android_app *app, AInputEvent *event)
     if (CORE.Input.Touch.pointCount > 0) CORE.Input.Touch.currentTouchState[MOUSE_BUTTON_LEFT] = 1;
     else CORE.Input.Touch.currentTouchState[MOUSE_BUTTON_LEFT] = 0;
 
+    // Stores the previous position of touch[0] only while it's active to calculate the delta.
+    if (flags == AMOTION_EVENT_ACTION_MOVE)
+    {
+        CORE.Input.Mouse.previousPosition = CORE.Input.Mouse.currentPosition;
+    }
+    else
+    {
+        CORE.Input.Mouse.previousPosition = CORE.Input.Touch.position[0];
+    }
+
     // Map touch[0] as mouse input for convenience
     CORE.Input.Mouse.currentPosition = CORE.Input.Touch.position[0];
     CORE.Input.Mouse.currentWheelMove = (Vector2){ 0.0f, 0.0f };


### PR DESCRIPTION
As mentioned in the [discussion](https://github.com/raysan5/raylib/issues/3313#issuecomment-1760386046) regarding the split of rcore.c by platform, here is the fix for the issue with `Vector2 GetMouseDelta(void)` on Android.

This now allows obtaining the delta for the first touch on Android. Tests were conducted with multitouch, and there were no problems or interference reported.