### PR TITLE
[EXAMPLES] Remove unused structures from lighting fragment shaders

### DIFF
--- a/examples/shaders/resources/shaders/glsl100/lighting.fs
+++ b/examples/shaders/resources/shaders/glsl100/lighting.fs
@@ -18,12 +18,6 @@ uniform vec4 colDiffuse;
 #define     LIGHT_DIRECTIONAL       0
 #define     LIGHT_POINT             1
 
-struct MaterialProperty {
-    vec3 color;
-    int useSampler;
-    sampler2D sampler;
-};
-
 struct Light {
     int enabled;
     int type;

--- a/examples/shaders/resources/shaders/glsl120/lighting.fs
+++ b/examples/shaders/resources/shaders/glsl120/lighting.fs
@@ -16,12 +16,6 @@ uniform vec4 colDiffuse;
 #define     LIGHT_DIRECTIONAL       0
 #define     LIGHT_POINT             1
 
-struct MaterialProperty {
-    vec3 color;
-    int useSampler;
-    sampler2D sampler;
-};
-
 struct Light {
     int enabled;
     int type;

--- a/examples/shaders/resources/shaders/glsl330/lighting.fs
+++ b/examples/shaders/resources/shaders/glsl330/lighting.fs
@@ -19,12 +19,6 @@ out vec4 finalColor;
 #define     LIGHT_DIRECTIONAL       0
 #define     LIGHT_POINT             1
 
-struct MaterialProperty {
-    vec3 color;
-    int useSampler;
-    sampler2D sampler;
-};
-
 struct Light {
     int enabled;
     int type;


### PR DESCRIPTION
The lighting shaders had a structure that was not used, this PR removes it.