### PR TITLE
Review UnloadAutomationEventList

### DIFF
--- a/examples/core/core_automation_events.c
+++ b/examples/core/core_automation_events.c
@@ -71,7 +71,7 @@ int main(void)
     
     // Automation events
     AutomationEventList aelist = LoadAutomationEventList(0);  // Initialize list of automation events to record new events
-    SetAutomationEventList(aelist);
+    SetAutomationEventList(&aelist);
     bool eventRecording = false;
     bool eventPlaying = false;
     
@@ -98,7 +98,7 @@ int main(void)
             // Supports loading .rgs style files (text or binary) and .png style palette images
             if (IsFileExtension(droppedFiles.paths[0], ".txt;.rae"))
             {
-                UnloadAutomationEventList(&aelist);
+                UnloadAutomationEventList(aelist);
                 aelist = LoadAutomationEventList(droppedFiles.paths[0]);
                 
                 eventRecording = false;

--- a/examples/core/core_automation_events.c
+++ b/examples/core/core_automation_events.c
@@ -71,7 +71,7 @@ int main(void)
     
     // Automation events
     AutomationEventList aelist = LoadAutomationEventList(0);  // Initialize list of automation events to record new events
-    SetAutomationEventList(&aelist);
+    SetAutomationEventList(aelist);
     bool eventRecording = false;
     bool eventPlaying = false;
     

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1138,7 +1138,7 @@ RLAPI unsigned char *DecodeDataBase64(const unsigned char *data, int *outputSize
 
 // Automation events functionality
 RLAPI AutomationEventList LoadAutomationEventList(const char *fileName);                // Load automation events list from file, NULL for empty list, capacity = MAX_AUTOMATION_EVENTS
-RLAPI void UnloadAutomationEventList(AutomationEventList *list);                        // Unload automation events list from file
+RLAPI void UnloadAutomationEventList(AutomationEventList list);                        // Unload automation events list from file
 RLAPI bool ExportAutomationEventList(AutomationEventList list, const char *fileName);   // Export automation events list as text file
 RLAPI void SetAutomationEventList(AutomationEventList *list);                           // Set automation event list to record to
 RLAPI void SetAutomationEventBaseFrame(int frame);                                      // Set automation event internal base frame to start recording

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -2483,7 +2483,7 @@ AutomationEventList LoadAutomationEventList(const char *fileName)
 void UnloadAutomationEventList(AutomationEventList list)
 {
 #if defined(SUPPORT_AUTOMATION_EVENTS)
-    RL_FREE(list->events);
+    RL_FREE(list.events);
 #endif
 }
 

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -2480,13 +2480,10 @@ AutomationEventList LoadAutomationEventList(const char *fileName)
 }
 
 // Unload automation events list from file
-void UnloadAutomationEventList(AutomationEventList *list)
+void UnloadAutomationEventList(AutomationEventList list)
 {
 #if defined(SUPPORT_AUTOMATION_EVENTS)
     RL_FREE(list->events);
-    list->events = NULL;
-    list->count = 0;
-    list->capacity = 0;
 #endif
 }
 


### PR DESCRIPTION
Currently it manipulates the object directly, and thus breaks the expectations of Unload* functions accepting a copy and only freeing dynamic memory. It would be harder for binding devs to port their work to raylib 5.0, if all the functions don't follow a common pattern.