### PR TITLE
Remove the `rcore.h` include from `drm`, `web`, `template`

### DIFF
--- a/src/rcore_drm.c
+++ b/src/rcore_drm.c
@@ -47,8 +47,6 @@
 *
 **********************************************************************************************/
 
-#include "rcore.h"
-
 #include <fcntl.h>   // POSIX file control definitions - open(), creat(), fcntl()
 #include <unistd.h>  // POSIX standard function definitions - read(), close(), STDIN_FILENO
 #include <termios.h> // POSIX terminal control definitions - tcgetattr(), tcsetattr()
@@ -218,12 +216,12 @@ void InitWindow(int width, int height, const char *title)
     CORE.Input.Mouse.scale = (Vector2){ 1.0f, 1.0f };
     CORE.Input.Mouse.cursor = MOUSE_CURSOR_ARROW;
     CORE.Input.Gamepad.lastButtonPressed = GAMEPAD_BUTTON_UNKNOWN;
-    
+
     // Initialize platform
-    //--------------------------------------------------------------   
+    //--------------------------------------------------------------
     InitPlatform();
     //--------------------------------------------------------------
-    
+
     // Initialize rlgl default data (buffers and shaders)
     // NOTE: CORE.Window.currentFbo.width and CORE.Window.currentFbo.height not used, just stored as globals in rlgl
     rlglInit(CORE.Window.currentFbo.width, CORE.Window.currentFbo.height);
@@ -272,10 +270,10 @@ void InitWindow(int width, int height, const char *title)
     events = (AutomationEvent *)RL_CALLOC(MAX_CODE_AUTOMATION_EVENTS, sizeof(AutomationEvent));
     CORE.Time.frameCounter = 0;
 #endif
-    
+
     // Initialize random seed
     SetRandomSeed((unsigned int)time(NULL));
-    
+
     TRACELOG(LOG_INFO, "PLATFORM: DRM: Application initialized successfully");
 }
 
@@ -302,7 +300,7 @@ void CloseWindow(void)
 #endif
 
     // De-initialize platform
-    //--------------------------------------------------------------   
+    //--------------------------------------------------------------
     ClosePlatform();
     //--------------------------------------------------------------
 
@@ -721,7 +719,7 @@ static int InitPlatform(void)
     platform.gbmSurface = NULL;
     platform.prevBO = NULL;
     platform.prevFB = 0;
-    
+
     CORE.Window.fullscreen = true;
     CORE.Window.flags |= FLAG_FULLSCREEN_MODE;
 
@@ -1034,9 +1032,9 @@ static int InitPlatform(void)
     rlLoadExtensions(eglGetProcAddress);
 
     if ((CORE.Window.flags & FLAG_WINDOW_MINIMIZED) > 0) MinimizeWindow();
-    
+
     CORE.Window.ready = true;   // TODO: Proper validation on windows/context creation
-    
+
         // If graphic device is no properly initialized, we end program
     if (!CORE.Window.ready) { TRACELOG(LOG_FATAL, "PLATFORM: Failed to initialize graphic device"); return -1; }
     else SetWindowPosition(GetMonitorWidth(GetCurrentMonitor()) / 2 - CORE.Window.screen.width / 2, GetMonitorHeight(GetCurrentMonitor()) / 2 - CORE.Window.screen.height / 2);
@@ -1057,7 +1055,7 @@ static int InitPlatform(void)
     InitEvdevInput(); // Evdev inputs initialization
     InitGamepad();    // Gamepad init
     InitKeyboard();   // Keyboard init (stdin)
-    
+
     return 0;
 }
 

--- a/src/rcore_template.c
+++ b/src/rcore_template.c
@@ -46,8 +46,6 @@
 *
 **********************************************************************************************/
 
-#include "rcore.h"
-
 // TODO: Include the platform specific libraries
 
 //----------------------------------------------------------------------------------
@@ -130,8 +128,8 @@ void InitWindow(int width, int height, const char *title)
     CORE.Input.Mouse.cursor = MOUSE_CURSOR_ARROW;
     CORE.Input.Gamepad.lastButtonPressed = 0;       // GAMEPAD_BUTTON_UNKNOWN
     CORE.Window.eventWaiting = false;
-    
-    
+
+
     // TODO: Platform specific init window
     //--------------------------------------------------------------
     CORE.Window.screen.width = width;
@@ -144,7 +142,7 @@ void InitWindow(int width, int height, const char *title)
     CORE.Window.ready = InitGraphicsDevice(width, height);
 
 
-    
+
     // Initialize OpenGL context (states and resources)
     // NOTE: CORE.Window.currentFbo.width and CORE.Window.currentFbo.height not used, just stored as globals in rlgl
     rlglInit(CORE.Window.currentFbo.width, CORE.Window.currentFbo.height);
@@ -711,13 +709,13 @@ static int InitPlatform(void)
     rlLoadExtensions(eglGetProcAddress);
 
     CORE.Window.ready = true;
