### PR TITLE
Update to latest zig 0.12.0dev while keeping 0.11.0 compatibility

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const raylib = @import("src/build.zig");
 
-// This has been tested to work with zig 0.11.0
+// This has been tested to work with zig 0.11.0 and zig 0.12.0-dev.2075+f5978181e
 pub fn build(b: *std.Build) void {
     raylib.build(b);
 }

--- a/src/build.zig
+++ b/src/build.zig
@@ -3,10 +3,16 @@ const builtin = @import("builtin");
 
 // This has been tested to work with zig 0.11.0 and zig 0.12.0-dev.2075+f5978181e
 //
-// anytype is used here for target because in 0.12.0dev the std.zig.CrossTarget type
+// anytype is used here to preserve compatibility, in 0.12.0dev the std.zig.CrossTarget type
 // was reworked into std.Target.Query and std.Build.ResolvedTarget. Using anytype allows
-// us to accept both types and act accordingly in getOsTagVersioned
+// us to accept both CrossTarget and ResolvedTarget and act accordingly in getOsTagVersioned.
 pub fn addRaylib(b: *std.Build, target: anytype, optimize: std.builtin.OptimizeMode, options: Options) *std.Build.Step.Compile {
+    if (comptime builtin.zig_version.minor >= 12 and @TypeOf(target) != std.Build.ResolvedTarget) {
+        @compileError("Expected 'std.Build.ResolvedTarget' for argument 2 'target' in 'addRaylib', found '" ++ @typeName(@TypeOf(target)) ++ "'");
+    } else if (comptime builtin.zig_version.minor == 11 and @TypeOf(target) != std.zig.CrossTarget) {
+        @compileError("Expected 'std.zig.CrossTarget' for argument 2 'target' in 'addRaylib', found '" ++ @typeName(@TypeOf(target)) ++ "'");
+    }
+
     const raylib_flags = &[_][]const u8{
         "-std=gnu99",
         "-D_GNU_SOURCE",


### PR DESCRIPTION
The recent 0.12.0dev update caused some breakage in the build system.

This method does require the use of `anytype`, but the argument name and type checks should make it obvious what type it expects. This should not break any existing code.

Tested on linux with zig 0.12.0dev and 0.11.0
```
raylib$ zig build
raylib$ zigup run 0.11.0 build
raylib$ cd examples/
raylib/examples$ zig build
raylib/examples$ zigup run 0.11.0 build
```

Once 0.12.0 is released we can remove all of these compatibility functions