### PR TITLE
Expose OpenGL take 2

### DIFF
--- a/src/rlgl.h
+++ b/src/rlgl.h
@@ -777,6 +777,7 @@ RLAPI void rlLoadDrawQuad(void);     // Load and draw a quad
 
 // Expose OpenGL functions from glad in raylib
 #if defined(BUILD_LIBTYPE_SHARED)
+    #define GLAD_API_CALL_EXPORT
     #define GLAD_API_CALL_EXPORT_BUILD
 #endif
 


### PR DESCRIPTION
For some reason, there are actually two macros needed to control this.
Yes, I tried with only one, both are needed.

Sorry for the iterations...