### PR TITLE
Update Makefile: Build shared lib when platform is SDL

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -602,7 +602,7 @@ ifeq ($(PLATFORM),PLATFORM_WEB)
 	@echo "raylib library generated (lib$(RAYLIB_LIB_NAME).a)!"
 else
     ifeq ($(RAYLIB_LIBTYPE),SHARED)
-        ifeq ($(PLATFORM),PLATFORM_DESKTOP)
+        ifeq ($(PLATFORM),$(filter $(PLATFORM),PLATFORM_DESKTOP PLATFORM_DESKTOP_SDL))
             ifeq ($(PLATFORM_OS),WINDOWS)
                 # NOTE: Linking with provided resource file
 				$(CC) -shared -o $(RAYLIB_RELEASE_PATH)/$(RAYLIB_LIB_NAME).dll $(OBJS) $(RAYLIB_RES_FILE) $(LDFLAGS) $(LDLIBS)


### PR DESCRIPTION
When using `PLATFORM=PLATFORM_DESKTOP_SDL` and `RAYLIB_LIBTYPE=SHARED`, it didn't build the library (.so file).