### PR TITLE
Added viewport independent raycast

### DIFF
--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1050,7 +1050,7 @@ RLAPI void UnloadShader(Shader shader);                                    // Un
 
 // Screen-space-related functions
 RLAPI Ray GetMouseRay(Vector2 mousePosition, Camera camera);      // Get a ray trace from mouse position
-RLAPI Ray GetMouseRayEx(Vector2 mousePosition, Camera camera, float width, float height);      // Get a ray trace from mouse position
+RLAPI Ray GetViewRay(Vector2 mousePosition, Camera camera, float width, float height);      // Get a ray trace from mouse position in a viewport
 RLAPI Matrix GetCameraMatrix(Camera camera);                      // Get camera transform matrix (view matrix)
 RLAPI Matrix GetCameraMatrix2D(Camera2D camera);                  // Get camera 2d transform matrix
 RLAPI Vector2 GetWorldToScreen(Vector3 position, Camera camera);  // Get the screen space position for a 3d world space position

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1050,6 +1050,7 @@ RLAPI void UnloadShader(Shader shader);                                    // Un
 
 // Screen-space-related functions
 RLAPI Ray GetMouseRay(Vector2 mousePosition, Camera camera);      // Get a ray trace from mouse position
+RLAPI Ray GetMouseRayEx(Vector2 mousePosition, Camera camera, float width, float height);      // Get a ray trace from mouse position
 RLAPI Matrix GetCameraMatrix(Camera camera);                      // Get camera transform matrix (view matrix)
 RLAPI Matrix GetCameraMatrix2D(Camera2D camera);                  // Get camera 2d transform matrix
 RLAPI Vector2 GetWorldToScreen(Vector3 position, Camera camera);  // Get the screen space position for a 3d world space position

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -1395,11 +1395,11 @@ void SetShaderValueTexture(Shader shader, int locIndex, Texture2D texture)
 // Get a ray trace from mouse position
 Ray GetMouseRay(Vector2 mousePosition, Camera camera)
 {
-    return GetMouseRayEx(mousePosition, camera, GetScreenWidth(), GetScreenHeight());
+    return GetViewRay(mousePosition, camera, GetScreenWidth(), GetScreenHeight());
 }
 
 // Get a ray trace from the mouse position within a specific section of the screen
-Ray GetMouseRayEx(Vector2 mousePosition, Camera camera, float width, float height)
+Ray GetViewRay(Vector2 mousePosition, Camera camera, float width, float height)
 {
     Ray ray = { 0 };
 

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -1393,14 +1393,20 @@ void SetShaderValueTexture(Shader shader, int locIndex, Texture2D texture)
 //----------------------------------------------------------------------------------
 
 // Get a ray trace from mouse position
-Ray GetMouseRay(Vector2 mouse, Camera camera)
+Ray GetMouseRay(Vector2 mousePosition, Camera camera)
+{
+    return GetMouseRayEx(mousePosition, camera, GetScreenWidth(), GetScreenHeight());
+}
+
+// Get a ray trace from the mouse position within a specific section of the screen
+Ray GetMouseRayEx(Vector2 mousePosition, Camera camera, float width, float height)
 {
     Ray ray = { 0 };
 
     // Calculate normalized device coordinates
     // NOTE: y value is negative
-    float x = (2.0f*mouse.x)/(float)GetScreenWidth() - 1.0f;
-    float y = 1.0f - (2.0f*mouse.y)/(float)GetScreenHeight();
+    float x = (2.0f*mousePosition.x)/width - 1.0f;
+    float y = 1.0f - (2.0f*mousePosition.y)/height;
     float z = 1.0f;
 
     // Store values in a vector
@@ -1414,11 +1420,11 @@ Ray GetMouseRay(Vector2 mouse, Camera camera)
     if (camera.projection == CAMERA_PERSPECTIVE)
     {
         // Calculate projection matrix from perspective
-        matProj = MatrixPerspective(camera.fovy*DEG2RAD, ((double)GetScreenWidth()/(double)GetScreenHeight()), RL_CULL_DISTANCE_NEAR, RL_CULL_DISTANCE_FAR);
+        matProj = MatrixPerspective(camera.fovy*DEG2RAD, ((double)width/(double)height), RL_CULL_DISTANCE_NEAR, RL_CULL_DISTANCE_FAR);
     }
     else if (camera.projection == CAMERA_ORTHOGRAPHIC)
     {
-        double aspect = (double)CORE.Window.screen.width/(double)CORE.Window.screen.height;
+        double aspect = (double)width/(double)height;
         double top = camera.fovy/2.0;
         double right = top*aspect;
 


### PR DESCRIPTION
`GetMouseRay` did not allow the user to cast a ray from the camera to the world view while in a `viewport` or `renderTexture`. To improve raylib, I added `GetMouseRayEx`, which has new arguments (width and height), making it easier to cast a ray to a specific viewport.