### PR TITLE
Ignore compiled `DLL` binaries.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ packages/
 *.bc
 *.so
 *.so.*
+*.dll
 
 # Ignore wasm data in examples/
 examples/**/*.wasm


### PR DESCRIPTION
I build Raylib as a share lib on Windows. Compiled `DLL` binaries should be Ignored.