### PR TITLE
Fix `android`, `drm` compilation issue on `InitWindow`

### DIFF
--- a/src/rcore_android.c
+++ b/src/rcore_android.c
@@ -190,7 +190,7 @@ void InitWindow(int width, int height, const char *title)
     CORE.Window.screen.height = height;
     CORE.Window.currentFbo.width = width;
     CORE.Window.currentFbo.height = height;
-    
+
     // Set desired windows flags before initializing anything
     ANativeActivity_setWindowFlags(platform.app->activity, AWINDOW_FLAG_FULLSCREEN, 0);  //AWINDOW_FLAG_SCALED, AWINDOW_FLAG_DITHER
 
@@ -228,12 +228,12 @@ void InitWindow(int width, int height, const char *title)
 
     // Initialize base path for storage
     CORE.Storage.basePath = platform.app->activity->internalDataPath;
-    
+
     // Set some default window flags
     CORE.Window.flags &= ~FLAG_WINDOW_HIDDEN;       // false
-    CORE.Window.flags &= ~FLAG_WINDOW_MINIMIZED);   // false
-    CORE.Window.flags |= FLAG_WINDOW_MAXIMIZED);    // true
-    CORE.Window.flags &= ~FLAG_WINDOW_UNFOCUSED);   // false
+    CORE.Window.flags &= ~FLAG_WINDOW_MINIMIZED;    // false
+    CORE.Window.flags |= FLAG_WINDOW_MAXIMIZED;     // true
+    CORE.Window.flags &= ~FLAG_WINDOW_UNFOCUSED;    // false
 
     TRACELOG(LOG_INFO, "PLATFORM: ANDROID: Application initialized successfully");
 

--- a/src/rcore_drm.c
+++ b/src/rcore_drm.c
@@ -228,16 +228,16 @@ void InitWindow(int width, int height, const char *title)
 
     // Set some default window flags
     CORE.Window.flags &= ~FLAG_WINDOW_HIDDEN;       // false
-    CORE.Window.flags &= ~FLAG_WINDOW_MINIMIZED);   // false
-    CORE.Window.flags |= FLAG_WINDOW_MAXIMIZED);    // true
-    CORE.Window.flags &= ~FLAG_WINDOW_UNFOCUSED);   // false
-    
+    CORE.Window.flags &= ~FLAG_WINDOW_MINIMIZED;    // false
+    CORE.Window.flags |= FLAG_WINDOW_MAXIMIZED;     // true
+    CORE.Window.flags &= ~FLAG_WINDOW_UNFOCUSED;    // false
+
     // Initialize hi-res timer
     InitTimer();
-    
+
     // Initialize base path for storage
     CORE.Storage.basePath = GetWorkingDirectory();
-    
+
     // Initialize raw input system
     InitEvdevInput(); // Evdev inputs initialization
     InitGamepad();    // Gamepad init


### PR DESCRIPTION
Removes leftover `)`s on `InitWindow` that were stopping `PLATFORM_DRM` and `PLATFORM_ANDROID` compilation.
- `rcore_drm.c`: [R231-R233](https://github.com/raysan5/raylib/pull/3407/files#diff-ae04a2ff3974ba8bcfeb7ddfde3038688d4c2aac31d22c745f52680dcdaf1ddaR231-R233).
- `rcore_android.c`: [R234-R236](https://github.com/raysan5/raylib/pull/3407/files#diff-df7f2529f920b22e7f3b28d8c53b9042fe9ba3e0c4be0a421ac8d9e0c3bde72dR234-R236).

**Edit 1:** added line marks.
**Edit 2:** added android fix.