### PR TITLE
Update a comment

### DIFF
--- a/src/rcore.c
+++ b/src/rcore.c
@@ -3265,7 +3265,7 @@ static void ScanDirectoryFilesRecursively(const char *basePath, FilePathList *fi
 
 #if defined(SUPPORT_AUTOMATION_EVENTS)
 // Automation event recording
-// NOTE: Recording is by default done at EndDrawing(), after PollInputEvents()
+// NOTE: Recording is by default done at EndDrawing(), before PollInputEvents()
 static void RecordAutomationEvent(void)
 {
     // Checking events in current frame and save them into currentEventList


### PR DESCRIPTION
in #3523 we moved `RecordAutomationEvent()` from after `PollInputEvents()` to before it, but the comment was not updated.