### PR TITLE
Fix box blur symmetry & simplify code

### DIFF
--- a/src/rtextures.c
+++ b/src/rtextures.c
@@ -1959,29 +1959,24 @@ void ImageBlurGaussian(Image *image, int blurSize) {
             float avgG = 0.0f;
             float avgB = 0.0f;
             float avgAlpha = 0.0f;
-            int convolutionSize = blurSize+1;
+            int convolutionSize = blurSize;
 
-            for (int i = 0; i < blurSize+1; i++)
+            for (int i = 0; i < blurSize; i++)
             {
                 avgR += pixelsCopy1[row*image->width + i].x;
                 avgG += pixelsCopy1[row*image->width + i].y;
                 avgB += pixelsCopy1[row*image->width + i].z;
                 avgAlpha += pixelsCopy1[row*image->width + i].w;
-            }
+			}
 
-            pixelsCopy2[row*image->width].x = avgR/convolutionSize;
-            pixelsCopy2[row*image->width].y = avgG/convolutionSize;
-            pixelsCopy2[row*image->width].z = avgB/convolutionSize;
-            pixelsCopy2[row*image->width].w = avgAlpha/convolutionSize;
-
-            for (int x = 1; x < image->width; x++)
+            for (int x = 0; x < image->width; x++)
             {
-                if (x-blurSize >= 0)
+                if (x-blurSize-1 >= 0)
                 {
-                    avgR -= pixelsCopy1[row*image->width + x-blurSize].x;
-                    avgG -= pixelsCopy1[row*image->width + x-blurSize].y;
-                    avgB -= pixelsCopy1[row*image->width + x-blurSize].z;
-                    avgAlpha -= pixelsCopy1[row*image->width + x-blurSize].w;
+                    avgR -= pixelsCopy1[row*image->width + x-blurSize-1].x;
+                    avgG -= pixelsCopy1[row*image->width + x-blurSize-1].y;
+                    avgB -= pixelsCopy1[row*image->width + x-blurSize-1].z;
+                    avgAlpha -= pixelsCopy1[row*image->width + x-blurSize-1].w;
                     convolutionSize--;
                 }
 
@@ -1999,7 +1994,7 @@ void ImageBlurGaussian(Image *image, int blurSize) {
                 pixelsCopy2[row*image->width + x].z = avgB/convolutionSize;
                 pixelsCopy2[row*image->width + x].w = avgAlpha/convolutionSize;
             }
-                }
+        }
 
         // Vertical motion blur
         for (int col = 0; col < image->width; col++)
@@ -2008,9 +2003,9 @@ void ImageBlurGaussian(Image *image, int blurSize) {
             float avgG = 0.0f;
             float avgB = 0.0f;
             float avgAlpha = 0.0f;
-            int convolutionSize = blurSize+1;
+            int convolutionSize = blurSize;
 
-            for (int i = 0; i < blurSize+1; i++)
+            for (int i = 0; i < blurSize; i++)
             {
                 avgR += pixelsCopy2[i*image->width + col].x;
                 avgG += pixelsCopy2[i*image->width + col].y;
@@ -2018,19 +2013,14 @@ void ImageBlurGaussian(Image *image, int blurSize) {
                 avgAlpha += pixelsCopy2[i*image->width + col].w;
             }
 
-            pixelsCopy1[col].x = (unsigned char) (avgR/convolutionSize);
-            pixelsCopy1[col].y = (unsigned char) (avgG/convolutionSize);
-            pixelsCopy1[col].z = (unsigned char) (avgB/convolutionSize);
-            pixelsCopy1[col].w = (unsigned char) (avgAlpha/convolutionSize);
-
-            for (int y = 1; y < image->height; y++)
+            for (int y = 0; y < image->height; y++)
             {
-                if (y-blurSize >= 0)
+                if (y-blurSize-1 >= 0)
                 {
-                    avgR -= pixelsCopy2[(y-blurSize)*image->width + col].x;
-                    avgG -= pixelsCopy2[(y-blurSize)*image->width + col].y;
-                    avgB -= pixelsCopy2[(y-blurSize)*image->width + col].z;
-                    avgAlpha -= pixelsCopy2[(y-blurSize)*image->width + col].w;
+                    avgR -= pixelsCopy2[(y-blurSize-1)*image->width + col].x;
+                    avgG -= pixelsCopy2[(y-blurSize-1)*image->width + col].y;
+                    avgB -= pixelsCopy2[(y-blurSize-1)*image->width + col].z;
+                    avgAlpha -= pixelsCopy2[(y-blurSize-1)*image->width + col].w;
                     convolutionSize--;
                 }
                 if (y+blurSize < image->height)


### PR DESCRIPTION
Previous version of box blur kernel was asymmetrical, because the leftmost and topmost pixels were subtracted from the average values too early, causing the image to offset by GAUSSIAN_BLUR_ITERATIONS pixels after blurring. You can see this at the rightmost and bottommost borders of the image. This commit fixes this bug.

|Original image|Old box blur|Fixed box blur|
|-|-|-|
|![image](https://github.com/raysan5/raylib/assets/33938415/7a144a1a-7188-4591-965a-ec03dd19d594)|![image](https://github.com/raysan5/raylib/assets/33938415/7ea67fd8-71a6-4537-8f45-24573fa2a50b)|![image](https://github.com/raysan5/raylib/assets/33938415/057ea9a5-0c7e-4d39-afa5-975a82f03978)|

Image is also a bit more blurry now since the blur kernel is now 1 pixel wider.
PS. Perhaps GAUSSIAN_BLUR_ITERATIONS could be a function argument rather than a predefined value?