### PR TITLE
 Make sure rcore.o gets compiled in more situations

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -632,6 +632,9 @@ endif
 
 # Compile all modules with their prerequisites
 
+# Prerequisites of core module
+rcore.o : rcore_android.c rcore_desktop.c rcore_drm.c rcore_template.c rcore_web.c
+
 # Compile core module
 rcore.o : rcore.c raylib.h rlgl.h utils.h raymath.h rcamera.h rgestures.h
 	$(CC) -c $< $(CFLAGS) $(INCLUDE_PATHS)


### PR DESCRIPTION
Currently doing the following:
```bash
make
touch rcore_desktop.c
make
```

Will not result in rcore.o getting compiled again, despite that rcore_desktop.c has changed

This commit resolves that

The one downside this has is that for example, when building for desktop, if rcore_web.c is modified, rcore.c will get compiled again, despite that its changes are not used in this situation - I think this is unimportant, though, as make clean would be required to switch between platforms anyway