### PR TITLE
Fix SDL keyboard issue

### DIFF
--- a/src/rcore_desktop_sdl.c
+++ b/src/rcore_desktop_sdl.c
@@ -72,10 +72,118 @@ extern CoreData CORE;                   // Global CORE state context
 static PlatformData platform = { 0 };   // Platform specific data
 
 //----------------------------------------------------------------------------------
+// Local Variables Definition
+//----------------------------------------------------------------------------------
+#define SCANCODE_MAPPED_NUM 100
+static const short ScancodeToKey[SCANCODE_MAPPED_NUM] = {
+    KEY_NULL,           // SDL_SCANCODE_UNKNOWN
+    0,
+    0,
+    0,
+    KEY_A,              // SDL_SCANCODE_A
+    KEY_B,              // SDL_SCANCODE_B
+    KEY_C,              // SDL_SCANCODE_C
+    KEY_D,              // SDL_SCANCODE_D
+    KEY_E,              // SDL_SCANCODE_E
+    KEY_F,              // SDL_SCANCODE_F
+    KEY_G,              // SDL_SCANCODE_G
+    KEY_H,              // SDL_SCANCODE_H
+    KEY_I,              // SDL_SCANCODE_I
+    KEY_J,              // SDL_SCANCODE_J
+    KEY_K,              // SDL_SCANCODE_K
+    KEY_L,              // SDL_SCANCODE_L
+    KEY_M,              // SDL_SCANCODE_M
+    KEY_N,              // SDL_SCANCODE_N
+    KEY_O,              // SDL_SCANCODE_O
+    KEY_P,              // SDL_SCANCODE_P
+    KEY_Q,              // SDL_SCANCODE_Q
+    KEY_R,              // SDL_SCANCODE_R
+    KEY_S,              // SDL_SCANCODE_S
+    KEY_T,              // SDL_SCANCODE_T
+    KEY_U,              // SDL_SCANCODE_U
+    KEY_V,              // SDL_SCANCODE_V
+    KEY_W,              // SDL_SCANCODE_W
+    KEY_X,              // SDL_SCANCODE_X
+    KEY_Y,              // SDL_SCANCODE_Y
+    KEY_Z,              // SDL_SCANCODE_Z
+    KEY_ONE,            // SDL_SCANCODE_1
+    KEY_TWO,            // SDL_SCANCODE_2
+    KEY_THREE,          // SDL_SCANCODE_3
+    KEY_FOUR,           // SDL_SCANCODE_4
+    KEY_FIVE,           // SDL_SCANCODE_5
+    KEY_SIX,            // SDL_SCANCODE_6
+    KEY_SEVEN,          // SDL_SCANCODE_7
+    KEY_EIGHT,          // SDL_SCANCODE_8
+    KEY_NINE,           // SDL_SCANCODE_9
+    KEY_ZERO,           // SDL_SCANCODE_0
+    KEY_ENTER,          // SDL_SCANCODE_RETURN
+    KEY_ESCAPE,         // SDL_SCANCODE_ESCAPE
+    KEY_BACKSPACE,      // SDL_SCANCODE_BACKSPACE
+    KEY_TAB,            // SDL_SCANCODE_TAB
+    KEY_SPACE,          // SDL_SCANCODE_SPACE
+    KEY_MINUS,          // SDL_SCANCODE_MINUS
+    KEY_EQUAL,          // SDL_SCANCODE_EQUALS
+    KEY_LEFT_BRACKET,   // SDL_SCANCODE_LEFTBRACKET
+    KEY_RIGHT_BRACKET,  // SDL_SCANCODE_RIGHTBRACKET
+    KEY_BACKSLASH,      // SDL_SCANCODE_BACKSLASH
+    0,                  // SDL_SCANCODE_NONUSHASH
+    KEY_SEMICOLON,      // SDL_SCANCODE_SEMICOLON
+    KEY_APOSTROPHE,     // SDL_SCANCODE_APOSTROPHE
+    KEY_GRAVE,          // SDL_SCANCODE_GRAVE
+    KEY_COMMA,          // SDL_SCANCODE_COMMA
+    KEY_PERIOD,         // SDL_SCANCODE_PERIOD
+    KEY_SLASH,          // SDL_SCANCODE_SLASH
+    KEY_CAPS_LOCK,      // SDL_SCANCODE_CAPSLOCK
+    KEY_F1,             // SDL_SCANCODE_F1
+    KEY_F2,             // SDL_SCANCODE_F2
+    KEY_F3,             // SDL_SCANCODE_F3
+    KEY_F4,             // SDL_SCANCODE_F4
+    KEY_F5,             // SDL_SCANCODE_F5
+    KEY_F6,             // SDL_SCANCODE_F6
+    KEY_F7,             // SDL_SCANCODE_F7
+    KEY_F8,             // SDL_SCANCODE_F8
+    KEY_F9,             // SDL_SCANCODE_F9
+    KEY_F10,            // SDL_SCANCODE_F10
+    KEY_F11,            // SDL_SCANCODE_F11
+    KEY_F12,            // SDL_SCANCODE_F12
+    KEY_PRINT_SCREEN,   // SDL_SCANCODE_PRINTSCREEN
+    KEY_SCROLL_LOCK,    // SDL_SCANCODE_SCROLLLOCK
+    KEY_PAUSE,          // SDL_SCANCODE_PAUSE
+    KEY_INSERT,         // SDL_SCANCODE_INSERT
+    KEY_HOME,           // SDL_SCANCODE_HOME
+    KEY_PAGE_UP,        // SDL_SCANCODE_PAGEUP
+    KEY_DELETE,         // SDL_SCANCODE_DELETE
+    KEY_END,            // SDL_SCANCODE_END
+    KEY_PAGE_DOWN,      // SDL_SCANCODE_PAGEDOWN
+    KEY_RIGHT,          // SDL_SCANCODE_RIGHT
+    KEY_LEFT,           // SDL_SCANCODE_LEFT
+    KEY_DOWN,           // SDL_SCANCODE_DOWN
+    KEY_UP,             // SDL_SCANCODE_UP
+    KEY_NUM_LOCK,       // SDL_SCANCODE_NUMLOCKCLEAR
+    KEY_KP_DIVIDE,      // SDL_SCANCODE_KP_DIVIDE
+    KEY_KP_MULTIPLY,    // SDL_SCANCODE_KP_MULTIPLY
+    KEY_KP_SUBTRACT,    // SDL_SCANCODE_KP_MINUS
+    KEY_KP_ADD,         // SDL_SCANCODE_KP_PLUS
+    KEY_KP_ENTER,       // SDL_SCANCODE_KP_ENTER
+    KEY_KP_1,           // SDL_SCANCODE_KP_1
+    KEY_KP_2,           // SDL_SCANCODE_KP_2
+    KEY_KP_3,           // SDL_SCANCODE_KP_3
+    KEY_KP_4,           // SDL_SCANCODE_KP_4
+    KEY_KP_5,           // SDL_SCANCODE_KP_5
+    KEY_KP_6,           // SDL_SCANCODE_KP_6
+    KEY_KP_7,           // SDL_SCANCODE_KP_7
+    KEY_KP_8,           // SDL_SCANCODE_KP_8
+    KEY_KP_9,           // SDL_SCANCODE_KP_9
+    KEY_KP_0,           // SDL_SCANCODE_KP_0
+    KEY_KP_DECIMAL      // SDL_SCANCODE_KP_PERIOD
+};
+
+//----------------------------------------------------------------------------------
 // Module Internal Functions Declaration
 //----------------------------------------------------------------------------------
