### PR TITLE
Fix GetFPS so it doesn't hold on last time from previous window

### DIFF
--- a/src/rcore.c
+++ b/src/rcore.c
@@ -1235,9 +1235,14 @@ int GetFPS(void)
 
     if (fpsFrame == 0) return 0;
 
-    if ((GetTime() - last) > FPS_STEP)
+    float newTime = (float)GetTime();
+
+    if (last > newTime)
+        last = newTime; // Last value is from a previous window so reset it
+
+    if ((newTime - last) > FPS_STEP)
     {
-        last = (float)GetTime();
+        last = newTime;
         index = (index + 1)%FPS_CAPTURE_FRAMES_COUNT;
         average -= history[index];
         history[index] = fpsFrame/FPS_CAPTURE_FRAMES_COUNT;


### PR DESCRIPTION
Defect: GetFPS holds on to the last time value from previous windows.

In this example, second window displays the last FPS value from the first window. Until it lives longer than the first:
```
#include "raylib.h"

int main(void)
{
    InitWindow(800, 450, "first window");

    // Keep this window open N seconds then close it
    while (!WindowShouldClose())
    {
      BeginDrawing();
      ClearBackground(RAYWHITE);
      DrawFPS(10, 10);
      EndDrawing();
    }

    CloseWindow();

    InitWindow(800, 450, "second window");

    // Notice that DrawFPS is stuck on the last fps value from the first window
    // only after N seconds it starts drawing the correct fps
    while(!WindowShouldClose())
    {
        BeginDrawing();
        ClearBackground(RAYWHITE);
        DrawFPS(10, 10);
        EndDrawing();
    }

    CloseWindow();
    return 0;
}
```

The proposed fix relies on the fact that GetTime must return incremental (or same) values.