### PR TITLE
Updating CMake version to 5.0 so libraries are correctly versioned

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Setup the project and settings
 project(raylib C)
-set(PROJECT_VERSION 4.5.0)
-set(API_VERSION 450)
+set(PROJECT_VERSION 5.0.0)
+set(API_VERSION 500)
 
 include(GNUInstallDirs)
 include(JoinPaths)


### PR DESCRIPTION
CMakeLists.txt still shows the RayLib version to be 4.5.0.

This PR updates it to 5.0.0

