### PR TITLE
[rcore] Fix `SUPPORT_WINMM_HIGHRES_TIMER` for `PLATFORM_DESKTOP_SDL`

### DIFF
--- a/src/platforms/rcore_desktop_sdl.c
+++ b/src/platforms/rcore_desktop_sdl.c
@@ -1112,7 +1112,7 @@ void PollInputEvents(void)
             case SDL_TEXTINPUT:
             {
                 // NOTE: event.text.text data comes an UTF-8 text sequence but we register codepoints (int)
-                
+
                 int codepointSize = 0;
 
                 // Check if there is space available in the key queue
@@ -1426,6 +1426,10 @@ int InitPlatform(void)
     //----------------------------------------------------------------------------
     // NOTE: No need to call InitTimer(), let SDL manage it internally
     CORE.Time.previous = GetTime();     // Get time as double
+
+    #if defined(_WIN32) && defined(SUPPORT_WINMM_HIGHRES_TIMER) && !defined(SUPPORT_BUSY_WAIT_LOOP)
+    SDL_SetHint(SDL_HINT_TIMER_RESOLUTION, "1");     // SDL equivalent of timeBeginPeriod() and timeEndPeriod()
+    #endif
     //----------------------------------------------------------------------------
 
     // Initialize storage system


### PR DESCRIPTION
### Context
- During the Christmas holidays a visiting relative was playing a game I've made with my kernel library on his very up-to-date notebook, but there were (low) framerates issues. Upon inspection the issue was the frame sleep time being too long on Windows. The problem was solved with `SDL_HINT_TIMER_RESOLUTION` which is kind of equivalent to Windows `timeBeginPeriod()/timeEndPeriod()`.

- Since `raylib`'s `PLATFORM_DESKTOP_SDL` doesn't use `rcore.c`'s `InitTimer()` ([L3040-L3047](https://github.com/raysan5/raylib/blob/99f22a47ff09ae3bef4ee16c1910953efc46832b/src/rcore.c#L3040-L3047)), it ends up having the same issue. And since this looks relevant enough, I'm sending this PR.

- This issue is more noticeable when `vsync` is turned off and a given frame cap is enforced.

### Changes
1. Adds a `SDL_HINT_TIMER_RESOLUTION` hint to `InitPlatform()` ([R1430-R1432](https://github.com/raysan5/raylib/pull/3679/files#diff-43fa9fe6c2302f00d9c0b8bcbe58d8ca92ca52e157d5b19a612f90a81c698c12R1430-R1432)) for `PLATFORM_DESKTOP_SDL` to handle the `SUPPORT_WINMM_HIGHRES_TIMER` option.

2. This is similar to how `PLATFORM_DESKTOP` handles it using Windows `timeBeginPeriod()/timeEndPeriod()` ([L66-L70](https://github.com/raysan5/raylib/blob/master/src/platforms/rcore_desktop.c#L66-L70), [L3040-L3047](https://github.com/raysan5/raylib/blob/master/src/rcore.c#L3040-L3047), [L1590-L1596](https://github.com/raysan5/raylib/blob/master/src/platforms/rcore_desktop.c#L1590-L1596)).

### Edits
- **1:** editing, added line marks.