### PR TITLE
Review prerequisites of rcore.c

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -633,7 +633,7 @@ endif
 # Compile all modules with their prerequisites
 
 # Prerequisites of core module
-rcore.o : platforms/rcore_android.c platforms/rcore_desktop.c platforms/rcore_drm.c platforms/rcore_template.c platforms/rcore_web.c
+rcore.o : platforms/*.c
 
 # Compile core module
 rcore.o : rcore.c raylib.h rlgl.h utils.h raymath.h rcamera.h rgestures.h


### PR DESCRIPTION
I noticed rcore_desktop_sdl.c was missing from the prerequisites list
Now that the platforms are split to their own directory, it is simple to just use a "wildcard" to match them all in the makefile