### PR TITLE
[core] Fix `absRange` for `PLATFORM_DRM` (complement #3515)

### DIFF
--- a/src/platforms/rcore_drm.c
+++ b/src/platforms/rcore_drm.c
@@ -1549,9 +1549,14 @@ static void ConfigureEvdevDevice(char *device)
             ioctl(fd, EVIOCGABS(ABS_X), &absinfo);
             worker->absRange.x = absinfo.minimum;
             worker->absRange.width = absinfo.maximum - absinfo.minimum;
+            platform.absRange.x = absinfo.minimum;
+            platform.absRange.width = absinfo.maximum - absinfo.minimum;
+
             ioctl(fd, EVIOCGABS(ABS_Y), &absinfo);
             worker->absRange.y = absinfo.minimum;
             worker->absRange.height = absinfo.maximum - absinfo.minimum;
+            platform.absRange.y = absinfo.minimum;
+            platform.absRange.height = absinfo.maximum - absinfo.minimum;
         }
 
         // Check for multiple absolute movement support (usually multitouch touchscreens)
@@ -1563,9 +1568,14 @@ static void ConfigureEvdevDevice(char *device)
             ioctl(fd, EVIOCGABS(ABS_X), &absinfo);
             worker->absRange.x = absinfo.minimum;
             worker->absRange.width = absinfo.maximum - absinfo.minimum;
+            platform.absRange.x = absinfo.minimum;
+            platform.absRange.width = absinfo.maximum - absinfo.minimum;
+
             ioctl(fd, EVIOCGABS(ABS_Y), &absinfo);
             worker->absRange.y = absinfo.minimum;
             worker->absRange.height = absinfo.maximum - absinfo.minimum;
+            platform.absRange.y = absinfo.minimum;
+            platform.absRange.height = absinfo.maximum - absinfo.minimum;
         }
     }
 


### PR DESCRIPTION
### Changes
- Very quick fix to add the `platform.absRange` to the `ConfigureEvdevDevice()` ([R1552-R1553](https://github.com/raysan5/raylib/pull/3517/files#diff-757f4c9c5f0be7473e385fa72b35d509c5af4ee2dc8204d2dbe2418bb9b98922R1552-R1553), [R1558-R1559](https://github.com/raysan5/raylib/pull/3517/files#diff-757f4c9c5f0be7473e385fa72b35d509c5af4ee2dc8204d2dbe2418bb9b98922R1558-R1559), [R1571-R1572](https://github.com/raysan5/raylib/pull/3517/files#diff-757f4c9c5f0be7473e385fa72b35d509c5af4ee2dc8204d2dbe2418bb9b98922R1571-R1572), [R1577-R1578](https://github.com/raysan5/raylib/pull/3517/files#diff-757f4c9c5f0be7473e385fa72b35d509c5af4ee2dc8204d2dbe2418bb9b98922R1577-R1578)) that was missing on the #3515.

### Note
- While I was cleaning up the previous PR I forgot to add `platform.absRange` part. Really sorry, my bad.

### Reference
- https://github.com/raysan5/raylib/pull/3515

### Environment
- Tested on Raspberry Pi 3 Model B 1.2 with Linux (Raspberry Pi OS 11 Bullseye 32-bit armhf).

### Edits
- **1:** added line marks.
- **2:** editing.