### PR TITLE
Fix `UpdateSound` parameter name

### DIFF
--- a/src/raudio.c
+++ b/src/raudio.c
@@ -981,14 +981,14 @@ void UnloadSoundAlias(Sound alias)
 }
 
 // Update sound buffer with new data
-void UpdateSound(Sound sound, const void *data, int sampleCount)
+void UpdateSound(Sound sound, const void *data, int frameCount)
 {
     if (sound.stream.buffer != NULL)
     {
         StopAudioBuffer(sound.stream.buffer);
 
         // TODO: May want to lock/unlock this since this data buffer is read at mixing time
-        memcpy(sound.stream.buffer->data, data, sampleCount*ma_get_bytes_per_frame(sound.stream.buffer->converter.formatIn, sound.stream.buffer->converter.channelsIn));
+        memcpy(sound.stream.buffer->data, data, frameCount*ma_get_bytes_per_frame(sound.stream.buffer->converter.formatIn, sound.stream.buffer->converter.channelsIn));
     }
 }
 


### PR DESCRIPTION
The parameter `sampleCount` is multiplied by `ma_get_bytes_per_frame` meaning it is actually the number of frames, not samples. `ma_get_bytes_per_frame(format, channels)` is `ma_get_bytes_per_sample(format) * channels`.