### PR TITLE
[rcore] Complement `SetWindowState()` and `ClearWindowState()` for `PLATFORM_WEB`

### DIFF
--- a/src/platforms/rcore_web.c
+++ b/src/platforms/rcore_web.c
@@ -257,9 +257,10 @@ void SetWindowState(unsigned int flags)
     }
 
     // State change: FLAG_WINDOW_RESIZABLE
-    if ((flags & FLAG_WINDOW_RESIZABLE) > 0)
+    if (((CORE.Window.flags & FLAG_WINDOW_RESIZABLE) != (flags & FLAG_WINDOW_RESIZABLE)) && ((flags & FLAG_WINDOW_RESIZABLE) > 0))
     {
-        TRACELOG(LOG_WARNING, "SetWindowState(FLAG_WINDOW_RESIZABLE) not available yet on target platform");
+        glfwSetWindowAttrib(platform.handle, GLFW_RESIZABLE, GLFW_TRUE);
+        CORE.Window.flags |= FLAG_WINDOW_RESIZABLE;
     }
 
     // State change: FLAG_WINDOW_UNDECORATED
@@ -363,9 +364,10 @@ void ClearWindowState(unsigned int flags)
     }
 
     // State change: FLAG_WINDOW_RESIZABLE
-    if ((flags & FLAG_WINDOW_RESIZABLE) > 0)
+    if (((CORE.Window.flags & FLAG_WINDOW_RESIZABLE) > 0) && ((flags & FLAG_WINDOW_RESIZABLE) > 0))
     {
-        TRACELOG(LOG_WARNING, "ClearWindowState(FLAG_WINDOW_RESIZABLE) not available yet on target platform");
+        glfwSetWindowAttrib(platform.handle, GLFW_RESIZABLE, GLFW_FALSE);
+        CORE.Window.flags &= ~FLAG_WINDOW_RESIZABLE;
     }
 
     // State change: FLAG_WINDOW_HIDDEN

