### PR TITLE
[rtextures] Fix `LoadImageAnimFromMemory()` warning for `fileData`

### DIFF
--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1302,6 +1302,7 @@ RLAPI Image LoadImage(const char *fileName);                                    
 RLAPI Image LoadImageRaw(const char *fileName, int width, int height, int format, int headerSize);       // Load image from RAW file data
 RLAPI Image LoadImageSvg(const char *fileNameOrString, int width, int height);                           // Load image from SVG file data or string with specified size
 RLAPI Image LoadImageAnim(const char *fileName, int *frames);                                            // Load image sequence from file (frames appended to image.data)
+RLAPI Image LoadImageAnimFromMemory(const char *fileType, const unsigned char *fileData, int dataSize, int *frames) // Load image sequence from memory buffer
 RLAPI Image LoadImageFromMemory(const char *fileType, const unsigned char *fileData, int dataSize);      // Load image from memory buffer, fileType refers to extension: i.e. '.png'
 RLAPI Image LoadImageFromTexture(Texture2D texture);                                                     // Load image from GPU texture data
 RLAPI Image LoadImageFromScreen(void);                                                                   // Load image from screen buffer and (screenshot)

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1302,7 +1302,7 @@ RLAPI Image LoadImage(const char *fileName);                                    
 RLAPI Image LoadImageRaw(const char *fileName, int width, int height, int format, int headerSize);       // Load image from RAW file data
 RLAPI Image LoadImageSvg(const char *fileNameOrString, int width, int height);                           // Load image from SVG file data or string with specified size
 RLAPI Image LoadImageAnim(const char *fileName, int *frames);                                            // Load image sequence from file (frames appended to image.data)
-RLAPI Image LoadImageAnimFromMemory(const char *fileType, const unsigned char *fileData, int dataSize, int *frames) // Load image sequence from memory buffer
+RLAPI Image LoadImageAnimFromMemory(const char *fileType, const unsigned char *fileData, int dataSize, int *frames); // Load image sequence from memory buffer
 RLAPI Image LoadImageFromMemory(const char *fileType, const unsigned char *fileData, int dataSize);      // Load image from memory buffer, fileType refers to extension: i.e. '.png'
 RLAPI Image LoadImageFromTexture(Texture2D texture);                                                     // Load image from GPU texture data
 RLAPI Image LoadImageFromScreen(void);                                                                   // Load image from screen buffer and (screenshot)

--- a/src/rtextures.c
+++ b/src/rtextures.c
@@ -443,7 +443,7 @@ Image LoadImageAnim(const char *fileName, int *frames)
 //  - Number of frames is returned through 'frames' parameter
 //  - All frames are returned in RGBA format
 //  - Frames delay data is discarded
-Image LoadImageAnimFromMemory(const char *fileType, const unsigned char *fileData, int dataSize,int *frames)
+Image LoadImageAnimFromMemory(const char *fileType, const unsigned char *fileData, int dataSize, int *frames)
 {
     Image image = { 0 };
     int frameCount = 0;

--- a/src/rtextures.c
+++ b/src/rtextures.c
@@ -443,7 +443,7 @@ Image LoadImageAnim(const char *fileName, int *frames)
 //  - Number of frames is returned through 'frames' parameter
 //  - All frames are returned in RGBA format
 //  - Frames delay data is discarded
-Image LoadImageAnimFromMemory(const char *fileType,const char *fileData, int dataSize,int *frames)
+Image LoadImageAnimFromMemory(const char *fileType, const unsigned char *fileData, int dataSize,int *frames)
 {
     Image image = { 0 };
     int frameCount = 0;
@@ -2147,14 +2147,14 @@ void ImageKernelConvolution(Image *image, float* kernel, int kernelSize){
     {
         startRange = -kernelWidth/2;
         endRange = kernelWidth/2;
-    } else 
+    } else
     {
         startRange = -kernelWidth/2;
         endRange = kernelWidth/2+1;
     }
-    for(int x = 0; x < image->height; x++) 
+    for(int x = 0; x < image->height; x++)
     {
-        for(int y = 0; y < image->width; y++) 
+        for(int y = 0; y < image->width; y++)
         {
 
             for(int xk = startRange; xk < endRange; xk++)
@@ -2232,14 +2232,14 @@ void ImageKernelConvolution(Image *image, float* kernel, int kernelSize){
         }
     }
 
-    for (int i = 0; i < (image->width) * (image->height); i++) 
+    for (int i = 0; i < (image->width) * (image->height); i++)
     {
         float alpha = (float)imageCopy2[i].w;
         pixels[i].r = (unsigned char)((imageCopy2[i].x)*255.0f);
         pixels[i].g = (unsigned char)((imageCopy2[i].y)*255.0f);
         pixels[i].b = (unsigned char)((imageCopy2[i].z)*255.0f);
         pixels[i].a = (unsigned char)((alpha)*255.0f);
-        // printf("pixels[%d] = %d", i, pixels[i].r); 
+        // printf("pixels[%d] = %d", i, pixels[i].r);
     }
 
 
@@ -3817,7 +3817,7 @@ TextureCubemap LoadTextureCubemap(Image image, int layout)
             if ((image.height/6) == image.width) { layout = CUBEMAP_LAYOUT_LINE_VERTICAL; cubemap.width = image.height/6; }
             else if ((image.width/3) == (image.height/4)) { layout = CUBEMAP_LAYOUT_CROSS_THREE_BY_FOUR; cubemap.width = image.width/3; }
         }
-    } 
+    }
     else
     {
         if (layout == CUBEMAP_LAYOUT_LINE_VERTICAL) cubemap.width = image.height/6;
@@ -3836,7 +3836,7 @@ TextureCubemap LoadTextureCubemap(Image image, int layout)
 
         Image faces = { 0 };                // Vertical column image
         Rectangle faceRecs[6] = { 0 };      // Face source rectangles
-        
+
         for (int i = 0; i < 6; i++) faceRecs[i] = (Rectangle){ 0, 0, (float)size, (float)size };
 
         if (layout == CUBEMAP_LAYOUT_LINE_VERTICAL)


### PR DESCRIPTION
### Changes
1. Fixes the warning below (introduced after [#3681](https://github.com/raysan5/raylib/pull/3681)):
```
rtextures.c: In function ‘LoadImageAnimFromMemory’:
rtextures.c:472:46: warning: pointer targets in passing argument 2 of ‘LoadImageFromMemory’ differ in signedness [-Wpointer-sign]
  472 |         image = LoadImageFromMemory(fileType,fileData,dataSize);
      |                                              ^~~~~~~~
      |                                              |
      |                                              const char *
In file included from rtextures.c:64:
raylib.h:1305:76: note: expected ‘const unsigned char *’ but argument is of type ‘const char *’
 1305 | RLAPI Image LoadImageFromMemory(const char *fileType, const unsigned char *fileData, int dataSize);      // Load image from memory buffer, fileType refers to extension: i.e. '.png'
      |                                                       ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~
In file included from rtextures.c:216:
```
2. Does that by changing `const char *fileData` to `const unsigned char *fileData` ([R446](https://github.com/raysan5/raylib/pull/3686/files#diff-dd413e2d4cd85989a953b899ac2460398a88402b5717efc95fb11e592b83a767R446)).

3. Adds `LoadImageAnimFromMemory()` to `raylib.h` ([R1305](https://github.com/raysan5/raylib/pull/3686/files#diff-008ec254b9e10087d979356eaa799f93f24b3173a6a0c44445c24fee791a1e90R1305)) that was missing.

### Edits:
- **1.** added line marks.
- **2.** added function to `raylib.h`.