### PR TITLE
[rtextures] Hide unused warnings from `stb_image_resize2.h`

### DIFF
--- a/src/rtextures.c
+++ b/src/rtextures.c
@@ -212,8 +212,18 @@
 
 #define STBIR_MALLOC(size,c) ((void)(c), RL_MALLOC(size))
 #define STBIR_FREE(ptr,c) ((void)(c), RL_FREE(ptr))
+
+#if defined(__GNUC__) // GCC and Clang
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wunused-function"
+#endif
+
 #define STB_IMAGE_RESIZE_IMPLEMENTATION
 #include "external/stb_image_resize2.h"     // Required for: stbir_resize_uint8_linear() [ImageResize()]
+
+#if defined(__GNUC__) // GCC and Clang
+    #pragma GCC diagnostic pop
+#endif
 
 #if defined(SUPPORT_FILEFORMAT_SVG)
     #define NANOSVG_IMPLEMENTATION          // Expands implementation


### PR DESCRIPTION
### Changes
1. Fixes #3707.

2. Does that by hiding the `stb_image_resize2.h` unused warnings during compilation by using `#pragma` ([R216-R219](https://github.com/raysan5/raylib/pull/3708/files#diff-dd413e2d4cd85989a953b899ac2460398a88402b5717efc95fb11e592b83a767R216-R219), [R224-R226](https://github.com/raysan5/raylib/pull/3708/files#diff-dd413e2d4cd85989a953b899ac2460398a88402b5717efc95fb11e592b83a767R224-R226)) like it was done for `stb_truetype.h` at [#3235](https://github.com/raysan5/raylib/pull/3235).

### Note
- Not sure if this is really necessary as it's just two warnings. Please close this PR if that's too much.

### Environment
- `PLATFORM_DESKTOP`, `Linux` (Mint 21.1 64-bit).

### Code example
```
cd raylib-master/
make PLATFORM=PLATFORM_DESKTOP
```

### Edits
- **1:** added line marks.