### PR TITLE
[rcore] Fix real touch gestures for `PLATFORM_DESKTOP_SDL`

### DIFF
--- a/src/platforms/rcore_desktop_sdl.c
+++ b/src/platforms/rcore_desktop_sdl.c
@@ -1186,10 +1186,10 @@ void PollInputEvents(void)
             // NOTE: These cases need to be reviewed on a real touch screen
             case SDL_FINGERDOWN:
             {
-                CORE.Input.Touch.currentTouchState[(int)event.tfinger.fingerId] = 1;
-
-                CORE.Input.Touch.position[(int)event.tfinger.fingerId].x = event.tfinger.x * CORE.Window.screen.width;
-                CORE.Input.Touch.position[(int)event.tfinger.fingerId].y = event.tfinger.y * CORE.Window.screen.height;
+                const int touchId = (int)event.tfinger.fingerId;
+                CORE.Input.Touch.currentTouchState[touchId] = 1;
+                CORE.Input.Touch.position[touchId].x = event.tfinger.x * CORE.Window.screen.width;
+                CORE.Input.Touch.position[touchId].y = event.tfinger.y * CORE.Window.screen.height;
 
                 touchAction = 1;
                 gestureUpdate = true;
@@ -1197,10 +1197,10 @@ void PollInputEvents(void)
             } break;
             case SDL_FINGERUP:
             {
-                CORE.Input.Touch.currentTouchState[(int)event.tfinger.fingerId] = 0;
-
-                CORE.Input.Touch.position[(int)event.tfinger.fingerId].x = event.tfinger.x * CORE.Window.screen.width;
-                CORE.Input.Touch.position[(int)event.tfinger.fingerId].y = event.tfinger.y * CORE.Window.screen.height;
+                const int touchId = (int)event.tfinger.fingerId;
+                CORE.Input.Touch.currentTouchState[touchId] = 0;
+                CORE.Input.Touch.position[touchId].x = event.tfinger.x * CORE.Window.screen.width;
+                CORE.Input.Touch.position[touchId].y = event.tfinger.y * CORE.Window.screen.height;
 
                 touchAction = 0;
                 gestureUpdate = true;
@@ -1208,8 +1208,9 @@ void PollInputEvents(void)
             } break;
             case SDL_FINGERMOTION:
             {
-                CORE.Input.Touch.position[(int)event.tfinger.fingerId].x = event.tfinger.x * CORE.Window.screen.width;
-                CORE.Input.Touch.position[(int)event.tfinger.fingerId].y = event.tfinger.y * CORE.Window.screen.height;
+                const int touchId = (int)event.tfinger.fingerId;
+                CORE.Input.Touch.position[touchId].x = event.tfinger.x * CORE.Window.screen.width;
+                CORE.Input.Touch.position[touchId].y = event.tfinger.y * CORE.Window.screen.height;
 
                 touchAction = 2;
                 gestureUpdate = true;

--- a/src/platforms/rcore_desktop_sdl.c
+++ b/src/platforms/rcore_desktop_sdl.c
@@ -996,7 +996,6 @@ void PollInputEvents(void)
     CORE.Input.Touch.position[0] = CORE.Input.Mouse.currentPosition;
 
     int touchAction = -1;       // 0-TOUCH_ACTION_UP, 1-TOUCH_ACTION_DOWN, 2-TOUCH_ACTION_MOVE
-    bool gestureUpdate = false; // Flag to note gestures require to update
     bool realTouch = false;     // Flag to differentiate real touch gestures from mouse ones
 
     // Register previous keys states
@@ -1142,7 +1141,6 @@ void PollInputEvents(void)
                 CORE.Input.Touch.currentTouchState[btn] = 1;
 
                 touchAction = 1;
-                gestureUpdate = true;
             } break;
             case SDL_MOUSEBUTTONUP:
             {
@@ -1156,7 +1154,6 @@ void PollInputEvents(void)
                 CORE.Input.Touch.currentTouchState[btn] = 0;
 
                 touchAction = 0;
-                gestureUpdate = true;
             } break;
             case SDL_MOUSEWHEEL:
             {
@@ -1179,7 +1176,6 @@ void PollInputEvents(void)
 
                 CORE.Input.Touch.position[0] = CORE.Input.Mouse.currentPosition;
                 touchAction = 2;
-                gestureUpdate = true;
             } break;
 
             // Check touch events
@@ -1192,7 +1188,6 @@ void PollInputEvents(void)
                 CORE.Input.Touch.position[touchId].y = event.tfinger.y * CORE.Window.screen.height;
 
                 touchAction = 1;
