### PR TITLE
WindowShouldClose(), reset shouldClose flag when window is inited

### DIFF
--- a/src/rcore.c
+++ b/src/rcore.c
@@ -658,6 +658,7 @@ void InitWindow(int width, int height, const char *title)
 #endif
 
     CORE.Time.frameCounter = 0;
+    CORE.Window.shouldClose = false;
 
     // Initialize random seed
     SetRandomSeed((unsigned int)time(NULL));


### PR DESCRIPTION
Similar issue with: https://github.com/raysan5/raylib/pull/3410

Window shouldClose flag does not reset after closing and opening another window. So for the subsequent windows `WindowShouldClose` always return true.