### PR TITLE
[core] Add more missing implementations to SDL

### DIFF
--- a/src/rcore_desktop_sdl.c
+++ b/src/rcore_desktop_sdl.c
@@ -221,7 +221,16 @@ bool WindowShouldClose(void)
 // Toggle fullscreen mode
 void ToggleFullscreen(void)
 {
-    //SDL_SetWindowFullscreen
+    if (!IsWindowState(FLAG_FULLSCREEN_MODE))
+    {
+        SDL_SetWindowFullscreen(platform.window, SDL_WINDOW_FULLSCREEN);
+        CORE.Window.flags |= FLAG_FULLSCREEN_MODE;
+    }
+    else
+    {
+        SDL_SetWindowFullscreen(platform.window, 0);
+        CORE.Window.flags &= ~FLAG_FULLSCREEN_MODE; 
+    }
 }
 
 // Toggle borderless windowed mode

--- a/src/rcore_desktop_sdl.c
+++ b/src/rcore_desktop_sdl.c
@@ -647,8 +647,20 @@ int GetCurrentMonitor(void)
 // Get selected monitor position
 Vector2 GetMonitorPosition(int monitor)
 {
-    TRACELOG(LOG_WARNING, "GetMonitorPosition() not implemented on target platform");
-    return (Vector2){ 0, 0 };
+    if (monitor < 0 || monitor >= SDL_GetNumVideoDisplays())
+    {
+        TRACELOG(LOG_ERROR, "Invalid monitor index");
+        return (Vector2) { 0, 0 };
+    }
+
+    SDL_Rect displayBounds;
+    if (SDL_GetDisplayBounds(monitor, &displayBounds) != 0)
+    {
+        TRACELOG(LOG_ERROR, "Failed to get display bounds");
+        return (Vector2) { 0, 0 };
+    }
+
+    return (Vector2) { displayBounds.x, displayBounds.y };
 }
 
 // Get selected monitor width (currently used by monitor)

