### PR TITLE
[core] Add more missing implementations to `SDL`

### DIFF
--- a/src/rcore_desktop_sdl.c
+++ b/src/rcore_desktop_sdl.c
@@ -452,15 +452,14 @@ Vector2 GetWindowScaleDPI(void)
 // Set clipboard text content
 void SetClipboardText(const char *text)
 {
-    TRACELOG(LOG_WARNING, "SetClipboardText() not implemented on target platform");
+    SDL_SetClipboardText(text);
 }
 
 // Get clipboard text content
-// NOTE: returned string is allocated and freed by GLFW
+// NOTE: returned string must be freed with SDL_free()
 const char *GetClipboardText(void)
 {
-    TRACELOG(LOG_WARNING, "GetClipboardText() not implemented on target platform");
-    return NULL;
+    return SDL_GetClipboardText();
 }
 
 // Show mouse cursor

--- a/src/rcore_desktop_sdl.c
+++ b/src/rcore_desktop_sdl.c
@@ -482,8 +482,8 @@ void HideCursor(void)
 // Enables cursor (unlock cursor)
 void EnableCursor(void)
 {
-    // Set cursor position in the middle
-    SetMousePosition(CORE.Window.screen.width/2, CORE.Window.screen.height/2);
+    SDL_SetRelativeMouseMode(SDL_FALSE);
+    SDL_ShowCursor(SDL_ENABLE);
 
     CORE.Input.Mouse.cursorHidden = false;
 }
@@ -491,8 +491,7 @@ void EnableCursor(void)
 // Disables cursor (lock cursor)
 void DisableCursor(void)
 {
-    // Set cursor position in the middle
-    SetMousePosition(CORE.Window.screen.width/2, CORE.Window.screen.height/2);
+    SDL_SetRelativeMouseMode(SDL_TRUE);
 
     CORE.Input.Mouse.cursorHidden = true;
 }

--- a/src/rcore_desktop_sdl.c
+++ b/src/rcore_desktop_sdl.c
@@ -338,8 +338,7 @@ void SetWindowFocused(void)
 // Get native window handle
 void *GetWindowHandle(void)
 {
-    TRACELOG(LOG_WARNING, "GetWindowHandle() not implemented on target platform");
-    return NULL;
+    return (void *)platform.window;
 }
 
 // Get number of monitors
@@ -573,8 +572,7 @@ void OpenURL(const char *url)
 // Set internal gamepad mappings
 int SetGamepadMappings(const char *mappings)
 {
-    TRACELOG(LOG_WARNING, "SetGamepadMappings() not implemented on target platform");
-    return 0;
+    SDL_GameControllerAddMapping(mappings);
 }
 
 // Set mouse position XY

--- a/src/rcore_desktop_sdl.c
+++ b/src/rcore_desktop_sdl.c
@@ -62,6 +62,7 @@ typedef struct {
     SDL_GLContext glContext;
 
     SDL_Joystick *gamepad;
+    SDL_Cursor *cursor;
 } PlatformData;
 
 //----------------------------------------------------------------------------------
@@ -176,6 +177,22 @@ static const KeyboardKey ScancodeToKey[SCANCODE_MAPPED_NUM] = {
     KEY_KP_9,           // SDL_SCANCODE_KP_9
     KEY_KP_0,           // SDL_SCANCODE_KP_0
     KEY_KP_DECIMAL      // SDL_SCANCODE_KP_PERIOD
+};
+
+static const int CursorsLUT[] = {
+    SDL_SYSTEM_CURSOR_ARROW,       // 0  MOUSE_CURSOR_DEFAULT
+    SDL_SYSTEM_CURSOR_ARROW,       // 1  MOUSE_CURSOR_ARROW
+    SDL_SYSTEM_CURSOR_IBEAM,       // 2  MOUSE_CURSOR_IBEAM
+    SDL_SYSTEM_CURSOR_CROSSHAIR,   // 3  MOUSE_CURSOR_CROSSHAIR
+    SDL_SYSTEM_CURSOR_HAND,        // 4  MOUSE_CURSOR_POINTING_HAND
+    SDL_SYSTEM_CURSOR_SIZEWE,      // 5  MOUSE_CURSOR_RESIZE_EW
+    SDL_SYSTEM_CURSOR_SIZENS,      // 6  MOUSE_CURSOR_RESIZE_NS
+    SDL_SYSTEM_CURSOR_SIZENWSE,    // 7  MOUSE_CURSOR_RESIZE_NWSE
+    SDL_SYSTEM_CURSOR_SIZENESW,    // 8  MOUSE_CURSOR_RESIZE_NESW
+    SDL_SYSTEM_CURSOR_SIZEALL,     // 9  MOUSE_CURSOR_RESIZE_ALL
+    SDL_SYSTEM_CURSOR_NO           // 10 MOUSE_CURSOR_NOT_ALLOWED
+    //SDL_SYSTEM_CURSOR_WAIT,      // No equivalent implemented on MouseCursor enum on raylib.h
+    //SDL_SYSTEM_CURSOR_WAITARROW, // No equivalent implemented on MouseCursor enum on raylib.h
 };
 
 //----------------------------------------------------------------------------------
