### PR TITLE
[core] Fix `IsKeyPressedRepeat()` for `PLATFORM_DRM` direct input

### DIFF
--- a/src/platforms/rcore_drm.c
+++ b/src/platforms/rcore_drm.c
@@ -1709,6 +1709,7 @@ static void PollKeyboardEvents(void)
                     // Event interface: 'value' is the value the event carries. Either a relative change for EV_REL,
                     // absolute new value for EV_ABS (joysticks ...), or 0 for EV_KEY for release, 1 for keypress and 2 for autorepeat
                     CORE.Input.Keyboard.currentKeyState[keycode] = (event.value >= 1)? 1 : 0;
+                    CORE.Input.Keyboard.keyRepeatInFrame[keycode] = (event.value == 2)? 1 : 0;
                     if (event.value >= 1)
                     {
                         CORE.Input.Keyboard.keyPressedQueue[CORE.Input.Keyboard.keyPressedQueueCount] = keycode;     // Register last key pressed


### PR DESCRIPTION
### Changes
- Fixes `IsKeyPressedRepeat()` for `PLATFORM_DRM` direct input by adding the missing `CORE.Input.Keyboard.keyRepeatInFrame` to `PollKeyboardEvents()` ([R1712](https://github.com/raysan5/raylib/pull/3583/files#diff-757f4c9c5f0be7473e385fa72b35d509c5af4ee2dc8204d2dbe2418bb9b98922R1712)).

### Reference
- Issue spotted by @larry104 at [#3569#issuecomment-1832811076](https://github.com/raysan5/raylib/issues/3569#issuecomment-1832811076).

### Code example
```
#include "raylib.h"

int main(void) {
    InitWindow(800, 450, "test");
    SetTargetFPS(60);
    while (!WindowShouldClose()) {
        BeginDrawing();
        ClearBackground(RAYWHITE);

        if (IsKeyPressedRepeat(KEY_ONE)) {
            DrawText("1 is repeat", 20, 20, 20, BLACK);
            TraceLog(LOG_INFO, "1 is repeat");
        }
        if (IsKeyPressedRepeat(KEY_TWO)) {
            DrawText("2 is repeat", 20, 40, 20, BLACK);
            TraceLog(LOG_INFO, "2 is repeat");
        }

        EndDrawing();
    }
    CloseWindow();
    return 0;
}
```

### Environment
- Tested on Raspberry Pi 3 Model B 1.2 (2015) with Linux (Raspberry Pi OS 12 Bookworm 32-bit armhf).

### Edits
- 1: added line marks.