### PR TITLE
[rcore] Send raylib logs to stderr by default

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -45,7 +45,7 @@
 #endif
 
 #include <stdlib.h>                     // Required for: exit()
-#include <stdio.h>                      // Required for: FILE, fopen(), fseek(), ftell(), fread(), fwrite(), fprintf(), vprintf(), fclose()
+#include <stdio.h>                      // Required for: FILE, fopen(), fseek(), ftell(), fread(), fwrite(), fprintf(), vfprintf(), fclose()
 #include <stdarg.h>                     // Required for: va_list, va_start(), va_end()
 #include <string.h>                     // Required for: strcpy(), strcat()
 
@@ -147,8 +147,7 @@ void TraceLog(int logType, const char *text, ...)
     unsigned int textSize = (unsigned int)strlen(text);
     memcpy(buffer + strlen(buffer), text, (textSize < (MAX_TRACELOG_MSG_LENGTH - 12))? textSize : (MAX_TRACELOG_MSG_LENGTH - 12));
     strcat(buffer, "\n");
-    vprintf(buffer, args);
-    fflush(stdout);
+    vfprintf(stderr, buffer, args);
 #endif
 
     va_end(args);


### PR DESCRIPTION
from man stderr:

       Under  normal circumstances every UNIX program has three streams opened
       for it when it starts up, one for input, one for output,  and  one  for
       printing diagnostic or error messages.

It's a more appropriate place for programs to send logs, as it's a stream meant explicitly for it.

stderr is unbuffered, so it doesn't need to be flushed.