### PR TITLE
Fix version info in rlgl.h

### DIFF
--- a/src/rlgl.h
+++ b/src/rlgl.h
@@ -1,6 +1,6 @@
 /**********************************************************************************************
 *
-*   rlgl v4.5 - A multi-OpenGL abstraction layer with an immediate-mode style API
+*   rlgl v5.0 - A multi-OpenGL abstraction layer with an immediate-mode style API
 *
 *   DESCRIPTION:
 *       An abstraction layer for multiple OpenGL versions (1.1, 2.1, 3.3 Core, 4.3 Core, ES 2.0)


### PR DESCRIPTION
Doing the binding for 5.0, I noticed this seems to not have been changed.

Most of the .h files don't follow the release versions, so I'm not 100% sure if this is correct...