### PR TITLE
[core] Fix some mouse issues on `SDL`

### DIFF
--- a/src/rcore_desktop_sdl.c
+++ b/src/rcore_desktop_sdl.c
@@ -535,6 +535,9 @@ void PollInputEvents(void)
     CORE.Input.Mouse.currentWheelMove.x = 0;
     CORE.Input.Mouse.currentWheelMove.y = 0;
 
+    // Register previous mouse position
+    CORE.Input.Mouse.previousPosition = CORE.Input.Mouse.currentPosition;
+
     // Reset last gamepad button/axis registered state
     CORE.Input.Gamepad.lastButtonPressed = GAMEPAD_BUTTON_UNKNOWN;
     for (int i = 0; i < MAX_GAMEPADS; i++) CORE.Input.Gamepad.axisCount[i] = 0;

--- a/src/rcore_desktop_sdl.c
+++ b/src/rcore_desktop_sdl.c
@@ -60,7 +60,7 @@
 typedef struct {
     SDL_Window *window;
     SDL_GLContext glContext;
-    
+
     SDL_Joystick *gamepad;
 } PlatformData;
 
@@ -134,12 +134,12 @@ void InitWindow(int width, int height, const char *title)
     CORE.Input.Mouse.scale = (Vector2){ 1.0f, 1.0f };
     CORE.Input.Mouse.cursor = MOUSE_CURSOR_ARROW;
     CORE.Input.Gamepad.lastButtonPressed = GAMEPAD_BUTTON_UNKNOWN;
-    
+
     // Initialize platform
-    //--------------------------------------------------------------   
+    //--------------------------------------------------------------
     InitPlatform();
     //--------------------------------------------------------------
-    
+
     // Initialize rlgl default data (buffers and shaders)
     // NOTE: CORE.Window.currentFbo.width and CORE.Window.currentFbo.height not used, just stored as globals in rlgl
     rlglInit(CORE.Window.currentFbo.width, CORE.Window.currentFbo.height);
@@ -214,7 +214,7 @@ void CloseWindow(void)
     rlglClose();                // De-init rlgl
 
     // De-initialize platform
-    //--------------------------------------------------------------   
+    //--------------------------------------------------------------
     ClosePlatform();
     //--------------------------------------------------------------
 
@@ -481,7 +481,7 @@ void SwapScreenBuffer(void)
 double GetTime(void)
 {
     unsigned int ms = SDL_GetTicks();    // Elapsed time in milliseconds since SDL_Init()
-    double time = (double)ms/1000; 
+    double time = (double)ms/1000;
     return time;
 }
 
@@ -530,6 +530,10 @@ void PollInputEvents(void)
 
     // Reset key repeats
     for (int i = 0; i < MAX_KEYBOARD_KEYS; i++) CORE.Input.Keyboard.keyRepeatInFrame[i] = 0;
+
+    // Reset mouse wheel
+    CORE.Input.Mouse.currentWheelMove.x = 0;
+    CORE.Input.Mouse.currentWheelMove.y = 0;
 
     // Reset last gamepad button/axis registered state
     CORE.Input.Gamepad.lastButtonPressed = GAMEPAD_BUTTON_UNKNOWN;
@@ -602,12 +606,12 @@ void PollInputEvents(void)
             case SDL_KEYUP: break;
 
             // Check mouse events
-            case SDL_MOUSEBUTTONDOWN: 
+            case SDL_MOUSEBUTTONDOWN:
             {
                 CORE.Input.Mouse.currentButtonState[event.button.button - 1] = 1;
             } break;
             case SDL_MOUSEBUTTONUP: break;
-            case SDL_MOUSEWHEEL: 
+            case SDL_MOUSEWHEEL:
             {
                 CORE.Input.Mouse.currentWheelMove.x = (float)event.wheel.x;
                 CORE.Input.Mouse.currentWheelMove.y = (float)event.wheel.y;
@@ -653,7 +657,7 @@ static int InitPlatform(void)
     // Initialize SDL internal global state
     int result = SDL_Init(SDL_INIT_EVERYTHING);
     if (result < 0) { TRACELOG(LOG_WARNING, "SDL: Failed to initialize SDL"); return -1; }
-    
+
     unsigned int flags = 0;
     flags |= SDL_WINDOW_SHOWN;
     flags |= SDL_WINDOW_OPENGL;
@@ -662,12 +666,12 @@ static int InitPlatform(void)
     flags |= SDL_WINDOW_MOUSE_CAPTURE;  // Window has mouse captured
 
     // Check window creation flags
-    if ((CORE.Window.flags & FLAG_FULLSCREEN_MODE) > 0) 
+    if ((CORE.Window.flags & FLAG_FULLSCREEN_MODE) > 0)
     {
         CORE.Window.fullscreen = true;
         flags |= SDL_WINDOW_FULLSCREEN;
     }
-    
+
     //if ((CORE.Window.flags & FLAG_WINDOW_HIDDEN) == 0) flags |= SDL_WINDOW_HIDDEN;
     if ((CORE.Window.flags & FLAG_WINDOW_UNDECORATED) > 0) flags |= SDL_WINDOW_BORDERLESS;
     if ((CORE.Window.flags & FLAG_WINDOW_RESIZABLE) > 0) flags |= SDL_WINDOW_RESIZABLE;
@@ -684,11 +688,11 @@ static int InitPlatform(void)
     if ((CORE.Window.flags & FLAG_WINDOW_MOUSE_PASSTHROUGH) > 0) flags &= ~SDL_WINDOW_MOUSE_CAPTURE;
 
     if ((CORE.Window.flags & FLAG_WINDOW_HIGHDPI) > 0) flags |= SDL_WINDOW_ALLOW_HIGHDPI;
-    
+
     //if ((CORE.Window.flags & FLAG_WINDOW_TRANSPARENT) > 0) flags |= SDL_WINDOW_TRANSPARENT;     // Alternative: SDL_GL_ALPHA_SIZE = 8
-    
+
     //if ((CORE.Window.flags & FLAG_FULLSCREEN_DESKTOP) > 0) flags |= SDL_WINDOW_FULLSCREEN_DESKTOP;
-    
+
     // NOTE: Some OpenGL context attributes must be set before window creation
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 3);
@@ -702,12 +706,12 @@ static int InitPlatform(void)
 
     // Init window
     platform.window = SDL_CreateWindow(CORE.Window.title, SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, CORE.Window.screen.width, CORE.Window.screen.height, flags);
