### PR TITLE
Introduce c-style context pointer on AudioCallback

### DIFF
--- a/examples/audio/audio_mixed_processor.c
+++ b/examples/audio/audio_mixed_processor.c
@@ -21,7 +21,7 @@ static float averageVolume[400] = { 0.0f };   // Average volume history
 //------------------------------------------------------------------------------------
 // Audio processing function
 //------------------------------------------------------------------------------------
-void ProcessAudio(void *buffer, unsigned int frames)
+void ProcessAudio(void *buffer, unsigned int frames, void *context)
 {
     float *samples = (float *)buffer;   // Samples internally stored as <float>s
     float average = 0.0f;               // Temporary average volume
@@ -57,7 +57,7 @@ int main(void)
 
     InitAudioDevice();              // Initialize audio device
 
-    AttachAudioMixedProcessor(ProcessAudio);
+    AttachAudioMixedProcessor(ProcessAudio, 0);
 
     Music music = LoadMusicStream("resources/country.mp3");
     Sound sound = LoadSound("resources/coin.wav");

--- a/examples/audio/audio_raw_stream.c
+++ b/examples/audio/audio_raw_stream.c
@@ -35,7 +35,7 @@ float oldFrequency = 1.0f;
 float sineIdx = 0.0f;
 
 // Audio input processing callback
-void AudioInputCallback(void *buffer, unsigned int frames)
+void AudioInputCallback(void *buffer, unsigned int frames, void *context)
 {
     audioFrequency = frequency + (audioFrequency - frequency)*0.95f;
 
@@ -69,7 +69,7 @@ int main(void)
     // Init raw audio stream (sample rate: 44100, sample size: 16bit-short, channels: 1-mono)
     AudioStream stream = LoadAudioStream(44100, 16, 1);
 
-    SetAudioStreamCallback(stream, AudioInputCallback);
+    SetAudioStreamCallback(stream, AudioInputCallback, 0);
 
     // Buffer for the single cycle waveform we are synthesizing
     short *data = (short *)malloc(sizeof(short)*MAX_SAMPLES);

--- a/examples/audio/audio_stream_effects.c
+++ b/examples/audio/audio_stream_effects.c
@@ -24,8 +24,8 @@ static unsigned int delayWriteIndex = 0;
 //------------------------------------------------------------------------------------
 // Module Functions Declaration
 //------------------------------------------------------------------------------------
-static void AudioProcessEffectLPF(void *buffer, unsigned int frames);   // Audio effect: lowpass filter
-static void AudioProcessEffectDelay(void *buffer, unsigned int frames); // Audio effect: delay
+static void AudioProcessEffectLPF(void *buffer, unsigned int frames, void *context);   // Audio effect: lowpass filter
+static void AudioProcessEffectDelay(void *buffer, unsigned int frames, void *context); // Audio effect: delay
 
 //------------------------------------------------------------------------------------
 // Program main entry point
@@ -51,7 +51,7 @@ int main(void)
 
     float timePlayed = 0.0f;        // Time played normalized [0.0f..1.0f]
     bool pause = false;             // Music playing paused
-    
+
     bool enableEffectLPF = false;   // Enable effect low-pass-filter
     bool enableEffectDelay = false; // Enable effect delay (1 second)
 
@@ -85,7 +85,7 @@ int main(void)
         if (IsKeyPressed(KEY_F))
         {
             enableEffectLPF = !enableEffectLPF;
-            if (enableEffectLPF) AttachAudioStreamProcessor(music.stream, AudioProcessEffectLPF);
+            if (enableEffectLPF) AttachAudioStreamProcessor(music.stream, AudioProcessEffectLPF, 0);
             else DetachAudioStreamProcessor(music.stream, AudioProcessEffectLPF);
         }
 
@@ -93,10 +93,10 @@ int main(void)
         if (IsKeyPressed(KEY_D))
         {
             enableEffectDelay = !enableEffectDelay;
-            if (enableEffectDelay) AttachAudioStreamProcessor(music.stream, AudioProcessEffectDelay);
+            if (enableEffectDelay) AttachAudioStreamProcessor(music.stream, AudioProcessEffectDelay, 0);
             else DetachAudioStreamProcessor(music.stream, AudioProcessEffectDelay);
         }
-        
+
         // Get normalized time played for current music stream
         timePlayed = GetMusicTimePlayed(music)/GetMusicTimeLength(music);
 
@@ -117,7 +117,7 @@ int main(void)
 
             DrawText("PRESS SPACE TO RESTART MUSIC", 215, 230, 20, LIGHTGRAY);
             DrawText("PRESS P TO PAUSE/RESUME MUSIC", 208, 260, 20, LIGHTGRAY);
-            
+
             DrawText(TextFormat("PRESS F TO TOGGLE LPF EFFECT: %s", enableEffectLPF? "ON" : "OFF"), 200, 320, 20, GRAY);
             DrawText(TextFormat("PRESS D TO TOGGLE DELAY EFFECT: %s", enableEffectDelay? "ON" : "OFF"), 180, 350, 20, GRAY);
 
@@ -143,7 +143,7 @@ int main(void)
 // Module Functions Definition
 //------------------------------------------------------------------------------------
 // Audio effect: lowpass filter
-static void AudioProcessEffectLPF(void *buffer, unsigned int frames)
+static void AudioProcessEffectLPF(void *buffer, unsigned int frames, void *context)
 {
     static float low[2] = { 0.0f, 0.0f };
     static const float cutoff = 70.0f / 44100.0f; // 70 Hz lowpass filter
@@ -164,7 +164,7 @@ static void AudioProcessEffectLPF(void *buffer, unsigned int frames)
 }
 
 // Audio effect: delay
-static void AudioProcessEffectDelay(void *buffer, unsigned int frames)
+static void AudioProcessEffectDelay(void *buffer, unsigned int frames, void *context)
 {
     for (unsigned int i = 0; i < frames*2; i += 2)
     {

--- a/projects/Notepad++/raylib_npp_parser/raylib_to_parse.h
+++ b/projects/Notepad++/raylib_npp_parser/raylib_to_parse.h
@@ -694,11 +694,10 @@ RLAPI void SetAudioStreamVolume(AudioStream stream, float volume);    // Set vol
 RLAPI void SetAudioStreamPitch(AudioStream stream, float pitch);      // Set pitch for audio stream (1.0 is base level)
 RLAPI void SetAudioStreamPan(AudioStream stream, float pan);          // Set pan for audio stream (0.5 is centered)
 RLAPI void SetAudioStreamBufferSizeDefault(int size);                 // Default size for new audio streams
-RLAPI void SetAudioStreamCallback(AudioStream stream, AudioCallback callback); // Audio thread callback to request new data
+RLAPI void SetAudioStreamCallback(AudioStream stream, AudioCallback callback, void *context); // Audio thread callback to request new data
 
-RLAPI void AttachAudioStreamProcessor(AudioStream stream, AudioCallback processor); // Attach audio stream processor to stream, receives the samples as <float>s
+RLAPI void AttachAudioStreamProcessor(AudioStream stream, AudioCallback processor, void *context); // Attach audio stream processor to stream, receives the samples as <float>s
 RLAPI void DetachAudioStreamProcessor(AudioStream stream, AudioCallback processor); // Detach audio stream processor from stream
 
-RLAPI void AttachAudioMixedProcessor(AudioCallback processor); // Attach audio stream processor to the entire audio pipeline, receives the samples as <float>s
+RLAPI void AttachAudioMixedProcessor(AudioCallback processor, void *context); // Attach audio stream processor to the entire audio pipeline, receives the samples as <float>s
 RLAPI void DetachAudioMixedProcessor(AudioCallback processor); // Detach audio stream processor from the entire audio pipeline
-

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1585,7 +1585,7 @@ RLAPI RayCollision GetRayCollisionQuad(Ray ray, Vector3 p1, Vector3 p2, Vector3 
 //------------------------------------------------------------------------------------
 // Audio Loading and Playing Functions (Module: audio)
 //------------------------------------------------------------------------------------
-typedef void (*AudioCallback)(void *bufferData, unsigned int frames);
+typedef void (*AudioCallback)(void *bufferData, unsigned int frames, void *context);
 
 // Audio device management functions
 RLAPI void InitAudioDevice(void);                                     // Initialize audio device and context
@@ -1657,12 +1657,12 @@ RLAPI void SetAudioStreamVolume(AudioStream stream, float volume);    // Set vol
 RLAPI void SetAudioStreamPitch(AudioStream stream, float pitch);      // Set pitch for audio stream (1.0 is base level)
 RLAPI void SetAudioStreamPan(AudioStream stream, float pan);          // Set pan for audio stream (0.5 is centered)
 RLAPI void SetAudioStreamBufferSizeDefault(int size);                 // Default size for new audio streams
-RLAPI void SetAudioStreamCallback(AudioStream stream, AudioCallback callback); // Audio thread callback to request new data
+RLAPI void SetAudioStreamCallback(AudioStream stream, AudioCallback callback, void* context); // Audio thread callback to request new data
 
-RLAPI void AttachAudioStreamProcessor(AudioStream stream, AudioCallback processor); // Attach audio stream processor to stream, receives the samples as <float>s
+RLAPI void AttachAudioStreamProcessor(AudioStream stream, AudioCallback processor, void* context); // Attach audio stream processor to stream, receives the samples as <float>s
 RLAPI void DetachAudioStreamProcessor(AudioStream stream, AudioCallback processor); // Detach audio stream processor from stream
 
-RLAPI void AttachAudioMixedProcessor(AudioCallback processor); // Attach audio stream processor to the entire audio pipeline, receives the samples as <float>s
+RLAPI void AttachAudioMixedProcessor(AudioCallback processor, void* context); // Attach audio stream processor to the entire audio pipeline, receives the samples as <float>s
 RLAPI void DetachAudioMixedProcessor(AudioCallback processor); // Detach audio stream processor from the entire audio pipeline
 
 #if defined(__cplusplus)


### PR DESCRIPTION
## Intro
Hey folks, 
I hope to be able to contribute to this amazing project, so let's get started with the PR description...

## Summary:
The existing [`AudioCallback`](https://github.com/raysan5/raylib/blob/e46b6147fc30e69dd300bbda90ff0a62bf8a4df0/src/raylib.h#L1588C16-L1588C29) definition, `void *buffer, unsigned int frames`, presents limitations by preventing the use of the same callback for multiple streams. In dynamic scenarios, accommodating this requirement becomes unfeasible.

This change introduces the capability to pass a void pointer as a parameter to the callback function, a common c pattern, enabling the function to have user-provided context for achieving desired results. 

## Changes Made:
Modified AudioCallback to accept a void pointer parameter, enhancing its flexibility both for AudioStreams and AudioProcessors in general.

## Example Usage:
Consider the following example to illustrate the enhanced flexibility:

```cpp
struct Info {
    AudioStream stream;
    float frequency;
    float time;
};

void callback(void *buffer, unsigned int frames, void *context) {
    Info *info = (Info *)context;
    TraceLog(LOG_DEBUG, "main: %.2f", info->frequency);
    short *sampleBuffer = (short *)buffer;

    float incr = info->frequency / 44100.0f;

    for (int i = 0; i < frames; i++) {
        sampleBuffer[i] = (short)(32000.0f * sinf(2.0f * PI * info->time));
        info->time += incr;
        if (info->time > 1.0f) info->time -= 1.0f;
    }
}

int main(void) {
    InitWindow(WIDTH, HEIGHT, "Raylib example!");
    InitAudioDevice();
    SetAudioStreamBufferSizeDefault(4096);
    SetMasterVolume(0.25f);

    Info info1 = {
        .stream = LoadAudioStream(44100, 16, 1),
        .frequency = 440.0f,
        .time = 0.0f
    };
    Info info2 = {
        .stream = LoadAudioStream(44100, 16, 1),
        .frequency = 880.0f,
        .time = 0.0f
    };

    SetAudioStreamCallback(info1.stream, callback, &info1);
    SetAudioStreamCallback(info2.stream, callback, &info2);

    PlayAudioStream(info1.stream);
    PlayAudioStream(info2.stream);

    SetTargetFPS(60);

    while (!WindowShouldClose()) {
        BeginDrawing();

        ClearBackground(BLACK);

        info1.frequency += GetFrameTime() * 40.0f;
        info2.frequency += GetFrameTime() * 40.0f;

        DrawText(TextFormat("%i FPS", GetFPS()), 10, 10, 20, WHITE);
        DrawText(TextFormat("Frequency 1: %.2f", info1.frequency), 10, 30, 20, WHITE);
        DrawText(TextFormat("Frequency 2: %.2f", info2.frequency), 10, 50, 20, WHITE);

        EndDrawing();
    }

    UnloadAudioStream(info1.stream);
    UnloadAudioStream(info2.stream);

    CloseAudioDevice();
    CloseWindow();

    return 0;
}
```


This modification ensures a more versatile and user-friendly AudioCallback interface, allowing developers to seamlessly manage multiple streams within dynamic scenarios.
