### PR TITLE
2 important fixes for borderless fullscreen on rcore_desktop

### DIFF
--- a/src/platforms/rcore_web.c
+++ b/src/platforms/rcore_web.c
@@ -330,9 +330,9 @@ void SetWindowState(unsigned int flags)
         {
             const int canvasWidth = EM_ASM_INT( { return document.getElementById('canvas').width; }, 0);
             const int canvasStyleWidth = EM_ASM_INT( { return parseInt(document.getElementById('canvas').style.width); }, 0);
-            if ((CORE.Window.flags & FLAG_FULLSCREEN_MODE) || canvasStyleWidth > canvasWidth) ToggleBorderlessWindowed();
+            if ((CORE.Window.flags & FLAG_FULLSCREEN_MODE) || canvasStyleWidth > canvasWidth) ToggleBorderlessWindowed(0);
         }
-        else ToggleBorderlessWindowed();
+        else ToggleBorderlessWindowed(0);
     }
 
     // State change: FLAG_FULLSCREEN_MODE

--- a/src/platforms/rcore_web.c
+++ b/src/platforms/rcore_web.c
@@ -247,7 +247,7 @@ void ToggleFullscreen(void)
 }
 
 // Toggle borderless windowed mode
-void ToggleBorderlessWindowed(void)
+void ToggleBorderlessWindowed(int extraWidth)
 {
     platform.ourFullscreen = true;
     bool enterBorderless = false;

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -968,8 +968,8 @@ RLAPI bool IsWindowResized(void);                                 // Check if wi
 RLAPI bool IsWindowState(unsigned int flag);                      // Check if one specific window flag is enabled
 RLAPI void SetWindowState(unsigned int flags);                    // Set window configuration state using flags (only PLATFORM_DESKTOP)
 RLAPI void ClearWindowState(unsigned int flags);                  // Clear window configuration state flags
-RLAPI void ToggleFullscreen(void);                                // Toggle window state: fullscreen/windowed (only PLATFORM_DESKTOP)
-RLAPI void ToggleBorderlessWindowed(void);                        // Toggle window state: borderless windowed (only PLATFORM_DESKTOP)
+RLAPI void ToggleFullscreen(void);                                // Toggle window state: fullscreen/windowed
+RLAPI void ToggleBorderlessWindowed(int extraWidth);              // Toggle window state: borderless windowed (extraWidth ignored on PLATFORM_WEB)
 RLAPI void MaximizeWindow(void);                                  // Set window state: maximized, if resizable (only PLATFORM_DESKTOP)
 RLAPI void MinimizeWindow(void);                                  // Set window state: minimized, if resizable (only PLATFORM_DESKTOP)
 RLAPI void RestoreWindow(void);                                   // Set window state: not minimized/maximized (only PLATFORM_DESKTOP)


### PR DESCRIPTION
Fix 1: In windowfocuscallback, toggle topmost flag if borderless fullscreen is active so that you can alt tab while retaining borderless fullscreen. Currently it will let you lose focus but it won't go to the background.

Fix 2: When in an opengl window, setting the window size to monitor size causes some flickering which can be really annoying. Other games get around this by adding or removing 1 pixel to either size or position. This is not opinionated you can see games like supertuxkart doing it for yourself. I decided to only add a parameter for extra width because imo it's the least noticable but you can still set it to 0 to have it work the same as now.

You can test 1. by going fullscreen and alt tabbing, and 2. by setting extrawidth to -1 or +1.

Also changed comments for some documentation and updating the functions to remove the desktop only as I think that was forgotten to be changed.

1 problem with fix 2 is that SetWindowState only sets extraWidth to 0 now, ideally you'd have some value you can set and read because you don't really change it anyway. But not sure how you want to add that and I just want this merged to have a nice cross platform way to get fullscreen (I used custom fullscreen before this implementing the above).