-    
+
     // Init OpenGL context
     platform.glContext = SDL_GL_CreateContext(platform.window);
-    
+
     // Check window and glContext have been initialized succesfully
-    if ((platform.window != NULL) && (platform.glContext != NULL)) 
+    if ((platform.window != NULL) && (platform.glContext != NULL))
     {
         CORE.Window.ready = true;
 
@@ -728,21 +732,21 @@ static int InitPlatform(void)
     // NOTE: GL procedures address loader is required to load extensions
     rlLoadExtensions(SDL_GL_GetProcAddress);
 
-    
+
     // Init input gamepad
     if (SDL_NumJoysticks() >= 1)
     {
         SDL_Joystick *gamepad = SDL_JoystickOpen(0);
         //if (SDL_Joystick *gamepad == NULL) SDL_Log("WARNING: Unable to open game controller! SDL Error: %s\n", SDL_GetError());
     }
-    
+
     // Initialize hi-res timer
     //InitTimer();
     CORE.Time.previous = GetTime();     // Get time as double
-    
+
     // Initialize base path for storage
     CORE.Storage.basePath = GetWorkingDirectory();
-    
+
     return 0;
 }
 

--- a/src/rcore_desktop_sdl.c
+++ b/src/rcore_desktop_sdl.c
@@ -558,6 +558,9 @@ void PollInputEvents(void)
         CORE.Input.Keyboard.keyRepeatInFrame[i] = 0;
     }
 
+    // Register previous mouse states
+    for (int i = 0; i < MAX_MOUSE_BUTTONS; i++) CORE.Input.Mouse.previousButtonState[i] = CORE.Input.Mouse.currentButtonState[i];
+
     // Poll input events for current plaform
     //-----------------------------------------------------------------------------
     /*
@@ -613,7 +616,10 @@ void PollInputEvents(void)
             {
                 CORE.Input.Mouse.currentButtonState[event.button.button - 1] = 1;
             } break;
-            case SDL_MOUSEBUTTONUP: break;
+            case SDL_MOUSEBUTTONUP:
+            {
+                CORE.Input.Mouse.currentButtonState[event.button.button - 1] = 0;
+            } break;
             case SDL_MOUSEWHEEL:
             {
                 CORE.Input.Mouse.currentWheelMove.x = (float)event.wheel.x;


### PR DESCRIPTION
### Fixes
1. Fixes the mouse wheel getting stucked scrolling up or down by adding the missing reset ([R534-R536](https://github.com/raysan5/raylib/pull/3428/files#diff-b7c2628cbe74c1722110bdc42bc4239493b1be7ff2836f8892e3e942a42e9aefR534-R536)).

2. Fixes the mouse sensitivity being really high on 3D by adding the missing previous mouse position registry ([R538-R539](https://github.com/raysan5/raylib/pull/3428/files#diff-b7c2628cbe74c1722110bdc42bc4239493b1be7ff2836f8892e3e942a42e9aefR538-R539)).

3. Fixes the mouse button presses not working properly by adding the missing previous mouse button registry ([R561-R562](https://github.com/raysan5/raylib/pull/3428/files#diff-b7c2628cbe74c1722110bdc42bc4239493b1be7ff2836f8892e3e942a42e9aefR561-R562)) and by adding handling for `SDL_MOUSEBUTTONUP` ([R619-R622](https://github.com/raysan5/raylib/pull/3428/files#diff-b7c2628cbe74c1722110bdc42bc4239493b1be7ff2836f8892e3e942a42e9aefR619-R622)).
.
**VERY IMPORTANT NOTE:** @raysan5 
The `SDL2` mouse button order is `LEFT, MIDDLE, RIGHT, ...` ([doc](https://wiki.libsdl.org/SDL2/SDL_MouseButtonEvent)), but we currently use `LEFT, RIGHT, MIDDLE, ...` ([L674-L676](https://github.com/raysan5/raylib/blob/master/src/raylib.h#L674-L676)), so, when the migration to `SDL2` is complete, that `MouseButton enum` on `raylib.h` needs to be adjusted. Until then, the middle and right mouse binds will be inverted.

### Reference
Items 1, 2, 6 of https://github.com/raysan5/raylib/issues/3313#issuecomment-1763623854.

### Environment
Tested this changes successfully on Linux (Ubuntu 22.04 64-bit, gcc 11.2.0) with SDL2 (2.28.4).

### Edits
**1:** added line marks.
**2:** added another fix, environment, formatting.
**3:** added another fix.