### PR TITLE
[core] Fix IsMouseButtonUp for PLATFORM_DESKTOP

### DIFF
--- a/src/platforms/rcore_desktop.c
+++ b/src/platforms/rcore_desktop.c
@@ -1739,7 +1739,8 @@ static void MouseButtonCallback(GLFWwindow *window, int button, int action, int 
     // WARNING: GLFW could only return GLFW_PRESS (1) or GLFW_RELEASE (0) for now,
     // but future releases may add more actions (i.e. GLFW_REPEAT)
     CORE.Input.Mouse.currentButtonState[button] = action;
-
+    CORE.Input.Touch.currentTouchState[button] = action;
+    
 #if defined(SUPPORT_GESTURES_SYSTEM) && defined(SUPPORT_MOUSE_GESTURES)
     // Process mouse events as touches to be able to use mouse-gestures
     GestureEvent gestureEvent = { 0 };


### PR DESCRIPTION
Fixes #3606

CORE.Input.Touch.currentTouchState[button] was never being set, causing a the `up` value in `IsMouseButtonUp()` to be overridden as `true` constantly.