### PR TITLE
[ fix-crash-caused-by-zig-build ] - Fixed 'Illegal instruction' crash on 'rtextures' and 'raudio' model that caused by zig build.

### DIFF
--- a/src/build.zig
+++ b/src/build.zig
@@ -29,7 +29,9 @@ pub fn addRaylib(b: *std.Build, target: std.zig.CrossTarget, optimize: std.built
     if (options.raudio) {
         addCSourceFilesVersioned(raylib, &.{
             srcdir ++ "/raudio.c",
-        }, raylib_flags);
+        }, &[_][]const u8{
+            "-fno-sanitize=undefined", // https://github.com/raysan5/raylib/issues/3674
+        } ++ raylib_flags);
     }
     if (options.rmodels) {
         addCSourceFilesVersioned(raylib, &.{
@@ -51,7 +53,9 @@ pub fn addRaylib(b: *std.Build, target: std.zig.CrossTarget, optimize: std.built
     if (options.rtextures) {
         addCSourceFilesVersioned(raylib, &.{
             srcdir ++ "/rtextures.c",
-        }, raylib_flags);
+        }, &[_][]const u8{
+            "-fno-sanitize=undefined", // https://github.com/raysan5/raylib/issues/3674
+        } ++ raylib_flags);
     }
 
     var gen_step = b.addWriteFiles();


### PR DESCRIPTION
A quick fix for [3674](https://github.com/raysan5/raylib/issues/3674).

- When a `zig` raylib program links to `zig-out/lib/libraylib.a` and tries to call `ImageResize`, it crashes with the following error:

    ```bash
    INFO: IMAGE: Data loaded successfully (848x836 | R8G8B8A8 | 1 mipmaps)
    Illegal instruction at address 0x506653
    src/external/stb_image_resize2.h:6806:5: 0x506653 in stbir__alloc_internal_mem_and_build_samplers (/home/wison/zig/raylib-box2d-tutorials/raylib/src/rtextures.c)
    src/external/stb_image_resize2.h:7603:14: 0x483415 in stbir__perform_build (/home/wison/zig/raylib-box2d-tutorials/raylib/src/rtextures.c)
    src/external/stb_image_resize2.h:7639:12: 0x482184 in stbir_build_samplers_with_splits (/home/wison/zig/raylib-box2d-tutorials/raylib/src/rtextures.c)
    src/external/stb_image_resize2.h:7649:10: 0x4835c9 in stbir_build_samplers (/home/wison/zig/raylib-box2d-tutorials/raylib/src/rtextures.c)
    src/external/stb_image_resize2.h:7666:11: 0x483840 in stbir_resize_extended (/home/wison/zig/raylib-box2d-tutorials/raylib/src/rtextures.c)
    src/external/stb_image_resize2.h:7775:9: 0x4866e9 in stbir_resize_uint8_linear (/home/wison/zig/raylib-box2d-tutorials/raylib/src/rtextures.c)
    src/rtextures.c:1628:53: 0x4a3c4f in ImageResize (/home/wison/zig/raylib-box2d-tutorials/raylib/src/rtextures.c)
    /home/wison/zig/raylib-box2d-tutorials/src/temp_test.zig:74:19: 0x27b295 in main (temp-test)
        rl.ImageResize(
                    ^
    /home/wison/my-shell/zig-nightly/lib/std/start.zig:585:37: 0x27ba1b in main (temp-test)
                const result = root.main() catch |err| {
                                        ^
    ???:?:?: 0x7fa9a0274ccf in ??? (libc.so.6)
    Unwind information for `libc.so.6:0x7fa9a0274ccf` was not available, trace may be incomplete
    ```



- When a `zig` raylib program links to `zig-out/lib/libraylib.a` and tries to call `LoadSound`, it crashes with the following error:

    ```bash
    NFO: AUDIO: Device initialized successfully
    INFO:     > Backend:       miniaudio / PulseAudio
    INFO:     > Format:        32-bit IEEE Floating Point -> 16-bit Signed Integer
    INFO:     > Channels:      2 -> 2
    INFO:     > Sample rate:   48000 -> 48000
    INFO:     > Periods size:  3600
    INFO: FILEIO: [resources/enable_fireball.wav] File loaded successfully
    INFO: WAVE: Data loaded successfully (48000 Hz, 16 bit, 2 channels)
    Illegal instruction at address 0x6fc636
    src/external/miniaudio.h:54131:82: 0x6fc636 in ma_data_converter_init_preallocated (/home/wison/zig/raylib-box2d-tutorials/raylib/src/raudio.c)
    src/external/miniaudio.h:54242:14: 0x6fe619 in ma_data_converter_init (/home/wison/zig/raylib-box2d-tutorials/raylib/src/raudio.c)
    src/external/miniaudio.h:56061:14: 0x704fd5 in ma_convert_frames_ex (/home/wison/zig/raylib-box2d-tutorials/raylib/src/raudio.c)
    src/external/miniaudio.h:56049:12: 0x704f71 in ma_convert_frames (/home/wison/zig/raylib-box2d-tutorials/raylib/src/raudio.c)
    src/raudio.c:911:43: 0x7b599f in LoadSoundFromWave (/home/wison/zig/raylib-box2d-tutorials/raylib/src/raudio.c)
    src/raudio.c:884:19: 0x7b5796 in LoadSound (/home/wison/zig/raylib-box2d-tutorials/raylib/src/raudio.c)
    /home/wison/zig/raylib-box2d-tutorials/src/temp_test.zig:41:38: 0x2a3ff6 in main (temp-test)
        const sound_effect = rl.LoadSound("resources/enable_fireball.wav");
                                        ^
    /home/wison/my-shell/zig-nightly/lib/std/start.zig:585:37: 0x2a480b in main (temp-test)
                const result = root.main() catch |err| {
                                        ^
    ???:?:?: 0x7fe8c9a77ccf in ??? (libc.so.6)
    Unwind information for `libc.so.6:0x7fe8c9a77ccf` was not available, trace may be incomplete
    ```