### PR TITLE
[rtext] Adjust font atlas area calculation so padding area is not underestimated at small font sizes.

### DIFF
--- a/src/rtext.c
+++ b/src/rtext.c
@@ -725,7 +725,7 @@ Image GenImageFontAtlas(const GlyphInfo *glyphs, Rectangle **glyphRecs, int glyp
     for (int i = 0; i < glyphCount; i++)
     {
         if (glyphs[i].image.width > maxGlyphWidth) maxGlyphWidth = glyphs[i].image.width;
-        totalWidth += glyphs[i].image.width + 4*padding;
+        totalWidth += glyphs[i].image.width + 2*padding;
     }
 
 //#define SUPPORT_FONT_ATLAS_SIZE_CONSERVATIVE
@@ -743,8 +743,9 @@ Image GenImageFontAtlas(const GlyphInfo *glyphs, Rectangle **glyphRecs, int glyp
     atlas.width = imageSize;   // Atlas bitmap width
     atlas.height = imageSize;  // Atlas bitmap height
 #else
+    int paddedFontSize = fontSize + 2*padding;
     // No need for a so-conservative atlas generation
-    float totalArea = totalWidth*fontSize*1.2f;
+    float totalArea = totalWidth*paddedFontSize*1.2f;
     float imageMinSize = sqrtf(totalArea);
     int imageSize = (int)powf(2, ceilf(logf(imageMinSize)/logf(2)));
 


### PR DESCRIPTION
#3717 

The old padding*4 results in around 80px of padding area when the actual amount of padding area was 144px. Adding the padding to the width and height separately instead of only to width should give the exact amount of area after padding, and should better account for fonts with very wide glyphs. With this change I no longer lose glyphs even at impractically small font sizes in the 1-7px range. The 1.2x constant could potentially be reduced now that the area calculation is more accurate.

![image](https://github.com/raysan5/raylib/assets/573471/8fb3d229-6b47-45cf-9727-2e4005ef5932)
