### PR TITLE
[core] Remove `rcore.h` include from `SDL`

### DIFF
--- a/src/platforms/rcore_desktop_sdl.c
+++ b/src/platforms/rcore_desktop_sdl.c
@@ -49,8 +49,6 @@
 *
 **********************************************************************************************/
 
-#include "rcore.h"
-
 #include "SDL.h"            // SDL base library (window/rendered, input, timming... functionality)
 #include "SDL_opengl.h"     // SDL OpenGL functionality (if required, instead of internal renderer)
 
@@ -998,7 +996,7 @@ void PollInputEvents(void)
         switch (event.type)
         {
             case SDL_QUIT: CORE.Window.shouldClose = true; break;
-            
+
             case SDL_DROPFILE:      // Dropped file
             {
                 if (CORE.Window.dropFileCount == 0)
@@ -1019,7 +1017,7 @@ void PollInputEvents(void)
                     CORE.Window.dropFilepaths[CORE.Window.dropFileCount] = (char *)RL_CALLOC(MAX_FILEPATH_LENGTH, sizeof(char));
                     strcpy(CORE.Window.dropFilepaths[CORE.Window.dropFileCount], event.drop.file);
                     SDL_free(event.drop.file);
-                    
+
                     CORE.Window.dropFileCount++;
                 }
                 else TRACELOG(LOG_WARNING, "FILE: Maximum drag and drop files at once is limited to 1024 files!");
@@ -1274,7 +1272,7 @@ int InitPlatform(void)
         SDL_Joystick *gamepad = SDL_JoystickOpen(0);
         //if (SDL_Joystick *gamepad == NULL) SDL_Log("WARNING: Unable to open game controller! SDL Error: %s\n", SDL_GetError());
     }
-    
+
     SDL_EventState(SDL_DROPFILE, SDL_ENABLE);
     //----------------------------------------------------------------------------
 


### PR DESCRIPTION
### Changes
1. Very short fix to remove the `rcore.h` include from `rcore_desktop_sdl.c` ([L52](https://github.com/raysan5/raylib/pull/3475/files#diff-43fa9fe6c2302f00d9c0b8bcbe58d8ca92ca52e157d5b19a612f90a81c698c12L52)) so it matches the other submodules.
**References:** [#3420](https://github.com/raysan5/raylib/pull/3420), [#3429](https://github.com/raysan5/raylib/pull/3429).

### Environment
Changes successfully tested on Linux (Ubuntu 22.04 64-bit, gcc 11.2.0) with SDL2 (2.28.4).

### Edits
1: added line marks.