### PR TITLE
Fix for running OpenGL ES2 with SDL on desktop

### DIFF
--- a/src/platforms/rcore_desktop_sdl.c
+++ b/src/platforms/rcore_desktop_sdl.c
@@ -49,7 +49,14 @@
 **********************************************************************************************/
 
 #include "SDL.h"            // SDL base library (window/rendered, input, timming... functionality)
+#ifdef GRAPHICS_API_OPENGL_ES2
+// I suspect that the gles2 version of the SDL header should be used
+// but the compilation fails if we do. Not including anything appears
+// to work fine.
+//#include "SDL_opengles2.h"
+#else
 #include "SDL_opengl.h"     // SDL OpenGL functionality (if required, instead of internal renderer)
+#endif
 
 //----------------------------------------------------------------------------------
 // Types and Structures Definition


### PR DESCRIPTION
System: Artix Linux, Desktop PC

---

When trying to compile Raylib configured with SDL and OpenGL ES2 it will fail like the following:

![2023-11-14-19:48:00](https://github.com/raysan5/raylib/assets/11139432/cecce169-591e-4019-94bb-06998a739b23)

By editing `rcore_desktop_sdl.c` to not include `SDL_opengl.h` when compiling for OpenGL ES2 it compiles and works. See here:

![2023-11-14-20:07:25](https://github.com/raysan5/raylib/assets/11139432/bd7458c7-2a64-4d22-964b-e736ee5c8d62)

However when looking through the headerfiles of SDL I see there is a `SDL_opengles2.h` which I suspect should be used in place of `SDL_opengl.h` but it fails to compile when I do that. I am not entire sure why, I tried to do some digging but havent come up with anything yet, if anyone else has any insight it would be much appreciated however I think the current fix is sufficient.

I have not tested this yet on Windows or Mac. I can test it on Windows and Mac most likely sometime later this week or next week.
