### PR TITLE
[rtextures] implemented fill color TODO in ImageResizeCanvas()

### DIFF
--- a/src/rtextures.c
+++ b/src/rtextures.c
@@ -1741,8 +1741,22 @@ void ImageResizeCanvas(Image *image, int newWidth, int newHeight, int offsetX, i
         int bytesPerPixel = GetPixelDataSize(1, 1, image->format);
         unsigned char *resizedData = (unsigned char *)RL_CALLOC(newWidth*newHeight*bytesPerPixel, 1);
 
-        // TODO: Fill resized canvas with fill color (must be formatted to image->format)
+        // Fill resized canvas with fill color
+        // Set first pixel with image->format
+        SetPixelColor(resizedData, fill, image->format);
 
+        // Fill remaining bytes of first row
+        for (int x = 1; x < newWidth; x++)
+        {
+            memcpy(resizedData + x*bytesPerPixel, resizedData, bytesPerPixel);
+        }
+        // Copy the first row into the other rows
+        for (int y = 1; y < newHeight; y++)
+        {
+            memcpy(resizedData + y*newWidth*bytesPerPixel, resizedData, newWidth*bytesPerPixel);
+        }
+
+        // Copy old image to resized canvas
         int dstOffsetSize = ((int)dstPos.y*newWidth + (int)dstPos.x)*bytesPerPixel;
 
         for (int y = 0; y < (int)srcRec.height; y++)


### PR DESCRIPTION
`ImageResizeCanvas()` accepts a fill color, that was so far unused, with a TODO to implement it.

This is a fairly simple implementation that fills in the entire canvas, with a minor optimization to copy entire rows once the first one is filled.
The implementation is similar to `ImageClearBackground()`, this could possibly be unified in the future.

I was unsure about the desired level of code commenting, so I opted for extensive comments, in line with the contributing guide.

Tested on Linux:
- build
- functionality
- with valgrind (for invalid read/writes)