### PR TITLE
[rcore] Remove unused vScreenCenter

### DIFF
--- a/examples/core/core_vr_simulator.c
+++ b/examples/core/core_vr_simulator.c
@@ -39,7 +39,6 @@ int main(void)
         .vResolution = 1200,                 // Vertical resolution in pixels
         .hScreenSize = 0.133793f,            // Horizontal size in meters
         .vScreenSize = 0.0669f,              // Vertical size in meters
-        .vScreenCenter = 0.04678f,           // Screen center in meters
         .eyeToScreenDistance = 0.041f,       // Distance between eye and display in meters
         .lensSeparationDistance = 0.07f,     // Lens separation distance in meters
         .interpupillaryDistance = 0.07f,     // IPD (distance between pupils) in meters

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -484,7 +484,6 @@ typedef struct VrDeviceInfo {
     int vResolution;                // Vertical resolution in pixels
     float hScreenSize;              // Horizontal size in meters
     float vScreenSize;              // Vertical size in meters
-    float vScreenCenter;            // Screen center in meters
     float eyeToScreenDistance;      // Distance between eye and display in meters
     float lensSeparationDistance;   // Lens separation distance in meters
     float interpupillaryDistance;   // IPD (distance between pupils) in meters


### PR DESCRIPTION
It looks like the `vScreenCenter` member in the `VrDeviceInfo` struct is never used in code. Thus this pull requests removes it.