### PR TITLE
Make centering clearer in 'Texture source and destination rectangles' example

### DIFF
--- a/examples/textures/textures_srcrec_dstrec.c
+++ b/examples/textures/textures_srcrec_dstrec.c
@@ -39,7 +39,7 @@ int main(void)
     Rectangle destRec = { screenWidth/2.0f, screenHeight/2.0f, frameWidth*2.0f, frameHeight*2.0f };
 
     // Origin of the texture (rotation/scale point), it's relative to destination rectangle size
-    Vector2 origin = { (float)frameWidth, (float)frameHeight };
+    Vector2 origin = { destRec.width/2, destRec.height/2 };
 
     int rotation = 0;
 


### PR DESCRIPTION
When trying to center a sprite using DrawTexturePro(), it can be done by setting the origin vector to be half the width and height of the destination rectangle. In the example, it is simply set to the original frame width and height. This works, but only because destRec is twice the size of the original. In my opinion it would be clearer for new users if origin was defined as half the size of destRec, as that works regardless of how much you scale destRec.