### PR TITLE
[core] Fix mouse button order for `PLATFORM_DESKTOP_SDL`

### DIFF
--- a/src/platforms/rcore_desktop_sdl.c
+++ b/src/platforms/rcore_desktop_sdl.c
@@ -1084,14 +1084,26 @@ void PollInputEvents(void)
             // Check mouse events
             case SDL_MOUSEBUTTONDOWN:
             {
-                CORE.Input.Mouse.currentButtonState[event.button.button - 1] = 1;
+                // NOTE: SDL2 mouse button order is LEFT, MIDDLE, RIGHT, but raylib uses LEFT, RIGHT, MIDDLE like GLFW
+                //       The following conditions align SDL with raylib.h MouseButton enum order
+                int btn = event.button.button - 1;
+                if (btn == 2) btn = 1;
+                else if (btn == 1) btn = 2;
+
+                CORE.Input.Mouse.currentButtonState[btn] = 1;
 
                 touchAction = 1;
                 gestureUpdate = true;
             } break;
             case SDL_MOUSEBUTTONUP:
             {
-                CORE.Input.Mouse.currentButtonState[event.button.button - 1] = 0;
+                // NOTE: SDL2 mouse button order is LEFT, MIDDLE, RIGHT, but raylib uses LEFT, RIGHT, MIDDLE like GLFW
+                //       The following conditions align SDL with raylib.h MouseButton enum order
+                int btn = event.button.button - 1;
+                if (btn == 2) btn = 1;
+                else if (btn == 1) btn = 2;
+
+                CORE.Input.Mouse.currentButtonState[btn] = 0;
 
                 touchAction = 0;
                 gestureUpdate = true;


### PR DESCRIPTION
### Changes
- The `SDL2` mouse button order is `LEFT, MIDDLE, RIGHT, ...` ([doc](https://wiki.libsdl.org/SDL2/SDL_MouseButtonEvent)), but `raylib.h`'s `MouseButton enum` uses `LEFT, RIGHT, MIDDLE, ...` ([L689-L690](https://github.com/raysan5/raylib/blob/master/src/raylib.h#L689-L690)) like `GLFW`.
- Fixes the `MOUSE_BUTTON_RIGHT` and `MOUSE_BUTTON_MIDDLE` order by remapping them during the input polling for `PLATFORM_DESKTOP_SDL` ([R1087-R1093](https://github.com/raysan5/raylib/pull/3534/files#diff-43fa9fe6c2302f00d9c0b8bcbe58d8ca92ca52e157d5b19a612f90a81c698c12R1087-R1093), [R1100-R1106](https://github.com/raysan5/raylib/pull/3534/files#diff-43fa9fe6c2302f00d9c0b8bcbe58d8ca92ca52e157d5b19a612f90a81c698c12R1100-R1106)).

### Reference
- https://github.com/raysan5/raylib/pull/3428#issuecomment-1764433516

### Environment
- Tested on Linux (Ubuntu 22.04 64-bit) with SDL2 (2.28.4).

### Edits
- **1:** added line marks.
- **2:** correction.
