### PR TITLE
Add shared library build option for build.zig and update to zig 0.12.0-dev.2139

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -2,6 +2,6 @@ const std = @import("std");
 const raylib = @import("src/build.zig");
 
 // This has been tested to work with zig 0.11.0 and zig 0.12.0-dev.2075+f5978181e
-pub fn build(b: *std.Build) void {
-    raylib.build(b);
+pub fn build(b: *std.Build) !void {
+    try raylib.build(b);
 }

--- a/src/build.zig
+++ b/src/build.zig
@@ -20,10 +20,10 @@ pub fn addRaylib(b: *std.Build, target: anytype, optimize: std.builtin.OptimizeM
     var raylib_flags_arr = std.ArrayList([]const u8).init(std.heap.page_allocator);
     defer raylib_flags_arr.deinit();
     try raylib_flags_arr.appendSlice(&[_][]const u8{
-        // "-fno-sanitize=undefined", // https://github.com/raysan5/raylib/issues/1891
         "-std=gnu99",
         "-D_GNU_SOURCE",
         "-DGL_SILENCE_DEPRECATION=199309L",
+        "-fno-sanitize=undefined", // https://github.com/raysan5/raylib/issues/3674
     });
     if (options.shared) {
         try raylib_flags_arr.appendSlice(shared_flags);

--- a/src/build.zig
+++ b/src/build.zig
@@ -6,24 +6,41 @@ const builtin = @import("builtin");
 // anytype is used here to preserve compatibility, in 0.12.0dev the std.zig.CrossTarget type
 // was reworked into std.Target.Query and std.Build.ResolvedTarget. Using anytype allows
 // us to accept both CrossTarget and ResolvedTarget and act accordingly in getOsTagVersioned.
-pub fn addRaylib(b: *std.Build, target: anytype, optimize: std.builtin.OptimizeMode, options: Options) *std.Build.Step.Compile {
+pub fn addRaylib(b: *std.Build, target: anytype, optimize: std.builtin.OptimizeMode, options: Options) !*std.Build.Step.Compile {
     if (comptime builtin.zig_version.minor >= 12 and @TypeOf(target) != std.Build.ResolvedTarget) {
         @compileError("Expected 'std.Build.ResolvedTarget' for argument 2 'target' in 'addRaylib', found '" ++ @typeName(@TypeOf(target)) ++ "'");
     } else if (comptime builtin.zig_version.minor == 11 and @TypeOf(target) != std.zig.CrossTarget) {
         @compileError("Expected 'std.zig.CrossTarget' for argument 2 'target' in 'addRaylib', found '" ++ @typeName(@TypeOf(target)) ++ "'");
     }
 
-    const raylib_flags = &[_][]const u8{
+    const shared_flags = &[_][]const u8{
+        "-fPIC",
+        "-DBUILD_LIBTYPE_SHARED",
+    };
+    var raylib_flags_arr = std.ArrayList([]const u8).init(std.heap.page_allocator);
+    defer raylib_flags_arr.deinit();
+    try raylib_flags_arr.appendSlice(&[_][]const u8{
+        // "-fno-sanitize=undefined", // https://github.com/raysan5/raylib/issues/1891
         "-std=gnu99",
         "-D_GNU_SOURCE",
         "-DGL_SILENCE_DEPRECATION=199309L",
-    };
-
-    const raylib = b.addStaticLibrary(.{
-        .name = "raylib",
-        .target = target,
-        .optimize = optimize,
     });
+    if (options.shared) {
+        try raylib_flags_arr.appendSlice(shared_flags);
+    }
+
+    const raylib = if (options.shared)
+        b.addSharedLibrary(.{
+            .name = "raylib",
+            .target = target,
+            .optimize = optimize,
+        })
+    else
+        b.addStaticLibrary(.{
+            .name = "raylib",
+            .target = target,
+            .optimize = optimize,
+        });
     raylib.linkLibC();
 
     // No GLFW required on PLATFORM_DRM
@@ -34,38 +51,32 @@ pub fn addRaylib(b: *std.Build, target: anytype, optimize: std.builtin.OptimizeM
     addCSourceFilesVersioned(raylib, &.{
         srcdir ++ "/rcore.c",
         srcdir ++ "/utils.c",
-    }, raylib_flags);
+    }, raylib_flags_arr.items);
 
     if (options.raudio) {
         addCSourceFilesVersioned(raylib, &.{
             srcdir ++ "/raudio.c",
-        }, &[_][]const u8{
-            "-fno-sanitize=undefined", // https://github.com/raysan5/raylib/issues/3674
-        } ++ raylib_flags);
+        }, raylib_flags_arr.items);
     }
     if (options.rmodels) {
         addCSourceFilesVersioned(raylib, &.{
             srcdir ++ "/rmodels.c",
-        }, &[_][]const u8{
-            "-fno-sanitize=undefined", // https://github.com/raysan5/raylib/issues/1891
-        } ++ raylib_flags);
+        }, raylib_flags_arr.items);
     }
     if (options.rshapes) {
         addCSourceFilesVersioned(raylib, &.{
             srcdir ++ "/rshapes.c",
-        }, raylib_flags);
+        }, raylib_flags_arr.items);
     }
     if (options.rtext) {
         addCSourceFilesVersioned(raylib, &.{
             srcdir ++ "/rtext.c",
-        }, raylib_flags);
+        }, raylib_flags_arr.items);
     }
     if (options.rtextures) {
         addCSourceFilesVersioned(raylib, &.{
             srcdir ++ "/rtextures.c",
-        }, &[_][]const u8{
-            "-fno-sanitize=undefined", // https://github.com/raysan5/raylib/issues/3674
-        } ++ raylib_flags);
+        }, raylib_flags_arr.items);
     }
 
     var gen_step = b.addWriteFiles();
