### PR TITLE
High DPI bug fixes

### DIFF
--- a/src/platforms/rcore_web.c
+++ b/src/platforms/rcore_web.c
@@ -110,11 +110,12 @@ void ClosePlatform(void);        // Close platform
 static void ErrorCallback(int error, const char *description);                      // GLFW3 Error Callback, runs on GLFW3 error
 
 // Window callbacks events
-static void WindowSizeCallback(GLFWwindow *window, int width, int height);          // GLFW3 WindowSize Callback, runs when window is resized
-static void WindowIconifyCallback(GLFWwindow *window, int iconified);               // GLFW3 WindowIconify Callback, runs when window is minimized/restored
-//static void WindowMaximizeCallback(GLFWwindow *window, int maximized);              // GLFW3 Window Maximize Callback, runs when window is maximized
-static void WindowFocusCallback(GLFWwindow *window, int focused);                   // GLFW3 WindowFocus Callback, runs when window get/lose focus
-static void WindowDropCallback(GLFWwindow *window, int count, const char **paths);  // GLFW3 Window Drop Callback, runs when drop files into window
+static void WindowSizeCallback(GLFWwindow *window, int width, int height);              // GLFW3 WindowSize Callback, runs when window is resized
+static void WindowIconifyCallback(GLFWwindow *window, int iconified);                   // GLFW3 WindowIconify Callback, runs when window is minimized/restored
+//static void WindowMaximizeCallback(GLFWwindow *window, int maximized);                // GLFW3 Window Maximize Callback, runs when window is maximized
+static void WindowFocusCallback(GLFWwindow *window, int focused);                       // GLFW3 WindowFocus Callback, runs when window get/lose focus
+static void WindowDropCallback(GLFWwindow *window, int count, const char **paths);      // GLFW3 Window Drop Callback, runs when drop files into window
+static void WindowContentScaleCallback(GLFWwindow *window, float scalex, float scaley); // GLFW3 Window Content Scale Callback, runs when window changes scale
 
 // Input callbacks events
 static void KeyCallback(GLFWwindow *window, int key, int scancode, int action, int mods); // GLFW3 Keyboard Callback, runs on key pressed
@@ -1190,6 +1191,11 @@ int InitPlatform(void)
     glfwSetWindowFocusCallback(platform.handle, WindowFocusCallback);
     glfwSetDropCallback(platform.handle, WindowDropCallback);
 
+    if ((CORE.Window.flags & FLAG_WINDOW_HIGHDPI) > 0)
+    {
+       glfwSetWindowContentScaleCallback(platform.handle, WindowContentScaleCallback);
+    }
+
     // Set input callback events
     glfwSetKeyCallback(platform.handle, KeyCallback);
     glfwSetCharCallback(platform.handle, CharCallback);
@@ -1325,6 +1331,11 @@ static void WindowSizeCallback(GLFWwindow *window, int width, int height)
     }
 
     // NOTE: Postprocessing texture is not scaled to new size
+}
+
+static void WindowContentScaleCallback(GLFWwindow *window, float scalex, float scaley)
+{
+    CORE.Window.screenScale = MatrixScale(scalex, scaley, 1.0f);
 }
 
 // GLFW3 WindowIconify Callback, runs when window is minimized/restored


### PR DESCRIPTION
Simplified `GetWindowScaleDPI()` so it does not fetch the wrong DPI scale some times (Windows or GLFW looks at center of window while the old raylib code looked on upper left corner of window, now it just uses the `glfwGetWindowContentScale` function to fetch the window's current scaling). The old behavior caused problems when having a system with multiple monitors where one monitor had different scaling than the other. When you moved the window back and forth between the monitors, then `WindowSizeCallback` happened since the window size changes due to the scaling. But since the upper left corner was still on the other monitor (when pulling the window to a new monitor that is to the right of the old one), then `GetWindowScaleDPI()` reported the wrong scale and used that to update the screen.height and screen.width, giving them incorrect values.

Also introduced a callback to update the `CORE.Window.screenScaling` when the content scaling updates, previously it was never updated, so scaling did not work correctly on systems with multiple monitors that have different DPI scaling.

Note: I have only tested this on Windows. I did the same changes to the web platform, but I have not tested those.

I wrote about this on the Discord server, for reference here's my initial message: https://discord.com/channels/426912293134270465/426912293956222978/1192401955025334313 and my final message: https://discord.com/channels/426912293134270465/426912293956222978/1192503638267003011