### PR TITLE
Fix the zooming in the Julia set shader example.

### DIFF
--- a/examples/shaders/resources/shaders/glsl100/julia_set.fs
+++ b/examples/shaders/resources/shaders/glsl100/julia_set.fs
@@ -13,7 +13,9 @@ uniform float zoom;             // Zoom of the scale.
 
 // NOTE: Maximum number of shader for-loop iterations depend on GPU,
 // for example, on RasperryPi for this examply only supports up to 60
-const int MAX_ITERATIONS = 48;  // Max iterations to do
+const int MAX_ITERATIONS = 48;  // Max iterations to do.
+
+const float COLOR_CYCLES = 1;   // Number of times the palette repeats.
 
 // Square a complex number
 vec2 ComplexSquare(vec2 z)
@@ -79,5 +81,5 @@ void main()
 
     // If in set, color black. 0.999 allows for some float accuracy error.
     if (norm > 0.999) gl_FragColor = vec4(0.0, 0.0, 0.0, 1.0);
-    else gl_FragColor = vec4(Hsv2rgb(vec3(norm, 1.0, 1.0)), 1.0);
+    else gl_FragColor = vec4(Hsv2rgb(vec3(norm * COLOR_CYCLES, 1.0, 1.0)), 1.0);
 }

--- a/examples/shaders/resources/shaders/glsl330/julia_set.fs
+++ b/examples/shaders/resources/shaders/glsl330/julia_set.fs
@@ -12,7 +12,8 @@ uniform vec2 c;                 // c.x = real, c.y = imaginary component. Equati
 uniform vec2 offset;            // Offset of the scale.
 uniform float zoom;             // Zoom of the scale.
 
-const int MAX_ITERATIONS = 255; // Max iterations to do.
+const int MAX_ITERATIONS = 255;  // Max iterations to do.
+const float COLOR_CYCLES = 2;    // Number of times the palette repeats. Can show higher detail for higher iteration numbers.
 
 // Square a complex number
 vec2 ComplexSquare(vec2 z)
@@ -77,5 +78,5 @@ void main()
 
     // If in set, color black. 0.999 allows for some float accuracy error.
     if (norm > 0.999) finalColor = vec4(0.0, 0.0, 0.0, 1.0);
-    else finalColor = vec4(Hsv2rgb(vec3(norm, 1.0, 1.0)), 1.0);
+    else finalColor = vec4(Hsv2rgb(vec3(norm * COLOR_CYCLES, 1.0, 1.0)), 1.0);
 }

--- a/examples/shaders/shaders_julia_set.c
+++ b/examples/shaders/shaders_julia_set.c
@@ -9,12 +9,12 @@
 *
 *   Example originally created with raylib 2.5, last time updated with raylib 4.0
 *
-*   Example contributed by eggmund (@eggmund) and reviewed by Ramon Santamaria (@raysan5)
+*   Example contributed by Josh Colclough (@joshcol9232) and reviewed by Ramon Santamaria (@raysan5)
 *
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2019-2023 eggmund (@eggmund) and Ramon Santamaria (@raysan5)
+*   Copyright (c) 2019-2023 Josh Colclough (@joshcol9232) and Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 
@@ -46,8 +46,8 @@ int main(void)
     //--------------------------------------------------------------------------------------
     const int screenWidth = 800;
     const int screenHeight = 450;
+    const float zoomSpeed = 1.005f;
 
-    //SetConfigFlags(FLAG_WINDOW_HIGHDPI);
     InitWindow(screenWidth, screenHeight, "raylib [shaders] example - julia sets");
 
     // Load julia set shader
@@ -63,8 +63,6 @@ int main(void)
     // Offset and zoom to draw the julia set at. (centered on screen and default size)
     float offset[2] = { -(float)GetScreenWidth()/2, -(float)GetScreenHeight()/2 };
     float zoom = 1.0f;
-
-    Vector2 offsetSpeed = { 0.0f, 0.0f };
 
     // Get variable (uniform) locations on the shader to connect with the program
     // NOTE: If uniform variable could not be found in the shader, function returns -1
