### PR TITLE
Expose glad functions when building raylib as a shared lib

### DIFF
--- a/src/rlgl.h
+++ b/src/rlgl.h
@@ -773,6 +773,11 @@ RLAPI void rlLoadDrawQuad(void);     // Load and draw a quad
 
 #if defined(RLGL_IMPLEMENTATION)
 
+// Expose OpenGL functions from glad in raylib
+#if defined(BUILD_SHARED_LIBS)
+    #define GLAD_API_CALL_EXPORT_BUILD
+#endif
+
 #if defined(GRAPHICS_API_OPENGL_11)
     #if defined(__APPLE__)
         #include <OpenGL/gl.h>          // OpenGL 1.1 library for OSX


### PR DESCRIPTION
Currently, if you build raylib as a DLL, and then try to build the examples, examples/other/raylib_opengl_interop.c will fail to link, because none of the opengl functions are exposed in raylib.dll
These can also help some binding users, like raylib-cs users who would like to call some opengl functions directly, bypassing rlgl.
Currently these users have to call wglGetProcAddress to get a function pointer manually.

examples/other/rlgl_standalone.c also has this issue, and it can be fixed by exposing GLFW. I don't know whether this is a good idea, though, since GLFW is not used by all platforms, while OpenGL is.
I'm happy to open a PR exposing those symbols too, if it's desired, though.