### PR TITLE
[rcore rglfw] Feature Test Macros before include

### DIFF
--- a/src/rcore.c
+++ b/src/rcore.c
@@ -82,6 +82,19 @@
 *
 **********************************************************************************************/
 
+//----------------------------------------------------------------------------------
+// Feature Test Macros required for this module
+//----------------------------------------------------------------------------------
+#if (defined(__linux__) || defined(PLATFORM_WEB)) && (_XOPEN_SOURCE < 500)
+    #undef _XOPEN_SOURCE
+    #define _XOPEN_SOURCE 500 // Required for: readlink if compiled with c99 without gnu ext.
+#endif
+
+#if (defined(__linux__) || defined(PLATFORM_WEB)) && (_POSIX_C_SOURCE < 199309L)
+    #undef _POSIX_C_SOURCE
+    #define _POSIX_C_SOURCE 199309L // Required for: CLOCK_MONOTONIC if compiled with c99 without gnu ext.
+#endif
+
 #include "raylib.h"                 // Declares module functions
 
 // Check if config flags have been externally provided on compilation line
@@ -234,11 +247,6 @@ __declspec(dllimport) int __stdcall WideCharToMultiByte(unsigned int cp, unsigne
 #define FLAG_CLEAR(n, f) ((n) &= ~(f))
 #define FLAG_TOGGLE(n, f) ((n) ^= (f))
 #define FLAG_CHECK(n, f) ((n) & (f))
-
-#if (defined(__linux__) || defined(PLATFORM_WEB)) && (_POSIX_C_SOURCE < 199309L)
-    #undef _POSIX_C_SOURCE
-    #define _POSIX_C_SOURCE 199309L // Required for: CLOCK_MONOTONIC if compiled with c99 without gnu ext.
-#endif
 
 //----------------------------------------------------------------------------------
 // Types and Structures Definition

--- a/src/rglfw.c
+++ b/src/rglfw.c
@@ -37,6 +37,18 @@
 // _GLFW_OSMESA     to use the OSMesa API (headless and non-interactive)
 // _GLFW_MIR        experimental, not supported at this moment
 
+//----------------------------------------------------------------------------------
+// Feature Test Macros required for this module
+//----------------------------------------------------------------------------------
+#if (defined(__linux__) || defined(PLATFORM_WEB)) && (_POSIX_C_SOURCE < 199309L)
+    #undef _POSIX_C_SOURCE
+    #define _POSIX_C_SOURCE 199309L // Required for: CLOCK_MONOTONIC if compiled with c99 without gnu ext.
+#endif
+#if (defined(__linux__) || defined(PLATFORM_WEB)) && !defined(_GNU_SOURCE)
+    #undef _GNU_SOURCE
+    #define _GNU_SOURCE // Required for: ppoll if compiled with c99 without gnu ext.
+#endif
+
 #if defined(_WIN32) || defined(__CYGWIN__)
     #define _GLFW_WIN32
 #endif


### PR DESCRIPTION
Reference to #254 

Original issue seems resolved by build step (make, cmake, zig), however looking at the source code, it seems the original intent was to include the Feature Test Macros per file. This seems logical for self-documenting purposes and outline requirements for raylib.
However, the macros are defined after includes, so they won't work.
See: [GNU Feature Test Macros](https://www.gnu.org/software/libc/manual/html_node/Feature-Test-Macros.html)
> You should define these macros by using ‘#define’ preprocessor directives at the top of your source code files. These directives must come before any #include of a system header file. It is best to make them the very first thing in the file, preceded only by comments.

I've simply moved the rcore _POSIX_C_SOURCE feature test macro to the top and included _XOPEN_SOURCE for readlink function.
Alternative change to rcore would be to define_POSIX_C_SOURCE to 200809L, which removes the need to define _XOPEN_SOURCE >= 500.

These changes allow for compilation with -std=c* (such as -std=c99) without adding -D macros to the build step, for the specially interested. ~~(any tsoding nobbers in chat?)~~

Additionally, added the macros to rglfw, such that the external includes have their respective functions defined.
I went through the other modules and compiled their object files with both -std=c99 and -std=c2x, and found no other required macros. Also ran the Github Actions for Linux, Windows, Web, Android with no issues.