### PR TITLE
GetCurrentMonitor() - check window center instead of top-left corner

### DIFF
--- a/src/platforms/rcore_desktop.c
+++ b/src/platforms/rcore_desktop.c
@@ -755,6 +755,8 @@ int GetCurrentMonitor(void)
             int y = 0;
 
             glfwGetWindowPos(platform.handle, &x, &y);
+            x += (int)CORE.Window.screen.width / 2;
+            y += (int)CORE.Window.screen.height / 2;
 
             for (int i = 0; i < monitorCount; i++)
             {


### PR DESCRIPTION
Partial fix for #3456.

At present, in case the center of the window is out of any monitor, it detects the first one as current on the GLFW implementation, while ``SDL_GetWindowDisplayIndex()`` apparently detects the monitor that is the closest to the center of the window (https://github.com/libsdl-org/SDL/blob/b29128994e87d82eae4751d65ff38b935ce7d6a2/src/video/SDL_video.c#L1114).

Maybe we can merge this PR as is and leave the issue of the center of the window being out of any monitor to another one.