### PR TITLE
Fix Android keycode translation and duplicate key constants

### DIFF
--- a/parser/output/raylib_api.json
+++ b/parser/output/raylib_api.json
@@ -2069,7 +2069,7 @@
         },
         {
           "name": "KEY_MENU",
-          "value": 82,
+          "value": 5,
           "description": "Key: Android menu button"
         },
         {

--- a/parser/output/raylib_api.lua
+++ b/parser/output/raylib_api.lua
@@ -2069,7 +2069,7 @@ return {
         },
         {
           name = "KEY_MENU",
-          value = 82,
+          value = 5,
           description = "Key: Android menu button"
         },
         {

--- a/parser/output/raylib_api.txt
+++ b/parser/output/raylib_api.txt
@@ -717,7 +717,7 @@ Enum 03: KeyboardKey (110 values)
   Value[KEY_KP_ENTER]: 335
   Value[KEY_KP_EQUAL]: 336
   Value[KEY_BACK]: 4
-  Value[KEY_MENU]: 82
+  Value[KEY_MENU]: 5
   Value[KEY_VOLUME_UP]: 24
   Value[KEY_VOLUME_DOWN]: 25
 Enum 04: MouseButton (7 values)

--- a/parser/output/raylib_api.xml
+++ b/parser/output/raylib_api.xml
@@ -437,7 +437,7 @@
             <Value name="KEY_KP_ENTER" integer="335" desc="Key: Keypad Enter" />
             <Value name="KEY_KP_EQUAL" integer="336" desc="Key: Keypad =" />
             <Value name="KEY_BACK" integer="4" desc="Key: Android back button" />
-            <Value name="KEY_MENU" integer="82" desc="Key: Android menu button" />
+            <Value name="KEY_MENU" integer="5" desc="Key: Android menu button" />
             <Value name="KEY_VOLUME_UP" integer="24" desc="Key: Android volume up button" />
             <Value name="KEY_VOLUME_DOWN" integer="25" desc="Key: Android volume down button" />
         </Enum>

--- a/src/platforms/rcore_android.c
+++ b/src/platforms/rcore_android.c
@@ -78,6 +78,175 @@ extern CoreData CORE;                   // Global CORE state context
 static PlatformData platform = { 0 };   // Platform specific data
 
 //----------------------------------------------------------------------------------
+// Local Variables Definition
+//----------------------------------------------------------------------------------
+#define SCANCODE_MAPPED_NUM 162
+static const KeyboardKey ScancodeToKey[SCANCODE_MAPPED_NUM] = {
+    KEY_NULL,           // AKEYCODE_UNKNOWN
+    0,                  // AKEYCODE_SOFT_LEFT
+    0,                  // AKEYCODE_SOFT_RIGHT
+    0,                  // AKEYCODE_HOME
+    KEY_BACK,           // AKEYCODE_BACK
+    0,                  // AKEYCODE_CALL
+    0,                  // AKEYCODE_ENDCALL
+    KEY_ZERO,           // AKEYCODE_0
+    KEY_ONE,            // AKEYCODE_1
+    KEY_TWO,            // AKEYCODE_2
+    KEY_THREE,          // AKEYCODE_3
+    KEY_FOUR,           // AKEYCODE_4
+    KEY_FIVE,           // AKEYCODE_5
+    KEY_SIX,            // AKEYCODE_6
+    KEY_SEVEN,          // AKEYCODE_7
+    KEY_EIGHT,          // AKEYCODE_8
+    KEY_NINE,           // AKEYCODE_9
+    0,                  // AKEYCODE_STAR
+    0,                  // AKEYCODE_POUND
+    KEY_UP,             // AKEYCODE_DPAD_UP
+    KEY_DOWN,           // AKEYCODE_DPAD_DOWN
+    KEY_LEFT,           // AKEYCODE_DPAD_LEFT
+    KEY_RIGHT,          // AKEYCODE_DPAD_RIGHT
+    0,                  // AKEYCODE_DPAD_CENTER
+    KEY_VOLUME_UP,      // AKEYCODE_VOLUME_UP
+    KEY_VOLUME_DOWN,    // AKEYCODE_VOLUME_DOWN
+    0,                  // AKEYCODE_POWER
+    0,                  // AKEYCODE_CAMERA
+    0,                  // AKEYCODE_CLEAR
+    KEY_A,              // AKEYCODE_A
+    KEY_B,              // AKEYCODE_B
+    KEY_C,              // AKEYCODE_C
+    KEY_D,              // AKEYCODE_D
+    KEY_E,              // AKEYCODE_E
+    KEY_F,              // AKEYCODE_F
+    KEY_G,              // AKEYCODE_G
+    KEY_H,              // AKEYCODE_H
+    KEY_I,              // AKEYCODE_I
+    KEY_J,              // AKEYCODE_J
+    KEY_K,              // AKEYCODE_K
+    KEY_L,              // AKEYCODE_L
+    KEY_M,              // AKEYCODE_M
+    KEY_N,              // AKEYCODE_N
+    KEY_O,              // AKEYCODE_O
+    KEY_P,              // AKEYCODE_P
+    KEY_Q,              // AKEYCODE_Q
+    KEY_R,              // AKEYCODE_R
+    KEY_S,              // AKEYCODE_S
+    KEY_T,              // AKEYCODE_T
+    KEY_U,              // AKEYCODE_U
+    KEY_V,              // AKEYCODE_V
+    KEY_W,              // AKEYCODE_W
+    KEY_X,              // AKEYCODE_X
+    KEY_Y,              // AKEYCODE_Y
+    KEY_Z,              // AKEYCODE_Z
+    KEY_COMMA,          // AKEYCODE_COMMA
+    KEY_PERIOD,         // AKEYCODE_PERIOD
+    KEY_LEFT_ALT,       // AKEYCODE_ALT_LEFT
+    KEY_RIGHT_ALT,      // AKEYCODE_ALT_RIGHT
+    KEY_LEFT_SHIFT,     // AKEYCODE_SHIFT_LEFT
+    KEY_RIGHT_SHIFT,    // AKEYCODE_SHIFT_RIGHT
+    KEY_TAB,            // AKEYCODE_TAB
+    KEY_SPACE,          // AKEYCODE_SPACE
+    0,                  // AKEYCODE_SYM
+    0,                  // AKEYCODE_EXPLORER
+    0,                  // AKEYCODE_ENVELOPE
+    KEY_ENTER,          // AKEYCODE_ENTER
+    KEY_BACKSPACE,      // AKEYCODE_DEL
+    KEY_GRAVE,          // AKEYCODE_GRAVE
+    KEY_MINUS,          // AKEYCODE_MINUS
+    KEY_EQUAL,          // AKEYCODE_EQUALS
+    KEY_LEFT_BRACKET,   // AKEYCODE_LEFT_BRACKET
+    KEY_RIGHT_BRACKET,  // AKEYCODE_RIGHT_BRACKET
+    KEY_BACKSLASH,      // AKEYCODE_BACKSLASH
+    KEY_SEMICOLON,      // AKEYCODE_SEMICOLON
+    KEY_APOSTROPHE,     // AKEYCODE_APOSTROPHE
+    KEY_SLASH,          // AKEYCODE_SLASH
+    0,                  // AKEYCODE_AT
+    0,                  // AKEYCODE_NUM
+    0,                  // AKEYCODE_HEADSETHOOK
+    0,                  // AKEYCODE_FOCUS
+    0,                  // AKEYCODE_PLUS
+    0,                  // AKEYCODE_MENU
+    0,                  // AKEYCODE_NOTIFICATION
+    0,                  // AKEYCODE_SEARCH
+    0,                  // AKEYCODE_MEDIA_PLAY_PAUSE
+    0,                  // AKEYCODE_MEDIA_STOP
+    0,                  // AKEYCODE_MEDIA_NEXT
+    0,                  // AKEYCODE_MEDIA_PREVIOUS
+    0,                  // AKEYCODE_MEDIA_REWIND
+    0,                  // AKEYCODE_MEDIA_FAST_FORWARD
+    0,                  // AKEYCODE_MUTE
+    KEY_PAGE_UP,        // AKEYCODE_PAGE_UP
+    KEY_PAGE_DOWN,      // AKEYCODE_PAGE_DOWN
+    0,                  // AKEYCODE_PICTSYMBOLS
+    0,                  // AKEYCODE_SWITCH_CHARSET
+    0,                  // AKEYCODE_BUTTON_A
+    0,                  // AKEYCODE_BUTTON_B
+    0,                  // AKEYCODE_BUTTON_C
+    0,                  // AKEYCODE_BUTTON_X
+    0,                  // AKEYCODE_BUTTON_Y
+    0,                  // AKEYCODE_BUTTON_Z
+    0,                  // AKEYCODE_BUTTON_L1
+    0,                  // AKEYCODE_BUTTON_R1
+    0,                  // AKEYCODE_BUTTON_L2
+    0,                  // AKEYCODE_BUTTON_R2
+    0,                  // AKEYCODE_BUTTON_THUMBL
+    0,                  // AKEYCODE_BUTTON_THUMBR
+    0,                  // AKEYCODE_BUTTON_START
+    0,                  // AKEYCODE_BUTTON_SELECT
+    0,                  // AKEYCODE_BUTTON_MODE
+    KEY_ESCAPE,         // AKEYCODE_ESCAPE
+    KEY_DELETE,         // AKEYCODE_FORWARD_DELL
+    KEY_LEFT_CONTROL,   // AKEYCODE_CTRL_LEFT
+    KEY_RIGHT_CONTROL,  // AKEYCODE_CTRL_RIGHT
+    KEY_CAPS_LOCK,      // AKEYCODE_CAPS_LOCK
+    KEY_SCROLL_LOCK,    // AKEYCODE_SCROLL_LOCK
+    KEY_LEFT_SUPER,     // AKEYCODE_META_LEFT
+    KEY_RIGHT_SUPER,    // AKEYCODE_META_RIGHT
+    0,                  // AKEYCODE_FUNCTION
+    KEY_PRINT_SCREEN,   // AKEYCODE_SYSRQ
+    KEY_PAUSE,          // AKEYCODE_BREAK
+    KEY_HOME,           // AKEYCODE_MOVE_HOME
+    KEY_END,            // AKEYCODE_MOVE_END
+    KEY_INSERT,         // AKEYCODE_INSERT
+    0,                  // AKEYCODE_FORWARD
+    0,                  // AKEYCODE_MEDIA_PLAY
+    0,                  // AKEYCODE_MEDIA_PAUSE
+    0,                  // AKEYCODE_MEDIA_CLOSE
+    0,                  // AKEYCODE_MEDIA_EJECT
+    0,                  // AKEYCODE_MEDIA_RECORD
+    KEY_F1,             // AKEYCODE_F1
+    KEY_F2,             // AKEYCODE_F2
+    KEY_F3,             // AKEYCODE_F3
+    KEY_F4,             // AKEYCODE_F4
+    KEY_F5,             // AKEYCODE_F5
+    KEY_F6,             // AKEYCODE_F6
+    KEY_F7,             // AKEYCODE_F7
+    KEY_F8,             // AKEYCODE_F8
+    KEY_F9,             // AKEYCODE_F9
+    KEY_F10,            // AKEYCODE_F10
+    KEY_F11,            // AKEYCODE_F11
+    KEY_F12,            // AKEYCODE_F12
+    KEY_NUM_LOCK,       // AKEYCODE_NUM_LOCK
+    KEY_KP_0,           // AKEYCODE_NUMPAD_0
+    KEY_KP_1,           // AKEYCODE_NUMPAD_1
+    KEY_KP_2,           // AKEYCODE_NUMPAD_2
+    KEY_KP_3,           // AKEYCODE_NUMPAD_3
+    KEY_KP_4,           // AKEYCODE_NUMPAD_4
+    KEY_KP_5,           // AKEYCODE_NUMPAD_5
+    KEY_KP_6,           // AKEYCODE_NUMPAD_6
+    KEY_KP_7,           // AKEYCODE_NUMPAD_7
+    KEY_KP_8,           // AKEYCODE_NUMPAD_8
+    KEY_KP_9,           // AKEYCODE_NUMPAD_9
+    KEY_KP_DIVIDE,      // AKEYCODE_NUMPAD_DIVIDE
+    KEY_KP_MULTIPLY,    // AKEYCODE_NUMPAD_MULTIPLY
+    KEY_KP_SUBTRACT,    // AKEYCODE_NUMPAD_SUBTRACT
+    KEY_KP_ADD,         // AKEYCODE_NUMPAD_ADD
+    KEY_KP_DECIMAL,     // AKEYCODE_NUMPAD_DOT
+    0,                  // AKEYCODE_NUMPAD_COMMA
+    KEY_KP_ENTER,       // AKEYCODE_NUMPAD_ENTER
+    KEY_KP_EQUAL        // AKEYCODE_NUMPAD_EQUALS
+};
+
+//----------------------------------------------------------------------------------
 // Module Internal Functions Declaration
 //----------------------------------------------------------------------------------
 int InitPlatform(void);          // Initialize platform (graphics, inputs and more)
@@ -1016,17 +1185,26 @@ static int32_t AndroidInputCallback(struct android_app *app, AInputEvent *event)
             return 1; // Handled gamepad button
         }
 
-        // Save current button and its state
-        // NOTE: Android key action is 0 for down and 1 for up
-        if (AKeyEvent_getAction(event) == AKEY_EVENT_ACTION_DOWN)
+        KeyboardKey key = KEY_NULL;
+        if (keycode > 0 && keycode < SCANCODE_MAPPED_NUM)
         {
-            CORE.Input.Keyboard.currentKeyState[keycode] = 1;   // Key down
+            key = ScancodeToKey[keycode];
 
-            CORE.Input.Keyboard.keyPressedQueue[CORE.Input.Keyboard.keyPressedQueueCount] = keycode;
-            CORE.Input.Keyboard.keyPressedQueueCount++;
+            if (key > 0)
+            {
+                // Save current key and its state
+                // NOTE: Android key action is 0 for down and 1 for up
+                if (AKeyEvent_getAction(event) == AKEY_EVENT_ACTION_DOWN)
+                {
+                    CORE.Input.Keyboard.currentKeyState[key] = 1;   // Key down
+
+                    CORE.Input.Keyboard.keyPressedQueue[CORE.Input.Keyboard.keyPressedQueueCount] = key;
+                    CORE.Input.Keyboard.keyPressedQueueCount++;
+                }
+                else if (AKeyEvent_getAction(event) == AKEY_EVENT_ACTION_MULTIPLE) CORE.Input.Keyboard.keyRepeatInFrame[key] = 1;
+                else CORE.Input.Keyboard.currentKeyState[key] = 0;  // Key up
+            }
         }
-        else if (AKeyEvent_getAction(event) == AKEY_EVENT_ACTION_MULTIPLE) CORE.Input.Keyboard.keyRepeatInFrame[keycode] = 1;
-        else CORE.Input.Keyboard.currentKeyState[keycode] = 0;  // Key up
 
         if (keycode == AKEYCODE_POWER)
         {

--- a/src/platforms/rcore_android.c
+++ b/src/platforms/rcore_android.c
@@ -80,8 +80,8 @@ static PlatformData platform = { 0 };   // Platform specific data
 //----------------------------------------------------------------------------------
 // Local Variables Definition
 //----------------------------------------------------------------------------------
-#define SCANCODE_MAPPED_NUM 162
-static const KeyboardKey ScancodeToKey[SCANCODE_MAPPED_NUM] = {
+#define KEYCODE_MAPPED_NUM 162
+static const KeyboardKey KeycodeMap[KEYCODE_MAPPED_NUM] = {
     KEY_NULL,           // AKEYCODE_UNKNOWN
     0,                  // AKEYCODE_SOFT_LEFT
     0,                  // AKEYCODE_SOFT_RIGHT
@@ -1185,25 +1185,20 @@ static int32_t AndroidInputCallback(struct android_app *app, AInputEvent *event)
             return 1; // Handled gamepad button
         }
 
-        KeyboardKey key = KEY_NULL;
-        if (keycode > 0 && keycode < SCANCODE_MAPPED_NUM)
+        KeyboardKey key = (keycode > 0 && keycode < KEYCODE_MAPPED_NUM) ? KeycodeMap[keycode] : KEY_NULL;
+        if (key != KEY_NULL)
         {
-            key = ScancodeToKey[keycode];
-
-            if (key > 0)
+            // Save current key and its state
+            // NOTE: Android key action is 0 for down and 1 for up
+            if (AKeyEvent_getAction(event) == AKEY_EVENT_ACTION_DOWN)
             {
-                // Save current key and its state
-                // NOTE: Android key action is 0 for down and 1 for up
-                if (AKeyEvent_getAction(event) == AKEY_EVENT_ACTION_DOWN)
-                {
-                    CORE.Input.Keyboard.currentKeyState[key] = 1;   // Key down
+                CORE.Input.Keyboard.currentKeyState[key] = 1;   // Key down
 
-                    CORE.Input.Keyboard.keyPressedQueue[CORE.Input.Keyboard.keyPressedQueueCount] = key;
-                    CORE.Input.Keyboard.keyPressedQueueCount++;
-                }
-                else if (AKeyEvent_getAction(event) == AKEY_EVENT_ACTION_MULTIPLE) CORE.Input.Keyboard.keyRepeatInFrame[key] = 1;
-                else CORE.Input.Keyboard.currentKeyState[key] = 0;  // Key up
+                CORE.Input.Keyboard.keyPressedQueue[CORE.Input.Keyboard.keyPressedQueueCount] = key;
+                CORE.Input.Keyboard.keyPressedQueueCount++;
             }
+            else if (AKeyEvent_getAction(event) == AKEY_EVENT_ACTION_MULTIPLE) CORE.Input.Keyboard.keyRepeatInFrame[key] = 1;
+            else CORE.Input.Keyboard.currentKeyState[key] = 0;  // Key up
         }
 
         if (keycode == AKEYCODE_POWER)

--- a/src/platforms/rcore_android.c
+++ b/src/platforms/rcore_android.c
@@ -80,8 +80,8 @@ static PlatformData platform = { 0 };   // Platform specific data
 //----------------------------------------------------------------------------------
 // Local Variables Definition
 //----------------------------------------------------------------------------------
-#define KEYCODE_MAPPED_NUM 162
-static const KeyboardKey KeycodeMap[KEYCODE_MAPPED_NUM] = {
+#define KEYCODE_MAP_SIZE 162
+static const KeyboardKey KeycodeMap[KEYCODE_MAP_SIZE] = {
     KEY_NULL,           // AKEYCODE_UNKNOWN
     0,                  // AKEYCODE_SOFT_LEFT
     0,                  // AKEYCODE_SOFT_RIGHT
@@ -1185,7 +1185,7 @@ static int32_t AndroidInputCallback(struct android_app *app, AInputEvent *event)
             return 1; // Handled gamepad button
         }
 
-        KeyboardKey key = (keycode > 0 && keycode < KEYCODE_MAPPED_NUM) ? KeycodeMap[keycode] : KEY_NULL;
+        KeyboardKey key = (keycode > 0 && keycode < KEYCODE_MAP_SIZE) ? KeycodeMap[keycode] : KEY_NULL;
         if (key != KEY_NULL)
         {
             // Save current key and its state

--- a/src/platforms/rcore_android.c
+++ b/src/platforms/rcore_android.c
@@ -164,7 +164,7 @@ static const KeyboardKey KeycodeMap[KEYCODE_MAP_SIZE] = {
     0,                  // AKEYCODE_HEADSETHOOK
     0,                  // AKEYCODE_FOCUS
     0,                  // AKEYCODE_PLUS
-    0,                  // AKEYCODE_MENU
+    KEY_MENU,           // AKEYCODE_MENU
     0,                  // AKEYCODE_NOTIFICATION
     0,                  // AKEYCODE_SEARCH
     0,                  // AKEYCODE_MEDIA_PLAY_PAUSE

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -677,7 +677,7 @@ typedef enum {
     KEY_KP_EQUAL        = 336,      // Key: Keypad =
     // Android key buttons
     KEY_BACK            = 4,        // Key: Android back button
-    KEY_MENU            = 82,       // Key: Android menu button
+    KEY_MENU            = 5,        // Key: Android menu button
     KEY_VOLUME_UP       = 24,       // Key: Android volume up button
     KEY_VOLUME_DOWN     = 25        // Key: Android volume down button
 } KeyboardKey;


### PR DESCRIPTION
Fixes #3729
Fixes #3734

All of the keys I am able to test are correct. However, I cannot test the keypad (because I use a tenkeyless keyboard), the keyboard menu key (because my keyboard lacks it) and the Android menu key (because my phone lacks it and also because of #3734). Additionally, the Super (Windows) and Print Screen keys are grabbed by the system and apparently cannot be caught by the app.

~**Note:** there seems to be an issue (already present, not introduced by this PR) in which the app freezes on Android if a keyboard is connected after the app starts. For this reason, I recommend testers to connect a keyboard and force stop the test app before starting it~ (fixed by including ``keyboard`` in the manifest's ``android:configChanges``).

**Update:** with 1df491c54, #3734 is also fixed, but it introduces a breaking change, as the value of ``KEY_MENU`` is changed.

## Code example ##

```C
#include <raylib.h>
#include <stdio.h>

static const char* get_key_name(int key);

int main()
{
	int last_key = 0;

	InitWindow(800, 600, "Android Keyboard Test");

	while (!WindowShouldClose()) {
		int pressed_key = GetKeyPressed();
		char str[64] = "";

		if (pressed_key != KEY_NULL) {
			last_key = pressed_key;
		}


		BeginDrawing();
		ClearBackground(GRAY);

		sprintf(str, "%d - %s", last_key, get_key_name(last_key));
		DrawText(str, 16, 16, 32, BLACK);

		sprintf(str, "%d", (int)GetTime());
		DrawText(str, 16, 64, 32, BLACK);

		EndDrawing();
	}

	CloseWindow();

	return 0;
}

static const char* get_key_name(int key)
{
	switch (key) {
		case KEY_APOSTROPHE:
			return "Apostrophe";

		case KEY_COMMA:
			return "Comma";

		case KEY_MINUS:
			return "Minus";

		case KEY_PERIOD:
			return "Period";

		case KEY_SLASH:
			return "Slash";

		case KEY_ZERO:
			return "0";

		case KEY_ONE:
			return "1";

		case KEY_TWO:
			return "2";

		case KEY_THREE:
			return "3";

		case KEY_FOUR:
			return "4";

		case KEY_FIVE:
			return "5";

		case KEY_SIX:
			return "6";

		case KEY_SEVEN:
			return "7";

		case KEY_EIGHT:
			return "8";

		case KEY_NINE:
			return "9";

		case KEY_SEMICOLON:
			return "Semicolon";

		case KEY_EQUAL:
			return "Equal";

		case KEY_A:
			return "A";

		case KEY_B:
			return "B";

		case KEY_C:
			return "C";

		case KEY_D:
			return "D";

		case KEY_E:
			return "E";

		case KEY_F:
			return "F";

		case KEY_G:
			return "G";

		case KEY_H:
			return "H";

		case KEY_I:
			return "I";

		case KEY_J:
			return "J";

		case KEY_K:
			return "K";

		case KEY_L:
			return "L";

		case KEY_M:
			return "M";

		case KEY_N:
			return "N";

		case KEY_O:
			return "O";

		case KEY_P:
			return "P";

		case KEY_Q:
			return "Q";

		case KEY_R:
			return "R";

		case KEY_S:
			return "S";

		case KEY_T:
			return "T";

		case KEY_U:
			return "U";

		case KEY_V:
			return "V";

		case KEY_W:
			return "W";

		case KEY_X:
			return "X";

		case KEY_Y:
			return "Y";

		case KEY_Z:
			return "Z";

		case KEY_LEFT_BRACKET:
			return "Left bracket";

		case KEY_BACKSLASH:
			return "Backslash";

		case KEY_RIGHT_BRACKET:
			return "Right bracket";

		case KEY_GRAVE:
			return "Grave";

		case KEY_SPACE:
			return "Space";

		case KEY_ESCAPE:
			return "Escape";

		case KEY_ENTER:
			return "Enter";

		case KEY_TAB:
			return "Tab";

		case KEY_BACKSPACE:
			return "Backspace";

		case KEY_INSERT:
			return "Insert";

		case KEY_DELETE:
			return "Delete";

		case KEY_RIGHT:
			return "Right";

		case KEY_LEFT:
			return "Left";

		case KEY_DOWN:
			return "Down";

		case KEY_UP:
			return "Up";

		case KEY_PAGE_UP:
			return "Page Up";

		case KEY_PAGE_DOWN:
			return "Page Down";

		case KEY_HOME:
			return "Home";

		case KEY_END:
			return "End";

		case KEY_CAPS_LOCK:
			return "Caps Lock";

		case KEY_SCROLL_LOCK:
			return "Scroll Lock";

		case KEY_NUM_LOCK:
			return "Num Lock";

		case KEY_PRINT_SCREEN:
			return "Print Screen";

		case KEY_PAUSE:
			return "Pause";

		case KEY_F1:
			return "F1";

		case KEY_F2:
			return "F2";

		case KEY_F3:
			return "F3";

		case KEY_F4:
			return "F4";

		case KEY_F5:
			return "F5";

		case KEY_F6:
			return "F6";

		case KEY_F7:
			return "F7";

		case KEY_F8:
			return "F8";

		case KEY_F9:
			return "F9";

		case KEY_F10:
			return "F10";

		case KEY_F11:
			return "F11";

		case KEY_F12:
			return "F12";

		case KEY_LEFT_SHIFT:
			return "Left Shift";

		case KEY_LEFT_CONTROL:
			return "Left Ctrl";

		case KEY_LEFT_ALT:
			return "Left Alt";

		case KEY_LEFT_SUPER:
			return "Left Super";

		case KEY_RIGHT_SHIFT:
			return "Right Shift";

		case KEY_RIGHT_CONTROL:
			return "Right Ctrl";

		case KEY_RIGHT_ALT:
			return "Right Alt";

		case KEY_RIGHT_SUPER:
			return "Right Super";

		case KEY_KP_0:
			return "Keypad 0";

		case KEY_KP_1:
			return "Keypad 1";

		case KEY_KP_2:
			return "Keypad 2";

		case KEY_KP_3:
			return "Keypad 3";

		case KEY_KP_4:
			return "Keypad 4";

		case KEY_KP_5:
			return "Keypad 5";

		case KEY_KP_6:
			return "Keypad 6";

		case KEY_KP_7:
			return "Keypad 7";

		case KEY_KP_8:
			return "Keypad 8";

		case KEY_KP_9:
			return "Keypad 9";

		case KEY_KP_DECIMAL:
			return "Keypad Decimal";

		case KEY_KP_DIVIDE:
			return "Keypad Divide";

		case KEY_KP_MULTIPLY:
			return "Keypad Multiply";

		case KEY_KP_SUBTRACT:
			return "Keypad Subtract";

		case KEY_KP_ADD:
			return "Keypad Add";

		case KEY_KP_ENTER:
			return "Keypad Enter";

		case KEY_KP_EQUAL:
			return "Keypad Equal";

		case KEY_BACK:
			return "Android Back";

		case KEY_MENU:
			return "Android Menu";

		case KEY_VOLUME_UP:
			return "Android Volume Up";

		case KEY_VOLUME_DOWN:
			return "Android Volume Down";

		default:
			return "Unknown";
    }
}
```