### PR TITLE
[build]: add uninstall cmake target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,6 +88,7 @@ CMakeFiles
 CMakeScripts
 Testing
 cmake_install.cmake
+cmake_uninstall.cmake
 install_manifest.txt
 compile_commands.json
 CTestTestfile.cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,17 @@ include(BuildOptions)
 # Main sources directory (the second parameter sets the output directory name to raylib)
 add_subdirectory(src raylib)
 
+# Uninstall target
+if(NOT TARGET uninstall)
+  configure_file(
+    "${CMAKE_MODULE_PATH}/Uninstall.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
+    IMMEDIATE @ONLY)
+
+  add_custom_target(uninstall
+    COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
+endif()
+
 if (${BUILD_EXAMPLES})
   MESSAGE(STATUS "Building examples is enabled")
   add_subdirectory(examples)

--- a/cmake/Uninstall.cmake
+++ b/cmake/Uninstall.cmake
@@ -1,0 +1,21 @@
+if(NOT EXISTS "@CMAKE_BINARY_DIR@/install_manifest.txt")
+  message(FATAL_ERROR "Cannot find install manifest: @CMAKE_BINARY_DIR@/install_manifest.txt")
+endif()
+
+file(READ "@CMAKE_BINARY_DIR@/install_manifest.txt" files)
+string(REGEX REPLACE "\n" ";" files "${files}")
+foreach(file ${files})
+  message(STATUS "Uninstalling $ENV{DESTDIR}${file}")
+  if(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+    exec_program(
+      "@CMAKE_COMMAND@" ARGS "-E remove \"$ENV{DESTDIR}${file}\""
+      OUTPUT_VARIABLE rm_out
+      RETURN_VALUE rm_retval
+      )
+    if(NOT "${rm_retval}" STREQUAL 0)
+      message(FATAL_ERROR "Problem when removing $ENV{DESTDIR}${file}")
+    endif()
+  else(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+    message(STATUS "File $ENV{DESTDIR}${file} does not exist.")
+  endif()
+endforeach()


### PR DESCRIPTION
The handwritten `Makefile` in `src` [has](https://github.com/raysan5/raylib/blob/a470cdce4c3d77e543d90a5fc2aab05e8d41b51b/src/Makefile#L764) a `uninstall` target. Auto-generated `Makefile` doesn't get one as [mentioned](https://gitlab.kitware.com/cmake/community/-/wikis/FAQ#can-i-do-make-uninstall-with-cmake) in the CMake's FAQs. So adding for completeness' sake.