### PR TITLE
[rcore] Flip VR screens

### DIFF
--- a/src/rcore.c
+++ b/src/rcore.c
@@ -1192,8 +1192,8 @@ VrStereoConfig LoadVrStereoConfig(VrDeviceInfo device)
         // NOTE: Camera movement might seem more natural if we model the head.
         // Our axis of rotation is the base of our head, so we might want to add
         // some y (base of head to eye level) and -z (center of head to eye protrusion) to the camera positions.
-        config.viewOffset[0] = MatrixTranslate(-device.interpupillaryDistance*0.5f, 0.075f, 0.045f);
-        config.viewOffset[1] = MatrixTranslate(device.interpupillaryDistance*0.5f, 0.075f, 0.045f);
+        config.viewOffset[0] = MatrixTranslate(device.interpupillaryDistance*0.5f, 0.075f, 0.045f);
+        config.viewOffset[1] = MatrixTranslate(-device.interpupillaryDistance*0.5f, 0.075f, 0.045f);
 
         // Compute eyes Viewports
         /*


### PR DESCRIPTION
The left and right screens when calling `LoadVrStereoConfig` is flipped. This pull request simply flips them back to the correct configuration.