### PR TITLE
Fix SetMouseCursor implementation for PLATFORM_WEB

### DIFF
--- a/src/rcore_web.c
+++ b/src/rcore_web.c
@@ -685,8 +685,9 @@ void SetMouseCursor(int cursor)
         } break;
     }
 
-    // Set the cursor element on the CSS
-    EM_ASM({document.body.style.cursor = UTF8ToString($0);}, cursorName);
+    // Set the cursor element on the canvas CSS
+    // The canvas is coded to the Id "canvas" on init
+    EM_ASM({document.getElementById("canvas").style.cursor = UTF8ToString($0);}, cursorName);
 }
 
 // Register all input events

--- a/src/rcore_web.c
+++ b/src/rcore_web.c
@@ -659,6 +659,7 @@ void SetMousePosition(int x, int y)
 // Set mouse cursor
 void SetMouseCursor(int cursor)
 {
+    CORE.Input.Mouse.cursor = cursor;
     const char *cursorName;
     switch (cursor)
     {
@@ -682,6 +683,7 @@ void SetMouseCursor(int cursor)
         {
             TRACELOG(LOG_WARNING, "Cursor value out of bound (%d). Setting to default", cursor);
             cursorName = "default";
+            CORE.Input.Mouse.cursor = MOUSE_CURSOR_DEFAULT;
         } break;
     }
 


### PR DESCRIPTION
Correction to the merge #3414  
Restrict function to only set the cursor inside the canvas.

Done by getting the canvas element via its id and setting its cursor.

Build tested on Linux Mint 21.2 x64.  
Tested on Firefox 118.0.2 x64 and Brave Browser Version 1.59.117 Chromium: 118.0.5993.70 x64.  
The cursor return back to the default cursor outside of the canvas as expected.

Test program:
```c
#include "raylib.h"
#include <stdio.h>


//-------------------- PROTOTYPE CURSOR FUNCTION ------------------
#if defined(PLATFORM_WEB)
#include <emscripten/emscripten.h>
#endif
//-------------------------------------------------------------------

// Window size
static const int width = 800;
static const int height = 600;

// Grid sizes
const float grid_width = 200.0f;
const float grid_height = 200.0f;
const int grid_w = 4;

// Display name for cursor
static const char* CURSOR_NAMES[11] = 
{
    "default", "arrow", "text", "crosshair",
    "pointer", "ew-resize", "ns-resize", "nwse-resize",
    "nesw-resize", "move", "not-allowed"
};

void update_step(void)
{
    // Set the cursor based on mouse position in the grid
    Vector2 mouse_pos = GetMousePosition();
    int mouse_idx = (int)(mouse_pos.x / grid_width) + (int)(mouse_pos.y / grid_height) * grid_w;
    // Allow out of bound idx, function should handle this
    SetMouseCursor(mouse_idx);

    static char buffer[64];
    snprintf(buffer, 64, "x: %.2f, y: %.2f, idx: %d", mouse_pos.x, mouse_pos.y, mouse_idx);
    buffer[63] = '\0';

    BeginDrawing();
        ClearBackground(LIGHTGRAY);
        for (int i = 0; i < grid_width; ++i)
        {
            DrawLine(grid_width*i, 0, grid_width*i, height, BLACK);
        }
        for (int i = 0; i < grid_height; ++i)
        {
            DrawLine(0, grid_height*i, width, grid_height*i, BLACK);
        }
        for (int i = 0; i < 11; i++)
        {
            int x = (i % grid_w) * grid_width + grid_width / 2;
            int y = (i / grid_w) * grid_height + grid_height / 2;
            DrawText(CURSOR_NAMES[i], x, y, 12, BLACK);
        }
        DrawText(buffer, 20, 20, 12, BLACK);
    EndDrawing();
}

int main(void)
{
    InitWindow(width, height, "raylib");
    SetTargetFPS(60);

    #if defined(PLATFORM_WEB)
        puts("Setting emscripten main loop");
        emscripten_set_main_loop(update_step, 0, 1);
    #else
        puts("Regular main loop");
        while(true)
        {
            update_step();
            if (WindowShouldClose()) break;
        }
    #endif
    CloseWindow();

}
```

It is similar to the last test, but it allows out of bound int to test the default switch case.  
On the last grid, it prints out the warning as expected.

Edit: Forgot to set the CORE input mouse value. Updated