### PR TITLE
[CORE,RLGL] Fix scale issues when ending a mode

### DIFF
--- a/src/rcore.c
+++ b/src/rcore.c
@@ -1062,6 +1062,11 @@ void EndTextureMode(void)
     // Set viewport to default framebuffer size
     SetupViewport(CORE.Window.render.width, CORE.Window.render.height);
 
+    // go back to the modelview state from BeginDrawing since we are back to the default FBO
+	rlMatrixMode(RL_MODELVIEW);     // Switch back to modelview matrix
+	rlLoadIdentity();               // Reset current matrix (modelview)
+    rlMultMatrixf(MatrixToFloat(CORE.Window.screenScale)); // Apply screen scaling if required
+
     // Reset current fbo to screen size
     CORE.Window.currentFbo.width = CORE.Window.render.width;
     CORE.Window.currentFbo.height = CORE.Window.render.height;

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -952,9 +952,6 @@ void BeginMode2D(Camera2D camera)
 
     // Apply 2d camera transformation to modelview
     rlMultMatrixf(MatrixToFloat(GetCameraMatrix2D(camera)));
-
-    // Apply screen scaling if required
-    rlMultMatrixf(MatrixToFloat(CORE.Window.screenScale));
 }
 
 // Ends 2D mode with custom camera
@@ -963,7 +960,9 @@ void EndMode2D(void)
     rlDrawRenderBatchActive();      // Update and draw internal render batch
 
     rlLoadIdentity();               // Reset current matrix (modelview)
-    rlMultMatrixf(MatrixToFloat(CORE.Window.screenScale)); // Apply screen scaling if required
+
+    if (rlGetActiveFramebuffer() == 0)
+        rlMultMatrixf(MatrixToFloat(CORE.Window.screenScale)); // Apply screen scaling if required
 }
 
 // Initializes 3D mode with custom camera (3D)
@@ -1016,7 +1015,8 @@ void EndMode3D(void)
     rlMatrixMode(RL_MODELVIEW);     // Switch back to modelview matrix
     rlLoadIdentity();               // Reset current matrix (modelview)
 
-    rlMultMatrixf(MatrixToFloat(CORE.Window.screenScale)); // Apply screen scaling if required
+    if (rlGetActiveFramebuffer() == 0)
+        rlMultMatrixf(MatrixToFloat(CORE.Window.screenScale)); // Apply screen scaling if required
 
     rlDisableDepthTest();           // Disable DEPTH_TEST for 2D
 }

--- a/src/rlgl.h
+++ b/src/rlgl.h
@@ -1734,7 +1734,7 @@ unsigned int rlGetActiveFramebuffer(void)
     glGetIntegerv(GL_DRAW_FRAMEBUFFER_BINDING, &fboId);
     return fboId;
 #endif
-	return 0;
+    return 0;
 }
 
 // Disable rendering to texture

--- a/src/rlgl.h
+++ b/src/rlgl.h
@@ -621,6 +621,7 @@ RLAPI void rlDisableShader(void);                       // Disable shader progra
 // Framebuffer state
 RLAPI void rlEnableFramebuffer(unsigned int id);        // Enable render texture (fbo)
 RLAPI void rlDisableFramebuffer(void);                  // Disable render texture (fbo), return to default framebuffer
+RLAPI unsigned int rlGetActiveFramebuffer(void);        // Returns the active render texture (fbo), 0 for default framebuffer
 RLAPI void rlActiveDrawBuffers(int count);              // Activate multiple draw color buffers
 RLAPI void rlBlitFramebuffer(int srcX, int srcY, int srcWidth, int srcHeight, int dstX, int dstY, int dstWidth, int dstHeight, int bufferMask); // Blit active framebuffer to main framebuffer
 RLAPI void rlBindFramebuffer(unsigned int target, unsigned int framebuffer); // Bind framebuffer (FBO) 
@@ -1723,6 +1724,17 @@ void rlEnableFramebuffer(unsigned int id)
 #if (defined(GRAPHICS_API_OPENGL_33) || defined(GRAPHICS_API_OPENGL_ES2)) && defined(RLGL_RENDER_TEXTURES_HINT)
     glBindFramebuffer(GL_FRAMEBUFFER, id);
 #endif
+}
+
+// return the active render texture (fbo)
+unsigned int rlGetActiveFramebuffer(void)
+{
+#if (defined(GRAPHICS_API_OPENGL_33) || defined(GRAPHICS_API_OPENGL_ES3)) && defined(RLGL_RENDER_TEXTURES_HINT)
+    GLint fboId = 0;
+    glGetIntegerv(GL_DRAW_FRAMEBUFFER_BINDING, &fboId);
+    return fboId;
+#endif
+	return 0;
 }
 
 // Disable rendering to texture


### PR DESCRIPTION
There are 3 places in raylib that set the OpenGL modelview matrix scale to the screen scale (for HighDPI).
1 of these is incorrect, BeginMode2d, as the camera is going to do it's own scale.
The other two assume that when we end 2d and 3d mode that we are going back to the screen. That is not always true. BeginMode2d/3d can be used with a render texture and a render texture can be any size and doesn't have to match the screen DPI scale (it's not a screen).

This PR exposes the GL function to get the active draw FBO, and then has raylib use that to know what render target it is restoring to, and if it needs to apply the scale. 

This change should make using a render texture more consistent.