### PR TITLE
Hide unneeded internal symbols when building raylib as an so or dylib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(raylib)
 
 # Avoid excessive expansion of variables in conditionals. In particular, if
-# "PLATFORM" is "DRM" than:
+# "PLATFORM" is "DRM" then:
 #
 # if (${PLATFORM} MATCHES "DRM")
 #
@@ -12,6 +12,11 @@ project(raylib)
 #
 # See https://cmake.org/cmake/help/latest/policy/CMP0054.html
 cmake_policy(SET CMP0054 NEW)
+
+# Makes a hidden visibility preset on a static lib respected
+# This is used to hide glfw's symbols from the library exports when building an so/dylib
+# See https://cmake.org/cmake/help/latest/policy/CMP0063.html
+cmake_policy(SET CMP0063 NEW)
 
 # Directory for easier includes
 # Anywhere you see include(...) you can check <root>/cmake for that file

--- a/cmake/GlfwImport.cmake
+++ b/cmake/GlfwImport.cmake
@@ -17,16 +17,16 @@ if(NOT glfw3_FOUND AND NOT USE_EXTERNAL_GLFW STREQUAL "ON" AND "${PLATFORM}" MAT
     set(GLFW_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
     set(GLFW_INSTALL OFF CACHE BOOL "" FORCE)
     set(GLFW_USE_WAYLAND ${USE_WAYLAND} CACHE BOOL "" FORCE)
+    set(GLFW_LIBRARY_TYPE "STATIC" CACHE STRING "" FORCE)
     
-    set(WAS_SHARED ${BUILD_SHARED_LIBS})
-    set(BUILD_SHARED_LIBS OFF CACHE BOOL " " FORCE)
 
     add_subdirectory(external/glfw)
 
-    set(BUILD_SHARED_LIBS ${WAS_SHARED} CACHE BOOL " " FORCE)
-    unset(WAS_SHARED)
+    # Hide glfw's symbols when building a shared lib
+    if (BUILD_SHARED_LIBS)
+        set_property(TARGET glfw PROPERTY C_VISIBILITY_PRESET hidden)
+    endif()
     
-    list(APPEND raylib_sources $<TARGET_OBJECTS:glfw>)
     include_directories(BEFORE SYSTEM external/glfw/include)
 elseif("${PLATFORM}" STREQUAL "DRM")
     MESSAGE(STATUS "No GLFW required on PLATFORM_DRM")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -62,12 +62,10 @@ if (NOT BUILD_SHARED_LIBS)
     add_library(raylib_static ALIAS raylib)
 else()
     MESSAGE(STATUS "Building raylib shared library")
-    if (WIN32)
-        target_compile_definitions(raylib
-                                   PRIVATE $<BUILD_INTERFACE:BUILD_LIBTYPE_SHARED>
-                                   INTERFACE $<INSTALL_INTERFACE:USE_LIBTYPE_SHARED>
-                                   )
-    endif ()
+    target_compile_definitions(raylib
+                               PRIVATE $<BUILD_INTERFACE:BUILD_LIBTYPE_SHARED>
+                               INTERFACE $<INSTALL_INTERFACE:USE_LIBTYPE_SHARED>
+                               )
 endif()
 
 if (${PLATFORM} MATCHES "Web")
@@ -82,6 +80,11 @@ set_target_properties(raylib PROPERTIES
 
 if (WITH_PIC OR BUILD_SHARED_LIBS)
     set_property(TARGET raylib PROPERTY POSITION_INDEPENDENT_CODE ON)
+endif ()
+
+if (BUILD_SHARED_LIBS)
+    # Hide raylib's symbols by default so RLAPI can expose them
+    set_property(TARGET raylib PROPERTY C_VISIBILITY_PRESET hidden)
 endif ()
 
 target_link_libraries(raylib "${LIBS_PRIVATE}")

--- a/src/Makefile
+++ b/src/Makefile
@@ -385,7 +385,13 @@ ifeq ($(RAYLIB_LIBTYPE),SHARED)
     # BE CAREFUL: It seems that for gcc -fpic is not the same as -fPIC
     # MinGW32 just doesn't need -fPIC, it shows warnings
     CFLAGS += -fPIC -DBUILD_LIBTYPE_SHARED
+
+    # hide all symbols by default, so RLAPI can expose them
+    ifeq ($(PLATFORM_OS),$(filter $(PLATFORM_OS), LINUX BSD OSX))
+        CFLAGS += -fvisibility=hidden
+    endif
 endif
+
 ifeq ($(PLATFORM),PLATFORM_DRM)
     # without EGL_NO_X11 eglplatform.h tears Xlib.h in which tears X.h in
     # which contains a conflicting type Font

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -86,16 +86,21 @@
 #define RAYLIB_VERSION_PATCH 0
 #define RAYLIB_VERSION  "5.1-dev"
 
-// Function specifiers in case library is build/used as a shared library (Windows)
+// Function specifiers in case library is build/used as a shared library
 // NOTE: Microsoft specifiers to tell compiler that symbols are imported/exported from a .dll
+// NOTE: visibility("default") attribute makes symbols "visible" when compiled with -fvisibility=hidden
 #if defined(_WIN32)
+    #if defined(__TINYC__)
+        #define __declspec(x) __attribute__((x))
+    #endif
     #if defined(BUILD_LIBTYPE_SHARED)
-        #if defined(__TINYC__)
-            #define __declspec(x) __attribute__((x))
-        #endif
         #define RLAPI __declspec(dllexport)     // We are building the library as a Win32 shared library (.dll)
     #elif defined(USE_LIBTYPE_SHARED)
         #define RLAPI __declspec(dllimport)     // We are using the library as a Win32 shared library (.dll)
+    #endif
+#else
+    #if defined(BUILD_LIBTYPE_SHARED)
+        #define RLAPI __attribute__((visibility("default"))) // We are building as a Unix shared library (.so/.dylib)
     #endif
 #endif
 

--- a/src/raymath.h
+++ b/src/raymath.h
@@ -59,7 +59,9 @@
 // Function specifiers definition
 #if defined(RAYMATH_IMPLEMENTATION)
     #if defined(_WIN32) && defined(BUILD_LIBTYPE_SHARED)
-        #define RMAPI __declspec(dllexport) extern inline // We are building raylib as a Win32 shared library (.dll).
+        #define RMAPI __declspec(dllexport) extern inline // We are building raylib as a Win32 shared library (.dll)
+    #elif defined(BUILD_LIBTYPE_SHARED)
+        #define RMAPI __attribute__((visibility("default"))) // We are building raylib as a Unix shared library (.so/.dylib)
     #elif defined(_WIN32) && defined(USE_LIBTYPE_SHARED)
         #define RMAPI __declspec(dllimport)         // We are using raylib as a Win32 shared library (.dll)
     #else

--- a/src/rlgl.h
+++ b/src/rlgl.h
@@ -109,15 +109,17 @@
 
 #define RLGL_VERSION  "4.5"
 
-// Function specifiers in case library is build/used as a shared library (Windows)
+// Function specifiers in case library is build/used as a shared library
 // NOTE: Microsoft specifiers to tell compiler that symbols are imported/exported from a .dll
-#if defined(_WIN32)
-    #if defined(BUILD_LIBTYPE_SHARED)
-        #define RLAPI __declspec(dllexport)     // We are building the library as a Win32 shared library (.dll)
-    #elif defined(USE_LIBTYPE_SHARED)
-        #define RLAPI __declspec(dllimport)     // We are using the library as a Win32 shared library (.dll)
-    #endif
+// NOTE: visibility(default) attribute makes symbols "visible" when compiled with -fvisibility=hidden
+#if defined(_WIN32) && defined(BUILD_LIBTYPE_SHARED)
+    #define RLAPI __declspec(dllexport)     // We are building the library as a Win32 shared library (.dll)
+#elif defined(BUILD_LIBTYPE_SHARED)
+    #define RLAPI __attribute__((visibility("default"))) // We are building he library as a Unix shared library (.so/.dylib)
+#elif defined(_WIN32) && defined(USE_LIBTYPE_SHARED)
+    #define RLAPI __declspec(dllimport)     // We are using the library as a Win32 shared library (.dll)
 #endif
+
 
 // Function specifiers definition
 #ifndef RLAPI


### PR DESCRIPTION
Currently, raylib makes no attempt to hide any of its symbols when building as an so or dylib.
This means the symbols of glfw, miniaudio, stb_image, etc are all exposed to call.
This results in a bit of inconsistency compared to the windows dll, which exposes far less (just raylib+glad+raymath+rlgl).

This PR handles this by passing -fvisibility=hidden to all of raylib's source files when building as an SO, and using \_\_attribute__((visibility("default"))) to expose each symbol, much like __declspec(dllexport).

In theory, this improves the load times and size of the so, as well as providing better "api hygine"
https://gcc.gnu.org/wiki/Visibility

I updated both CMake and the Makefile to do this. I checked zig, but it does not seem to handle building shared libs at all, so I don't think it needs any changes.

NOTE: I did not test BSD or OSX dylibs, but as far as I can tell, the changes here should do the same thing on both platforms.
The risk of breaking anything is fairly low, though testing is welcome.