--- a/src/rcore_desktop_sdl.c
+++ b/src/rcore_desktop_sdl.c
@@ -255,17 +255,25 @@ void SetWindowState(unsigned int flags)
 {
     CORE.Window.flags |= flags;
 
+    if (flags & FLAG_VSYNC_HINT)
+    {
+        SDL_GL_SetSwapInterval(1);
+    }
     if (flags & FLAG_FULLSCREEN_MODE)
     {
         SDL_SetWindowFullscreen(platform.window, SDL_WINDOW_FULLSCREEN);
+    }
+    if (flags & FLAG_WINDOW_RESIZABLE)
+    {
+        SDL_SetWindowResizable(platform.window, SDL_TRUE);
     }
     if (flags & FLAG_WINDOW_UNDECORATED)
     {
         SDL_SetWindowBordered(platform.window, SDL_FALSE);
     }
-    if (flags & FLAG_WINDOW_RESIZABLE)
+    if (flags & FLAG_WINDOW_HIDDEN)
     {
-        SDL_SetWindowResizable(platform.window, SDL_TRUE);
+        SDL_HideWindow(platform.window);
     }
     if (flags & FLAG_WINDOW_MINIMIZED)
     {
@@ -279,19 +287,43 @@ void SetWindowState(unsigned int flags)
     {
         // NOTE: To be able to implement this part it seems that we should
         // do it ourselves, via `Windows.h`, `X11/Xlib.h` or even `Cocoa.h`
+        TraceLog(LOG_WARNING, "SetWindowState() - FLAG_WINDOW_UNFOCUSED is not supported on PLATFORM_DESKTOP_SDL");
     }
     if (flags & FLAG_WINDOW_TOPMOST)
     {
-        // NOTE: To be able to implement this part it seems that we should
-        // do it ourselves, via `Windows.h`, `X11/Xlib.h` or even `Cocoa.h`
+        SDL_SetWindowAlwaysOnTop(platform.window, SDL_FALSE);
     }
-    if (flags & FLAG_WINDOW_MOUSE_PASSTHROUGH)
+    if (flags & FLAG_WINDOW_ALWAYS_RUN)
     {
-        SDL_SetWindowGrab(platform.window, SDL_FALSE);
+        TraceLog(LOG_WARNING, "SetWindowState() - FLAG_WINDOW_ALWAYS_RUN is not supported on PLATFORM_DESKTOP_SDL");
+    }
+    if (flags & FLAG_WINDOW_TRANSPARENT)
+    {
+        TraceLog(LOG_WARNING, "SetWindowState() - FLAG_WINDOW_TRANSPARENT is not supported on PLATFORM_DESKTOP_SDL");
     }
     if (flags & FLAG_WINDOW_HIGHDPI)
     {
         // NOTE: Such a function does not seem to exist
+        TraceLog(LOG_WARNING, "SetWindowState() - FLAG_WINDOW_HIGHDPI is not supported on PLATFORM_DESKTOP_SDL");
+    }
+    if (flags & FLAG_WINDOW_MOUSE_PASSTHROUGH)
+    {
+        //SDL_SetWindowGrab(platform.window, SDL_FALSE);
+        TraceLog(LOG_WARNING, "SetWindowState() - FLAG_WINDOW_MOUSE_PASSTHROUGH is not supported on PLATFORM_DESKTOP_SDL");
+    }
+    if (flags & FLAG_BORDERLESS_WINDOWED_MODE)
+    {
+        // NOTE: Same as FLAG_WINDOW_UNDECORATED with SDL ?
+        SDL_SetWindowBordered(platform.window, SDL_FALSE);
+    }
+    if (flags & FLAG_MSAA_4X_HINT)
+    {
+        SDL_GL_SetAttribute(SDL_GL_MULTISAMPLEBUFFERS, 1); // Enable multisampling buffers
+        SDL_GL_SetAttribute(SDL_GL_MULTISAMPLESAMPLES, 4); // Enable multisampling
+    }
+    if (flags & FLAG_INTERLACED_HINT)
+    {
+        TraceLog(LOG_WARNING, "SetWindowState() - FLAG_INTERLACED_HINT is not supported on PLATFORM_DESKTOP_SDL");
     }
 }
 
@@ -300,17 +332,25 @@ void ClearWindowState(unsigned int flags)
 {
     CORE.Window.flags &= ~flags;
 
+    if (flags & FLAG_VSYNC_HINT)
+    {
+        SDL_GL_SetSwapInterval(0);
+    }
     if (flags & FLAG_FULLSCREEN_MODE)
     {
         SDL_SetWindowFullscreen(platform.window, 0);
+    }
+    if (flags & FLAG_WINDOW_RESIZABLE)
+    {
+        SDL_SetWindowResizable(platform.window, SDL_FALSE);
     }
     if (flags & FLAG_WINDOW_UNDECORATED)
     {
         SDL_SetWindowBordered(platform.window, SDL_TRUE);
     }
-    if (flags & FLAG_WINDOW_RESIZABLE)
+    if (flags & FLAG_WINDOW_HIDDEN)
     {
-        SDL_SetWindowResizable(platform.window, SDL_FALSE);
+        SDL_ShowWindow(platform.window);
     }
     if (flags & FLAG_WINDOW_MINIMIZED)
     {
@@ -323,18 +363,43 @@ void ClearWindowState(unsigned int flags)
     if (flags & FLAG_WINDOW_UNFOCUSED)
     {
         //SDL_RaiseWindow(platform.window);
+        TraceLog(LOG_WARNING, "ClearWindowState() - FLAG_WINDOW_UNFOCUSED is not supported on PLATFORM_DESKTOP_SDL");
     }
     if (flags & FLAG_WINDOW_TOPMOST)
     {
-        // NOTE: You will have to manage the window priority manually, as mentioned earlier
+        SDL_SetWindowAlwaysOnTop(platform.window, SDL_FALSE);
     }
-    if (flags & FLAG_WINDOW_MOUSE_PASSTHROUGH)
+    if (flags & FLAG_WINDOW_ALWAYS_RUN)
     {
-        SDL_SetWindowGrab(platform.window, SDL_TRUE);
+        TraceLog(LOG_WARNING, "ClearWindowState() - FLAG_WINDOW_ALWAYS_RUN is not supported on PLATFORM_DESKTOP_SDL");
+    }
+    if (flags & FLAG_WINDOW_TRANSPARENT)
+    {
+        TraceLog(LOG_WARNING, "ClearWindowState() - FLAG_WINDOW_TRANSPARENT is not supported on PLATFORM_DESKTOP_SDL");
     }
     if (flags & FLAG_WINDOW_HIGHDPI)
     {
         // NOTE: There also doesn't seem to be a feature to disable high DPI once enabled
+        TraceLog(LOG_WARNING, "ClearWindowState() - FLAG_WINDOW_HIGHDPI is not supported on PLATFORM_DESKTOP_SDL");
+    }
+    if (flags & FLAG_WINDOW_MOUSE_PASSTHROUGH)
+    {
+        //SDL_SetWindowGrab(platform.window, SDL_TRUE);
+        TraceLog(LOG_WARNING, "ClearWindowState() - FLAG_WINDOW_MOUSE_PASSTHROUGH is not supported on PLATFORM_DESKTOP_SDL");
+    }
+    if (flags & FLAG_BORDERLESS_WINDOWED_MODE)
+    {
+        // NOTE: Same as FLAG_WINDOW_UNDECORATED with SDL ?
+        SDL_SetWindowBordered(platform.window, SDL_TRUE);
+    }
+    if (flags & FLAG_MSAA_4X_HINT)
+    {
+        SDL_GL_SetAttribute(SDL_GL_MULTISAMPLEBUFFERS, 0); // Disable multisampling buffers
+        SDL_GL_SetAttribute(SDL_GL_MULTISAMPLESAMPLES, 0); // Disable multisampling
+    }
+    if (flags & FLAG_INTERLACED_HINT)
+    {
+        TraceLog(LOG_WARNING, "ClearWindowState() - FLAG_INTERLACED_HINT is not supported on PLATFORM_DESKTOP_SDL");
     }
 }
 

--- a/src/rcore_desktop_sdl.c
+++ b/src/rcore_desktop_sdl.c
@@ -1018,6 +1018,12 @@ static int InitPlatform(void)
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 3);
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
     //SDL_GL_SetAttribute(SDL_GL_CONTEXT_FLAGS, SDL_GL_CONTEXT_DEBUG_FLAG | SDL_GL_CONTEXT_FORWARD_COMPATIBLE_FLAG);
+
+    if (CORE.Window.flags & FLAG_VSYNC_HINT)
+    {
+        SDL_GL_SetSwapInterval(1);
+    }
+
     if (CORE.Window.flags & FLAG_MSAA_4X_HINT)
     {
         SDL_GL_SetAttribute(SDL_GL_MULTISAMPLEBUFFERS, 1);

--- a/src/rcore_desktop_sdl.c
+++ b/src/rcore_desktop_sdl.c
@@ -581,7 +581,20 @@ void SetWindowPosition(int x, int y)
 // Set monitor for the current window
 void SetWindowMonitor(int monitor)
 {
-    TRACELOG(LOG_WARNING, "SetWindowMonitor() not available on target platform");
+    if (monitor < 0 || monitor >= SDL_GetNumVideoDisplays())
+    {
+        TRACELOG(LOG_ERROR, "Invalid monitor index");
+        return;
+    }
+
+    SDL_Rect displayBounds;
+    if (SDL_GetDisplayBounds(monitor, &displayBounds) != 0)
+    {
+        TRACELOG(LOG_ERROR, "Failed to get display bounds");
+        return;
+    }
+
+    SDL_SetWindowPosition(platform.window, displayBounds.x, displayBounds.y);
 }
 
 // Set window minimum dimensions (FLAG_WINDOW_RESIZABLE)

--- a/src/rcore_desktop_sdl.c
+++ b/src/rcore_desktop_sdl.c
@@ -944,7 +944,7 @@ void PollInputEvents(void)
 
     // Register previous keys states
     // NOTE: Android supports up to 260 keys
-    for (int i = 0; i < 260; i++)
+    for (int i = 0; i < MAX_KEYBOARD_KEYS; i++)
     {
         CORE.Input.Keyboard.previousKeyState[i] = CORE.Input.Keyboard.currentKeyState[i];
         CORE.Input.Keyboard.keyRepeatInFrame[i] = 0;
@@ -978,16 +978,16 @@ void PollInputEvents(void)
             {
                 switch (event.window.event)
                 {
-                case SDL_WINDOWEVENT_LEAVE:
-                case SDL_WINDOWEVENT_HIDDEN:
-                case SDL_WINDOWEVENT_MINIMIZED:
-                case SDL_WINDOWEVENT_FOCUS_LOST:
-                case SDL_WINDOWEVENT_ENTER:
-                case SDL_WINDOWEVENT_SHOWN:
-                case SDL_WINDOWEVENT_FOCUS_GAINED:
-                case SDL_WINDOWEVENT_MAXIMIZED:
-                case SDL_WINDOWEVENT_RESTORED:
-                default: break;
+                    case SDL_WINDOWEVENT_LEAVE:
+                    case SDL_WINDOWEVENT_HIDDEN:
+                    case SDL_WINDOWEVENT_MINIMIZED:
+                    case SDL_WINDOWEVENT_FOCUS_LOST:
+                    case SDL_WINDOWEVENT_ENTER:
+                    case SDL_WINDOWEVENT_SHOWN:
+                    case SDL_WINDOWEVENT_FOCUS_GAINED:
+                    case SDL_WINDOWEVENT_MAXIMIZED:
+                    case SDL_WINDOWEVENT_RESTORED:
+                    default: break;
                 }
             } break;
 

--- a/src/rcore_desktop_sdl.c
+++ b/src/rcore_desktop_sdl.c
@@ -887,7 +887,7 @@ void OpenURL(const char *url)
 // Set internal gamepad mappings
 int SetGamepadMappings(const char *mappings)
 {
-    SDL_GameControllerAddMapping(mappings);
+    return SDL_GameControllerAddMapping(mappings);
 }
 
 // Set mouse position XY

--- a/src/rcore_desktop_sdl.c
+++ b/src/rcore_desktop_sdl.c
@@ -1041,6 +1041,12 @@ static int InitPlatform(void)
     {
         CORE.Window.ready = true;
 
+        SDL_DisplayMode displayMode;
+        SDL_GetCurrentDisplayMode(0, &displayMode);
+
+        CORE.Window.display.width = displayMode.w;
+        CORE.Window.display.height = displayMode.h;
+
         CORE.Window.render.width = CORE.Window.screen.width;
         CORE.Window.render.height = CORE.Window.screen.height;
         CORE.Window.currentFbo.width = CORE.Window.render.width;

--- a/src/rcore_desktop_sdl.c
+++ b/src/rcore_desktop_sdl.c
@@ -1042,7 +1042,7 @@ static int InitPlatform(void)
         CORE.Window.ready = true;
 
         SDL_DisplayMode displayMode;
-        SDL_GetCurrentDisplayMode(0, &displayMode);
+        SDL_GetCurrentDisplayMode(SDL_GetWindowDisplayIndex(platform.window), &displayMode);
 
         CORE.Window.display.width = displayMode.w;
         CORE.Window.display.height = displayMode.h;

--- a/src/rcore_desktop_sdl.c
+++ b/src/rcore_desktop_sdl.c
@@ -346,7 +346,7 @@ void SetWindowState(unsigned int flags)
     {
         // NOTE: To be able to implement this part it seems that we should
         // do it ourselves, via `Windows.h`, `X11/Xlib.h` or even `Cocoa.h`
-        TraceLog(LOG_WARNING, "SetWindowState() - FLAG_WINDOW_UNFOCUSED is not supported on PLATFORM_DESKTOP_SDL");
+        TRACELOG(LOG_WARNING, "SetWindowState() - FLAG_WINDOW_UNFOCUSED is not supported on PLATFORM_DESKTOP_SDL");
     }
     if (flags & FLAG_WINDOW_TOPMOST)
     {
@@ -354,21 +354,21 @@ void SetWindowState(unsigned int flags)
     }
     if (flags & FLAG_WINDOW_ALWAYS_RUN)
     {
-        TraceLog(LOG_WARNING, "SetWindowState() - FLAG_WINDOW_ALWAYS_RUN is not supported on PLATFORM_DESKTOP_SDL");
+        TRACELOG(LOG_WARNING, "SetWindowState() - FLAG_WINDOW_ALWAYS_RUN is not supported on PLATFORM_DESKTOP_SDL");
     }
     if (flags & FLAG_WINDOW_TRANSPARENT)
     {
-        TraceLog(LOG_WARNING, "SetWindowState() - FLAG_WINDOW_TRANSPARENT is not supported on PLATFORM_DESKTOP_SDL");
+        TRACELOG(LOG_WARNING, "SetWindowState() - FLAG_WINDOW_TRANSPARENT is not supported on PLATFORM_DESKTOP_SDL");
     }
     if (flags & FLAG_WINDOW_HIGHDPI)
     {
         // NOTE: Such a function does not seem to exist
-        TraceLog(LOG_WARNING, "SetWindowState() - FLAG_WINDOW_HIGHDPI is not supported on PLATFORM_DESKTOP_SDL");
+        TRACELOG(LOG_WARNING, "SetWindowState() - FLAG_WINDOW_HIGHDPI is not supported on PLATFORM_DESKTOP_SDL");
     }
     if (flags & FLAG_WINDOW_MOUSE_PASSTHROUGH)
     {
         //SDL_SetWindowGrab(platform.window, SDL_FALSE);
-        TraceLog(LOG_WARNING, "SetWindowState() - FLAG_WINDOW_MOUSE_PASSTHROUGH is not supported on PLATFORM_DESKTOP_SDL");
+        TRACELOG(LOG_WARNING, "SetWindowState() - FLAG_WINDOW_MOUSE_PASSTHROUGH is not supported on PLATFORM_DESKTOP_SDL");
     }
     if (flags & FLAG_BORDERLESS_WINDOWED_MODE)
     {
@@ -382,7 +382,7 @@ void SetWindowState(unsigned int flags)
     }
     if (flags & FLAG_INTERLACED_HINT)
     {
-        TraceLog(LOG_WARNING, "SetWindowState() - FLAG_INTERLACED_HINT is not supported on PLATFORM_DESKTOP_SDL");
+        TRACELOG(LOG_WARNING, "SetWindowState() - FLAG_INTERLACED_HINT is not supported on PLATFORM_DESKTOP_SDL");
     }
 }
 
@@ -422,7 +422,7 @@ void ClearWindowState(unsigned int flags)
     if (flags & FLAG_WINDOW_UNFOCUSED)
     {
         //SDL_RaiseWindow(platform.window);
-        TraceLog(LOG_WARNING, "ClearWindowState() - FLAG_WINDOW_UNFOCUSED is not supported on PLATFORM_DESKTOP_SDL");
+        TRACELOG(LOG_WARNING, "ClearWindowState() - FLAG_WINDOW_UNFOCUSED is not supported on PLATFORM_DESKTOP_SDL");
     }
     if (flags & FLAG_WINDOW_TOPMOST)
     {
@@ -430,21 +430,21 @@ void ClearWindowState(unsigned int flags)
     }
     if (flags & FLAG_WINDOW_ALWAYS_RUN)
     {
-        TraceLog(LOG_WARNING, "ClearWindowState() - FLAG_WINDOW_ALWAYS_RUN is not supported on PLATFORM_DESKTOP_SDL");
+        TRACELOG(LOG_WARNING, "ClearWindowState() - FLAG_WINDOW_ALWAYS_RUN is not supported on PLATFORM_DESKTOP_SDL");
     }
     if (flags & FLAG_WINDOW_TRANSPARENT)
     {
-        TraceLog(LOG_WARNING, "ClearWindowState() - FLAG_WINDOW_TRANSPARENT is not supported on PLATFORM_DESKTOP_SDL");
+        TRACELOG(LOG_WARNING, "ClearWindowState() - FLAG_WINDOW_TRANSPARENT is not supported on PLATFORM_DESKTOP_SDL");
     }
     if (flags & FLAG_WINDOW_HIGHDPI)
     {
         // NOTE: There also doesn't seem to be a feature to disable high DPI once enabled
-        TraceLog(LOG_WARNING, "ClearWindowState() - FLAG_WINDOW_HIGHDPI is not supported on PLATFORM_DESKTOP_SDL");
+        TRACELOG(LOG_WARNING, "ClearWindowState() - FLAG_WINDOW_HIGHDPI is not supported on PLATFORM_DESKTOP_SDL");
     }
     if (flags & FLAG_WINDOW_MOUSE_PASSTHROUGH)
     {
         //SDL_SetWindowGrab(platform.window, SDL_TRUE);
-        TraceLog(LOG_WARNING, "ClearWindowState() - FLAG_WINDOW_MOUSE_PASSTHROUGH is not supported on PLATFORM_DESKTOP_SDL");
+        TRACELOG(LOG_WARNING, "ClearWindowState() - FLAG_WINDOW_MOUSE_PASSTHROUGH is not supported on PLATFORM_DESKTOP_SDL");
     }
     if (flags & FLAG_BORDERLESS_WINDOWED_MODE)
     {
@@ -458,7 +458,7 @@ void ClearWindowState(unsigned int flags)
     }
     if (flags & FLAG_INTERLACED_HINT)
     {
-        TraceLog(LOG_WARNING, "ClearWindowState() - FLAG_INTERLACED_HINT is not supported on PLATFORM_DESKTOP_SDL");
+        TRACELOG(LOG_WARNING, "ClearWindowState() - FLAG_INTERLACED_HINT is not supported on PLATFORM_DESKTOP_SDL");
     }
 }
 

--- a/src/rcore_desktop_sdl.c
+++ b/src/rcore_desktop_sdl.c
@@ -63,6 +63,7 @@ typedef struct {
 
     SDL_Joystick *gamepad;
     SDL_Cursor *cursor;
+    bool cursorRelative;
 } PlatformData;
 
 //----------------------------------------------------------------------------------
@@ -842,6 +843,7 @@ void EnableCursor(void)
     SDL_SetRelativeMouseMode(SDL_FALSE);
     SDL_ShowCursor(SDL_ENABLE);
 
+    platform.cursorRelative = false;
     CORE.Input.Mouse.cursorHidden = false;
 }
 
@@ -850,6 +852,7 @@ void DisableCursor(void)
 {
     SDL_SetRelativeMouseMode(SDL_TRUE);
 
+    platform.cursorRelative = true;
     CORE.Input.Mouse.cursorHidden = true;
 }
 
@@ -924,7 +927,8 @@ void PollInputEvents(void)
     CORE.Input.Mouse.currentWheelMove.y = 0;
 
     // Register previous mouse position
-    CORE.Input.Mouse.previousPosition = CORE.Input.Mouse.currentPosition;
+    if (platform.cursorRelative) CORE.Input.Mouse.currentPosition = (Vector2){ 0.0f, 0.0f };
+    else CORE.Input.Mouse.previousPosition = CORE.Input.Mouse.currentPosition;
 
     // Reset last gamepad button/axis registered state
     CORE.Input.Gamepad.lastButtonPressed = GAMEPAD_BUTTON_UNKNOWN;
@@ -1022,8 +1026,17 @@ void PollInputEvents(void)
             } break;
             case SDL_MOUSEMOTION:
             {
-                CORE.Input.Mouse.currentPosition.x = (float)event.motion.x;
-                CORE.Input.Mouse.currentPosition.y = (float)event.motion.y;
+                if (platform.cursorRelative)
+                {
+                    CORE.Input.Mouse.currentPosition.x = (float)event.motion.xrel;
+                    CORE.Input.Mouse.currentPosition.y = (float)event.motion.yrel;
+                    CORE.Input.Mouse.previousPosition = (Vector2){ 0.0f, 0.0f };
+                }
+                else
+                {
+                    CORE.Input.Mouse.currentPosition.x = (float)event.motion.x;
+                    CORE.Input.Mouse.currentPosition.y = (float)event.motion.y;
+                }
             } break;
 
             // Check gamepad events

