### PR TITLE
[core] Moves `keymapUS[]` and fixes `GetCharPressed` for `PLATFORM_DRM`

### DIFF
--- a/src/platforms/rcore_drm.c
+++ b/src/platforms/rcore_drm.c
@@ -138,6 +138,39 @@ extern CoreData CORE;                   // Global CORE state context
 static PlatformData platform = { 0 };   // Platform specific data
 
 //----------------------------------------------------------------------------------
+// Local Variables Definition
+//----------------------------------------------------------------------------------
+// Scancode to keycode mapping for US keyboards
+// TODO: Replace this with a keymap from the X11 to get the correct regional map for the keyboard:
+// Currently non US keyboards will have the wrong mapping for some keys
+static const int keymapUS[] = {
+    0, 256, 49, 50, 51, 52, 53, 54, 55, 56, 57, 48, 45, 61, 259, 258, 81, 87, 69, 82, 84,
+    89, 85, 73, 79, 80, 91, 93, 257, 341, 65, 83, 68, 70, 71, 72, 74, 75, 76, 59, 39, 96,
+    340, 92, 90, 88, 67, 86, 66, 78, 77, 44, 46, 47, 344, 332, 342, 32, 280, 290, 291,
+    292, 293, 294, 295, 296, 297, 298, 299, 282, 281, 327, 328, 329, 333, 324, 325,
+    326, 334, 321, 322, 323, 320, 330, 0, 85, 86, 300, 301, 89, 90, 91, 92, 93, 94, 95,
+    335, 345, 331, 283, 346, 101, 268, 265, 266, 263, 262, 269, 264, 267, 260, 261,
+    112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 347, 127,
+    128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143,
+    144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159,
+    160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175,
+    176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191,
+    192, 193, 194, 0, 0, 0, 0, 0, 200, 201, 202, 203, 204, 205, 206, 207, 208, 209, 210,
+    211, 212, 213, 214, 215, 216, 217, 218, 219, 220, 221, 222, 223, 224, 225, 226,
+    227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241, 242,
+    243, 244, 245, 246, 247, 248, 0, 0, 0, 0, 0, 0, 0
+};
+
+// NOTE: The complete evdev EV_KEY list can be found at /usr/include/linux/input-event-codes.h
+// TODO: Complete the LUT with all unicode decimal values
+static const int EvkeyToUnicodeLUT[] = {
+    0, 27, 49, 50, 51, 52, 53, 54, 55, 56, 57, 48, 45, 61, 8, 0, 113, 119, 101, 114,
+    116, 121, 117, 105, 111, 112, 0, 0, 13, 0, 97, 115, 100, 102, 103, 104, 106, 107, 108, 59,
+    39, 96, 0, 92, 122, 120, 99, 118, 98, 110, 109, 44, 46, 47, 0, 0, 0, 32
+    // LUT currently incomplete, just mapped the most essential keys
+};
+
+//----------------------------------------------------------------------------------
 // Module Internal Functions Declaration
 //----------------------------------------------------------------------------------
 int InitPlatform(void);          // Initialize platform (graphics, inputs and more)
