### PR TITLE
[rcore] Alternative fix for `CORE.Input.Mouse.cursorHidden` for `PLATFORM_WEB`

### DIFF
--- a/src/platforms/rcore_web.c
+++ b/src/platforms/rcore_web.c
@@ -114,6 +114,7 @@ static EM_BOOL EmscriptenResizeCallback(int eventType, const EmscriptenUiEvent *
 
 // Emscripten input callback events
 static EM_BOOL EmscriptenMouseCallback(int eventType, const EmscriptenMouseEvent *mouseEvent, void *userData);
+static EM_BOOL EmscriptenPointerlockCallback(int eventType, const EmscriptenPointerlockChangeEvent *pointerlockChangeEvent, void *userData);
 static EM_BOOL EmscriptenTouchCallback(int eventType, const EmscriptenTouchEvent *touchEvent, void *userData);
 static EM_BOOL EmscriptenGamepadCallback(int eventType, const EmscriptenGamepadEvent *gamepadEvent, void *userData);
 
@@ -718,7 +719,7 @@ void EnableCursor(void)
     // Set cursor position in the middle
     SetMousePosition(CORE.Window.screen.width/2, CORE.Window.screen.height/2);
 
-    CORE.Input.Mouse.cursorHidden = false;
+    // NOTE: CORE.Input.Mouse.cursorHidden handled by EmscriptenPointerlockCallback()
 }
 
 // Disables cursor (lock cursor)
@@ -730,7 +731,7 @@ void DisableCursor(void)
     // Set cursor position in the middle
     SetMousePosition(CORE.Window.screen.width/2, CORE.Window.screen.height/2);
 
-    CORE.Input.Mouse.cursorHidden = true;
+    // NOTE: CORE.Input.Mouse.cursorHidden handled by EmscriptenPointerlockCallback()
 }
 
 // Swap back buffer with front buffer (screen drawing)
@@ -1204,6 +1205,7 @@ int InitPlatform(void)
 
     // Support mouse events
     emscripten_set_click_callback("#canvas", NULL, 1, EmscriptenMouseCallback);
+    emscripten_set_pointerlockchange_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW, NULL, 1, EmscriptenPointerlockCallback);
 
     // Support touch events
     emscripten_set_touchstart_callback("#canvas", NULL, 1, EmscriptenTouchCallback);
@@ -1519,6 +1521,14 @@ static EM_BOOL EmscriptenResizeCallback(int eventType, const EmscriptenUiEvent *
 static EM_BOOL EmscriptenMouseCallback(int eventType, const EmscriptenMouseEvent *mouseEvent, void *userData)
 {
     // This is only for registering mouse click events with emscripten and doesn't need to do anything
+
+    return 1; // The event was consumed by the callback handler
+}
+
+// Register pointer lock events
+static EM_BOOL EmscriptenPointerlockCallback(int eventType, const EmscriptenPointerlockChangeEvent *pointerlockChangeEvent, void *userData)
+{
+    CORE.Input.Mouse.cursorHidden = EM_ASM_INT( { if (document.pointerLockElement) return 1; }, 0);
 
     return 1; // The event was consumed by the callback handler
 }


### PR DESCRIPTION
### Changes
1. This is an alternative fix for the `CORE.Input.Mouse.cursorHidden` issue reported by @lesleyrs on #3643.

2. IMHO, a better way to handle that issue is through the use of `emscripten`'s `em_pointerlockchange_callback_func` and `EmscriptenPointerlockChangeEvent` ([R117](https://github.com/raysan5/raylib/pull/3644/files#diff-14c6a8a6962cf65222635a523e877bbaa1f07b791028685f92bf6b44d87530d7R117), [R1208](https://github.com/raysan5/raylib/pull/3644/files#diff-14c6a8a6962cf65222635a523e877bbaa1f07b791028685f92bf6b44d87530d7R1208)) callback functions ([doc](https://emscripten.org/docs/api_reference/html5.h.html)). That way, there's no need to change `rcore.c` and the value can be updated internally on `rcore_web.c` when such event happen ([R1528-R1534](https://github.com/raysan5/raylib/pull/3644/files#diff-14c6a8a6962cf65222635a523e877bbaa1f07b791028685f92bf6b44d87530d7R1528-R1534), [R722](https://github.com/raysan5/raylib/pull/3644/files#diff-14c6a8a6962cf65222635a523e877bbaa1f07b791028685f92bf6b44d87530d7R722), [R734](https://github.com/raysan5/raylib/pull/3644/files#diff-14c6a8a6962cf65222635a523e877bbaa1f07b791028685f92bf6b44d87530d7R734)).

### Credit
- Issue found by @lesleyrs at #3643

### Notes
> [!CAUTION]
> Beware that, per spec (https://www.w3.org/TR/pointerlock-2/):
>
> _"A [requestPointerLock](https://www.w3.org/TR/pointerlock-2/#dom-element-requestpointerlock)() call immediately after the [default unlock gesture](https://www.w3.org/TR/pointerlock-2/#dfn-default-unlock-gesture) MUST fail even when [transient activation](https://html.spec.whatwg.org/multipage/interaction.html#transient-activation) is available, to prevent malicious sites from acquiring an unescapable locked state through repeated lock attempts. On the other hand, a [requestPointerLock](https://www.w3.org/TR/pointerlock-2/#dom-element-requestpointerlock)() call immediately after a programmatic lock exit (through a [exitPointerLock](https://www.w3.org/TR/pointerlock-2/#dom-document-exitpointerlock)() call) MUST succeed when [transient activation](https://html.spec.whatwg.org/multipage/interaction.html#transient-activation) is available, to enable applications to move frequently between interaction modes, possibly through a timer or remote network activity."_

> [!IMPORTANT]
> For `Firefox`, after calling `DisableCursor()`, the user has to actively click the `canvas` area to complete the `pointer lock`, as per documentation (https://developer.mozilla.org/en-US/docs/Web/API/Element/requestPointerLock):
>
> _"[Transient activation](https://developer.mozilla.org/en-US/docs/Glossary/Transient_activation) is required when calling requestPointerLock(). The user has to interact with the page or a UI element in order for this feature to work. Also, the target element's associated document must be in the active state."_

### Code example
- This change can be tested for `PLATFORM_WEB` (requires `ASYNCIFY`) with:
```
#include "raylib.h"

int main(void) {
    InitWindow(800, 450, "test");
    SetTargetFPS(60);
    while (!WindowShouldClose()) {

        if (IsKeyPressed(KEY_E)) EnableCursor();
        if (IsKeyPressed(KEY_D)) DisableCursor();

        BeginDrawing();
        ClearBackground(RAYWHITE);

        DrawText("[E] EnableCursor()", 20, 40, 20, BLACK);
        DrawText("[D] DisableCursor()", 20, 20, 20, BLACK);
        DrawText(TextFormat("CORE.Input.Mouse.cursorHidden = %i", IsCursorHidden()), 20, 80, 20, BLACK);

        EndDrawing();
    }
    CloseWindow();
    return 0;
}
```

### Environment
- Compiled on `Linux` (Ubuntu 22.04 64-bit) and tested on `Firefox` (115.3.1esr 64-bit) and `Chromium` (117.0.5938.149 64-bit) for both `minshell.html` and `shell.html` files.

### Edits
- **1:** added line marks.
- **2, 3:** formatting.
- **4, 5:** added note about `Firefox`.