### PR TITLE
Fix `SetGamepadMappings` returning

### DIFF
--- a/src/rcore_desktop_sdl.c
+++ b/src/rcore_desktop_sdl.c
@@ -572,7 +572,7 @@ void OpenURL(const char *url)
 // Set internal gamepad mappings
 int SetGamepadMappings(const char *mappings)
 {
-    SDL_GameControllerAddMapping(mappings);
+    return SDL_GameControllerAddMapping(mappings);
 }
 
 // Set mouse position XY


### PR DESCRIPTION
I fixed the return of `SetGamepadMappings` which returned nothing. The function now returns `SDL_GameControllerAddMapping` which returns this information according to the documentation:
> returns 1 if a new mapping is added, 0 if an existing mapping is updated,
> -1 on error; call SDL_GetError() for more information.