### PR TITLE
add ColorFromInt for convenance

### DIFF
--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1401,6 +1401,7 @@ RLAPI void DrawTextureNPatch(Texture2D texture, NPatchInfo nPatchInfo, Rectangle
 // Color/pixel related functions
 RLAPI Color Fade(Color color, float alpha);                                 // Get color with alpha applied, alpha goes from 0.0f to 1.0f
 RLAPI int ColorToInt(Color color);                                          // Get hexadecimal value for a Color
+RLAPI Color ColorFromInt(unsigned int hexValue);                            // Get Color structure from hexadecimal value
 RLAPI Vector4 ColorNormalize(Color color);                                  // Get Color normalized as float [0..1]
 RLAPI Color ColorFromNormalized(Vector4 normalized);                        // Get Color from normalized values [0..1]
 RLAPI Vector3 ColorToHSV(Color color);                                      // Get HSV values for a Color, hue [0..360], saturation/value [0..1]

--- a/src/rtextures.c
+++ b/src/rtextures.c
@@ -4437,6 +4437,12 @@ int ColorToInt(Color color)
     return (((int)color.r << 24) | ((int)color.g << 16) | ((int)color.b << 8) | (int)color.a);
 }
 
+// Get Color structure from hexadecimal value
+Color ColorFromInt(unsigned int hexValue)
+{
+    return GetColor(hexValue);
+}
+
 // Get color normalized as float [0..1]
 Vector4 ColorNormalize(Color color)
 {


### PR DESCRIPTION
because there's `ColorFromNormalized` -> `ColorToNormalized`, `ColorFromHSV` -> `ColorToHSV` 

**but** `GetColor` -> `ColorToInt`, not `ColorFromInt` -> `ColorToInt`