### PR TITLE
Fix `ImageDrawRectangleRec`

### DIFF
--- a/src/rtextures.c
+++ b/src/rtextures.c
@@ -3562,8 +3562,8 @@ void ImageDrawRectangleRec(Image *dst, Rectangle rec, Color color)
     if ((dst->data == NULL) || (dst->width == 0) || (dst->height == 0)) return;
 
     // Security check to avoid drawing out of bounds in case of bad user data
-    if (rec.x < 0) { rec.width -= rec.x; rec.x = 0; }
-    if (rec.y < 0) { rec.height -= rec.y; rec.y = 0; }
+    if (rec.x < 0) { rec.width += rec.x; rec.x = 0; }
+    if (rec.y < 0) { rec.height += rec.y; rec.y = 0; }
     if (rec.width < 0) rec.width = 0;
     if (rec.height < 0) rec.height = 0;
 


### PR DESCRIPTION
There seems to be an error in `ImageDrawRectangleRec` where we should subtract the absolute values of `rec.x` and `rec.y` from `rec.width` and `rec.height` when they are negative.

Currently, we are subtracting the negative values, which is equivalent to addition. For example, in the current implementation:
![GIF1](https://github.com/raysan5/raylib/assets/90587919/e852af23-7f79-4979-8a1c-68bb3ea0fd1b)

If we replace `size -= position` with `size += position`, considering that the position is negative, we correctly subtract the difference as desired. This results _(the visual glitches are from my screen recorder)_:
![GIF2](https://github.com/raysan5/raylib/assets/90587919/fcdcd1ca-ba67-4168-b764-1510869b207a)