### PR TITLE
[build] Fix `examples/Makefile` for `PLATFORM_DESKTOP_SDL`

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -52,6 +52,9 @@ PROJECT_NAME          ?= raylib_examples
 RAYLIB_VERSION        ?= 5.0.0
 RAYLIB_PATH           ?= ..
 
+# Define raylib source code path
+RAYLIB_SRC_PATH       ?= ../src
+
 # Locations of raylib.h and libraylib.a/libraylib.so
 # NOTE: Those variables are only used for PLATFORM_OS: LINUX, BSD
 RAYLIB_INCLUDE_PATH   ?= /usr/local/include


### PR DESCRIPTION
### Changes
Fixes the examples compilation for `PLATFORM_DESKTOP_SDL` by adding the missing `RAYLIB_SRC_PATH ?= ../src` to the `examples/Makefile` ([R55-R56](https://github.com/raysan5/raylib/pull/3486/files#diff-ae8bb09b4bbb919309d4c8bb8ffc46e031bf63b7274502171a183a4dc1138f53R55-R56)) so the `*_PATHS` ([R74-R75](https://github.com/raysan5/raylib/pull/3486/files#diff-ae8bb09b4bbb919309d4c8bb8ffc46e031bf63b7274502171a183a4dc1138f53R74-R75)) could reach its files.

### Environment
Tested on Linux (Ubuntu 22.04 64-bit) with SDL2 (2.28.4).

### Edits
**1:** added line marks.