### PR TITLE
[rcore] Fix `GetKeyPressed()` and `GetCharPressed()` for `PLATFORM_DESKTOP_SDL`

### DIFF
--- a/src/platforms/rcore_desktop_sdl.c
+++ b/src/platforms/rcore_desktop_sdl.c
@@ -1110,6 +1110,25 @@ void PollInputEvents(void)
                 if (key != KEY_NULL) CORE.Input.Keyboard.currentKeyState[key] = 0;
             } break;
 
+            case SDL_TEXTINPUT:
+            {
+                // Check if there is space available in the key queue
+                if (CORE.Input.Keyboard.keyPressedQueueCount < MAX_KEY_PRESSED_QUEUE)
+                {
+                    // Add character to the queue
+                    CORE.Input.Keyboard.keyPressedQueue[CORE.Input.Keyboard.keyPressedQueueCount] = event.text.text[0];
+                    CORE.Input.Keyboard.keyPressedQueueCount++;
+                }
+
+                // Check if there is space available in the queue
+                if (CORE.Input.Keyboard.charPressedQueueCount < MAX_CHAR_PRESSED_QUEUE)
+                {
+                    // Add character to the queue
+                    CORE.Input.Keyboard.charPressedQueue[CORE.Input.Keyboard.charPressedQueueCount] = event.text.text[0];
+                    CORE.Input.Keyboard.charPressedQueueCount++;
+                }
+            } break;
+
             // Check mouse events
             case SDL_MOUSEBUTTONDOWN:
             {


### PR DESCRIPTION
### Changes
1. Fixes `GetKeyPressed()` and `GetCharPressed()` for `PLATFORM_DESKTOP_SDL` by adding the missing handling for `CORE.Input.Keyboard.keyPressedQueue` ([R1115-R1121](https://github.com/raysan5/raylib/pull/3604/files#diff-43fa9fe6c2302f00d9c0b8bcbe58d8ca92ca52e157d5b19a612f90a81c698c12R1115-R1121)) and `CORE.Input.Keyboard.charPressedQueue` ([R1123-R1129](https://github.com/raysan5/raylib/pull/3604/files#diff-43fa9fe6c2302f00d9c0b8bcbe58d8ca92ca52e157d5b19a612f90a81c698c12R1123-R1129)).

2. Due to the way `SDL2` handles text input, it required adding the `SDL_TEXTINPUT` event case ([R1113](https://github.com/raysan5/raylib/pull/3604/files#diff-43fa9fe6c2302f00d9c0b8bcbe58d8ca92ca52e157d5b19a612f90a81c698c12R1113)) to `PollInputEvents()` to access the `text` data field ([doc](https://wiki.libsdl.org/SDL2/SDL_TextInputEvent)).

### Code example
- This change can be tested with the `text_input_box.c` [example](https://github.com/raysan5/raylib/blob/master/examples/text/text_input_box.c).

### Environment
- Tested successfully on `Linux` (Mint 21.1 64-bit) with `SDL2` (2.28.4).

### Edits
- **1:** added line marks.
- **2:** formatting.