### PR TITLE
Fix a bug in examples/shapes/shapes_following_eyes

### DIFF
--- a/examples/shapes/shapes_following_eyes.c
+++ b/examples/shapes/shapes_following_eyes.c
@@ -50,7 +50,7 @@ int main(void)
         irisRightPosition = GetMousePosition();
 
         // Check not inside the left eye sclera
-        if (!CheckCollisionPointCircle(irisLeftPosition, scleraLeftPosition, scleraRadius - 20))
+        if (!CheckCollisionPointCircle(irisLeftPosition, scleraLeftPosition, scleraRadius - irisRadius))
         {
             dx = irisLeftPosition.x - scleraLeftPosition.x;
             dy = irisLeftPosition.y - scleraLeftPosition.y;
@@ -65,7 +65,7 @@ int main(void)
         }
 
         // Check not inside the right eye sclera
-        if (!CheckCollisionPointCircle(irisRightPosition, scleraRightPosition, scleraRadius - 20))
+        if (!CheckCollisionPointCircle(irisRightPosition, scleraRightPosition, scleraRadius - irisRadius))
         {
             dx = irisRightPosition.x - scleraRightPosition.x;
             dy = irisRightPosition.y - scleraRightPosition.y;


### PR DESCRIPTION
![Screenshot_20240105_234738](https://github.com/raysan5/raylib/assets/96765450/88fa09ae-b857-43d2-a50c-c7e8601f65c7)
I found this bug and a trivial fix in the [shapes_following_eyes](https://www.raylib.com/examples/shapes/loader.html?name=shapes_following_eyes) example.