-                gestureUpdate = true;
                 realTouch = true;
             } break;
             case SDL_FINGERUP:
@@ -1203,7 +1198,6 @@ void PollInputEvents(void)
                 CORE.Input.Touch.position[touchId].y = event.tfinger.y * CORE.Window.screen.height;
 
                 touchAction = 0;
-                gestureUpdate = true;
                 realTouch = true;
             } break;
             case SDL_FINGERMOTION:
@@ -1213,7 +1207,6 @@ void PollInputEvents(void)
                 CORE.Input.Touch.position[touchId].y = event.tfinger.y * CORE.Window.screen.height;
 
                 touchAction = 2;
-                gestureUpdate = true;
                 realTouch = true;
             } break;
 
@@ -1239,7 +1232,7 @@ void PollInputEvents(void)
         }
 
 #if defined(SUPPORT_GESTURES_SYSTEM)
-        if (gestureUpdate)
+        if (touchAction > -1)
         {
             // Process mouse events as touches to be able to use mouse-gestures
             GestureEvent gestureEvent = { 0 };

--- a/src/platforms/rcore_desktop_sdl.c
+++ b/src/platforms/rcore_desktop_sdl.c
@@ -996,6 +996,7 @@ void PollInputEvents(void)
     CORE.Input.Touch.position[0] = CORE.Input.Mouse.currentPosition;
 
     int touchAction = -1;       // 0-TOUCH_ACTION_UP, 1-TOUCH_ACTION_DOWN, 2-TOUCH_ACTION_MOVE
+    bool gestureUpdate = false; // Flag to note gestures require to update
     bool realTouch = false;     // Flag to differentiate real touch gestures from mouse ones
 
     // Register previous keys states
@@ -1141,6 +1142,7 @@ void PollInputEvents(void)
                 CORE.Input.Touch.currentTouchState[btn] = 1;
 
                 touchAction = 1;
+                gestureUpdate = true;
             } break;
             case SDL_MOUSEBUTTONUP:
             {
@@ -1154,6 +1156,7 @@ void PollInputEvents(void)
                 CORE.Input.Touch.currentTouchState[btn] = 0;
 
                 touchAction = 0;
+                gestureUpdate = true;
             } break;
             case SDL_MOUSEWHEEL:
             {
@@ -1176,6 +1179,7 @@ void PollInputEvents(void)
 
                 CORE.Input.Touch.position[0] = CORE.Input.Mouse.currentPosition;
                 touchAction = 2;
+                gestureUpdate = true;
             } break;
 
             // Check touch events
@@ -1188,6 +1192,7 @@ void PollInputEvents(void)
                 CORE.Input.Touch.position[touchId].y = event.tfinger.y * CORE.Window.screen.height;
 
                 touchAction = 1;
+                gestureUpdate = true;
                 realTouch = true;
             } break;
             case SDL_FINGERUP:
@@ -1198,6 +1203,7 @@ void PollInputEvents(void)
                 CORE.Input.Touch.position[touchId].y = event.tfinger.y * CORE.Window.screen.height;
 
                 touchAction = 0;
+                gestureUpdate = true;
                 realTouch = true;
             } break;
             case SDL_FINGERMOTION:
@@ -1207,6 +1213,7 @@ void PollInputEvents(void)
                 CORE.Input.Touch.position[touchId].y = event.tfinger.y * CORE.Window.screen.height;
 
                 touchAction = 2;
+                gestureUpdate = true;
                 realTouch = true;
             } break;
 
@@ -1232,7 +1239,7 @@ void PollInputEvents(void)
         }
 
 #if defined(SUPPORT_GESTURES_SYSTEM)
-        if (touchAction > -1)
+        if (gestureUpdate)
         {
             // Process mouse events as touches to be able to use mouse-gestures
             GestureEvent gestureEvent = { 0 };
@@ -1256,6 +1263,8 @@ void PollInputEvents(void)
 
             // Gesture data is sent to gestures-system for processing
             ProcessGestureEvent(gestureEvent);
+
+            gestureUpdate = false;
         }
 #endif
     }

--- a/src/platforms/rcore_desktop_sdl.c
+++ b/src/platforms/rcore_desktop_sdl.c
@@ -996,7 +996,6 @@ void PollInputEvents(void)
     CORE.Input.Touch.position[0] = CORE.Input.Mouse.currentPosition;
 
     int touchAction = -1;       // 0-TOUCH_ACTION_UP, 1-TOUCH_ACTION_DOWN, 2-TOUCH_ACTION_MOVE
