### PR TITLE
fix examples Makefile to use Makefile.Web when building for web (Fixes bug in the core/core_loading_thread example)

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -156,7 +156,7 @@ ifeq ($(PLATFORM),PLATFORM_ANDROID)
     MAKE = mingw32-make
 endif
 ifeq ($(PLATFORM),PLATFORM_WEB)
-    MAKE = mingw32-make
+    MAKE = emmake make
 endif
 
 # Define compiler flags: CFLAGS
@@ -533,6 +533,8 @@ others: $(OTHERS)
 %: %.c
 ifeq ($(PLATFORM),PLATFORM_ANDROID)
 	$(MAKE) -f Makefile.Android PROJECT_NAME=$@ PROJECT_SOURCE_FILES=$<
+else ifeq ($(PLATFORM),PLATFORM_WEB)
+	$(MAKE) -f Makefile.Web $@
 else
 	$(CC) -o $@$(EXT) $< $(CFLAGS) $(INCLUDE_PATHS) $(LDFLAGS) $(LDLIBS) -D$(PLATFORM)
 endif


### PR DESCRIPTION
The `examples` Makefile wasn't properly using `Makefile.Web` which caused the bug in the `core/core_loading_thread` to not work, as the compiler was not being passed the `-s USE_PTHREADS=1` arg, consider the following terminal session, (edited for brevity)

```
raylib/examples: make -B PLATFORM=PLATFORM_WEB core/core_loading_thread
```

Output:
```
emcc -o core/core_loading_thread.html core/core_loading_thread.c [...] -s TOTAL_MEMORY=134217728 -s FORCE_FILESYSTEM=1 -s ASYNCIFY --preload-file core/resources@resources --shell-file ../src/minshell.html ../src/libraylib.a -DPLATFORM_WEB
```
```
raylib/examples: make -f Makefile.Web -B PLATFORM=PLATFORM_WEB core/core_loading_thread
```

Output:
```
emcc -o core/core_loading_thread.html core/core_loading_thread.c -[...] -s ASYNCIFY -s EXPORTED_RUNTIME_METHODS=ccall --shell-file ../src/shell.html ../src/libraylib.a -DPLATFORM_WEB -s USE_PTHREADS=1
```

![image](https://github.com/raysan5/raylib/assets/13317074/6b127025-c2e3-4899-abac-6fd84c55ae4b)

Note that the `Makefile.Web` does produce an output where it's a bit more zoomed in, exploded, whatever you wanna call it. But, this seems to be a pre-existing issue that is exposed by this fix.
