### PR TITLE
Update BINDINGS.md for raylib-go

### DIFF
--- a/BINDINGS.md
+++ b/BINDINGS.md
@@ -27,7 +27,7 @@ Some people ported raylib to other languages in form of bindings or wrappers to 
 | raylib-freebasic   | **4.5** | [FreeBASIC](https://www.freebasic.net/) | MIT | https://github.com/WIITD/raylib-freebasic     |
 | fortran-raylib     | **4.5** | [Fortran](https://fortran-lang.org/) | ISC | https://github.com/interkosmos/fortran-raylib     |
 | raylib for Pascal  | **4.5** | [Object Pascal](https://en.wikipedia.org/wiki/Object_Pascal) | Modified Zlib | https://github.com/tinyBigGAMES/raylib |
-| raylib-go          | 4.5     | [Go](https://golang.org/)            | Zlib | https://github.com/gen2brain/raylib-go       |
+| raylib-go          | **5.0** | [Go](https://golang.org/)            | Zlib | https://github.com/gen2brain/raylib-go       |
 | raylib-guile       | **auto** | [Guile](https://www.gnu.org/software/guile/) | Zlib | https://github.com/petelliott/raylib-guile |
 | gforth-raylib      | 3.5     | [Gforth](https://gforth.org/)            | MIT  | https://github.com/ArnautDaniel/gforth-raylib   |
 | h-raylib           | **4.6-dev** | [Haskell](https://haskell.org/)          | Apache-2.0 | https://github.com/Anut-py/h-raylib       |


### PR DESCRIPTION
raylib-go uses raylib 5.0: https://github.com/gen2brain/raylib-go/blob/master/raylib/raylib.h

