### PR TITLE
Make raylib/raygui work better on touchscreen

### DIFF
--- a/src/platforms/rcore_web.c
+++ b/src/platforms/rcore_web.c
@@ -1635,6 +1635,11 @@ static EM_BOOL EmscriptenTouchCallback(int eventType, const EmscriptenTouchEvent
         else if (eventType == EMSCRIPTEN_EVENT_TOUCHEND) CORE.Input.Touch.currentTouchState[i] = 0;
     }
 
+    if (CORE.Input.Touch.pointCount == 1) {
+        CORE.Input.Mouse.currentPosition.x = CORE.Input.Touch.position[0].x;
+        CORE.Input.Mouse.currentPosition.y = CORE.Input.Touch.position[0].y;
+    }
+
 #if defined(SUPPORT_GESTURES_SYSTEM)
     GestureEvent gestureEvent = {0};
 

--- a/src/platforms/rcore_web.c
+++ b/src/platforms/rcore_web.c
@@ -1635,6 +1635,10 @@ static EM_BOOL EmscriptenTouchCallback(int eventType, const EmscriptenTouchEvent
         else if (eventType == EMSCRIPTEN_EVENT_TOUCHEND) CORE.Input.Touch.currentTouchState[i] = 0;
     }
 
+    // Update mouse position if we detect a single touch.
+    // This is essential for raylib to work on touchscreen.
+    // Otherwise, mouse position will always be 0,0, so that
+    // things such as raygui and examples/shapes/shapes_lines_bezier.c won't work
     if (CORE.Input.Touch.pointCount == 1) {
         CORE.Input.Mouse.currentPosition.x = CORE.Input.Touch.position[0].x;
         CORE.Input.Mouse.currentPosition.y = CORE.Input.Touch.position[0].y;

--- a/src/platforms/rcore_web.c
+++ b/src/platforms/rcore_web.c
@@ -1636,10 +1636,8 @@ static EM_BOOL EmscriptenTouchCallback(int eventType, const EmscriptenTouchEvent
     }
 
     // Update mouse position if we detect a single touch.
-    // This is essential for raylib to work on touchscreen.
-    // Otherwise, mouse position will always be 0,0, so that
-    // things such as raygui and examples/shapes/shapes_lines_bezier.c won't work
-    if (CORE.Input.Touch.pointCount == 1) {
+    if (CORE.Input.Touch.pointCount == 1)
+    {
         CORE.Input.Mouse.currentPosition.x = CORE.Input.Touch.position[0].x;
         CORE.Input.Mouse.currentPosition.y = CORE.Input.Touch.position[0].y;
     }


### PR DESCRIPTION
Hi,

I'm trying raylib on my iPad using emscripten. I found that raylib and raygui don't work well. We need updated mouse position yet it's never updated (always 0,0). As a result, [Cubic-bezier lines](https://www.raylib.com/examples/shapes/loader.html?name=shapes_lines_bezier) doesn't work on iPad.

I don't fully understand how it works on desktop browser, but it may be reasonable to update mouse position of we are using touch screen?

This is not pretty, but after this fix, raylib and raygui work just fine.
If you have better fix, then it's great. Just kindly discard this pull request.