### PR TITLE
[rcore] Fix `ShowCursor()`, `HideCursor()` and review `SetMouseCursor()` for `PLATFORM_WEB`

### DIFF
--- a/src/platforms/rcore_web.c
+++ b/src/platforms/rcore_web.c
@@ -864,10 +864,9 @@ void SetMouseCursor(int cursor)
 {
     if (CORE.Input.Mouse.cursor != cursor)
     {
-        EM_ASM( { document.getElementById('canvas').style.cursor = UTF8ToString($0); }, cursorLUT[cursor]);
+        if (!CORE.Input.Mouse.cursorHidden) EM_ASM( { document.getElementById('canvas').style.cursor = UTF8ToString($0); }, cursorLUT[cursor]);
 
         CORE.Input.Mouse.cursor = cursor;
-        CORE.Input.Mouse.cursorHidden = false;
     }
 }
 

--- a/src/platforms/rcore_web.c
+++ b/src/platforms/rcore_web.c
@@ -84,6 +84,23 @@ extern CoreData CORE;                   // Global CORE state context
 static PlatformData platform = { 0 };   // Platform specific data
 
 //----------------------------------------------------------------------------------
+// Local Variables Definition
+//----------------------------------------------------------------------------------
+const char cursorLUT[11][12] = {
+    "default",     // 0  MOUSE_CURSOR_DEFAULT
+    "default",     // 1  MOUSE_CURSOR_ARROW
+    "text",        // 2  MOUSE_CURSOR_IBEAM
+    "crosshair",   // 3  MOUSE_CURSOR_CROSSHAIR
+    "pointer",     // 4  MOUSE_CURSOR_POINTING_HAND
+    "ew-resize",   // 5  MOUSE_CURSOR_RESIZE_EW
+    "ns-resize",   // 6  MOUSE_CURSOR_RESIZE_NS
+    "nwse-resize", // 7  MOUSE_CURSOR_RESIZE_NWSE
+    "nesw-resize", // 8  MOUSE_CURSOR_RESIZE_NESW
+    "move",        // 9  MOUSE_CURSOR_RESIZE_ALL
+    "not-allowed"  // 10 MOUSE_CURSOR_NOT_ALLOWED
+};
+
+//----------------------------------------------------------------------------------
 // Module Internal Functions Declaration
 //----------------------------------------------------------------------------------
 int InitPlatform(void);          // Initialize platform (graphics, inputs and more)
@@ -749,13 +766,23 @@ const char *GetClipboardText(void)
 // Show mouse cursor
 void ShowCursor(void)
 {
-    CORE.Input.Mouse.cursorHidden = false;
+    if (CORE.Input.Mouse.cursorHidden)
+    {
+        EM_ASM( { document.getElementById("canvas").style.cursor = UTF8ToString($0); }, cursorLUT[CORE.Input.Mouse.cursor]);
+
+        CORE.Input.Mouse.cursorHidden = false;
+    }
 }
 
 // Hides mouse cursor
 void HideCursor(void)
 {
-    CORE.Input.Mouse.cursorHidden = true;
+    if (!CORE.Input.Mouse.cursorHidden)
+    {
+        EM_ASM(document.getElementById('canvas').style.cursor = 'none';);
+
+        CORE.Input.Mouse.cursorHidden = true;
+    }
 }
 
 // Enables cursor (unlock cursor)
@@ -837,32 +864,10 @@ void SetMouseCursor(int cursor)
 {
     if (CORE.Input.Mouse.cursor != cursor)
     {
-        const char *cursorName = NULL;
+        EM_ASM( { document.getElementById('canvas').style.cursor = UTF8ToString($0); }, cursorLUT[cursor]);
+
         CORE.Input.Mouse.cursor = cursor;
-
-        switch (cursor)
-        {
-            case MOUSE_CURSOR_IBEAM: cursorName = "text"; break;
-            case MOUSE_CURSOR_CROSSHAIR: cursorName = "crosshair"; break;
-            case MOUSE_CURSOR_POINTING_HAND: cursorName = "pointer"; break;
-            case MOUSE_CURSOR_RESIZE_EW: cursorName = "ew-resize"; break;
-            case MOUSE_CURSOR_RESIZE_NS: cursorName = "ns-resize"; break;
-            case MOUSE_CURSOR_RESIZE_NWSE: cursorName = "nwse-resize"; break;
-            case MOUSE_CURSOR_RESIZE_NESW: cursorName = "nesw-resize"; break;
-            case MOUSE_CURSOR_RESIZE_ALL: cursorName = "move"; break;
-            case MOUSE_CURSOR_NOT_ALLOWED: cursorName = "not-allowed"; break;
-            case MOUSE_CURSOR_ARROW: // WARNING: It does not seem t be a specific cursor for arrow
-            case MOUSE_CURSOR_DEFAULT: cursorName = "default"; break;
-            default:
-            {
-                cursorName = "default";
-                CORE.Input.Mouse.cursor = MOUSE_CURSOR_DEFAULT;
-            } break;
-        }
-
-        // Set the cursor element on the canvas CSS
-        // The canvas is coded to the Id "canvas" on init
-        EM_ASM({document.getElementById("canvas").style.cursor = UTF8ToString($0);}, cursorName);
+        CORE.Input.Mouse.cursorHidden = false;
     }
 }
 

