### PR TITLE
Update audio_stream_effects.c

### DIFF
--- a/examples/audio/audio_stream_effects.c
+++ b/examples/audio/audio_stream_effects.c
@@ -2,7 +2,7 @@
 *
 *   raylib [audio] example - Music stream processing effects
 *
-*   Example originally created with raylib 4.2, last time updated with raylib 4.2
+*   Example originally created with raylib 4.2, last time updated with raylib 5.0
 *
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
@@ -14,6 +14,7 @@
 #include "raylib.h"
 
 #include <stdlib.h>         // Required for: NULL
+#include <stdbool.h>        // Required for: bool
 
 // Required delay effect variables
 static float *delayBuffer = NULL;
@@ -149,13 +150,17 @@ static void AudioProcessEffectLPF(void *buffer, unsigned int frames)
     static const float cutoff = 70.0f / 44100.0f; // 70 Hz lowpass filter
     const float k = cutoff / (cutoff + 0.1591549431f); // RC filter formula
 
+    // Converts the buffer data before using it
+    float * bufferData = (float *)buffer;
     for (unsigned int i = 0; i < frames*2; i += 2)
     {
-        float l = ((float *)buffer)[i], r = ((float *)buffer)[i + 1];
+        const float l = bufferData[i];
+        const float r = bufferData[i + 1];
+
         low[0] += k * (l - low[0]);
         low[1] += k * (r - low[1]);
-        ((float *)buffer)[i] = low[0];
-        ((float *)buffer)[i + 1] = low[1];
+        bufferData[i] = low[0];
+        bufferData[i + 1] = low[1];
     }
 }
 

--- a/examples/audio/audio_stream_effects.c
+++ b/examples/audio/audio_stream_effects.c
@@ -13,8 +13,7 @@
 
 #include "raylib.h"
 
-#include <stdlib.h>         // Required for: NULL
-#include <stdbool.h>        // Required for: bool
+#include <stdlib.h> // Required for: NULL
 
 // Required delay effect variables
 static float *delayBuffer = NULL;
@@ -151,7 +150,7 @@ static void AudioProcessEffectLPF(void *buffer, unsigned int frames)
     const float k = cutoff / (cutoff + 0.1591549431f); // RC filter formula
 
     // Converts the buffer data before using it
-    float * bufferData = (float *)buffer;
+    float *bufferData = (float *)buffer;
     for (unsigned int i = 0; i < frames*2; i += 2)
     {
         const float l = bufferData[i];


### PR DESCRIPTION
This may slightly improve performance and be more welcoming for new users despite being an more advanced feature. `void *` usually throws an error in most compilers and it would be better to just avoid it.

Also added `<stdbool.h>` because booleans are, sometimes, not defined by `<stddef.h>`.