### PR TITLE
Fix missing `PLATFORM_DESKTOP_SDL` checks.

### DIFF
--- a/src/rlgl.h
+++ b/src/rlgl.h
@@ -803,7 +803,7 @@ RLAPI void rlLoadDrawQuad(void);     // Load and draw a quad
 #if defined(GRAPHICS_API_OPENGL_ES2)
     // NOTE: OpenGL ES 2.0 can be enabled on PLATFORM_DESKTOP,
     // in that case, functions are loaded from a custom glad for OpenGL ES 2.0
-    #if defined(PLATFORM_DESKTOP)
+    #if defined(PLATFORM_DESKTOP) || defined(PLATFORM_DESKTOP_SDL)
         #define GLAD_GLES2_IMPLEMENTATION
         #include "external/glad_gles2.h"
     #else
@@ -2248,7 +2248,7 @@ void rlLoadExtensions(void *loader)
     //       RLGL.ExtSupported.maxAnisotropyLevel
 #elif defined(GRAPHICS_API_OPENGL_ES2)
 
-    #if defined(PLATFORM_DESKTOP)
+    #if defined(PLATFORM_DESKTOP) || defined(PLATFORM_DESKTOP_SDL)
     // TODO: Support OpenGL ES 3.0
     if (gladLoadGLES2((GLADloadfunc)loader) == 0) TRACELOG(RL_LOG_WARNING, "GLAD: Cannot load OpenGL ES2.0 functions");
     else TRACELOG(RL_LOG_INFO, "GLAD: OpenGL ES 2.0 loaded successfully");


### PR DESCRIPTION
There are two missing `PLATFORM_DESKTOP_SDL` checks in `rlgl.h`, so that OpenGL ES support in `PLATFORM_DESKTOP_SDL` is broken.

Add missing PLATFORM* checks can fix that, but a bit dirty.

BTW, consider that more platforms will be supported here, so maybe `rlgl.h` should be more independent.