--- a/src/platforms/rcore_web.c
+++ b/src/platforms/rcore_web.c
@@ -86,7 +86,7 @@ static PlatformData platform = { 0 };   // Platform specific data
 //----------------------------------------------------------------------------------
 // Local Variables Definition
 //----------------------------------------------------------------------------------
-const char cursorLUT[11][12] = {
+static const char cursorLUT[11][12] = {
     "default",     // 0  MOUSE_CURSOR_DEFAULT
     "default",     // 1  MOUSE_CURSOR_ARROW
     "text",        // 2  MOUSE_CURSOR_IBEAM


### PR DESCRIPTION
### Changes
1. Adds a `cursorLUT` ([R86-R101](https://github.com/raysan5/raylib/pull/3647/files#diff-14c6a8a6962cf65222635a523e877bbaa1f07b791028685f92bf6b44d87530d7R86-R101)) for `PLATFORM_WEB` that will be used by `ShowCursor()` and `SetMouseCursor()` to select the correct mouse cursor, similar to how it's done for `PLATFORM_DESKTOP_SDL` ([L207-L221](https://github.com/raysan5/raylib/blob/master/src/platforms/rcore_desktop_sdl.c#L207-L221)).

2. Fixes `ShowCursor()` implementation for `PLATFORM_WEB` by adding the `EM_ASM` `style.cursor` call that will parse the `CORE.Input.Mouse.cursor` using the `cursorLUT` ([R771](https://github.com/raysan5/raylib/pull/3647/files#diff-14c6a8a6962cf65222635a523e877bbaa1f07b791028685f92bf6b44d87530d7R771)). To optimize this call, only executes if the cursor is hidden ([R769](https://github.com/raysan5/raylib/pull/3647/files#diff-14c6a8a6962cf65222635a523e877bbaa1f07b791028685f92bf6b44d87530d7R769)).

3. Fixes `HideCursor()` implementation for `PLATFORM_WEB` by adding the `EM_ASM` `style.cursor` to `none` call ([R782](https://github.com/raysan5/raylib/pull/3647/files#diff-14c6a8a6962cf65222635a523e877bbaa1f07b791028685f92bf6b44d87530d7R782)). To optimize this call, only executes if the cursor is not hidden ([R780](https://github.com/raysan5/raylib/pull/3647/files#diff-14c6a8a6962cf65222635a523e877bbaa1f07b791028685f92bf6b44d87530d7R780)).

4. Reviews `SetMouseCursor()` implementation for `PLATFORM_WEB` to use the `cursorLUT` instead of the `switch` ([R867](https://github.com/raysan5/raylib/pull/3647/files#diff-14c6a8a6962cf65222635a523e877bbaa1f07b791028685f92bf6b44d87530d7R867)), and also to respect and not override the `CORE.Input.Mouse.cursorHidden` state ([R867](https://github.com/raysan5/raylib/pull/3647/files#diff-14c6a8a6962cf65222635a523e877bbaa1f07b791028685f92bf6b44d87530d7R867), [R869](https://github.com/raysan5/raylib/pull/3647/files#diff-14c6a8a6962cf65222635a523e877bbaa1f07b791028685f92bf6b44d87530d7R869)).

### Code example
- This change can be tested for `PLATFORM_WEB` (requires `ASYNCIFY`) with:
```
#include "raylib.h"

int main(void) {
    InitWindow(800, 450, "test");
    SetTargetFPS(60);
    while (!WindowShouldClose()) {

        if (IsKeyPressed(KEY_H)) HideCursor();
        if (IsKeyPressed(KEY_S)) ShowCursor();
        if (IsKeyPressed(KEY_C)) SetMouseCursor(MOUSE_CURSOR_CROSSHAIR);
        if (IsKeyPressed(KEY_V)) SetMouseCursor(MOUSE_CURSOR_NOT_ALLOWED);

        BeginDrawing();
        ClearBackground(RAYWHITE);
        DrawText("[H] HideCursor()", 20, 20, 20, BLACK);
        DrawText("[S] ShowCursor()", 20, 40, 20, BLACK);
        DrawText("[C] SetMouseCursor(MOUSE_CURSOR_CROSSHAIR)", 20, 80, 20, BLACK);
        DrawText("[V] SetMouseCursor(MOUSE_CURSOR_NOT_ALLOWED)", 20, 100, 20, BLACK);
        EndDrawing();
    }
    CloseWindow();
    return 0;
}
```

### Environment
- Compiled on `Linux` (Ubuntu 22.04 64-bit) and tested on `Firefox` (115.3.1esr 64-bit) and `Chromium` (117.0.5938.149 64-bit) for both `minshell.html` and `shell.html` files.

### Edits
- **1:** added line marks.
- **2:** added re-review of `SetMouseCursor`.