### PR TITLE
Fix cmake-built libraylib.a to properly include GLFW's object files

### DIFF
--- a/cmake/GlfwImport.cmake
+++ b/cmake/GlfwImport.cmake
@@ -17,7 +17,7 @@ if(NOT glfw3_FOUND AND NOT USE_EXTERNAL_GLFW STREQUAL "ON" AND "${PLATFORM}" MAT
     set(GLFW_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
     set(GLFW_INSTALL OFF CACHE BOOL "" FORCE)
     set(GLFW_USE_WAYLAND ${USE_WAYLAND} CACHE BOOL "" FORCE)
-    set(GLFW_LIBRARY_TYPE "STATIC" CACHE STRING "" FORCE)
+    set(GLFW_LIBRARY_TYPE "OBJECT" CACHE STRING "" FORCE)
     
 
     add_subdirectory(external/glfw)
@@ -27,6 +27,7 @@ if(NOT glfw3_FOUND AND NOT USE_EXTERNAL_GLFW STREQUAL "ON" AND "${PLATFORM}" MAT
         set_property(TARGET glfw PROPERTY C_VISIBILITY_PRESET hidden)
     endif()
     
+    list(APPEND raylib_sources $<TARGET_OBJECTS:glfw>)
     include_directories(BEFORE SYSTEM external/glfw/include)
 elseif("${PLATFORM}" STREQUAL "DRM")
     MESSAGE(STATUS "No GLFW required on PLATFORM_DRM")


### PR DESCRIPTION
I broke this in PR #3573 by accidentally removing too much

The examples still compiled fine so I didn't notice - my guess is that cmake was still adding a separate link to glfw manually.

