### PR TITLE
VSCode sample project Mac fixup

### DIFF
--- a/projects/VSCode/.vscode/c_cpp_properties.json
+++ b/projects/VSCode/.vscode/c_cpp_properties.json
@@ -32,7 +32,7 @@
                 "PLATFORM_DESKTOP"
             ],
             "macFrameworkPath": [
-                "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/System/Library/Frameworks"
+                "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks"
             ],
             "compilerPath": "/usr/bin/clang",
             "cStandard": "c11",

--- a/projects/VSCode/Makefile
+++ b/projects/VSCode/Makefile
@@ -319,7 +319,7 @@ ifeq ($(PLATFORM),PLATFORM_DESKTOP)
     ifeq ($(PLATFORM_OS),OSX)
         # Libraries for OSX 10.9 desktop compiling
         # NOTE: Required packages: libopenal-dev libegl1-mesa-dev
-        LDLIBS = -lraylib -framework OpenGL -framework OpenAL -framework Cocoa
+        LDLIBS = -lraylib -framework OpenGL -framework OpenAL -framework Cocoa -framework IOKit
     endif
     ifeq ($(PLATFORM_OS),BSD)
         # Libraries for FreeBSD, OpenBSD, NetBSD, DragonFly desktop compiling


### PR DESCRIPTION
Change vscode config and makefile to add a missing IOKit framework reference and use whichever MacOSX sdk symlink is available