### PR TITLE
[rtext] Fix `TextReplace()` warning for `const`

### DIFF
--- a/src/rtext.c
+++ b/src/rtext.c
@@ -653,7 +653,7 @@ GlyphInfo *LoadFontData(const unsigned char *fileData, int dataSize, int fontSiz
                         chars[i].offsetY += (int)((float)ascent*scaleFactor);
                     }
 
-                    // NOTE: We create an empty image for space character, 
+                    // NOTE: We create an empty image for space character,
                     // it could be further required for atlas packing
                     if (ch == 32)
                     {
@@ -1534,7 +1534,7 @@ char *TextReplace(const char *text, const char *replace, const char *by)
     byLen = TextLength(by);
 
     // Count the number of replacements needed
-    insertPoint = text;
+    insertPoint = (char*)text;
     for (count = 0; (temp = strstr(insertPoint, replace)); count++) insertPoint = temp + replaceLen;
 
     // Allocate returning string and point temp to it
@@ -2086,9 +2086,9 @@ static Font LoadBMFont(const char *fileName)
     searchPoint = strstr(buffer, "lineHeight");
     readVars = sscanf(searchPoint, "lineHeight=%i base=%i scaleW=%i scaleH=%i pages=%i", &fontSize, &base, &imWidth, &imHeight, &pageCount);
     fileTextPtr += (readBytes + 1);
-    
+
     if (readVars < 4) { UnloadFileText(fileText); return font; } // Some data not available, file malformed
-    
+
     if (pageCount > MAX_FONT_IMAGE_PAGES)
     {
         TRACELOG(LOG_WARNING, "FONT: [%s] Font defines more pages than supported: %i/%i", fileName, pageCount, MAX_FONT_IMAGE_PAGES);
@@ -2148,17 +2148,17 @@ static Font LoadBMFont(const char *fileName)
     // NOTE: WARNING: This process could be really slow!
     if (pageCount > 1)
     {
-        // Resize font atlas to draw additional images 
-        ImageResizeCanvas(&fullFont, imWidth, imHeight*pageCount, 0, 0, BLACK); 
+        // Resize font atlas to draw additional images
+        ImageResizeCanvas(&fullFont, imWidth, imHeight*pageCount, 0, 0, BLACK);
 
         for (int i = 1; i < pageCount; i++)
         {
             Rectangle srcRec = { 0.0f, 0.0f, (float)imWidth, (float)imHeight };
             Rectangle destRec = { 0.0f, (float)imHeight*(float)i, (float)imWidth, (float)imHeight };
-            ImageDraw(&fullFont, imFonts[i], srcRec, destRec, WHITE);              
+            ImageDraw(&fullFont, imFonts[i], srcRec, destRec, WHITE);
         }
     }
-    
+
     RL_FREE(imFonts);
 
     font.texture = LoadTextureFromImage(fullFont);
@@ -2178,7 +2178,7 @@ static Font LoadBMFont(const char *fileName)
         readVars = sscanf(buffer, "char id=%i x=%i y=%i width=%i height=%i xoffset=%i yoffset=%i xadvance=%i page=%i",
                        &charId, &charX, &charY, &charWidth, &charHeight, &charOffsetX, &charOffsetY, &charAdvanceX, &pageID);
         fileTextPtr += (readBytes + 1);
-        
+
         if (readVars == 9)  // Make sure all char data has been properly read
         {
             // Get character rectangle in the font atlas texture


### PR DESCRIPTION
### Changes
1. Fixes the warning below (introduced after [#3678](https://github.com/raysan5/raylib/pull/3678)):
```
rtext.c: In function ‘TextReplace’:
rtext.c:1537:17: warning: assignment discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
 1537 |     insertPoint = text;
      |                 ^
```

2. Does that by adding a cast to `insertPoint = (char*)text;` ([R1537](https://github.com/raysan5/raylib/pull/3687/files#diff-6f1fe84ccc0076f84a73e0d81ebdb1804c2fd972bb78084ced6336db2f8b8363R1537)).

### Edits:
- **1.** added line marks.