### PR TITLE
[rcore] Add `GetWindowPosition()` implementation for `PLATFORM_WEB` and fixes #3636 style/format

### DIFF
--- a/src/platforms/rcore_web.c
+++ b/src/platforms/rcore_web.c
@@ -620,8 +620,8 @@ Vector2 GetWindowPosition(void)
 {
     // NOTE: Returned position is relative to the current monitor where the browser window is located
     Vector2 position = { 0, 0 };
-    position.x = (float)EM_ASM_INT( { return window.screenX;  }, 0);
-    position.y = (float)EM_ASM_INT( { return window.screenY;  }, 0);
+    position.x = (float)EM_ASM_INT( { return window.screenX; }, 0);
+    position.y = (float)EM_ASM_INT( { return window.screenY; }, 0);
     return position;
 }
 

--- a/src/platforms/rcore_web.c
+++ b/src/platforms/rcore_web.c
@@ -572,17 +572,19 @@ Vector2 GetMonitorPosition(int monitor)
 // Get selected monitor width (currently used by monitor)
 int GetMonitorWidth(int monitor)
 {
-    int w = 0;
-    w = EM_ASM_INT( { return screen.width; }, 0);
-    return w;
+    // NOTE: Returned value is limited to the current monitor where the browser window is located
+    int width = 0;
+    width = EM_ASM_INT( { return screen.width; }, 0);
+    return width;
 }
 
 // Get selected monitor height (currently used by monitor)
 int GetMonitorHeight(int monitor)
 {
-    int h = 0;
-    h = EM_ASM_INT( { return screen.height; }, 0);
-    return h;
+    // NOTE: Returned value is limited to the current monitor where the browser window is located
+    int height = 0;
+    height = EM_ASM_INT( { return screen.height; }, 0);
+    return height;
 }
 
 // Get selected monitor physical width in millimetres
@@ -616,8 +618,11 @@ const char *GetMonitorName(int monitor)
 // Get window position XY on monitor
 Vector2 GetWindowPosition(void)
 {
-    TRACELOG(LOG_WARNING, "GetWindowPosition() not implemented on target platform");
-    return (Vector2){ 0, 0 };
+    // NOTE: Returned position is relative to the current monitor where the browser window is located
+    Vector2 position = { 0, 0 };
+    position.x = (float)EM_ASM_INT( { return window.screenX;  }, 0);
+    position.y = (float)EM_ASM_INT( { return window.screenY;  }, 0);
+    return position;
 }
 
 // Get window scale DPI factor for current monitor


### PR DESCRIPTION
### Changes
1. Adds implementation for `GetWindowPosition()` that was missing for `PLATFORM_WEB`. Does that by using `emscripten` `EM_ASM_INT` and `DOM` `window.screenX` and `window.screenY` ([R621-R625](https://github.com/raysan5/raylib/pull/3637/files#diff-14c6a8a6962cf65222635a523e877bbaa1f07b791028685f92bf6b44d87530d7R621-R625)).

2. Fixes #3636 style/format to match the pattern generally used on `raylib`. Does that by changing `w` to `width` ([R576-R578](https://github.com/raysan5/raylib/pull/3637/files#diff-14c6a8a6962cf65222635a523e877bbaa1f07b791028685f92bf6b44d87530d7R576-R578)), `h` to `height` ([R585-R587](https://github.com/raysan5/raylib/pull/3637/files#diff-14c6a8a6962cf65222635a523e877bbaa1f07b791028685f92bf6b44d87530d7R585-R587)) and adding relevant notes ([R575](https://github.com/raysan5/raylib/pull/3637/files#diff-14c6a8a6962cf65222635a523e877bbaa1f07b791028685f92bf6b44d87530d7R575), [R584](https://github.com/raysan5/raylib/pull/3637/files#diff-14c6a8a6962cf65222635a523e877bbaa1f07b791028685f92bf6b44d87530d7R584)). My apologies for missing the code style/convention on the previous PR.

### Notes
- Returned position of `GetWindowPosition()` is relative to the current monitor where the browser window is located.

### Code example
- This change can be tested for `PLATFORM_WEB` (requires `ASYNCIFY`) with:

```
#include "raylib.h"

int main(void) {
    InitWindow(800, 450, "test");
    SetTargetFPS(60);
    while (!WindowShouldClose()) {
        BeginDrawing();
        ClearBackground(RAYWHITE);
        DrawText(TextFormat("Window position: %f x %f", GetWindowPosition().x, GetWindowPosition().y), 20, 20, 20, BLACK);
        EndDrawing();
    }
    CloseWindow();
    return 0;
}
```

### Environment
- Compiled on `Linux` (Ubuntu 22.04 64-bit) and tested on `Firefox` (115.3.1esr 64-bit) and `Chromium` (117.0.5938.149 64-bit) for both `minshell.html` and `shell.html` files.

### Edits
- **1:** added line marks, typo.