@@ -540,7 +557,10 @@ void SetMousePosition(int x, int y)
 // Set mouse cursor
 void SetMouseCursor(int cursor)
 {
-    TRACELOG(LOG_WARNING, "SetMouseCursor() not implemented on target platform");
+    platform.cursor = SDL_CreateSystemCursor(CursorsLUT[cursor]);
+    SDL_SetCursor(platform.cursor);
+
+    CORE.Input.Mouse.cursor = cursor;
 }
 
 // Register all input events
@@ -796,6 +816,7 @@ static int InitPlatform(void)
 
 static void ClosePlatform(void)
 {
+    SDL_FreeCursor(platform.cursor); // Free cursor
     SDL_GL_DeleteContext(platform.glContext); // Deinitialize OpenGL context
     SDL_DestroyWindow(platform.window);
     SDL_Quit(); // Deinitialize SDL internal global state

--- a/src/rcore_desktop_sdl.c
+++ b/src/rcore_desktop_sdl.c
@@ -332,7 +332,7 @@ void SetWindowOpacity(float opacity)
 // Set window focused
 void SetWindowFocused(void)
 {
-    TRACELOG(LOG_WARNING, "SetWindowFocused() not available on target platform");
+    SDL_RaiseWindow(platform.window);
 }
 
 // Get native window handle
@@ -406,15 +406,45 @@ int GetMonitorHeight(int monitor)
 // Get selected monitor physical width in millimetres
 int GetMonitorPhysicalWidth(int monitor)
 {
-    TRACELOG(LOG_WARNING, "GetMonitorPhysicalWidth() not implemented on target platform");
-    return 0;
+    int width = 0;
+
+    int monitorCount = 0;
+    monitorCount = SDL_GetNumVideoDisplays();
+
+    if ((monitor >= 0) && (monitor < monitorCount))
+    {
+        float vdpi = 0.0f;
+        SDL_GetDisplayDPI(monitor, NULL, NULL, &vdpi);
+        SDL_DisplayMode mode;
+        SDL_GetCurrentDisplayMode(monitor, &mode);
+        // Calculate size on inches, then convert to millimeter
+        if (vdpi > 0.0f) width = (mode.w/vdpi)*25.4f;
+    }
+    else TRACELOG(LOG_WARNING, "SDL: Failed to find selected monitor");
+
+    return width;
 }
 
 // Get selected monitor physical height in millimetres
 int GetMonitorPhysicalHeight(int monitor)
 {
-    TRACELOG(LOG_WARNING, "GetMonitorPhysicalHeight() not implemented on target platform");
-    return 0;
+    int height = 0;
+
+    int monitorCount = 0;
+    monitorCount = SDL_GetNumVideoDisplays();
+
+    if ((monitor >= 0) && (monitor < monitorCount))
+    {
+        float vdpi = 0.0f;
+        SDL_GetDisplayDPI(monitor, NULL, NULL, &vdpi);
+        SDL_DisplayMode mode;
+        SDL_GetCurrentDisplayMode(monitor, &mode);
+        // Calculate size on inches, then convert to millimeter
+        if (vdpi > 0.0f) height = (mode.h/vdpi)*25.4f;
+    }
+    else TRACELOG(LOG_WARNING, "SDL: Failed to find selected monitor");
+
+    return height;
 }
 
 // Get selected monitor refresh rate

--- a/src/rcore_desktop_sdl.c
+++ b/src/rcore_desktop_sdl.c
@@ -466,12 +466,16 @@ const char *GetClipboardText(void)
 // Show mouse cursor
 void ShowCursor(void)
 {
+    SDL_ShowCursor(SDL_ENABLE);
+
     CORE.Input.Mouse.cursorHidden = false;
 }
 
 // Hides mouse cursor
 void HideCursor(void)
 {
+    SDL_ShowCursor(SDL_DISABLE);
+
     CORE.Input.Mouse.cursorHidden = true;
 }
 


### PR DESCRIPTION
### Changes
1. Adds `ShowCursor` implementation ([R469-R471](https://github.com/raysan5/raylib/pull/3436/files#diff-b7c2628cbe74c1722110bdc42bc4239493b1be7ff2836f8892e3e942a42e9aefR469-R471)).
2. Adds `HideCursor` implementation ([R477-R479](https://github.com/raysan5/raylib/pull/3436/files#diff-b7c2628cbe74c1722110bdc42bc4239493b1be7ff2836f8892e3e942a42e9aefR477-R479)).
3. Adds `EnableCursor` implementation ([R485-R486](https://github.com/raysan5/raylib/pull/3436/files#diff-b7c2628cbe74c1722110bdc42bc4239493b1be7ff2836f8892e3e942a42e9aefR485-R486)).
4. Adds `DisableCursor` implementation ([R494](https://github.com/raysan5/raylib/pull/3436/files#diff-b7c2628cbe74c1722110bdc42bc4239493b1be7ff2836f8892e3e942a42e9aefR494)).
5. Adds `SetClipboardText` implementation ([R455](https://github.com/raysan5/raylib/pull/3436/files#diff-b7c2628cbe74c1722110bdc42bc4239493b1be7ff2836f8892e3e942a42e9aefR455)).
6. Adds `GetClipboardText` implementation ([R459](https://github.com/raysan5/raylib/pull/3436/files#diff-b7c2628cbe74c1722110bdc42bc4239493b1be7ff2836f8892e3e942a42e9aefR459), [R462](https://github.com/raysan5/raylib/pull/3436/files#diff-b7c2628cbe74c1722110bdc42bc4239493b1be7ff2836f8892e3e942a42e9aefR462)).
7. Adds `SetMouseCursor` implementation ([R65](https://github.com/raysan5/raylib/pull/3436/files#diff-b7c2628cbe74c1722110bdc42bc4239493b1be7ff2836f8892e3e942a42e9aefR65), [R182-R196](https://github.com/raysan5/raylib/pull/3436/files#diff-b7c2628cbe74c1722110bdc42bc4239493b1be7ff2836f8892e3e942a42e9aefR182-R196), [R560-R563](https://github.com/raysan5/raylib/pull/3436/files#diff-b7c2628cbe74c1722110bdc42bc4239493b1be7ff2836f8892e3e942a42e9aefR560-R563), [R819](https://github.com/raysan5/raylib/pull/3436/files#diff-b7c2628cbe74c1722110bdc42bc4239493b1be7ff2836f8892e3e942a42e9aefR819)).
8. Adds `SetWindowFocused` implementation ([R335](https://github.com/raysan5/raylib/pull/3436/files#diff-b7c2628cbe74c1722110bdc42bc4239493b1be7ff2836f8892e3e942a42e9aefR335)).
9. Adds `GetMonitorPhysicalWidth` implementation ([R409-R425](https://github.com/raysan5/raylib/pull/3436/files#diff-b7c2628cbe74c1722110bdc42bc4239493b1be7ff2836f8892e3e942a42e9aefR409-R425)).
10. Adds `GetMonitorPhysicalHeight` implementation ([R431-R447](https://github.com/raysan5/raylib/pull/3436/files#diff-b7c2628cbe74c1722110bdc42bc4239493b1be7ff2836f8892e3e942a42e9aefR431-R447)).
11. Adds `GetWindowHandle` implementation ([R341](https://github.com/raysan5/raylib/pull/3436/files#diff-b7c2628cbe74c1722110bdc42bc4239493b1be7ff2836f8892e3e942a42e9aefR341)).
12. Adds `SetGamepadMappings` implementation ([R575](https://github.com/raysan5/raylib/pull/3436/files#diff-b7c2628cbe74c1722110bdc42bc4239493b1be7ff2836f8892e3e942a42e9aefR575)).

### Notes
- I don't have a joystick/controller here right now, so I couldn't test `SetGamepadMappings`.

### Environment
Tested this changes successfully on Linux (Ubuntu 22.04 64-bit, gcc 11.2.0) with SDL2 (2.28.4).

### Edits
**1:** added line marks.
**2, 3, 4, 5, 6:** added more implementations.