### PR TITLE
[core] Complement implementations for `SDL` (2)

### DIFF
--- a/src/platforms/rcore_desktop_sdl.c
+++ b/src/platforms/rcore_desktop_sdl.c
@@ -827,8 +827,14 @@ Vector2 GetWindowPosition(void)
 // Get window scale DPI factor for current monitor
 Vector2 GetWindowScaleDPI(void)
 {
+    Vector2 scale = { 1.0f, 1.0f };
+
+    // NOTE: SDL_GetWindowDisplayScale was only added on SDL3
+    //       see https://wiki.libsdl.org/SDL3/SDL_GetWindowDisplayScale
+    // TODO: Implement the window scale factor calculation manually.
     TRACELOG(LOG_WARNING, "GetWindowScaleDPI() not implemented on target platform");
-    return (Vector2){ 1.0f, 1.0f };
+
+    return scale;
 }
 
 // Set clipboard text content

--- a/src/platforms/rcore_desktop_sdl.c
+++ b/src/platforms/rcore_desktop_sdl.c
@@ -295,7 +295,14 @@ void SetWindowState(unsigned int flags)
     }
     if (flags & FLAG_FULLSCREEN_MODE)
     {
-        SDL_SetWindowFullscreen(platform.window, SDL_WINDOW_FULLSCREEN);
+        const int monitor = SDL_GetWindowDisplayIndex(platform.window);
+        const int monitorCount = SDL_GetNumVideoDisplays();
+        if ((monitor >= 0) && (monitor < monitorCount))
+        {
+            SDL_SetWindowFullscreen(platform.window, SDL_WINDOW_FULLSCREEN);
+            CORE.Window.fullscreen = true;
+        }
+        else TRACELOG(LOG_WARNING, "SDL: Failed to find selected monitor");
     }
     if (flags & FLAG_WINDOW_RESIZABLE)
     {
@@ -347,8 +354,13 @@ void SetWindowState(unsigned int flags)
     }
     if (flags & FLAG_BORDERLESS_WINDOWED_MODE)
     {
-        // NOTE: Same as FLAG_WINDOW_UNDECORATED with SDL ?
-        SDL_SetWindowBordered(platform.window, SDL_FALSE);
+        const int monitor = SDL_GetWindowDisplayIndex(platform.window);
+        const int monitorCount = SDL_GetNumVideoDisplays();
+        if ((monitor >= 0) && (monitor < monitorCount))
+        {
+            SDL_SetWindowFullscreen(platform.window, SDL_WINDOW_FULLSCREEN_DESKTOP);
+        }
+        else TRACELOG(LOG_WARNING, "SDL: Failed to find selected monitor");
     }
     if (flags & FLAG_MSAA_4X_HINT)
     {
@@ -373,6 +385,7 @@ void ClearWindowState(unsigned int flags)
     if (flags & FLAG_FULLSCREEN_MODE)
     {
         SDL_SetWindowFullscreen(platform.window, 0);
+        CORE.Window.fullscreen = false;
     }
     if (flags & FLAG_WINDOW_RESIZABLE)
     {
@@ -423,8 +436,7 @@ void ClearWindowState(unsigned int flags)
     }
     if (flags & FLAG_BORDERLESS_WINDOWED_MODE)
     {
-        // NOTE: Same as FLAG_WINDOW_UNDECORATED with SDL ?
-        SDL_SetWindowBordered(platform.window, SDL_TRUE);
+        SDL_SetWindowFullscreen(platform.window, 0);
     }
     if (flags & FLAG_MSAA_4X_HINT)
     {

--- a/src/platforms/rcore_desktop_sdl.c
+++ b/src/platforms/rcore_desktop_sdl.c
@@ -223,72 +223,45 @@ bool WindowShouldClose(void)
 // Toggle fullscreen mode
 void ToggleFullscreen(void)
 {
-    if (!IsWindowState(FLAG_FULLSCREEN_MODE))
+    const int monitor = SDL_GetWindowDisplayIndex(platform.window);
+    const int monitorCount = SDL_GetNumVideoDisplays();
+    if ((monitor >= 0) && (monitor < monitorCount))
     {
-        SDL_SetWindowFullscreen(platform.window, SDL_WINDOW_FULLSCREEN);
-        CORE.Window.flags |= FLAG_FULLSCREEN_MODE;
+        if ((CORE.Window.flags & FLAG_FULLSCREEN_MODE) > 0)
+        {
+            SDL_SetWindowFullscreen(platform.window, 0);
+            CORE.Window.flags &= ~FLAG_FULLSCREEN_MODE;
+            CORE.Window.fullscreen = false;
+        }
+        else
+        {
+            SDL_SetWindowFullscreen(platform.window, SDL_WINDOW_FULLSCREEN);
+            CORE.Window.flags |= FLAG_FULLSCREEN_MODE;
+            CORE.Window.fullscreen = true;
+        }
     }
-    else
-    {
-        SDL_SetWindowFullscreen(platform.window, 0);
-        CORE.Window.flags &= ~FLAG_FULLSCREEN_MODE;
-    }
+    else TRACELOG(LOG_WARNING, "SDL: Failed to find selected monitor");
 }
 
 // Toggle borderless windowed mode
 void ToggleBorderlessWindowed(void)
 {
-    // Leave fullscreen before attempting to set borderless windowed mode and get screen position from it
-    bool wasOnFullscreen = false;
-    if (CORE.Window.fullscreen)
+    const int monitor = SDL_GetWindowDisplayIndex(platform.window);
+    const int monitorCount = SDL_GetNumVideoDisplays();
+    if ((monitor >= 0) && (monitor < monitorCount))
     {
-        CORE.Window.previousPosition = CORE.Window.position;
-        ToggleFullscreen();
-        wasOnFullscreen = true;
-    }
-
-    if (!IsWindowState(FLAG_BORDERLESS_WINDOWED_MODE))
-    {
-        // Store the window's current position and size
-        SDL_GetWindowPosition(platform.window, &CORE.Window.previousPosition.x, &CORE.Window.previousPosition.y);
-        CORE.Window.previousScreen = CORE.Window.screen;
-
-        // Set screen position and size inside valid bounds
-        SDL_Rect displayBounds;
-        if (SDL_GetDisplayBounds(GetCurrentMonitor(), &displayBounds) == 0)
+        if ((CORE.Window.flags & FLAG_BORDERLESS_WINDOWED_MODE) > 0)
         {
-            SDL_SetWindowPosition(platform.window, displayBounds.x, displayBounds.y);
-            SDL_SetWindowSize(platform.window, displayBounds.w, displayBounds.h);
+            SDL_SetWindowFullscreen(platform.window, 0);
+            CORE.Window.flags &= ~FLAG_BORDERLESS_WINDOWED_MODE;
         }
-
-        // Set borderless mode and flag
-        SDL_SetWindowBordered(platform.window, SDL_FALSE);
-        CORE.Window.flags |= FLAG_WINDOW_UNDECORATED;
-
-        // Set topmost modes and flag
-        SDL_SetWindowAlwaysOnTop(platform.window, SDL_TRUE);
-        CORE.Window.flags |= FLAG_WINDOW_TOPMOST;
-
-        // Set borderless windowed flag
-        CORE.Window.flags |= FLAG_BORDERLESS_WINDOWED_MODE;
+        else
+        {
+            SDL_SetWindowFullscreen(platform.window, SDL_WINDOW_FULLSCREEN_DESKTOP);
+            CORE.Window.flags |= FLAG_BORDERLESS_WINDOWED_MODE;
+        }
     }
-    else
-    {
-        // Remove borderless mode and flag
-        SDL_SetWindowBordered(platform.window, SDL_TRUE);
-        CORE.Window.flags &= ~FLAG_WINDOW_UNDECORATED;
-
-        // Remove topmost modes and flag
-        SDL_SetWindowAlwaysOnTop(platform.window, SDL_FALSE);
-        CORE.Window.flags &= ~FLAG_WINDOW_TOPMOST;
-
-        // Restore the window's previous size and position
-        SDL_SetWindowSize(platform.window, CORE.Window.previousScreen.width, CORE.Window.previousScreen.height);
-        SDL_SetWindowPosition(platform.window, CORE.Window.previousPosition.x, CORE.Window.previousPosition.y);
-
-        // Remove borderless windowed flag
-        CORE.Window.flags &= ~FLAG_BORDERLESS_WINDOWED_MODE;
-    }
+    else TRACELOG(LOG_WARNING, "SDL: Failed to find selected monitor");
 }
 
 // Set window state: maximized, if resizable


### PR DESCRIPTION
### Changes
1. Adds a note ([R832-R833](https://github.com/raysan5/raylib/pull/3447/files#diff-43fa9fe6c2302f00d9c0b8bcbe58d8ca92ca52e157d5b19a612f90a81c698c12R832-R833)), todo ([R834](https://github.com/raysan5/raylib/pull/3447/files#diff-43fa9fe6c2302f00d9c0b8bcbe58d8ca92ca52e157d5b19a612f90a81c698c12R834)) and small tweaks ([R830](https://github.com/raysan5/raylib/pull/3447/files#diff-43fa9fe6c2302f00d9c0b8bcbe58d8ca92ca52e157d5b19a612f90a81c698c12R830), [R837](https://github.com/raysan5/raylib/pull/3447/files#diff-43fa9fe6c2302f00d9c0b8bcbe58d8ca92ca52e157d5b19a612f90a81c698c12R837)) to `GetWindowScaleDPI`.
**Note:** `SDL_GetWindowDisplayScale` was only added on `SDL3` (see [doc](https://wiki.libsdl.org/SDL3/SDL_GetWindowDisplayScale)).
**Todo:** It will be necessary to implement the window scale factor calculation manually.

2. Complement `ToggleFullscreen`to match `rcore_desktop.c`'s more closely ([R226-R228](https://github.com/raysan5/raylib/pull/3447/files#diff-43fa9fe6c2302f00d9c0b8bcbe58d8ca92ca52e157d5b19a612f90a81c698c12R226-R228), [R230-R243](https://github.com/raysan5/raylib/pull/3447/files#diff-43fa9fe6c2302f00d9c0b8bcbe58d8ca92ca52e157d5b19a612f90a81c698c12R230-R243)).

3. Change `ToggleBorderlessWindowed` to use `SDL_WINDOW_FULLSCREEN_DESKTOP` that's supported directly by `SDL` ([R249-R251](https://github.com/raysan5/raylib/pull/3447/files#diff-43fa9fe6c2302f00d9c0b8bcbe58d8ca92ca52e157d5b19a612f90a81c698c12R249-R251), [R253](https://github.com/raysan5/raylib/pull/3447/files#diff-43fa9fe6c2302f00d9c0b8bcbe58d8ca92ca52e157d5b19a612f90a81c698c12R253), [R255-R261](https://github.com/raysan5/raylib/pull/3447/files#diff-43fa9fe6c2302f00d9c0b8bcbe58d8ca92ca52e157d5b19a612f90a81c698c12R255-R261), [R264](https://github.com/raysan5/raylib/pull/3447/files#diff-43fa9fe6c2302f00d9c0b8bcbe58d8ca92ca52e157d5b19a612f90a81c698c12R264)).

4. Complement `SetWindowState` just to be a bit safer by setting the CORE fullscreen var and requiring a monitor for fullscreen ([R298-R305](https://github.com/raysan5/raylib/pull/3447/files#diff-43fa9fe6c2302f00d9c0b8bcbe58d8ca92ca52e157d5b19a612f90a81c698c12R298-R305)). And enter fullscreen desktop from inside it ([R357-R363](https://github.com/raysan5/raylib/pull/3447/files#diff-43fa9fe6c2302f00d9c0b8bcbe58d8ca92ca52e157d5b19a612f90a81c698c12R357-R363)).

5. Complement `ClearWindowState` just to clear the CORE fullscreen var ([R388](https://github.com/raysan5/raylib/pull/3447/files#diff-43fa9fe6c2302f00d9c0b8bcbe58d8ca92ca52e157d5b19a612f90a81c698c12R388)). And leave fullscreen desktop from inside it ([R439](https://github.com/raysan5/raylib/pull/3447/files#diff-43fa9fe6c2302f00d9c0b8bcbe58d8ca92ca52e157d5b19a612f90a81c698c12R439)).

### Notes
- @Bigfoot71 I'm so sorry for asking you to implement `ToggleBorderlessWindowed` the same as `rcore_desktop.c`'s. `SDL_WINDOW_FULLSCREEN_DESKTOP` does work as expected on `SDL`. I was still thinking on the `GLFW` limitations. My apologies for giving you all that trouble. I'm really sorry, my bad.

### Environment
Changes tested on Linux (Mint 21.1 64-bit) with two monitors (14'' 1600x900 60Hz, 17'' 1280x1024 75Hz).

### Edits
**1:** added line marks.
**2, 3, 4:** update.