@@ -1454,27 +1487,6 @@ static void ConfigureEvdevDevice(char *device)
 // Poll and process evdev keyboard events
 static void PollKeyboardEvents(void)
 {
-    // Scancode to keycode mapping for US keyboards
-    // TODO: Replace this with a keymap from the X11 to get the correct regional map for the keyboard:
-    // Currently non US keyboards will have the wrong mapping for some keys
-    static const int keymapUS[] = {
-        0, 256, 49, 50, 51, 52, 53, 54, 55, 56, 57, 48, 45, 61, 259, 258, 81, 87, 69, 82, 84,
-        89, 85, 73, 79, 80, 91, 93, 257, 341, 65, 83, 68, 70, 71, 72, 74, 75, 76, 59, 39, 96,
-        340, 92, 90, 88, 67, 86, 66, 78, 77, 44, 46, 47, 344, 332, 342, 32, 280, 290, 291,
-        292, 293, 294, 295, 296, 297, 298, 299, 282, 281, 327, 328, 329, 333, 324, 325,
-        326, 334, 321, 322, 323, 320, 330, 0, 85, 86, 300, 301, 89, 90, 91, 92, 93, 94, 95,
-        335, 345, 331, 283, 346, 101, 268, 265, 266, 263, 262, 269, 264, 267, 260, 261,
-        112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 347, 127,
-        128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143,
-        144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159,
-        160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175,
-        176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191,
-        192, 193, 194, 0, 0, 0, 0, 0, 200, 201, 202, 203, 204, 205, 206, 207, 208, 209, 210,
-        211, 212, 213, 214, 215, 216, 217, 218, 219, 220, 221, 222, 223, 224, 225, 226,
-        227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241, 242,
-        243, 244, 245, 246, 247, 248, 0, 0, 0, 0, 0, 0, 0
-    };
-
     int fd = platform.keyboardFd;
     if (fd == -1) return;
 
@@ -1517,6 +1529,18 @@ static void PollKeyboardEvents(void)
                         screenshotCounter++;
                     }
                 #endif
+
+                    // Detect char presses (unicode)
+                    if (event.value == 1)
+                    {
+                        // Check if there is space available in the queue
+                        if (CORE.Input.Keyboard.charPressedQueueCount < MAX_CHAR_PRESSED_QUEUE)
+                        {
+                            // Add character to the queue
+                            CORE.Input.Keyboard.charPressedQueue[CORE.Input.Keyboard.charPressedQueueCount] = EvkeyToUnicodeLUT[event.code];
+                            CORE.Input.Keyboard.charPressedQueueCount++;
+                        }
+                    }
 
                     if (CORE.Input.Keyboard.currentKeyState[CORE.Input.Keyboard.exitKey] == 1) CORE.Window.shouldClose = true;
 


### PR DESCRIPTION
### Changes
1. Moves the `keymapUS[]` LUT out of `PollKeyboardEvents` ([L1457-L1476](https://github.com/raysan5/raylib/pull/3498/files#diff-757f4c9c5f0be7473e385fa72b35d509c5af4ee2dc8204d2dbe2418bb9b98922L1457-L1476)) to `Local Variables Definition` ([R143-R162](https://github.com/raysan5/raylib/pull/3498/files#diff-757f4c9c5f0be7473e385fa72b35d509c5af4ee2dc8204d2dbe2418bb9b98922R143-R162)) so it doesn't have to be redefined every time `PollKeyboardEvents()` runs on `PLATFORM_DRM`.

2. Adds handling for `CORE.Input.Keyboard.charPressedQueue` and `CORE.Input.Keyboard.charPressedQueueCount` ([R164-R171](https://github.com/raysan5/raylib/pull/3498/files#diff-757f4c9c5f0be7473e385fa72b35d509c5af4ee2dc8204d2dbe2418bb9b98922R164-R171), [R1533-R1543](https://github.com/raysan5/raylib/pull/3498/files#diff-757f4c9c5f0be7473e385fa72b35d509c5af4ee2dc8204d2dbe2418bb9b98922R1533-R1543)) that was missing on `PLATFORM_DRM`. That was the reason why couldn't type on `examples with type inputs` (e.g.: `text_draw_3d`, `text_input_box`), since they used `GetCharPressed()`. Therefore, fixes those examples.

### Note
- The `EvkeyToUnicodeLUT` ([R164-R171](https://github.com/raysan5/raylib/pull/3498/files#diff-757f4c9c5f0be7473e385fa72b35d509c5af4ee2dc8204d2dbe2418bb9b98922R164-R171)) is incomplete, I just mapped the most essential keys so we could get this working. If this doesn't get replaced on the `DRM` input rework, I'll comeback and finish the LUT.

### Reference
- https://github.com/raysan5/raylib/issues/3487

### Enviroment
- Tested on Raspberry Pi 3 Model B 1.2 with Linux (Raspberry Pi OS 11 Bullseye 32-bit armhf).

### Edits
- **1:** added line marks, formatting.