### PR TITLE
[core] Fix `SetMousePosition()` for `PLATFORM_DESKTOP_SDL`

### DIFF
--- a/src/platforms/rcore_desktop_sdl.c
+++ b/src/platforms/rcore_desktop_sdl.c
@@ -941,6 +941,8 @@ int SetGamepadMappings(const char *mappings)
 // Set mouse position XY
 void SetMousePosition(int x, int y)
 {
+    SDL_WarpMouseInWindow(platform.window, x, y);
+
     CORE.Input.Mouse.currentPosition = (Vector2){ (float)x, (float)y };
     CORE.Input.Mouse.previousPosition = CORE.Input.Mouse.currentPosition;
 }


### PR DESCRIPTION
### Changes
- Fixes `SetMousePosition()` for `PLATFORM_DESKTOP_SDL` by adding the missing `SDL_WarpMouseInWindow()` call on  ([R944](https://github.com/raysan5/raylib/pull/3580/files#diff-43fa9fe6c2302f00d9c0b8bcbe58d8ca92ca52e157d5b19a612f90a81c698c12R944)).

### Enviroment
- Tested successfully on Linux (Mint 21.1 64-bit) with SDL2 (2.28.4).

### Edit
- 1: added line marks.