--- a/src/rcore_desktop_sdl.c
+++ b/src/rcore_desktop_sdl.c
@@ -253,19 +253,182 @@ void RestoreWindow(void)
 // Set window configuration state using flags
 void SetWindowState(unsigned int flags)
 {
-    //SDL_HideWindow(platform.window);
+    CORE.Window.flags |= flags;
+
+    if (flags & FLAG_FULLSCREEN_MODE)
+    {
+        SDL_SetWindowFullscreen(platform.window, SDL_WINDOW_FULLSCREEN);
+    }
+    if (flags & FLAG_WINDOW_UNDECORATED)
+    {
+        SDL_SetWindowBordered(platform.window, SDL_FALSE);
+    }
+    if (flags & FLAG_WINDOW_RESIZABLE)
+    {
+        SDL_SetWindowResizable(platform.window, SDL_TRUE);
+    }
+    if (flags & FLAG_WINDOW_MINIMIZED)
+    {
+        SDL_MinimizeWindow(platform.window);
+    }
+    if (flags & FLAG_WINDOW_MAXIMIZED)
+    {
+        SDL_MaximizeWindow(platform.window);
+    }
+    if (flags & FLAG_WINDOW_UNFOCUSED)
+    {
+        // NOTE: To be able to implement this part it seems that we should
+        // do it ourselves, via `Windows.h`, `X11/Xlib.h` or even `Cocoa.h`
+    }
+    if (flags & FLAG_WINDOW_TOPMOST)
+    {
+        // NOTE: To be able to implement this part it seems that we should
+        // do it ourselves, via `Windows.h`, `X11/Xlib.h` or even `Cocoa.h`
+    }
+    if (flags & FLAG_WINDOW_MOUSE_PASSTHROUGH)
+    {
+        SDL_SetWindowGrab(platform.window, SDL_FALSE);
+    }
+    if (flags & FLAG_WINDOW_HIGHDPI)
+    {
+        // NOTE: Such a function does not seem to exist
+    }
 }
 
 // Clear window configuration state flags
 void ClearWindowState(unsigned int flags)
 {
-    TRACELOG(LOG_WARNING, "ClearWindowState() not available on target platform");
+    CORE.Window.flags &= ~flags;
+
+    if (flags & FLAG_FULLSCREEN_MODE)
+    {
+        SDL_SetWindowFullscreen(platform.window, 0);
+    }
+    if (flags & FLAG_WINDOW_UNDECORATED)
+    {
+        SDL_SetWindowBordered(platform.window, SDL_TRUE);
+    }
+    if (flags & FLAG_WINDOW_RESIZABLE)
+    {
+        SDL_SetWindowResizable(platform.window, SDL_FALSE);
+    }
+    if (flags & FLAG_WINDOW_MINIMIZED)
+    {
+        SDL_RestoreWindow(platform.window);
+    }
+    if (flags & FLAG_WINDOW_MAXIMIZED)
+    {
+        SDL_RestoreWindow(platform.window);
+    }
+    if (flags & FLAG_WINDOW_UNFOCUSED)
+    {
+        //SDL_RaiseWindow(platform.window);
+    }
+    if (flags & FLAG_WINDOW_TOPMOST)
+    {
+        // NOTE: You will have to manage the window priority manually, as mentioned earlier
+    }
+    if (flags & FLAG_WINDOW_MOUSE_PASSTHROUGH)
+    {
+        SDL_SetWindowGrab(platform.window, SDL_TRUE);
+    }
+    if (flags & FLAG_WINDOW_HIGHDPI)
+    {
+        // NOTE: There also doesn't seem to be a feature to disable high DPI once enabled
+    }
 }
 
 // Set icon for window
 void SetWindowIcon(Image image)
 {
-    TRACELOG(LOG_WARNING, "SetWindowIcon() not available on target platform");
+    SDL_Surface* iconSurface = NULL;
+
+    Uint32 rmask, gmask, bmask, amask;
+    int depth = 0;  // Depth in bits
+    int pitch = 0;  // Pixel spacing (pitch) in bytes
+
+    switch (image.format)
+    {
+        case PIXELFORMAT_UNCOMPRESSED_GRAYSCALE:
+            rmask = 0xFF, gmask = 0;
+            bmask = 0, amask = 0;
+            depth = 8, pitch = image.width;
+            break;
+        case PIXELFORMAT_UNCOMPRESSED_GRAY_ALPHA:
+            rmask = 0xFF, gmask = 0xFF00;
+            bmask = 0, amask = 0;
+            depth = 16, pitch = image.width * 2;
+            break;
+        case PIXELFORMAT_UNCOMPRESSED_R5G6B5:
+            rmask = 0xF800, gmask = 0x07E0;
+            bmask = 0x001F, amask = 0;
+            depth = 16, pitch = image.width * 2;
+            break;
+        case PIXELFORMAT_UNCOMPRESSED_R8G8B8:
+            rmask = 0xFF0000, gmask = 0x00FF00;
+            bmask = 0x0000FF, amask = 0;
+            depth = 24, pitch = image.width * 3;
+            break;
+        case PIXELFORMAT_UNCOMPRESSED_R5G5B5A1:
+            rmask = 0xF800, gmask = 0x07C0;
+            bmask = 0x003E, amask = 0x0001;
+            depth = 16, pitch = image.width * 2;
+            break;
+        case PIXELFORMAT_UNCOMPRESSED_R4G4B4A4:
+            rmask = 0xF000, gmask = 0x0F00;
+            bmask = 0x00F0, amask = 0x000F;
+            depth = 16, pitch = image.width * 2;
+            break;
+        case PIXELFORMAT_UNCOMPRESSED_R8G8B8A8:
+            rmask = 0xFF000000, gmask = 0x00FF0000;
+            bmask = 0x0000FF00, amask = 0x000000FF;
+            depth = 32, pitch = image.width * 4;
+            break;
+        case PIXELFORMAT_UNCOMPRESSED_R32:
+            rmask = 0xFFFFFFFF, gmask = 0;
+            bmask = 0, amask = 0;
+            depth = 32, pitch = image.width * 4;
+            break;
+        case PIXELFORMAT_UNCOMPRESSED_R32G32B32:
+            rmask = 0xFFFFFFFF, gmask = 0xFFFFFFFF;
+            bmask = 0xFFFFFFFF, amask = 0;
+            depth = 96, pitch = image.width * 12;
+            break;
+        case PIXELFORMAT_UNCOMPRESSED_R32G32B32A32:
+            rmask = 0xFFFFFFFF, gmask = 0xFFFFFFFF;
+            bmask = 0xFFFFFFFF, amask = 0xFFFFFFFF;
+            depth = 128, pitch = image.width * 16;
+            break;
+        case PIXELFORMAT_UNCOMPRESSED_R16:
+            rmask = 0xFFFF, gmask = 0;
+            bmask = 0, amask = 0;
+            depth = 16, pitch = image.width * 2;
+            break;
+        case PIXELFORMAT_UNCOMPRESSED_R16G16B16:
+            rmask = 0xFFFF, gmask = 0xFFFF;
+            bmask = 0xFFFF, amask = 0;
+            depth = 48, pitch = image.width * 6;
+            break;
+        case PIXELFORMAT_UNCOMPRESSED_R16G16B16A16:
+            rmask = 0xFFFF, gmask = 0xFFFF;
+            bmask = 0xFFFF, amask = 0xFFFF;
+            depth = 64, pitch = image.width * 8;
+            break;
+        default:
+            // Compressed formats are not supported
+            return;
+    }
+
+    iconSurface = SDL_CreateRGBSurfaceFrom(
+        image.data, image.width, image.height, depth, pitch,
+        rmask, gmask, bmask, amask
+    );
+
+    if (iconSurface)
+    {
+        SDL_SetWindowIcon(platform.window, iconSurface);
+        SDL_FreeSurface(iconSurface);
+    }
 }
 
 // Set icon for window


### PR DESCRIPTION
As requested in https://github.com/raysan5/raylib/issues/3313 here is the implementation of the `SetWindowState`, `ClearWindowState`, and `SetWindowIcon` functions for `rcore_desktop_sdl.c`.

The functions `SetWindowState` and `ClearWindowState` don't handle all flags, but it seems that some things can't be managed directly through SDL. Please take a look at the notes in the comments.

Otherwise, `SetWindowIcon` seems to work fine on my end on Cinnamon (Linux Mint). I don't have access to Windows to test it right now.

I'm sharing this work now so that if you have any feedback, I can make corrections, or you can merge it directly if everything looks good.