### PR TITLE
[core] Fix gestures for `PLATFORM_DESKTOP_SDL`

### DIFF
--- a/src/platforms/rcore_desktop_sdl.c
+++ b/src/platforms/rcore_desktop_sdl.c
@@ -1158,7 +1158,8 @@ void PollInputEvents(void)
             gestureEvent.pointCount = 1;
 
             // Register touch points position, only one point registered
-            gestureEvent.position[0] = GetMousePosition();
+            if (touchAction == 2) gestureEvent.position[0] = CORE.Input.Touch.position[0];
+            else gestureEvent.position[0] = GetMousePosition();
 
             // Normalize gestureEvent.position[0] for CORE.Window.screen.width and CORE.Window.screen.height
             gestureEvent.position[0].x /= (float)GetScreenWidth();
@@ -1171,7 +1172,6 @@ void PollInputEvents(void)
     }
     //-----------------------------------------------------------------------------
 }
-
 
 //----------------------------------------------------------------------------------
 // Module Internal Functions Definition


### PR DESCRIPTION
### Changes
1. Adds the missing gestures handling for `PLATFORM_DESKTOP_SDL`.

2. Does that by adding the `ProcessGestureEvent(gestureEvent)` call ([R1169](https://github.com/raysan5/raylib/pull/3499/files#diff-43fa9fe6c2302f00d9c0b8bcbe58d8ca92ca52e157d5b19a612f90a81c698c12R1169)) and `gestureEvent` composition ([R1149-R1166](https://github.com/raysan5/raylib/pull/3499/files#diff-43fa9fe6c2302f00d9c0b8bcbe58d8ca92ca52e157d5b19a612f90a81c698c12R1149-R1166)) inside the `PollInputEvents()`, similar to how it's done on `PLATFORM_DESKTOP`([L1744-L1769](https://github.com/raysan5/raylib/blob/master/src/platforms/rcore_desktop.c#L1744-L1769), [L1779-L1799](https://github.com/raysan5/raylib/blob/master/src/platforms/rcore_desktop.c#L1779-L1799)) and `PLATFORM_DRM` ([L1584-L1585](https://github.com/raysan5/raylib/blob/master/src/platforms/rcore_drm.c#L1584-L1585), [L1715-L1731](https://github.com/raysan5/raylib/blob/master/src/platforms/rcore_drm.c#L1715-L1731)).

3. Also complements the `PollInputEvents()` implementation by adding the missing `CORE.Input.Touch.position` to it ([R971](https://github.com/raysan5/raylib/pull/3499/files#diff-43fa9fe6c2302f00d9c0b8bcbe58d8ca92ca52e157d5b19a612f90a81c698c12R971), [R1119](https://github.com/raysan5/raylib/pull/3499/files#diff-43fa9fe6c2302f00d9c0b8bcbe58d8ca92ca52e157d5b19a612f90a81c698c12R1119)).

### Reference
- https://github.com/raysan5/raylib/issues/3335#issuecomment-1789311708

### Environment
- Tested on Linux (Ubuntu 22.04 64-bit) with SDL2 (2.28.4).

### Edits
- **1:** editing.