### PR TITLE
[core] Fix `PLATFORM_DRM` hang up on exit and mouse input issues

### DIFF
--- a/src/platforms/rcore_drm.c
+++ b/src/platforms/rcore_drm.c
@@ -906,16 +906,17 @@ int InitPlatform(void)
     rlLoadExtensions(eglGetProcAddress);
     //----------------------------------------------------------------------------
 
+    // Initialize timming system
+    //----------------------------------------------------------------------------
+    // NOTE: timming system must be initialized before the input events system
+    InitTimer();
+    //----------------------------------------------------------------------------
+
     // Initialize input events system
     //----------------------------------------------------------------------------
     InitEvdevInput();   // Evdev inputs initialization
     InitGamepad();      // Gamepad init
     InitKeyboard();     // Keyboard init (stdin)
-    //----------------------------------------------------------------------------
-
-    // Initialize timming system
-    //----------------------------------------------------------------------------
-    InitTimer();
     //----------------------------------------------------------------------------
 
     // Initialize storage system


### PR DESCRIPTION
### Changes
Moves `InitTimer()` to before the input events system initializations (from [L916-L919](https://github.com/raysan5/raylib/pull/3484/files#diff-757f4c9c5f0be7473e385fa72b35d509c5af4ee2dc8204d2dbe2418bb9b98922L916-L919) to [R909-R913](https://github.com/raysan5/raylib/pull/3484/files#diff-757f4c9c5f0be7473e385fa72b35d509c5af4ee2dc8204d2dbe2418bb9b98922R909-R913)) on `rcore_drm.c`.

### Reference
Fixes #3482

### Environment
Tested on Raspberry Pi 3 Model B 1.2 with Linux (Raspberry Pi OS 11 Bullseye 32-bit armhf).

### Edits
**1:** added line marks; editing.