-    bool gestureUpdate = false; // Flag to note gestures require to update
     bool realTouch = false;     // Flag to differentiate real touch gestures from mouse ones
 
     // Register previous keys states
@@ -1142,7 +1141,6 @@ void PollInputEvents(void)
                 CORE.Input.Touch.currentTouchState[btn] = 1;
 
                 touchAction = 1;
-                gestureUpdate = true;
             } break;
             case SDL_MOUSEBUTTONUP:
             {
@@ -1156,7 +1154,6 @@ void PollInputEvents(void)
                 CORE.Input.Touch.currentTouchState[btn] = 0;
 
                 touchAction = 0;
-                gestureUpdate = true;
             } break;
             case SDL_MOUSEWHEEL:
             {
@@ -1179,7 +1176,6 @@ void PollInputEvents(void)
 
                 CORE.Input.Touch.position[0] = CORE.Input.Mouse.currentPosition;
                 touchAction = 2;
-                gestureUpdate = true;
             } break;
 
             // Check touch events
@@ -1192,7 +1188,6 @@ void PollInputEvents(void)
                 CORE.Input.Touch.position[touchId].y = event.tfinger.y * CORE.Window.screen.height;
 
                 touchAction = 1;
-                gestureUpdate = true;
                 realTouch = true;
             } break;
             case SDL_FINGERUP:
@@ -1203,7 +1198,6 @@ void PollInputEvents(void)
                 CORE.Input.Touch.position[touchId].y = event.tfinger.y * CORE.Window.screen.height;
 
                 touchAction = 0;
-                gestureUpdate = true;
                 realTouch = true;
             } break;
             case SDL_FINGERMOTION:
@@ -1213,7 +1207,6 @@ void PollInputEvents(void)
                 CORE.Input.Touch.position[touchId].y = event.tfinger.y * CORE.Window.screen.height;
 
                 touchAction = 2;
-                gestureUpdate = true;
                 realTouch = true;
             } break;
 
@@ -1239,7 +1232,7 @@ void PollInputEvents(void)
         }
 
 #if defined(SUPPORT_GESTURES_SYSTEM)
-        if (gestureUpdate)
+        if (touchAction > -1)
         {
             // Process mouse events as touches to be able to use mouse-gestures
             GestureEvent gestureEvent = { 0 };
@@ -1264,7 +1257,7 @@ void PollInputEvents(void)
             // Gesture data is sent to gestures-system for processing
             ProcessGestureEvent(gestureEvent);
 
-            gestureUpdate = false;
+            touchAction = -1;
         }
 #endif
     }

--- a/src/platforms/rcore_desktop_sdl.c
+++ b/src/platforms/rcore_desktop_sdl.c
@@ -1253,8 +1253,7 @@ void PollInputEvents(void)
             gestureEvent.pointCount = 1;
 
             // Register touch points position, only one point registered
-            if (realTouch) gestureEvent.position[0] = CORE.Input.Touch.position[0];
-            else if (touchAction == 2) gestureEvent.position[0] = CORE.Input.Touch.position[0];
+            if (touchAction == 2 || realTouch) gestureEvent.position[0] = CORE.Input.Touch.position[0];
             else gestureEvent.position[0] = GetMousePosition();
 
             // Normalize gestureEvent.position[0] for CORE.Window.screen.width and CORE.Window.screen.height
@@ -1417,7 +1416,7 @@ int InitPlatform(void)
 
     // Disable mouse events being interpreted as touch events
     // NOTE: This is wanted because there are SDL_FINGER* events available which provide unique data
-    //       Due to the way rgestures.h is currently implemented, setting this doesn't break SUPPORT_MOUSE_GESTURES
+    //       Due to the way PollInputEvents() and rgestures.h are currently implemented, setting this won't break SUPPORT_MOUSE_GESTURES
     SDL_SetHint(SDL_HINT_TOUCH_MOUSE_EVENTS, "0");
 
     SDL_EventState(SDL_DROPFILE, SDL_ENABLE);


### PR DESCRIPTION
### Changes
1. Fixes/finishes implementing real touch gestures support for `PLATFORM_DESKTOP_SDL`.

