### PR TITLE
fix for deferred rendering example.

### DIFF
--- a/examples/shaders/shaders_deferred_render.c
+++ b/examples/shaders/shaders_deferred_render.c
@@ -254,8 +254,8 @@ int main(void)
                     EndMode3D();
 
                     // As a last step, we now copy over the depth buffer from our g-buffer to the default framebuffer.
-                    rlEnableFramebuffer(gBuffer.framebuffer); //glBindFramebuffer(GL_READ_FRAMEBUFFER, gBuffer.framebuffer);
-                    rlEnableFramebuffer(0); //glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
+                    rlBindFramebuffer(GL_READ_FRAMEBUFFER, gBuffer.framebuffer);
+                    rlBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
                     rlBlitFramebuffer(0, 0, screenWidth, screenHeight, 0, 0, screenWidth, screenHeight, 0x00000100);    // GL_DEPTH_BUFFER_BIT
                     rlDisableFramebuffer();
 

--- a/src/rlgl.h
+++ b/src/rlgl.h
@@ -320,6 +320,8 @@
 #define RL_BLEND_SRC_ALPHA                      0x80CB      // GL_BLEND_SRC_ALPHA
 #define RL_BLEND_COLOR                          0x8005      // GL_BLEND_COLOR
 
+#define GL_READ_FRAMEBUFFER                     0x8CA8
+#define GL_DRAW_FRAMEBUFFER                     0x8CA9
 
 //----------------------------------------------------------------------------------
 // Types and Structures Definition

--- a/src/rlgl.h
+++ b/src/rlgl.h
@@ -621,6 +621,7 @@ RLAPI void rlEnableFramebuffer(unsigned int id);        // Enable render texture
 RLAPI void rlDisableFramebuffer(void);                  // Disable render texture (fbo), return to default framebuffer
 RLAPI void rlActiveDrawBuffers(int count);              // Activate multiple draw color buffers
 RLAPI void rlBlitFramebuffer(int srcX, int srcY, int srcWidth, int srcHeight, int dstX, int dstY, int dstWidth, int dstHeight, int bufferMask); // Blit active framebuffer to main framebuffer
+RLAPI void rlBindFramebuffer(unsigned int id,unsigned int val); //  bind (FBO) 
 
 // General render state
 RLAPI void rlEnableColorBlend(void);                    // Enable color blending
@@ -631,6 +632,7 @@ RLAPI void rlEnableDepthMask(void);                     // Enable depth write
 RLAPI void rlDisableDepthMask(void);                    // Disable depth write
 RLAPI void rlEnableBackfaceCulling(void);               // Enable backface culling
 RLAPI void rlDisableBackfaceCulling(void);              // Disable backface culling
+RLAPI void rlColorMask(bool,bool,bool,bool);            // color mask control
 RLAPI void rlSetCullFace(int mode);                     // Set face culling mode
 RLAPI void rlEnableScissorTest(void);                   // Enable scissor test
 RLAPI void rlDisableScissorTest(void);                  // Disable scissor test
@@ -1737,6 +1739,14 @@ void rlBlitFramebuffer(int srcX, int srcY, int srcWidth, int srcHeight, int dstX
 #endif
 }
 
+//  bind framebuffer object
+void rlBindFramebuffer(unsigned int id,unsigned int val)
+{
+#if (defined(GRAPHICS_API_OPENGL_33) || defined(GRAPHICS_API_OPENGL_ES2)) && defined(RLGL_RENDER_TEXTURES_HINT)
+    glBindFramebuffer(id, val);
+#endif
+}
+
 // Activate multiple draw color buffers
 // NOTE: One color buffer is always active by default
 void rlActiveDrawBuffers(int count)
@@ -1812,6 +1822,8 @@ void rlEnableBackfaceCulling(void) { glEnable(GL_CULL_FACE); }
 
 // Disable backface culling
 void rlDisableBackfaceCulling(void) { glDisable(GL_CULL_FACE); }
+
+void rlColorMask(bool r,bool g,bool b,bool a) { glColorMask(r,g,b,a); }
 
 // Set face culling mode
 void rlSetCullFace(int mode)


### PR DESCRIPTION
previous example didn't correctly render with depth outside of the deferred pass. the DrawSphereWires didn't work.
