### PR TITLE
Implement miters in DrawSplineLinear

### DIFF
--- a/src/rshapes.c
+++ b/src/rshapes.c
@@ -1546,16 +1546,20 @@ void DrawPolyLinesEx(Vector2 center, int sides, float radius, float rotation, fl
 // Draw spline: linear, minimum 2 points
 void DrawSplineLinear(Vector2 *points, int pointCount, float thick, Color color)
 {
-    if (pointCount < 2) {
+    if (pointCount < 2)
+    {
         return;
     }
     
     Vector2 prevNormal = (Vector2){-(points[1].y - points[0].y), (points[1].x - points[0].x)};
     float prevLength = sqrtf(prevNormal.x*prevNormal.x + prevNormal.y*prevNormal.y);
-    if (prevLength > 0.0f) {
+    if (prevLength > 0.0f)
+    {
         prevNormal.x /= prevLength;
         prevNormal.y /= prevLength;
-    } else {
+    }
+    else
+    {
         prevNormal.x = 0.0f;
         prevNormal.y = 0.0f;
     }
@@ -1566,36 +1570,48 @@ void DrawSplineLinear(Vector2 *points, int pointCount, float thick, Color color)
     {
         Vector2 normal = {0};
 
-        if (i < pointCount - 2) {
+        if (i < pointCount - 2)
+        {
             normal = (Vector2){-(points[i+2].y - points[i+1].y), (points[i+2].x - points[i+1].x)};
             float normalLength = sqrtf(normal.x*normal.x + normal.y*normal.y);
-            if (normalLength > 0.0f) {
+            if (normalLength > 0.0f)
+            {
                 normal.x /= normalLength;
                 normal.y /= normalLength;
-            } else {
+            }
+            else
+            {
                 normal.x = 0.0f;
                 normal.y = 0.0f;
             }
-        } else {
+        }
+        else
+        {
             normal = prevNormal;
         }
 
         Vector2 radius = {prevNormal.x + normal.x, prevNormal.y + normal.y};
         float radiusLength = sqrtf(radius.x*radius.x + radius.y*radius.y);
-        if (radiusLength > 0.0f) {
+        if (radiusLength > 0.0f)
+        {
             radius.x /= radiusLength;
             radius.y /= radiusLength;
-        } else {
+        }
+        else
+        {
             radius.x = 0.0f;
             radius.y = 0.0f;
         }
 
         float cosTheta = radius.x * normal.x + radius.y * normal.y;
 
-        if (cosTheta != 0.0f) {
+        if (cosTheta != 0.0f)
+        {
             radius.x *= thick * .5f / cosTheta;
             radius.y *= thick * .5f / cosTheta;
-        } else {
+        }
+        else
+        {
             radius.x = 0.0f;
             radius.y = 0.0f;
         }

--- a/src/rshapes.c
+++ b/src/rshapes.c
@@ -1546,26 +1546,71 @@ void DrawPolyLinesEx(Vector2 center, int sides, float radius, float rotation, fl
 // Draw spline: linear, minimum 2 points
 void DrawSplineLinear(Vector2 *points, int pointCount, float thick, Color color)
 {
-    Vector2 delta = { 0 };
-    float length = 0.0f;
-    float scale = 0.0f;
+    if (pointCount < 2) {
+        return;
+    }
+    
+    Vector2 prevNormal = (Vector2){-(points[1].y - points[0].y), (points[1].x - points[0].x)};
+    float prevLength = sqrtf(prevNormal.x*prevNormal.x + prevNormal.y*prevNormal.y);
+    if (prevLength > 0.0f) {
+        prevNormal.x /= prevLength;
+        prevNormal.y /= prevLength;
+    } else {
+        prevNormal.x = 0.0f;
+        prevNormal.y = 0.0f;
+    }
 
+    Vector2 prevRadius = {.5f * thick * prevNormal.x, .5f * thick * prevNormal.y};
+    
     for (int i = 0; i < pointCount - 1; i++)
     {
-        delta = (Vector2){ points[i + 1].x - points[i].x, points[i + 1].y - points[i].y };
-        length = sqrtf(delta.x*delta.x + delta.y*delta.y);
+        Vector2 normal = {0};
 
-        if (length > 0) scale = thick/(2*length);
+        if (i < pointCount - 2) {
+            normal = (Vector2){-(points[i+2].y - points[i+1].y), (points[i+2].x - points[i+1].x)};
+            float normalLength = sqrtf(normal.x*normal.x + normal.y*normal.y);
+            if (normalLength > 0.0f) {
+                normal.x /= normalLength;
+                normal.y /= normalLength;
+            } else {
+                normal.x = 0.0f;
+                normal.y = 0.0f;
+            }
+        } else {
+            normal = prevNormal;
+        }
 
-        Vector2 radius = { -scale*delta.y, scale*delta.x };
+        Vector2 radius = {prevNormal.x + normal.x, prevNormal.y + normal.y};
+        float radiusLength = sqrtf(radius.x*radius.x + radius.y*radius.y);
+        if (radiusLength > 0.0f) {
+            radius.x /= radiusLength;
+            radius.y /= radiusLength;
+        } else {
+            radius.x = 0.0f;
+            radius.y = 0.0f;
+        }
+
+        float cosTheta = radius.x * normal.x + radius.y * normal.y;
+
+        if (cosTheta != 0.0f) {
+            radius.x *= thick * .5f / cosTheta;
+            radius.y *= thick * .5f / cosTheta;
+        } else {
+            radius.x = 0.0f;
+            radius.y = 0.0f;
+        }
+        
         Vector2 strip[4] = {
-            { points[i].x - radius.x, points[i].y - radius.y },
-            { points[i].x + radius.x, points[i].y + radius.y },
+            { points[i].x - prevRadius.x, points[i].y - prevRadius.y },
+            { points[i].x + prevRadius.x, points[i].y + prevRadius.y },
             { points[i + 1].x - radius.x, points[i + 1].y - radius.y },
             { points[i + 1].x + radius.x, points[i + 1].y + radius.y }
         };
 
         DrawTriangleStrip(strip, 4, color);
+
+        prevRadius = radius;
+        prevNormal = normal;
     }
 #if defined(SUPPORT_SPLINE_SEGMENT_CAPS)
 


### PR DESCRIPTION
Hi,

I implemented segment miters for linear splines, meaning that the lines go from this : 

![Screenshot from 2023-11-30 11-09-39](https://github.com/raysan5/raylib/assets/21238398/b44b0cdd-5496-4af6-966a-3db084a54c3a)

to this :

![Screenshot from 2023-11-30 11-07-37](https://github.com/raysan5/raylib/assets/21238398/ca3a2404-93ce-481d-89ef-c31750bdefae)

This breaks when the angle between two consecutive line segments is close to 0° (works fine when it's 180° though), so I'm not sure it should stay as a replacement to DrawSplineLinear, but a DrawSplineLinearMitered could maybe be created instead ?

I feel like the usual use case is to have reasonably small angles, in order to draw arbitrary, nice-looking lines, but this is probably not worth breaking existing code. 

Let me know what you think!