2. Does that by complementing the `SDL_FINGERMOTION` ([R1205-R1210](https://github.com/raysan5/raylib/pull/3614/files#diff-43fa9fe6c2302f00d9c0b8bcbe58d8ca92ca52e157d5b19a612f90a81c698c12R1205-R1210)), `SDL_FINGERDOWN` ([R1185-R1191](https://github.com/raysan5/raylib/pull/3614/files#diff-43fa9fe6c2302f00d9c0b8bcbe58d8ca92ca52e157d5b19a612f90a81c698c12R1185-R1191)) and `SDL_FINGERUP` ([R1195-R1201](https://github.com/raysan5/raylib/pull/3614/files#diff-43fa9fe6c2302f00d9c0b8bcbe58d8ca92ca52e157d5b19a612f90a81c698c12R1195-R1201)) implementations, by making them also set the `CORE.Input.Touch.position` and `CORE.Input.Touch.currentTouchState` values. 

3. Also adds a new `realTouch` bool variable on `PollInputEvents()` ([R999](https://github.com/raysan5/raylib/pull/3614/files#diff-43fa9fe6c2302f00d9c0b8bcbe58d8ca92ca52e157d5b19a612f90a81c698c12R999)), necessary to differentiate real touch gestures from mouse ones, to pass the correct `CORE.Input.Touch.position` to the `gestureEvent` ([R1250](https://github.com/raysan5/raylib/pull/3614/files#diff-43fa9fe6c2302f00d9c0b8bcbe58d8ca92ca52e157d5b19a612f90a81c698c12R1250)).

4. Also sets a `SDL` hint (`SDL_HINT_TOUCH_MOUSE_EVENTS`) during `InitPlatform()` ([R1413-R1416](https://github.com/raysan5/raylib/pull/3614/files#diff-43fa9fe6c2302f00d9c0b8bcbe58d8ca92ca52e157d5b19a612f90a81c698c12R1413-R1416)) to disable mouse events being interpreted as touch events. **This is wanted** because there are `SDL_FINGER*` events available which provide unique data ([doc](https://wiki.libsdl.org/SDL2/SDL_TouchFingerEvent)). And, due to the way `PollInputEvents()` and `rgestures.h` are currently implemented, setting this won't break `SUPPORT_MOUSE_GESTURES`.

5. Optimizes the gesture handling by reusing the `touchAction` var ([R1235](https://github.com/raysan5/raylib/pull/3614/files#diff-43fa9fe6c2302f00d9c0b8bcbe58d8ca92ca52e157d5b19a612f90a81c698c12R1235)) instead of the now redundant `gestureUpdate` ([L999](https://github.com/raysan5/raylib/pull/3614/files#diff-43fa9fe6c2302f00d9c0b8bcbe58d8ca92ca52e157d5b19a612f90a81c698c12L999), [L1144](https://github.com/raysan5/raylib/pull/3614/files#diff-43fa9fe6c2302f00d9c0b8bcbe58d8ca92ca52e157d5b19a612f90a81c698c12L1144), [L1158](https://github.com/raysan5/raylib/pull/3614/files#diff-43fa9fe6c2302f00d9c0b8bcbe58d8ca92ca52e157d5b19a612f90a81c698c12L1158), [L1181](https://github.com/raysan5/raylib/pull/3614/files#diff-43fa9fe6c2302f00d9c0b8bcbe58d8ca92ca52e157d5b19a612f90a81c698c12L1181), [L1191](https://github.com/raysan5/raylib/pull/3614/files#diff-43fa9fe6c2302f00d9c0b8bcbe58d8ca92ca52e157d5b19a612f90a81c698c12L1191), [L1198](https://github.com/raysan5/raylib/pull/3614/files#diff-43fa9fe6c2302f00d9c0b8bcbe58d8ca92ca52e157d5b19a612f90a81c698c12L1198), [L1206](https://github.com/raysan5/raylib/pull/3614/files#diff-43fa9fe6c2302f00d9c0b8bcbe58d8ca92ca52e157d5b19a612f90a81c698c12L1206)).

6. Fixes a case where `GESTURE_DRAG` could trigger a `GESTURE_SWIPE*` when it ends by adding a `touchAction` reset on the end of the gesture handling on `PollInputEvents()` ([R1260](https://github.com/raysan5/raylib/pull/3614/files#diff-43fa9fe6c2302f00d9c0b8bcbe58d8ca92ca52e157d5b19a612f90a81c698c12R1260)).

### Notes
- This change lays the groundwork necessary to allow more complex gesture handling for the platform in the future.

### Code example
- This change can be tested with the `core_input_gestures_web.c` [example](https://github.com/raysan5/raylib/blob/master/examples/core/core_input_gestures_web.c) or the `core_input_gestures.c` [example](https://github.com/raysan5/raylib/blob/master/examples/core/core_input_gestures.c).

### Environment
- Tested successfully on `Linux` (Mint 21.1 64-bit) with `SDL2` (2.28.4).

### Edits
- **1:** added line marks.
- **2:** editing.
- **3, 4:** update changes and line marks.