-    
+
     // If graphic device is no properly initialized, we end program
     if (!CORE.Window.ready) { TRACELOG(LOG_FATAL, "PLATFORM: Failed to initialize graphic device"); return -1; }
 
     // Initialize hi-res timer
     InitTimer();
-    
+
     // Initialize base path for storage
     CORE.Storage.basePath = GetWorkingDirectory();
 

--- a/src/rcore_web.c
+++ b/src/rcore_web.c
@@ -45,8 +45,6 @@
 *
 **********************************************************************************************/
 
-#include "rcore.h"
-
 #define GLFW_INCLUDE_ES2                // GLFW3: Enable OpenGL ES 2.0 (translated to WebGL)
 // #define GLFW_INCLUDE_ES3               // GLFW3: Enable OpenGL ES 3.0 (transalted to WebGL2?)
 #include "GLFW/glfw3.h"                 // GLFW3: Windows, OpenGL context and Input management
@@ -177,7 +175,7 @@ void InitWindow(int width, int height, const char *title)
     CORE.Input.Gamepad.lastButtonPressed = GAMEPAD_BUTTON_UNKNOWN;
 
     // Initialize platform
-    //--------------------------------------------------------------   
+    //--------------------------------------------------------------
     InitPlatform();
     //--------------------------------------------------------------
 
@@ -256,7 +254,7 @@ void CloseWindow(void)
     rlglClose(); // De-init rlgl
 
     // De-initialize platform
-    //--------------------------------------------------------------   
+    //--------------------------------------------------------------
     ClosePlatform();
     //--------------------------------------------------------------
 
@@ -1004,7 +1002,7 @@ static int InitPlatform(void)
     glfwSetCursorEnterCallback(platform.handle, CursorEnterCallback);
 
     glfwMakeContextCurrent(platform.handle);
-    
+
     // Load OpenGL extensions
     // NOTE: GL procedures address loader is required to load extensions
     rlLoadExtensions(glfwGetProcAddress);
@@ -1028,19 +1026,19 @@ static int InitPlatform(void)
     TRACELOG(LOG_INFO, "    > Screen size:  %i x %i", CORE.Window.screen.width, CORE.Window.screen.height);
     TRACELOG(LOG_INFO, "    > Render size:  %i x %i", CORE.Window.render.width, CORE.Window.render.height);
     TRACELOG(LOG_INFO, "    > Viewport offsets: %i, %i", CORE.Window.renderOffset.x, CORE.Window.renderOffset.y);
-    
+
     CORE.Window.ready = true;   // TODO: Proper validation on windows/context creation
-    
+
     // If graphic device is no properly initialized, we end program
     if (!CORE.Window.ready) { TRACELOG(LOG_FATAL, "PLATFORM: Failed to initialize graphic device"); return -1; }
     else SetWindowPosition(GetMonitorWidth(GetCurrentMonitor())/2 - CORE.Window.screen.width/2, GetMonitorHeight(GetCurrentMonitor())/2 - CORE.Window.screen.height/2);
 
     // Initialize hi-res timer
     InitTimer();
-    
+
     // Initialize base path for storage
     CORE.Storage.basePath = GetWorkingDirectory();
-    
+
     // Setup callback functions for the DOM events
     emscripten_set_fullscreenchange_callback("#canvas", NULL, 1, EmscriptenFullscreenChangeCallback);
 
@@ -1069,7 +1067,7 @@ static int InitPlatform(void)
     // Support gamepad events (not provided by GLFW3 on emscripten)
     emscripten_set_gamepadconnected_callback(NULL, 1, EmscriptenGamepadCallback);
     emscripten_set_gamepaddisconnected_callback(NULL, 1, EmscriptenGamepadCallback);
-    
+
     return 0;
 }
 


### PR DESCRIPTION
1. While reviewing the current changes, noticed `rcore_desktop.c` no longer includes `rcore.h`.

2. Since the library and examples on `PLATFORM_DESKTOP` are compiling and running fine, I think that include is no longer needed on the modules after the previous updates.

3. So also removed it from `rcore_drm.c` ([L50](https://github.com/raysan5/raylib/pull/3420/files#diff-ae04a2ff3974ba8bcfeb7ddfde3038688d4c2aac31d22c745f52680dcdaf1ddaL50)), `rcore_web.c` ([L48](https://github.com/raysan5/raylib/pull/3420/files#diff-5204360a69ae27d12753764f60a1cd59e3a11ef10b86fce7691c74de0becc8cdL48)) and `rcore_template.c` ([L49](https://github.com/raysan5/raylib/pull/3420/files#diff-8b082901dd641b3d10f6444023946081d7a3d3d84e8ed1c89b119499a82f33d1L49)). Compiled and tested here and everything appears to be working fine without it.

4. **Note:** The include is still present on `rcore_android.c` ([L49](https://github.com/raysan5/raylib/blob/master/src/rcore_android.c#L49)), but I didn't want to change anything there while @Bigfoot71 is working on it.

**Edit:** added line marks.