### PR TITLE
[core] Remove `rcore.h` include from `Android`

### DIFF
--- a/src/rcore_android.c
+++ b/src/rcore_android.c
@@ -46,8 +46,6 @@
 *
 **********************************************************************************************/
 
-#include "rcore.h"
-
 #include <android_native_app_glue.h>    // Required for: android_app struct and activity management
 #include <android/window.h>             // Required for: AWINDOW_FLAG_FULLSCREEN definition and others
 //#include <android/sensor.h>           // Required for: Android sensors functions (accelerometer, gyroscope, light...)
@@ -188,7 +186,7 @@ void InitWindow(int width, int height, const char *title)
     CORE.Input.Gamepad.lastButtonPressed = GAMEPAD_BUTTON_UNKNOWN;
 
     // Initialize platform
-    //--------------------------------------------------------------   
+    //--------------------------------------------------------------
     InitPlatform();
     //--------------------------------------------------------------
 }
@@ -216,7 +214,7 @@ void CloseWindow(void)
 #endif
 
     // De-initialize platform
-    //--------------------------------------------------------------   
+    //--------------------------------------------------------------
     ClosePlatform();
     //--------------------------------------------------------------
 
@@ -869,7 +867,7 @@ static void AndroidCommandCallback(struct android_app *app, int32_t cmd)
 
                     // Initialize graphics device (display device and OpenGL context)
                     InitGraphicsDevice();
-                    
+
                     // Initialize OpenGL context (states and resources)
                     // NOTE: CORE.Window.currentFbo.width and CORE.Window.currentFbo.height not used, just stored as globals in rlgl
                     rlglInit(CORE.Window.currentFbo.width, CORE.Window.currentFbo.height);
@@ -908,7 +906,7 @@ static void AndroidCommandCallback(struct android_app *app, int32_t cmd)
                     SetShapesTexture(texture, (Rectangle){ 0.0f, 0.0f, 1.0f, 1.0f });    // WARNING: Module required: rshapes
                     #endif
                 #endif
-                
+
                     // Initialize random seed
                     SetRandomSeed((unsigned int)time(NULL));
 


### PR DESCRIPTION
Very short fix to remove the `rcore.h` include from `PLATFORM_ANDROID` ([L49](https://github.com/raysan5/raylib/pull/3429/files#diff-df7f2529f920b22e7f3b28d8c53b9042fe9ba3e0c4be0a421ac8d9e0c3bde72dL49)) so it matches the other submodules.

References: #3420, https://github.com/raysan5/raylib/issues/3313#issuecomment-1764276021.

**Edit:** added line marks.