### PR TITLE
[rcore] Add `GetMonitorWidth()` and `GetMonitorHeight()` implementations for `PLATFORM_WEB`

### DIFF
--- a/src/platforms/rcore_web.c
+++ b/src/platforms/rcore_web.c
@@ -572,15 +572,17 @@ Vector2 GetMonitorPosition(int monitor)
 // Get selected monitor width (currently used by monitor)
 int GetMonitorWidth(int monitor)
 {
-    TRACELOG(LOG_WARNING, "GetMonitorWidth() not implemented on target platform");
-    return 0;
+    int w = 0;
+    w = EM_ASM_INT( { return screen.width; }, 0);
+    return w;
 }
 
 // Get selected monitor height (currently used by monitor)
 int GetMonitorHeight(int monitor)
 {
-    TRACELOG(LOG_WARNING, "GetMonitorHeight() not implemented on target platform");
-    return 0;
+    int h = 0;
+    h = EM_ASM_INT( { return screen.height; }, 0);
+    return h;
 }
 
 // Get selected monitor physical width in millimetres
@@ -946,7 +948,7 @@ int InitPlatform(void)
 
     // NOTE: Some GLFW flags are not supported on HTML5
     // e.g.: GLFW_TRANSPARENT_FRAMEBUFFER, GLFW_COCOA_RETINA_FRAMEBUFFER, GLFW_MOUSE_PASSTHROUGH
-    
+
     // Scale content area based on the monitor content scale where window is placed on
     // NOTE: This feature requires emscripten 3.1.51
     //if ((CORE.Window.flags & FLAG_WINDOW_HIGHDPI) > 0) glfwWindowHint(GLFW_SCALE_TO_MONITOR, GLFW_TRUE);


### PR DESCRIPTION
### Changes
1. Adds implementation for `GetMonitorWidth()` and `GetMonitorHeight()` that were missing for `PLATFORM_WEB`. Does that by using `emscripten` `EM_ASM_INT` and `DOM` `screen.width` ([R575-R577](https://github.com/raysan5/raylib/pull/3636/files#diff-14c6a8a6962cf65222635a523e877bbaa1f07b791028685f92bf6b44d87530d7R575-R577)) and `screen.height` ([R583-R585](https://github.com/raysan5/raylib/pull/3636/files#diff-14c6a8a6962cf65222635a523e877bbaa1f07b791028685f92bf6b44d87530d7R583-R585)).

### Notes
- Returned values are limited to the current monitor where the browser window is located.

### Code example
- This change can be tested for `PLATFORM_WEB` (requires `ASYNCIFY`) with:

```
#include "raylib.h"

int main(void) {
    InitWindow(800, 450, "test");
    SetTargetFPS(60);
    while (!WindowShouldClose()) {
        BeginDrawing();
        ClearBackground(RAYWHITE);
        DrawText(TextFormat("Monitor width: %i", GetMonitorWidth(0)), 20, 20, 20, BLACK);
        DrawText(TextFormat("Monitor height: %i", GetMonitorHeight(0)), 20, 40, 20, BLACK);
        EndDrawing();
    }
    CloseWindow();
    return 0;
}
```

### Environment
- Compiled on `Linux` (Ubuntu 22.04 64-bit) and tested on `Firefox` (115.3.1esr 64-bit) and `Chromium` (117.0.5938.149 64-bit) for both `minshell.html` and `shell.html` files.

### Edits
- **1:** added line marks, formatting.