### PR TITLE
Updated Makefile for correct lib folder

### DIFF
--- a/projects/VSCode/Makefile
+++ b/projects/VSCode/Makefile
@@ -271,7 +271,7 @@ ifeq ($(PLATFORM),PLATFORM_DESKTOP)
 endif
 
 # Define library paths containing required libs.
-LDFLAGS = -L. -L$(RAYLIB_RELEASE_PATH) -L$(RAYLIB_PATH)/src
+LDFLAGS = -L. -L$(RAYLIB_RELEASE_PATH) -L$(RAYLIB_PATH)/lib
 
 ifeq ($(PLATFORM),PLATFORM_DESKTOP)
     ifeq ($(PLATFORM_OS),BSD)


### PR DESCRIPTION
RAYLIB_RELEASE_PATH already resolves to `$(RAYLIB_PATH)/src`, this should be `$(RAYLIB_PATH)/lib` for the Library search