### PR TITLE
[core] Complement implementations for `SDL`

### DIFF
--- a/src/platforms/rcore_desktop_sdl.c
+++ b/src/platforms/rcore_desktop_sdl.c
@@ -693,20 +693,18 @@ int GetCurrentMonitor(void)
 // Get selected monitor position
 Vector2 GetMonitorPosition(int monitor)
 {
-    if (monitor < 0 || monitor >= SDL_GetNumVideoDisplays())
+    const int monitorCount = SDL_GetNumVideoDisplays();
+    if ((monitor >= 0) && (monitor < monitorCount))
     {
-        TRACELOG(LOG_ERROR, "Invalid monitor index");
-        return (Vector2) { 0, 0 };
+        SDL_Rect displayBounds;
+        if (SDL_GetDisplayUsableBounds(monitor, &displayBounds) == 0)
+        {
+            return (Vector2){ (float)displayBounds.x, (float)displayBounds.y };
+        }
+        else TRACELOG(LOG_WARNING, "SDL: Failed to get selected display usable bounds");
     }
-
-    SDL_Rect displayBounds;
-    if (SDL_GetDisplayBounds(monitor, &displayBounds) != 0)
-    {
-        TRACELOG(LOG_ERROR, "Failed to get display bounds");
-        return (Vector2) { 0, 0 };
-    }
-
-    return (Vector2) { displayBounds.x, displayBounds.y };
+    else TRACELOG(LOG_WARNING, "SDL: Failed to find selected monitor");
+    return (Vector2){ 0.0f, 0.0f };
 }
 
 // Get selected monitor width (currently used by monitor)

