### PR TITLE
Fix bounds check for `ImageDrawRectangleRec`

### DIFF
--- a/src/rtextures.c
+++ b/src/rtextures.c
@@ -3586,8 +3586,8 @@ void ImageDrawRectangleRec(Image *dst, Rectangle rec, Color color)
     if ((rec.y + rec.height) >= dst->height) rec.height = dst->height - rec.y;
 
     // Check if the rect is even inside the image
-    if ((rec.x > dst->width) || (rec.y > dst->height)) return;
-    if (((rec.x + rec.width) < 0) || (rec.y + rec.height < 0)) return;
+    if ((rec.x >= dst->width) || (rec.y >= dst->height)) return;
+    if (((rec.x + rec.width) <= 0) || (rec.y + rec.height <= 0)) return;
 
     int sy = (int)rec.y;
     int sx = (int)rec.x;


### PR DESCRIPTION
I was having originally having issues with image drawing functions causing memory corruptions, I found that the condition for the bounds check in `ImageDrawRectangleRec` misses cases near the edges of the `Image`. I used code like this, running with valgrind, to verify that the memory corruption no longer occurs: (sorry for the mess)

```c++
#include <stdio.h>

#include "raylib.h"

#define IMAGE_SIZE 4
#define OVERSCAN 2
#define MAX_DRAW_SIZE (IMAGE_SIZE + OVERSCAN * 2)

int main()
{
    Image image = GenImageColor(IMAGE_SIZE, IMAGE_SIZE, BLANK);

    for (int y = -(MAX_DRAW_SIZE + OVERSCAN); y <= IMAGE_SIZE + OVERSCAN; y++)
    {
        for (int x = -(MAX_DRAW_SIZE + OVERSCAN); x <= IMAGE_SIZE + OVERSCAN; x++)
        {
            for (int w = -MAX_DRAW_SIZE; w <= MAX_DRAW_SIZE; w++)
            {
                for (int h = -MAX_DRAW_SIZE; h <= MAX_DRAW_SIZE; h++)
                {
                    printf("x=%d, y=%d, w=%d, h=%d\n", x, y, w, h);
                    ImageDrawRectangle(&image, x, y, w, h, WHITE);
                }
            }
        }
    }

    printf("unloading...\n");
    UnloadImage(image);

    return 0;
}
```

I also implemented the additional suggestion from (#3721) and verified that extra pixels are no longer drawn at the edge of the image.