### PR TITLE
[rcore] Optimize gesture handling for `PLATFORM_DRM`

### DIFF
--- a/src/platforms/rcore_drm.c
+++ b/src/platforms/rcore_drm.c
@@ -612,7 +612,6 @@ void PollInputEvents(void)
         struct input_event event = { 0 };
 
         int touchAction = -1;           // 0-TOUCH_ACTION_UP, 1-TOUCH_ACTION_DOWN, 2-TOUCH_ACTION_MOVE
-        bool gestureUpdate = false;     // Flag to note gestures require to update
 
         // Try to read data from the mouse/touch/gesture and only continue if successful
         while (read(fd, &event, sizeof(event)) == (int)sizeof(event))
@@ -631,7 +630,6 @@ void PollInputEvents(void)
                     CORE.Input.Touch.position[0].x = CORE.Input.Mouse.currentPosition.x;
 
                     touchAction = 2;    // TOUCH_ACTION_MOVE
-                    gestureUpdate = true;
                 }
 
                 if (event.code == REL_Y)
@@ -645,7 +643,6 @@ void PollInputEvents(void)
                     CORE.Input.Touch.position[0].y = CORE.Input.Mouse.currentPosition.y;
 
                     touchAction = 2;    // TOUCH_ACTION_MOVE
-                    gestureUpdate = true;
                 }
 
                 if (event.code == REL_WHEEL) platform.eventWheelMove.y += event.value;
@@ -661,7 +658,6 @@ void PollInputEvents(void)
                     CORE.Input.Touch.position[0].x = (event.value - platform.absRange.x)*CORE.Window.screen.width/platform.absRange.width;        // Scale according to absRange
 
                     touchAction = 2;    // TOUCH_ACTION_MOVE
-                    gestureUpdate = true;
                 }
 
                 if (event.code == ABS_Y)
@@ -670,7 +666,6 @@ void PollInputEvents(void)
                     CORE.Input.Touch.position[0].y = (event.value - platform.absRange.y)*CORE.Window.screen.height/platform.absRange.height;      // Scale according to absRange
 
                     touchAction = 2;    // TOUCH_ACTION_MOVE
-                    gestureUpdate = true;
                 }
 
                 // Multitouch movement
@@ -706,7 +701,6 @@ void PollInputEvents(void)
                         platform.currentButtonStateEvdev[MOUSE_BUTTON_LEFT] = 0;
 
                         touchAction = 0;    // TOUCH_ACTION_UP
-                        gestureUpdate = true;
                     }
 
                     if (event.value && !previousMouseLeftButtonState)
@@ -714,7 +708,6 @@ void PollInputEvents(void)
                         platform.currentButtonStateEvdev[MOUSE_BUTTON_LEFT] = 1;
 
                         touchAction = 1;    // TOUCH_ACTION_DOWN
-                        gestureUpdate = true;
                     }
                 }
 
@@ -730,7 +723,6 @@ void PollInputEvents(void)
 
                     if (event.value > 0) touchAction = 1;   // TOUCH_ACTION_DOWN
                     else touchAction = 0;       // TOUCH_ACTION_UP
-                    gestureUpdate = true;
                 }
 
                 if (event.code == BTN_RIGHT) platform.currentButtonStateEvdev[MOUSE_BUTTON_RIGHT] = event.value;
@@ -759,7 +751,7 @@ void PollInputEvents(void)
             }
 
 #if defined(SUPPORT_GESTURES_SYSTEM)
-            if (gestureUpdate)
+            if (touchAction > -1)
             {
                 GestureEvent gestureEvent = { 0 };
 
@@ -774,7 +766,7 @@ void PollInputEvents(void)
 
                 ProcessGestureEvent(gestureEvent);
 
-                gestureUpdate = false;
+                touchAction = -1;
             }
 #endif
         }


### PR DESCRIPTION
### Changes
1. Optimizes the gesture handling for `PLATFORM_DRM` by reusing the `touchAction` var ([R754](https://github.com/raysan5/raylib/pull/3616/files#diff-757f4c9c5f0be7473e385fa72b35d509c5af4ee2dc8204d2dbe2418bb9b98922R754), [R769](https://github.com/raysan5/raylib/pull/3616/files#diff-757f4c9c5f0be7473e385fa72b35d509c5af4ee2dc8204d2dbe2418bb9b98922R769)) instead of the now redundant `gestureUpdate` ([L615](https://github.com/raysan5/raylib/pull/3616/files#diff-757f4c9c5f0be7473e385fa72b35d509c5af4ee2dc8204d2dbe2418bb9b98922L615), [L634](https://github.com/raysan5/raylib/pull/3616/files#diff-757f4c9c5f0be7473e385fa72b35d509c5af4ee2dc8204d2dbe2418bb9b98922L634), [L648](https://github.com/raysan5/raylib/pull/3616/files#diff-757f4c9c5f0be7473e385fa72b35d509c5af4ee2dc8204d2dbe2418bb9b98922L648), [L664](https://github.com/raysan5/raylib/pull/3616/files#diff-757f4c9c5f0be7473e385fa72b35d509c5af4ee2dc8204d2dbe2418bb9b98922L664), [L673](https://github.com/raysan5/raylib/pull/3616/files#diff-757f4c9c5f0be7473e385fa72b35d509c5af4ee2dc8204d2dbe2418bb9b98922L673), [L709](https://github.com/raysan5/raylib/pull/3616/files#diff-757f4c9c5f0be7473e385fa72b35d509c5af4ee2dc8204d2dbe2418bb9b98922L709), [L717](https://github.com/raysan5/raylib/pull/3616/files#diff-757f4c9c5f0be7473e385fa72b35d509c5af4ee2dc8204d2dbe2418bb9b98922L717), [L733](https://github.com/raysan5/raylib/pull/3616/files#diff-757f4c9c5f0be7473e385fa72b35d509c5af4ee2dc8204d2dbe2418bb9b98922L733)).

### Code example
- This change can be tested with the `core_input_gestures_web.c` [example](https://github.com/raysan5/raylib/blob/master/examples/core/core_input_gestures_web.c) or the `core_input_gestures.c` [example](https://github.com/raysan5/raylib/blob/master/examples/core/core_input_gestures.c).

### Environment
- Tested on Raspberry Pi 3 Model B 1.2 (2015) with `Linux` (Raspberry Pi OS 12 Bookworm 32-bit armhf).

### Edits
- **1:** added line marks; editing.