--- a/src/platforms/rcore_web.c
+++ b/src/platforms/rcore_web.c
@@ -235,13 +235,213 @@ void RestoreWindow(void)
 // Set window configuration state using flags
 void SetWindowState(unsigned int flags)
 {
-    TRACELOG(LOG_WARNING, "SetWindowState() not available on target platform");
+    // Check previous state and requested state to apply required changes
+    // NOTE: In most cases the functions already change the flags internally
+
+    // State change: FLAG_VSYNC_HINT
+    if ((flags & FLAG_VSYNC_HINT) > 0)
+    {
+        TRACELOG(LOG_WARNING, "SetWindowState(FLAG_VSYNC_HINT) not available on target platform");
+    }
+
+    // State change: FLAG_BORDERLESS_WINDOWED_MODE
+    if (((CORE.Window.flags & FLAG_BORDERLESS_WINDOWED_MODE) != (flags & FLAG_BORDERLESS_WINDOWED_MODE)) && ((flags & FLAG_BORDERLESS_WINDOWED_MODE) > 0))
+    {
+        ToggleBorderlessWindowed();     // NOTE: Window state flag updated inside function
+    }
+
+    // State change: FLAG_FULLSCREEN_MODE
+    if ((flags & FLAG_FULLSCREEN_MODE) > 0)
+    {
+        TRACELOG(LOG_WARNING, "SetWindowState(FLAG_FULLSCREEN_MODE) not available yet on target platform");
+    }
+
+    // State change: FLAG_WINDOW_RESIZABLE
+    if ((flags & FLAG_WINDOW_RESIZABLE) > 0)
+    {
+        TRACELOG(LOG_WARNING, "SetWindowState(FLAG_WINDOW_RESIZABLE) not available yet on target platform");
+    }
+
+    // State change: FLAG_WINDOW_UNDECORATED
+    if ((flags & FLAG_WINDOW_UNDECORATED) > 0)
+    {
+        TRACELOG(LOG_WARNING, "SetWindowState(FLAG_WINDOW_UNDECORATED) not available on target platform");
+    }
+
+    // State change: FLAG_WINDOW_HIDDEN
+    if ((flags & FLAG_WINDOW_HIDDEN) > 0)
+    {
+        TRACELOG(LOG_WARNING, "SetWindowState(FLAG_WINDOW_HIDDEN) not available on target platform");
+    }
+
+    // State change: FLAG_WINDOW_MINIMIZED
+    if ((flags & FLAG_WINDOW_MINIMIZED) > 0)
+    {
+        TRACELOG(LOG_WARNING, "SetWindowState(FLAG_WINDOW_MINIMIZED) not available on target platform");
+    }
+
+    // State change: FLAG_WINDOW_MAXIMIZED
+    if ((flags & FLAG_WINDOW_MAXIMIZED) > 0)
+    {
+        TRACELOG(LOG_WARNING, "SetWindowState(FLAG_WINDOW_MAXIMIZED) not available on target platform");
+    }
+
+    // State change: FLAG_WINDOW_UNFOCUSED
+    if ((flags & FLAG_WINDOW_UNFOCUSED) > 0)
+    {
+        TRACELOG(LOG_WARNING, "SetWindowState(FLAG_WINDOW_UNFOCUSED) not available on target platform");
+    }
+
+    // State change: FLAG_WINDOW_TOPMOST
+    if ((flags & FLAG_WINDOW_TOPMOST) > 0)
+    {
+        TRACELOG(LOG_WARNING, "SetWindowState(FLAG_WINDOW_TOPMOST) not available on target platform");
+    }
+
+    // State change: FLAG_WINDOW_ALWAYS_RUN
+    if ((flags & FLAG_WINDOW_ALWAYS_RUN) > 0)
+    {
+        TRACELOG(LOG_WARNING, "SetWindowState(FLAG_WINDOW_ALWAYS_RUN) not available on target platform");
+    }
+
+    // The following states can not be changed after window creation
+    // NOTE: Review for PLATFORM_WEB
+
+    // State change: FLAG_WINDOW_TRANSPARENT
+    if ((flags & FLAG_WINDOW_TRANSPARENT) > 0)
+    {
+        TRACELOG(LOG_WARNING, "SetWindowState(FLAG_WINDOW_TRANSPARENT) not available on target platform");
+    }
+
+    // State change: FLAG_WINDOW_HIGHDPI
+    if ((flags & FLAG_WINDOW_HIGHDPI) > 0)
+    {
+        TRACELOG(LOG_WARNING, "SetWindowState(FLAG_WINDOW_HIGHDPI) not available on target platform");
+    }
+
+    // State change: FLAG_WINDOW_MOUSE_PASSTHROUGH
+    if ((flags & FLAG_WINDOW_MOUSE_PASSTHROUGH) > 0)
+    {
+        TRACELOG(LOG_WARNING, "SetWindowState(FLAG_WINDOW_MOUSE_PASSTHROUGH) not available on target platform");
+    }
+
+    // State change: FLAG_MSAA_4X_HINT
+    if ((flags & FLAG_MSAA_4X_HINT) > 0)
+    {
+        TRACELOG(LOG_WARNING, "SetWindowState(FLAG_MSAA_4X_HINT) not available on target platform");
+    }
+
+    // State change: FLAG_INTERLACED_HINT
+    if ((flags & FLAG_INTERLACED_HINT) > 0)
+    {
+        TRACELOG(LOG_WARNING, "SetWindowState(FLAG_INTERLACED_HINT) not available on target platform");
+    }
 }
 
 // Clear window configuration state flags
 void ClearWindowState(unsigned int flags)
 {
-    TRACELOG(LOG_WARNING, "ClearWindowState() not available on target platform");
+    // Check previous state and requested state to apply required changes
+    // NOTE: In most cases the functions already change the flags internally
+
+    // State change: FLAG_VSYNC_HINT
+    if ((flags & FLAG_VSYNC_HINT) > 0)
+    {
+        TRACELOG(LOG_WARNING, "ClearWindowState(FLAG_VSYNC_HINT) not available on target platform");
+    }
+
+    // State change: FLAG_BORDERLESS_WINDOWED_MODE
+    if (((CORE.Window.flags & FLAG_BORDERLESS_WINDOWED_MODE) > 0) && ((flags & FLAG_BORDERLESS_WINDOWED_MODE) > 0))
+    {
+        ToggleBorderlessWindowed();     // NOTE: Window state flag updated inside function
+    }
+
+    // State change: FLAG_FULLSCREEN_MODE
+    if ((flags & FLAG_FULLSCREEN_MODE) > 0)
+    {
+        TRACELOG(LOG_WARNING, "ClearWindowState(FLAG_FULLSCREEN_MODE) not available yet on target platform");
+    }
+
+    // State change: FLAG_WINDOW_RESIZABLE
+    if ((flags & FLAG_WINDOW_RESIZABLE) > 0)
+    {
+        TRACELOG(LOG_WARNING, "ClearWindowState(FLAG_WINDOW_RESIZABLE) not available yet on target platform");
+    }
+
+    // State change: FLAG_WINDOW_HIDDEN
+    if ((flags & FLAG_WINDOW_HIDDEN) > 0)
+    {
+        TRACELOG(LOG_WARNING, "ClearWindowState(FLAG_WINDOW_HIDDEN) not available on target platform");
+    }
+
+    // State change: FLAG_WINDOW_MINIMIZED
+    if ((flags & FLAG_WINDOW_MINIMIZED) > 0)
+    {
+        TRACELOG(LOG_WARNING, "ClearWindowState(FLAG_WINDOW_MINIMIZED) not available on target platform");
+    }
+
+    // State change: FLAG_WINDOW_MAXIMIZED
+    if ((flags & FLAG_WINDOW_MAXIMIZED) > 0)
+    {
+        TRACELOG(LOG_WARNING, "ClearWindowState(FLAG_WINDOW_MAXIMIZED) not available on target platform");
+    }
+
+    // State change: FLAG_WINDOW_UNDECORATED
+    if ((flags & FLAG_WINDOW_UNDECORATED) > 0)
+    {
+        TRACELOG(LOG_WARNING, "ClearWindowState(FLAG_WINDOW_UNDECORATED) not available on target platform");
+    }
+
+    // State change: FLAG_WINDOW_UNFOCUSED
+    if ((flags & FLAG_WINDOW_UNFOCUSED) > 0)
+    {
+        TRACELOG(LOG_WARNING, "ClearWindowState(FLAG_WINDOW_UNFOCUSED) not available on target platform");
+    }
+
+    // State change: FLAG_WINDOW_TOPMOST
+    if ((flags & FLAG_WINDOW_TOPMOST) > 0)
+    {
+        TRACELOG(LOG_WARNING, "ClearWindowState(FLAG_WINDOW_TOPMOST) not available on target platform");
+    }
+
+    // State change: FLAG_WINDOW_ALWAYS_RUN
+    if ((flags & FLAG_WINDOW_ALWAYS_RUN) > 0)
+    {
+        TRACELOG(LOG_WARNING, "ClearWindowState(FLAG_WINDOW_ALWAYS_RUN) not available on target platform");
+    }
+
+    // The following states can not be changed after window creation
+    // NOTE: Review for PLATFORM_WEB
+
+    // State change: FLAG_WINDOW_TRANSPARENT
+    if ((flags & FLAG_WINDOW_TRANSPARENT) > 0)
+    {
+        TRACELOG(LOG_WARNING, "ClearWindowState(FLAG_WINDOW_TRANSPARENT) not available on target platform");
+    }
+
+    // State change: FLAG_WINDOW_HIGHDPI
+    if ((flags & FLAG_WINDOW_HIGHDPI) > 0)
+    {
+        TRACELOG(LOG_WARNING, "ClearWindowState(FLAG_WINDOW_HIGHDPI) not available on target platform");
+    }
+
+    // State change: FLAG_WINDOW_MOUSE_PASSTHROUGH
+    if ((flags & FLAG_WINDOW_MOUSE_PASSTHROUGH) > 0)
+    {
+        TRACELOG(LOG_WARNING, "ClearWindowState(FLAG_WINDOW_MOUSE_PASSTHROUGH) not available on target platform");
+    }
+
+    // State change: FLAG_MSAA_4X_HINT
+    if ((flags & FLAG_MSAA_4X_HINT) > 0)
+    {
+        TRACELOG(LOG_WARNING, "ClearWindowState(FLAG_MSAA_4X_HINT) not available on target platform");
+    }
+
+    // State change: FLAG_INTERLACED_HINT
+    if ((flags & FLAG_INTERLACED_HINT) > 0)
+    {
+        TRACELOG(LOG_WARNING, "ClearWindowState(FLAG_INTERLACED_HINT) not available on target platform");
+    }
 }
 
 // Set icon for window


