### PR TITLE
Add new chars to font ex

### DIFF
--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1427,6 +1427,7 @@ RLAPI int GetPixelDataSize(int width, int height, int format);              // G
 RLAPI Font GetFontDefault(void);                                                            // Get the default Font
 RLAPI Font LoadFont(const char *fileName);                                                  // Load font from file into GPU memory (VRAM)
 RLAPI Font LoadFontEx(const char *fileName, int fontSize, int *codepoints, int codepointCount);  // Load font from file with extended parameters, use NULL for codepoints and 0 for codepointCount to load the default character set
+RLAPI void AddNewCharsToFontEx(Font *font, const char *fileName, int fontSize, char *newChars);  // Reload the font after adding the new characters to the list of desired characters
 RLAPI Font LoadFontFromImage(Image image, Color key, int firstChar);                        // Load font from Image (XNA style)
 RLAPI Font LoadFontFromMemory(const char *fileType, const unsigned char *fileData, int dataSize, int fontSize, int *codepoints, int codepointCount); // Load font from memory buffer, fileType refers to extension: i.e. '.ttf'
 RLAPI bool IsFontReady(Font font);                                                          // Check if a font is ready

--- a/src/rtext.c
+++ b/src/rtext.c
@@ -379,14 +379,8 @@ Font LoadFontEx(const char *fileName, int fontSize, int *codepoints, int codepoi
 }
 
 // Reload the font after adding the new characters to the list of desired characters
-// Passing NULL to the newChars variable results in a reset to the default of LoadFontEx
 void AddNewCharsToFontEx(Font *font, const char *fileName, int fontSize, char *newChars)
 {
-  if (newChars == NULL) {
-    *font = LoadFontEx(fileName, fontSize, NULL, 0);
-    return;
-  }
-
   int codepointCount = 0;
   int *codepoints = LoadCodepoints(newChars, &codepointCount);
 

--- a/src/rtext.c
+++ b/src/rtext.c
@@ -403,7 +403,7 @@ void AddNewCharsToFontEx(Font *font, const char *fileName, int fontSize, char *n
         bool codepointIsUnique = true;
         int cp = codepoints[i-font->glyphCount];
 
-        // This loop checks for the existence for the existence of the newChars in the input Font
+        // This loop checks for the existence of the newChars in the input Font, and skips them if necessary
         for (int j = 0; j < font->glyphCount; j++)
         {
             if (cp == font->glyphs[j].value)

--- a/src/rtext.c
+++ b/src/rtext.c
@@ -378,6 +378,33 @@ Font LoadFontEx(const char *fileName, int fontSize, int *codepoints, int codepoi
     return font;
 }
 
+// Reload the font after adding the new characters to the list of desired characters
+// Passing NULL to the newChars variable results in a reset to the default of LoadFontEx
+void AddNewCharsToFontEx(Font *font, const char *fileName, int fontSize, char *newChars)
+{
+  if (newChars == NULL) {
+    *font = LoadFontEx(fileName, fontSize, NULL, 0);
+    return;
+  }
+
+  int codepointCount = 0;
+  int *codepoints = LoadCodepoints(newChars, &codepointCount);
+
+  int newCount = font->glyphCount + codepointCount;
+
+  int *newCodepoints = MemAlloc(newCount * sizeof(int));
+  for (int i=0; i<font->glyphCount; i++) {
+    newCodepoints[i] = font->glyphs[i].value;
+  }
+  for (int i=font->glyphCount; i<newCount; i++) {
+    newCodepoints[i] = codepoints[i-font->glyphCount];
+  }
+
+  *font = LoadFontEx(fileName, fontSize, newCodepoints, newCount);
+
+  MemFree(newCodepoints);
+}
+
 // Load an Image font file (XNA style)
 Font LoadFontFromImage(Image image, Color key, int firstChar)
 {


### PR DESCRIPTION
This PR proposes the addition of a new function `AddNewCharsToFontEx`.

# Problem

I found myself in need of adding a single codepoint to the default character set that is loaded when passing `NULL` to `LoadFontEx`.  (See [here](https://github.com/stevemolloy/fonts_in_raylib))

Lacking a suitable function I would have to load the font by passing the string I intended to supply.  This has the weakness that future unknown input (perhaps supplied by the user) would contain characters that are not part of this set.

What I really wanted was a way to say that I want the default character set plus the single extra codepoint.

# Idea

Provide a function that would allow reloading of a `Font` from file with the required extra codepoints.

# Potential weaknesses

One major potential weakness is the linear search I perform to search for requested codepoints that are already in the character set.  This scales with the length of the already-loaded set *and* the length of the requested set, and so could be somewhat long if these happen to be large.