--- a/src/platforms/rcore_desktop_sdl.c
+++ b/src/platforms/rcore_desktop_sdl.c
@@ -712,9 +712,7 @@ int GetMonitorWidth(int monitor)
 {
     int width = 0;
 
-    int monitorCount = 0;
-    monitorCount = SDL_GetNumVideoDisplays();
-
+    const int monitorCount = SDL_GetNumVideoDisplays();
     if ((monitor >= 0) && (monitor < monitorCount))
     {
         SDL_DisplayMode mode;
@@ -731,9 +729,7 @@ int GetMonitorHeight(int monitor)
 {
     int height = 0;
 
-    int monitorCount = 0;
-    monitorCount = SDL_GetNumVideoDisplays();
-
+    const int monitorCount = SDL_GetNumVideoDisplays();
     if ((monitor >= 0) && (monitor < monitorCount))
     {
         SDL_DisplayMode mode;
@@ -750,9 +746,7 @@ int GetMonitorPhysicalWidth(int monitor)
 {
     int width = 0;
 
-    int monitorCount = 0;
-    monitorCount = SDL_GetNumVideoDisplays();
-
+    const int monitorCount = SDL_GetNumVideoDisplays();
     if ((monitor >= 0) && (monitor < monitorCount))
     {
         float ddpi = 0.0f;
@@ -772,9 +766,7 @@ int GetMonitorPhysicalHeight(int monitor)
 {
     int height = 0;
 
-    int monitorCount = 0;
-    monitorCount = SDL_GetNumVideoDisplays();
-
+    const int monitorCount = SDL_GetNumVideoDisplays();
     if ((monitor >= 0) && (monitor < monitorCount))
     {
         float ddpi = 0.0f;
@@ -794,9 +786,7 @@ int GetMonitorRefreshRate(int monitor)
 {
     int refresh = 0;
 
-    int monitorCount = 0;
-    monitorCount = SDL_GetNumVideoDisplays();
-
+    const int monitorCount = SDL_GetNumVideoDisplays();
     if ((monitor >= 0) && (monitor < monitorCount))
     {
         SDL_DisplayMode mode;
@@ -811,8 +801,7 @@ int GetMonitorRefreshRate(int monitor)
 // Get the human-readable, UTF-8 encoded name of the selected monitor
 const char *GetMonitorName(int monitor)
 {
-    int monitorCount = 0;
-    monitorCount = SDL_GetNumVideoDisplays();
+    const int monitorCount = SDL_GetNumVideoDisplays();
 
     if ((monitor >= 0) && (monitor < monitorCount)) return SDL_GetDisplayName(monitor);
     else TRACELOG(LOG_WARNING, "SDL: Failed to find selected monitor");

--- a/src/platforms/rcore_desktop_sdl.c
+++ b/src/platforms/rcore_desktop_sdl.c
@@ -583,7 +583,7 @@ void SetWindowPosition(int x, int y)
 // Set monitor for the current window
 void SetWindowMonitor(int monitor)
 {
-    int monitorCount = SDL_GetNumVideoDisplays();
+    const int monitorCount = SDL_GetNumVideoDisplays();
     if ((monitor >= 0) && (monitor < monitorCount))
     {
         if (CORE.Window.fullscreen) ToggleFullscreen();
@@ -607,6 +607,8 @@ void SetWindowMonitor(int monitor)
                     // 3. It was't done here because we can't assume changing the window size automatically
                     //    is acceptable behavior by the user.
                     SDL_SetWindowPosition(platform.window, usableBounds.x, usableBounds.y);
+                    CORE.Window.position.x = x;
+                    CORE.Window.position.y = y;
                 }
                 else
                 {

--- a/src/platforms/rcore_desktop_sdl.c
+++ b/src/platforms/rcore_desktop_sdl.c
@@ -687,7 +687,11 @@ int GetMonitorCount(void)
 // Get number of monitors
 int GetCurrentMonitor(void)
 {
-    return SDL_GetWindowDisplayIndex(platform.window);
+    int currentMonitor = 0;
+
+    currentMonitor = SDL_GetWindowDisplayIndex(platform.window);
+
+    return currentMonitor;
 }
 
 // Get selected monitor position


### PR DESCRIPTION
### Changes
1. Complement `SetWindowMonitor` to match `rcore_desktop.c`'s more closely ([L586-R630](https://github.com/raysan5/raylib/pull/3444/files#diff-43fa9fe6c2302f00d9c0b8bcbe58d8ca92ca52e157d5b19a612f90a81c698c12L586-R630)).
**Note 1:** `SDL` started supporting moving exclusive fullscreen windows between displays on `SDL3` (see https://github.com/libsdl-org/SDL/commit/3f5ef7dd422057edbcf3e736107e34be4b75d9ba). A workround for `SDL2` is leaving fullscreen, moving the window, then entering full screen again.
**Note 2:** There's a known issue where if the window larger than the target display bounds, when moving the windows to that display, the window could be clipped back ending up positioned partly outside the target display. The workaround for that is, previously to moving the window, setting the window size to the target display size, so they match. It was't done here because we can't assume changing the window size automatically is acceptable behavior by the user.
2. Completement `GetMonitorPosition` to match `rcore_desktop.c` more closely ([L665-R707](https://github.com/raysan5/raylib/pull/3444/files#diff-43fa9fe6c2302f00d9c0b8bcbe58d8ca92ca52e157d5b19a612f90a81c698c12L665-R707)).
3. Small tweaks to:
a. `GetMonitorWidth` ([R715](https://github.com/raysan5/raylib/pull/3444/files#diff-43fa9fe6c2302f00d9c0b8bcbe58d8ca92ca52e157d5b19a612f90a81c698c12R715));
b. `GetMonitorHeight` ([R732](https://github.com/raysan5/raylib/pull/3444/files#diff-43fa9fe6c2302f00d9c0b8bcbe58d8ca92ca52e157d5b19a612f90a81c698c12R732));
c. `GetMonitorPhysicalWidth` ([R749](https://github.com/raysan5/raylib/pull/3444/files#diff-43fa9fe6c2302f00d9c0b8bcbe58d8ca92ca52e157d5b19a612f90a81c698c12R749));
d. `GetMonitorPhysicalHeight` ([R769](https://github.com/raysan5/raylib/pull/3444/files#diff-43fa9fe6c2302f00d9c0b8bcbe58d8ca92ca52e157d5b19a612f90a81c698c12R769));
e. `GetMonitorRefreshRate` ([R789](https://github.com/raysan5/raylib/pull/3444/files#diff-43fa9fe6c2302f00d9c0b8bcbe58d8ca92ca52e157d5b19a612f90a81c698c12R789));
f. `GetMonitorName` ([R804](https://github.com/raysan5/raylib/pull/3444/files#diff-43fa9fe6c2302f00d9c0b8bcbe58d8ca92ca52e157d5b19a612f90a81c698c12R804));
g. `GetMonitorCount` ([R690-R694](https://github.com/raysan5/raylib/pull/3444/files#diff-43fa9fe6c2302f00d9c0b8bcbe58d8ca92ca52e157d5b19a612f90a81c698c12R690-R694)).

### Environment
Changes tested on Linux (Mint 21.1 64-bit) with two monitors (14'' 1600x900 60Hz, 17'' 1280x1024 75Hz).

### Edits
**1:** added line marks and notes.
**2, 5:** editing.
**3, 4:** update.