### PR TITLE
[core] Add some missing implementations to `SDL`

### DIFF
--- a/src/rcore_desktop_sdl.c
+++ b/src/rcore_desktop_sdl.c
@@ -324,13 +324,19 @@ void SetWindowMaxSize(int width, int height)
 // Set window dimensions
 void SetWindowSize(int width, int height)
 {
-    TRACELOG(LOG_WARNING, "SetWindowSize() not available on target platform");
+    SDL_SetWindowSize(platform.window, width, height);
+
+    CORE.Window.screen.width = width;
+    CORE.Window.screen.height = height;
 }
 
 // Set window opacity, value opacity is between 0.0 and 1.0
 void SetWindowOpacity(float opacity)
 {
-    TRACELOG(LOG_WARNING, "SetWindowOpacity() not available on target platform");
+    if (opacity >= 1.0f) opacity = 1.0f;
+    else if (opacity <= 0.0f) opacity = 0.0f;
+
+    SDL_SetWindowOpacity(platform.window, opacity);
 }
 
 // Set window focused
@@ -349,8 +355,11 @@ void *GetWindowHandle(void)
 // Get number of monitors
 int GetMonitorCount(void)
 {
-    TRACELOG(LOG_WARNING, "GetMonitorCount() not implemented on target platform");
-    return 1;
+    int monitorCount = 0;
+
+    monitorCount = SDL_GetNumVideoDisplays();
+
+    return monitorCount;
 }
 
 // Get number of monitors


### PR DESCRIPTION
### Changes
1. Adds `SetWindowSize` implementation (LINE).
2. Adds `SetWindowOpacity` implementation (LINE).
3. Adds `GetMonitorCount` implementation (LINE).

### Environment
Tested this changes successfully on Linux (Ubuntu 22.04 64-bit, gcc 11.2.0) with SDL2 (2.28.4).

### Edits
**1:** added line marks.