### PR TITLE
Normalize `gestureEvent.position` coordinates

### DIFF
--- a/src/rcore_android.c
+++ b/src/rcore_android.c
@@ -1152,6 +1152,8 @@ static int32_t AndroidInputCallback(struct android_app *app, AInputEvent *event)
     {
         gestureEvent.pointId[i] = CORE.Input.Touch.pointId[i];
         gestureEvent.position[i] = CORE.Input.Touch.position[i];
+        gestureEvent.position[i].x /= (float)GetScreenWidth();
+        gestureEvent.position[i].y /= (float)GetScreenHeight();
     }
 
     // Gesture data is sent to gestures system for processing


### PR DESCRIPTION
Fixed the fact that coordinates were not normalized on Android, preventing detection of `GESTURE_DOUBLE_TAP`.
Issue mentioned in the [discussion](https://github.com/raysan5/raylib/issues/3313#issuecomment-1760344608) about splitting `rcore.c` for each platform.