### PR TITLE
[core] Complement implementations for `SDL` (3)

### DIFF
--- a/src/platforms/rcore_desktop_sdl.c
+++ b/src/platforms/rcore_desktop_sdl.c
@@ -983,6 +983,8 @@ void PollInputEvents(void)
     }
     */
 
+    CORE.Window.resizedLastFrame = false;
+
     SDL_Event event = { 0 };
     while (SDL_PollEvent(&event) != 0)
     {
@@ -996,6 +998,18 @@ void PollInputEvents(void)
             {
                 switch (event.window.event)
                 {
+                    case SDL_WINDOWEVENT_RESIZED:
+                    case SDL_WINDOWEVENT_SIZE_CHANGED:
+                    {
+                        int width = event.window.data1;
+                        int height = event.window.data2;
+                        SetupViewport(width, height);
+                        CORE.Window.screen.width = width;
+                        CORE.Window.screen.height = height;
+                        CORE.Window.currentFbo.width = width;
+                        CORE.Window.currentFbo.height = height;
+                        CORE.Window.resizedLastFrame = true;
+                    } break;
                     case SDL_WINDOWEVENT_LEAVE:
                     case SDL_WINDOWEVENT_HIDDEN:
                     case SDL_WINDOWEVENT_MINIMIZED:

--- a/src/platforms/rcore_desktop_sdl.c
+++ b/src/platforms/rcore_desktop_sdl.c
@@ -1001,8 +1001,8 @@ void PollInputEvents(void)
                     case SDL_WINDOWEVENT_RESIZED:
                     case SDL_WINDOWEVENT_SIZE_CHANGED:
                     {
-                        int width = event.window.data1;
-                        int height = event.window.data2;
+                        const int width = event.window.data1;
+                        const int height = event.window.data2;
                         SetupViewport(width, height);
                         CORE.Window.screen.width = width;
                         CORE.Window.screen.height = height;

--- a/src/platforms/rcore_desktop_sdl.c
+++ b/src/platforms/rcore_desktop_sdl.c
@@ -618,6 +618,8 @@ void SetWindowMonitor(int monitor)
 // Set window minimum dimensions (FLAG_WINDOW_RESIZABLE)
 void SetWindowMinSize(int width, int height)
 {
+    SDL_SetWindowMinimumSize(platform.window, width, height);
+
     CORE.Window.screenMin.width = width;
     CORE.Window.screenMin.height = height;
 }
@@ -625,6 +627,8 @@ void SetWindowMinSize(int width, int height)
 // Set window maximum dimensions (FLAG_WINDOW_RESIZABLE)
 void SetWindowMaxSize(int width, int height)
 {
+    SDL_SetWindowMaximumSize(platform.window, width, height);
+
     CORE.Window.screenMax.width = width;
     CORE.Window.screenMax.height = height;
 }


### PR DESCRIPTION
### Changes
1. Fixes `SetWindowMinSize` missing the equivalent `SDL` call ([R621](https://github.com/raysan5/raylib/pull/3450/files#diff-43fa9fe6c2302f00d9c0b8bcbe58d8ca92ca52e157d5b19a612f90a81c698c12R621)).

2. Fixes `SetWindowMaxSize` missing the equivalent `SDL` call ([R630](https://github.com/raysan5/raylib/pull/3450/files#diff-43fa9fe6c2302f00d9c0b8bcbe58d8ca92ca52e157d5b19a612f90a81c698c12R630)).

3. Fixes the window resizes not updating the viewport by adding updating on the `SDL_WINDOWEVENT` on `PollInputEvents` ([R986](https://github.com/raysan5/raylib/pull/3450/files#diff-43fa9fe6c2302f00d9c0b8bcbe58d8ca92ca52e157d5b19a612f90a81c698c12R986), [R1001-R1012](https://github.com/raysan5/raylib/pull/3450/files#diff-43fa9fe6c2302f00d9c0b8bcbe58d8ca92ca52e157d5b19a612f90a81c698c12R1001-R1012))
**Issue reference :** [3313#issuecomment-1773942383](https://github.com/raysan5/raylib/issues/3313#issuecomment-1773942383).

### Environment
Changes tested on Linux (Mint 21.1 64-bit) with two monitors (14'' 1600x900 60Hz, 17'' 1280x1024 75Hz).

### Edits

**1:** added line marks.
**2:** update.