### PR TITLE
[core] Fix some implementations for `SDL`

### DIFF
--- a/src/rcore_desktop_sdl.c
+++ b/src/rcore_desktop_sdl.c
@@ -230,7 +230,7 @@ void ToggleFullscreen(void)
     else
     {
         SDL_SetWindowFullscreen(platform.window, 0);
-        CORE.Window.flags &= ~FLAG_FULLSCREEN_MODE; 
+        CORE.Window.flags &= ~FLAG_FULLSCREEN_MODE;
     }
 }
 
@@ -725,12 +725,12 @@ int GetMonitorPhysicalWidth(int monitor)
 
     if ((monitor >= 0) && (monitor < monitorCount))
     {
-        float vdpi = 0.0f;
-        SDL_GetDisplayDPI(monitor, NULL, NULL, &vdpi);
+        float ddpi = 0.0f;
+        SDL_GetDisplayDPI(monitor, &ddpi, NULL, NULL);
         SDL_DisplayMode mode;
         SDL_GetCurrentDisplayMode(monitor, &mode);
         // Calculate size on inches, then convert to millimeter
-        if (vdpi > 0.0f) width = (mode.w/vdpi)*25.4f;
+        if (ddpi > 0.0f) width = (mode.w/ddpi)*25.4f;
     }
     else TRACELOG(LOG_WARNING, "SDL: Failed to find selected monitor");
 
@@ -747,12 +747,12 @@ int GetMonitorPhysicalHeight(int monitor)
 
     if ((monitor >= 0) && (monitor < monitorCount))
     {
-        float vdpi = 0.0f;
-        SDL_GetDisplayDPI(monitor, NULL, NULL, &vdpi);
+        float ddpi = 0.0f;
+        SDL_GetDisplayDPI(monitor, &ddpi, NULL, NULL);
         SDL_DisplayMode mode;
         SDL_GetCurrentDisplayMode(monitor, &mode);
         // Calculate size on inches, then convert to millimeter
-        if (vdpi > 0.0f) height = (mode.h/vdpi)*25.4f;
+        if (ddpi > 0.0f) height = (mode.h/ddpi)*25.4f;
     }
     else TRACELOG(LOG_WARNING, "SDL: Failed to find selected monitor");
 


### PR DESCRIPTION
### Changes
1. Hopefully fixes `GetMonitorPhysicalWidth` ([R728-R729](https://github.com/raysan5/raylib/pull/3442/files#diff-b7c2628cbe74c1722110bdc42bc4239493b1be7ff2836f8892e3e942a42e9aefR728-R729), [R733](https://github.com/raysan5/raylib/pull/3442/files#diff-b7c2628cbe74c1722110bdc42bc4239493b1be7ff2836f8892e3e942a42e9aefR733)) and `GetMonitorPhysicalHeight` ([R750-R751](https://github.com/raysan5/raylib/pull/3442/files#diff-b7c2628cbe74c1722110bdc42bc4239493b1be7ff2836f8892e3e942a42e9aefR750-R751), [R755](https://github.com/raysan5/raylib/pull/3442/files#diff-b7c2628cbe74c1722110bdc42bc4239493b1be7ff2836f8892e3e942a42e9aefR755)) to use `ddpi`. Tested the 3 `dpi` values (`ddpi`, `hdpi`, `vdpi`) and their values are almost the same here:

| Size | Resolution | ddpi | hdpi | vdpi |
| :---: | :---: | :---: | :---: | :---: |
| 14'' | 1600x900 | 131.486923 | 131.521042 | 131.379303 |
| 17'' | 1280x1024 | 96.244881 | 96.189346 | 96.331848 |

After being used to calculate the monitor's physical width ([R733](https://github.com/raysan5/raylib/pull/3442/files#diff-b7c2628cbe74c1722110bdc42bc4239493b1be7ff2836f8892e3e942a42e9aefR733)) and physical height ([R755](https://github.com/raysan5/raylib/pull/3442/files#diff-b7c2628cbe74c1722110bdc42bc4239493b1be7ff2836f8892e3e942a42e9aefR755)) and converted from `inch` to `millimeter` the results are also almost the same.

My best guess is that the `ddpi` is the correct one. If anyone knows if we should be using the others instead, please send a PR correcting it.

### Reference
https://github.com/raysan5/raylib/issues/3313#issuecomment-1769373885

### Environment
Linux (Mint 21.1 64-bit) with two monitors (14'' 1600x900 60Hz, 17'' 1280x1024 60Hz).

### Edits
**1:** added line marks, editing, formatting.