### PR DESCRIPTION
### Changes
1. Complements the implementation of `SetWindowState()` ([R238-R338](https://github.com/raysan5/raylib/pull/3625/files#diff-14c6a8a6962cf65222635a523e877bbaa1f07b791028685f92bf6b44d87530d7R238-R338)) and `ClearWindowState()` ([R344-R444](https://github.com/raysan5/raylib/pull/3625/files#diff-14c6a8a6962cf65222635a523e877bbaa1f07b791028685f92bf6b44d87530d7R344-R444)) for `PLATFORM_WEB`.
2. Adds the basic structure for handling more flags on `PLATFORM_WEB` (if supported) in the future.
3. Adds handling for `FLAG_BORDERLESS_WINDOWED_MODE` ([R248-R251](https://github.com/raysan5/raylib/pull/3625/files#diff-14c6a8a6962cf65222635a523e877bbaa1f07b791028685f92bf6b44d87530d7R248-R251), [R354-R358](https://github.com/raysan5/raylib/pull/3625/files#diff-14c6a8a6962cf65222635a523e877bbaa1f07b791028685f92bf6b44d87530d7R354-R358)).
4. Adds handling for `FLAG_WINDOW_RESIZABLE` ([R260-R264](https://github.com/raysan5/raylib/pull/3625/files#diff-14c6a8a6962cf65222635a523e877bbaa1f07b791028685f92bf6b44d87530d7R260-R264), [R367-R371](https://github.com/raysan5/raylib/pull/3625/files#diff-14c6a8a6962cf65222635a523e877bbaa1f07b791028685f92bf6b44d87530d7R367-R371)).

### Reference
- This change is also complementary to #3622.

### Code example
- This change can be tested for `PLATFORM_WEB` (requires `ASYNCIFY`) with:

```
#include "raylib.h"

int main(void) {
    InitWindow(800, 450, "test");
    SetTargetFPS(60);
    while (!WindowShouldClose()) {

        if (IsKeyPressed(KEY_ONE)) SetWindowState(FLAG_BORDERLESS_WINDOWED_MODE);
        if (IsKeyPressed(KEY_TWO)) ClearWindowState(FLAG_BORDERLESS_WINDOWED_MODE);

        BeginDrawing();
        ClearBackground(RAYWHITE);
        DrawText("Test", 20, 20, 20, BLACK);
        EndDrawing();
    }
    CloseWindow();
    return 0;
}
```

### Environment

- Compiled on `Linux` (Ubuntu 22.04 64-bit) and tested on `Firefox` (115.3.1esr 64-bit) and `Chromium` (117.0.5938.149 64-bit) for both `minshell.html` and `shell.html` files.

### Edits
- **1:** added line marks.
- **2:** update changes.