-static int InitPlatform(void);          // Initialize platform (graphics, inputs and more)
-static void ClosePlatform(void);        // Close platform
+static int InitPlatform(void);                                      // Initialize platform (graphics, inputs and more)
+static void ClosePlatform(void);                                    // Close platform
+static KeyboardKey ConvertScancodeToKey(SDL_Scancode sdlScancode);  // Help convert SDL scancodes to raylib key
 
 //----------------------------------------------------------------------------------
 // Module Functions Declaration
@@ -660,14 +768,21 @@ void PollInputEvents(void)
             // Keyboard events
             case SDL_KEYDOWN:
             {
-                CORE.Input.Keyboard.currentKeyState[event.key.keysym.sym] = 1;
+                KeyboardKey key = ConvertScancodeToKey(event.key.keysym.scancode);
+                if (key != KEY_NULL) CORE.Input.Keyboard.currentKeyState[key] = 1;
 
-                if (event.key.keysym.sym == SDLK_ESCAPE)
+                // TODO: Put exitKey verification outside the switch?
+                if (CORE.Input.Keyboard.currentKeyState[CORE.Input.Keyboard.exitKey])
                 {
                     CORE.Window.shouldClose = true;
                 }
             } break;
-            case SDL_KEYUP: break;
+
+            case SDL_KEYUP:
+            {
+                KeyboardKey key = ConvertScancodeToKey(event.key.keysym.scancode);
+                if (key != KEY_NULL) CORE.Input.Keyboard.currentKeyState[key] = 0;
+            } break;
 
             // Check mouse events
             case SDL_MOUSEBUTTONDOWN:
@@ -822,5 +937,14 @@ static void ClosePlatform(void)
     SDL_GL_DeleteContext(platform.glContext); // Deinitialize OpenGL context
     SDL_DestroyWindow(platform.window);
     SDL_Quit(); // Deinitialize SDL internal global state
+}
+
+static KeyboardKey ConvertScancodeToKey(SDL_Scancode sdlScancode)
+{
+    if (sdlScancode >= 0 && sdlScancode < SCANCODE_MAPPED_NUM)
+    {
+        return ScancodeToKey[sdlScancode];
+    }
+    return KEY_NULL; // No equivalent key in Raylib
 }
 // EOF

--- a/src/rcore_desktop_sdl.c
+++ b/src/rcore_desktop_sdl.c
@@ -75,7 +75,7 @@ static PlatformData platform = { 0 };   // Platform specific data
 // Local Variables Definition
 //----------------------------------------------------------------------------------
 #define SCANCODE_MAPPED_NUM 100
-static const short ScancodeToKey[SCANCODE_MAPPED_NUM] = {
+static const KeyboardKey ScancodeToKey[SCANCODE_MAPPED_NUM] = {
     KEY_NULL,           // SDL_SCANCODE_UNKNOWN
     0,
     0,


### PR DESCRIPTION
As originally mentioned by @ubkp in the issue [\[core\] Splitting rcore by platform into submodules](https://github.com/raysan5/raylib/issues/3313#issuecomment-1763623854), here is the fix for the keyboard handling issue with SDL.

This modification includes a mapping table between SDL scancodes and raylib keys, along with a function to safely retrieve them.

I've also revised the state change of `CORE.Window.shouldClose` by using `CORE.Input.Keyboard.exitKey` instead of `SDLK_ESCAPE` directly, but as indicated in the comment, I believe this part would be better placed outside of the switch statement.