### PR TITLE
rtext.c: Let user choose if they want an automatic FPS color or not

### DIFF
--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1440,7 +1440,8 @@ RLAPI void UnloadFont(Font font);                                               
 RLAPI bool ExportFontAsCode(Font font, const char *fileName);                               // Export font as code file, returns true on success
 
 // Text drawing functions
-RLAPI void DrawFPS(int posX, int posY);                                                     // Draw current FPS
+RLAPI void DrawFPS(int posX, int posY);							    // Draw current FPS
+RLAPI void DrawFPS(int posX, int posY, Color color);                                        // Draw current FPS in custom color
 RLAPI void DrawText(const char *text, int posX, int posY, int fontSize, Color color);       // Draw text (using default font)
 RLAPI void DrawTextEx(Font font, const char *text, Vector2 position, float fontSize, float spacing, Color tint); // Draw text using font and additional parameters
 RLAPI void DrawTextPro(Font font, const char *text, Vector2 position, Vector2 origin, float rotation, float fontSize, float spacing, Color tint); // Draw text using Font and pro parameters (rotation)

--- a/src/rtext.c
+++ b/src/rtext.c
@@ -1089,6 +1089,11 @@ void DrawFPS(int posX, int posY)
 
     DrawText(TextFormat("%2i FPS", fps), posX, posY, 20, color);
 }
+void DrawFPS(int posX, int posY, Color color)
+{                         
+    int fps = GetFPS();
+    DrawText(TextFormat("%2i FPS", fps), posX, posY, 20, color); // Draw FPS based on single color
+}
 
 // Draw text (using default font)
 // NOTE: fontSize work like in any drawing program but if fontSize is lower than font-base-size, then font-base-size is used


### PR DESCRIPTION
I made an overloaded function of DrawFPS(int posX, int posY) which takes an extra parameter of type Color. In the overloaded DrawFPS, the user can select a constant color, they want their FPS counter to be, instead of the default variable FPS color.