@@ -97,6 +95,7 @@ int main(void)
         {
             if (IsKeyPressed(k))
             {
+                // If this key is pressed, set the point of interest of the corresponding key.
                 c[0] = pointsOfInterest[k - KEY_ONE][0];
                 c[1] = pointsOfInterest[k - KEY_ONE][1];
                 SetShaderValue(shader, cLoc, c, SHADER_UNIFORM_VEC2);
@@ -112,30 +111,28 @@ int main(void)
             if (IsKeyPressed(KEY_RIGHT)) incrementSpeed++;
             else if (IsKeyPressed(KEY_LEFT)) incrementSpeed--;
 
-            
-
-            // TODO: The idea is to zoom and move around with the mouse
-            if (IsMouseButtonDown(MOUSE_BUTTON_LEFT) || IsMouseButtonDown(MOUSE_BUTTON_RIGHT))
+            // If either left or right button is pressed, zoom in/out.
+            const bool leftMouseButtonDown = IsMouseButtonDown(MOUSE_BUTTON_LEFT);
+            if (leftMouseButtonDown ^ IsMouseButtonDown(MOUSE_BUTTON_RIGHT))
             {
-                if (IsMouseButtonDown(MOUSE_BUTTON_LEFT)) zoom += zoom * 0.003f;
-                if (IsMouseButtonDown(MOUSE_BUTTON_RIGHT)) zoom -= zoom * 0.003f;
+                // Change zoom. If Mouse left -> zoom in. Mouse right -> zoom out.
+                zoom *= leftMouseButtonDown ? zoomSpeed : 1.0f / zoomSpeed;
 
                 const Vector2 mousePos = GetMousePosition();
-                
-                offsetSpeed.x = zoom * (mousePos.x - (float)screenWidth / 2.0);
-                offsetSpeed.y = zoom * (mousePos.y - (float)screenHeight / 2.0);
+                Vector2 offsetVelocity;
+                offsetVelocity.x = zoom * (mousePos.x - (float)screenWidth / 2.0);
+                offsetVelocity.y = zoom * (mousePos.y - (float)screenHeight / 2.0);
 
-                // Slowly move camera to targetOffset
-                offset[0] += GetFrameTime() * offsetSpeed.x;
-                offset[1] += GetFrameTime() * offsetSpeed.y;
+                // Apply move velocity to camera
+                offset[0] += GetFrameTime() * offsetVelocity.x;
+                offset[1] += GetFrameTime() * offsetVelocity.y;
             }
-            else offsetSpeed = (Vector2){ 0.0f, 0.0f };
 
             SetShaderValue(shader, zoomLoc, &zoom, SHADER_UNIFORM_FLOAT);
             SetShaderValue(shader, offsetLoc, offset, SHADER_UNIFORM_VEC2);
 
             // Increment c value with time
-            float amount = GetFrameTime()*incrementSpeed*0.0005f;
+            float amount = GetFrameTime() * incrementSpeed * 0.0005f;
             c[0] += amount;
             c[1] += amount;
 

--- a/examples/shaders/shaders_julia_set.c
+++ b/examples/shaders/shaders_julia_set.c
@@ -93,24 +93,18 @@ int main(void)
         // Update
         //----------------------------------------------------------------------------------
         // Press [1 - 6] to reset c to a point of interest
-        if (IsKeyPressed(KEY_ONE) ||
-            IsKeyPressed(KEY_TWO) ||
-            IsKeyPressed(KEY_THREE) ||
-            IsKeyPressed(KEY_FOUR) ||
-            IsKeyPressed(KEY_FIVE) ||
-            IsKeyPressed(KEY_SIX))
+        for (KeyboardKey k = KEY_ONE; k <= KEY_SIX; ++k)
         {
-            if (IsKeyPressed(KEY_ONE)) c[0] = pointsOfInterest[0][0], c[1] = pointsOfInterest[0][1];
-            else if (IsKeyPressed(KEY_TWO)) c[0] = pointsOfInterest[1][0], c[1] = pointsOfInterest[1][1];
-            else if (IsKeyPressed(KEY_THREE)) c[0] = pointsOfInterest[2][0], c[1] = pointsOfInterest[2][1];
-            else if (IsKeyPressed(KEY_FOUR)) c[0] = pointsOfInterest[3][0], c[1] = pointsOfInterest[3][1];
-            else if (IsKeyPressed(KEY_FIVE)) c[0] = pointsOfInterest[4][0], c[1] = pointsOfInterest[4][1];
-            else if (IsKeyPressed(KEY_SIX)) c[0] = pointsOfInterest[5][0], c[1] = pointsOfInterest[5][1];
-
-            SetShaderValue(shader, cLoc, c, SHADER_UNIFORM_VEC2);
+            if (IsKeyPressed(k))
+            {
+                c[0] = pointsOfInterest[k - KEY_ONE][0];
+                c[1] = pointsOfInterest[k - KEY_ONE][1];
+                SetShaderValue(shader, cLoc, c, SHADER_UNIFORM_VEC2);
+                break;
+            }
         }
 
-        if (IsKeyPressed(KEY_SPACE)) pause = !pause;                 // Pause animation (c change)
+        if (IsKeyPressed(KEY_SPACE)) pause = !pause;             // Pause animation (c change)
         if (IsKeyPressed(KEY_F1)) showControls = !showControls;  // Toggle whether or not to show controls
 
         if (!pause)
@@ -118,21 +112,22 @@ int main(void)
             if (IsKeyPressed(KEY_RIGHT)) incrementSpeed++;
             else if (IsKeyPressed(KEY_LEFT)) incrementSpeed--;
 
-            // TODO: The idea is to zoom and move around with mouse
-            // Probably offset movement should be proportional to zoom level
+            
+
+            // TODO: The idea is to zoom and move around with the mouse
             if (IsMouseButtonDown(MOUSE_BUTTON_LEFT) || IsMouseButtonDown(MOUSE_BUTTON_RIGHT))
             {
-                if (IsMouseButtonDown(MOUSE_BUTTON_LEFT)) zoom += zoom*0.003f;
-                if (IsMouseButtonDown(MOUSE_BUTTON_RIGHT)) zoom -= zoom*0.003f;
+                if (IsMouseButtonDown(MOUSE_BUTTON_LEFT)) zoom += zoom * 0.003f;
+                if (IsMouseButtonDown(MOUSE_BUTTON_RIGHT)) zoom -= zoom * 0.003f;
 
-                Vector2 mousePos = GetMousePosition();
-
-                offsetSpeed.x = mousePos.x -(float)screenWidth/2;
-                offsetSpeed.y = mousePos.y -(float)screenHeight/2;
+                const Vector2 mousePos = GetMousePosition();
+                
+                offsetSpeed.x = zoom * (mousePos.x - (float)screenWidth / 2.0);
+                offsetSpeed.y = zoom * (mousePos.y - (float)screenHeight / 2.0);
 
                 // Slowly move camera to targetOffset
-                offset[0] += GetFrameTime()*offsetSpeed.x*0.8f;
-                offset[1] += GetFrameTime()*offsetSpeed.y*0.8f;
+                offset[0] += GetFrameTime() * offsetSpeed.x;
+                offset[1] += GetFrameTime() * offsetSpeed.y;
             }
             else offsetSpeed = (Vector2){ 0.0f, 0.0f };
 


### PR DESCRIPTION
Hello! Ever since I added the Julia set shader example (5 years ago!) it had always bugged me that the zoom function was never correct. This PR fixes this, and is also a general tidy-up.

### In summary:

- Fix zoom issue.
- Add a `COLOR_CYCLES` variable to the shader to allow for cycling of the color palette. This allows for finer details of the fractal to be shown when using a high max iteration number.
- Fix some pretty terrible if statement mess.
- Update copyright.

### Issue

Fixes: #3465

### Testing

I have tested the code on my Linux machine. I have not tested on glsl100 platforms, or Windows.