@@ -73,7 +84,7 @@ pub fn addRaylib(b: *std.Build, target: anytype, optimize: std.builtin.OptimizeM
 
     if (options.raygui) {
         const raygui_c_path = gen_step.add("raygui.c", "#define RAYGUI_IMPLEMENTATION\n#include \"raygui.h\"\n");
-        raylib.addCSourceFile(.{ .file = raygui_c_path, .flags = raylib_flags });
+        raylib.addCSourceFile(.{ .file = raygui_c_path, .flags = raylib_flags_arr.items });
         raylib.addIncludePath(.{ .path = srcdir });
         raylib.addIncludePath(.{ .path = srcdir ++ "/../../raygui/src" });
     }
@@ -82,7 +93,7 @@ pub fn addRaylib(b: *std.Build, target: anytype, optimize: std.builtin.OptimizeM
         .windows => {
             addCSourceFilesVersioned(raylib, &.{
                 srcdir ++ "/rglfw.c",
-            }, raylib_flags);
+            }, raylib_flags_arr.items);
             raylib.linkSystemLibrary("winmm");
             raylib.linkSystemLibrary("gdi32");
             raylib.linkSystemLibrary("opengl32");
@@ -94,7 +105,7 @@ pub fn addRaylib(b: *std.Build, target: anytype, optimize: std.builtin.OptimizeM
             if (!options.platform_drm) {
                 addCSourceFilesVersioned(raylib, &.{
                     srcdir ++ "/rglfw.c",
-                }, raylib_flags);
+                }, raylib_flags_arr.items);
                 raylib.linkSystemLibrary("GL");
                 raylib.linkSystemLibrary("rt");
                 raylib.linkSystemLibrary("dl");
@@ -124,7 +135,7 @@ pub fn addRaylib(b: *std.Build, target: anytype, optimize: std.builtin.OptimizeM
         .freebsd, .openbsd, .netbsd, .dragonfly => {
             addCSourceFilesVersioned(raylib, &.{
                 srcdir ++ "/rglfw.c",
-            }, raylib_flags);
+            }, raylib_flags_arr.items);
             raylib.linkSystemLibrary("GL");
             raylib.linkSystemLibrary("rt");
             raylib.linkSystemLibrary("dl");
@@ -140,12 +151,10 @@ pub fn addRaylib(b: *std.Build, target: anytype, optimize: std.builtin.OptimizeM
         },
         .macos => {
             // On macos rglfw.c include Objective-C files.
-            const raylib_flags_extra_macos = &[_][]const u8{
-                "-ObjC",
-            };
+            try raylib_flags_arr.append("-ObjC");
             addCSourceFilesVersioned(raylib, &.{
                 srcdir ++ "/rglfw.c",
-            }, raylib_flags ++ raylib_flags_extra_macos);
+            }, raylib_flags_arr.items);
             raylib.linkFramework("Foundation");
             raylib.linkFramework("CoreServices");
             raylib.linkFramework("CoreGraphics");
@@ -186,9 +195,10 @@ pub const Options = struct {
     rtextures: bool = true,
     raygui: bool = false,
     platform_drm: bool = false,
+    shared: bool = false,
 };
 
-pub fn build(b: *std.Build) void {
+pub fn build(b: *std.Build) !void {
     // Standard target options allows the person running `zig build` to choose
     // what target to build for. Here we do not override the defaults, which
     // means any target is allowed, and the default is native. Other options
@@ -208,9 +218,10 @@ pub fn build(b: *std.Build) void {
         .rtextures = b.option(bool, "rtextures", "Compile with textures support") orelse defaults.rtextures,
         .rshapes = b.option(bool, "rshapes", "Compile with shapes support") orelse defaults.rshapes,
         .raygui = b.option(bool, "raygui", "Compile with raygui support") orelse defaults.raygui,
+        .shared = b.option(bool, "shared", "Compile as shared library") orelse defaults.shared,
     };
 
-    const lib = addRaylib(b, target, optimize, options);
+    const lib = try addRaylib(b, target, optimize, options);
 
     lib.installHeader("src/raylib.h", "raylib.h");
     lib.installHeader("src/raymath.h", "raymath.h");


### PR DESCRIPTION
Using raylib as a shared library was helpful for hot-module reloading, allowing both the main executable and shared game library to link with raylib and then we can reload without segfaulting. I needed the no-sanitize flag to work around an illegal instruction error.

Here is the source for that example: https://github.com/candrewlee14/tetris-raylib