### PR TITLE
Improving the stability of rendering frame rate

### DIFF
--- a/src/rcore.c
+++ b/src/rcore.c
@@ -870,8 +870,6 @@ void EndDrawing(void)
 #endif
 
 #if !defined(SUPPORT_CUSTOM_FRAME_CONTROL)
-    SwapScreenBuffer();                  // Copy back buffer to front buffer (screen)
-
     // Frame time control system
     CORE.Time.current = GetTime();
     CORE.Time.draw = CORE.Time.current - CORE.Time.previous;
@@ -890,6 +888,8 @@ void EndDrawing(void)
 
         CORE.Time.frame += waitTime;    // Total frame time: update + draw + wait
     }
+
+    SwapScreenBuffer();                  // Copy back buffer to front buffer (screen)
 
     PollInputEvents();      // Poll user events (before next frame update)
 #endif


### PR DESCRIPTION
In the current `rcore.c`, the invocation of `SwapScreenBuffer` in the `EndDrawing` function is placed before the frame rate control. This causes the interval between the current frame and the next frame to actually depend on the rendering/update time of the previous frame, rather than the current frame. When the rendering/update time of each frame is inconsistent but still within the frame interval (which is common for triggering events or asset loading in games), FPS stuttering occurs. In this case, the frame rate still maintains the target frame rate, but it gives a sensation of unsmoothness, which becomes particularly noticeable at low frame rates:

https://github.com/raysan5/raylib/assets/11132087/ea987529-755d-4166-bc17-e29db666691c

Here is the code snippet used in the mentioned video:

```c
#include "raylib.h"
#include <math.h>

int main(void) {
  int screenWidth = 800;
  int screenHeight = 200;
  InitWindow(screenWidth, screenHeight, "SwapScreenBuffer() before/after WaitTime()");
  SetTargetFPS(30);
  Vector2 pos = { .x = 100.0f, .y = 100.0f };
  float step = 1000.0f;
  while (!WindowShouldClose()) {
    BeginDrawing();
    ClearBackground(RAYWHITE);
    if (pos.x > 700.0f) step = -fabsf(step);
    else if (pos.x < 100.0f) step = fabsf(step);
    pos.x += step * GetFrameTime();
    DrawCircleV(pos, 50.0f, RED);
    DrawFPS(2, 2);
    EndDrawing();
    if(GetRandomValue(0, 1)) WaitTime(0.03); // Simulate unstable update time
  }
  CloseWindow();
  return 0;
}
```

This PR moves the invocation to `SwapScreenBuffer` function after the frame rate control, ensuring that it is called at a consistent frequency to improve frame rate stability.