### PR TITLE
BeginScissorMode checks for render texture to avoid using GetWindowScaleDPI

### DIFF
--- a/src/rcore.c
+++ b/src/rcore.c
@@ -1085,20 +1085,25 @@ void BeginScissorMode(int x, int y, int width, int height)
 
     rlEnableScissorTest();
 
+    GLint id = 0;
+    glGetIntegerv(GL_FRAMEBUFFER_BINDING, &id); // Test for render texture
 #if defined(__APPLE__)
-    Vector2 scale = GetWindowScaleDPI();
-    rlScissor((int)(x*scale.x), (int)(GetScreenHeight()*scale.y - (((y + height)*scale.y))), (int)(width*scale.x), (int)(height*scale.y));
+    if(!id)
+    {
+        Vector2 scale = GetWindowScaleDPI();
+        rlScissor((int)(x*scale.x), (int)(GetScreenHeight()*scale.y - (((y + height)*scale.y))), (int)(width*scale.x), (int)(height*scale.y));
+    }
 #else
-    if ((CORE.Window.flags & FLAG_WINDOW_HIGHDPI) > 0)
+    if (!id && (CORE.Window.flags & FLAG_WINDOW_HIGHDPI) > 0)
     {
         Vector2 scale = GetWindowScaleDPI();
         rlScissor((int)(x*scale.x), (int)(CORE.Window.currentFbo.height - (y + height)*scale.y), (int)(width*scale.x), (int)(height*scale.y));
     }
+#endif
     else
     {
         rlScissor(x, CORE.Window.currentFbo.height - (y + height), width, height);
     }
-#endif
 }
 
 // End scissor mode


### PR DESCRIPTION
When on a window with active `FLAG_WINDOW_HIGHDPI` window flag or on macOS the implementation of `BeginScissorMode` uses `GetWindowScaleDPI` to get scaling and uses it on the scissor rect.

If using `BeginScissorMode` inside of an open `BeginTextureMode`/`EndTextureMode` this scaling is
wrong as a `RenderTexture` is created with a defined resolution and doesn't share any implicit window dpi scalings.

I fixed this by checking if currently a frame buffer is bound to detect the texture mode. If there is a binding the else path of the original implementation will be used to avoid the wrong scaling.