### PR TITLE
Added missing "standalone" functions to raudio.c & fixed return bug

### DIFF
--- a/src/raudio.c
+++ b/src/raudio.c
@@ -2745,9 +2745,19 @@ static bool SaveFileData(const char *fileName, void *data, int dataSize)
 
             fclose(file);
         }
-        else TRACELOG(LOG_WARNING, "FILEIO: [%s] Failed to open file", fileName);
+        else
+        {
+            TRACELOG(LOG_WARNING, "FILEIO: [%s] Failed to open file", fileName);
+            return false;
+        }
     }
-    else TRACELOG(LOG_WARNING, "FILEIO: File name provided is not valid");
+    else 
+    {
+        TRACELOG(LOG_WARNING, "FILEIO: File name provided is not valid");
+        return false;
+    }
+
+    return true;
 }
 
 // Save text data to file (write), string must be '\0' terminated
@@ -2766,9 +2776,19 @@ static bool SaveFileText(const char *fileName, char *text)
 
             fclose(file);
         }
-        else TRACELOG(LOG_WARNING, "FILEIO: [%s] Failed to open text file", fileName);
+        else
+        {
+            TRACELOG(LOG_WARNING, "FILEIO: [%s] Failed to open text file", fileName);
+            return false;
+        }
     }
-    else TRACELOG(LOG_WARNING, "FILEIO: File name provided is not valid");
+    else
+    {
+        TRACELOG(LOG_WARNING, "FILEIO: File name provided is not valid");
+        return false;
+    }
+
+    return true;
 }
 #endif
 

--- a/src/raudio.c
+++ b/src/raudio.c
@@ -416,6 +416,8 @@ static void MixAudioFrames(float *framesOut, const float *framesIn, ma_uint32 fr
 #if defined(RAUDIO_STANDALONE)
 static bool IsFileExtension(const char *fileName, const char *ext); // Check file extension
 static const char *GetFileExtension(const char *fileName);          // Get pointer to extension for a filename string (includes the dot: .png)
+static const char *GetFileName(const char *filePath);               // Get pointer to filename for a path string
+static const char *GetFileNameWithoutExt(const char *filePath);     // Get filename string without extension (uses static string)
 
 static unsigned char *LoadFileData(const char *fileName, int *dataSize);    // Load file data as byte array (read)
 static bool SaveFileData(const char *fileName, void *data, int dataSize);   // Save data to file from byte array (write)
@@ -2640,6 +2642,50 @@ static const char *GetFileExtension(const char *fileName)
     if (!dot || dot == fileName) return NULL;
 
     return dot;
+}
+
+// String pointer reverse break: returns right-most occurrence of charset in s
+static const char *strprbrk(const char *s, const char *charset)
+{
+    const char *latestMatch = NULL;
+    for (; s = strpbrk(s, charset), s != NULL; latestMatch = s++) { }
+    return latestMatch;
+}
+
+// Get pointer to filename for a path string
+static const char *GetFileName(const char *filePath)
+{
+    const char *fileName = NULL;
+    if (filePath != NULL) fileName = strprbrk(filePath, "\\/");
+
+    if (!fileName) return filePath;
+
+    return fileName + 1;
+}
+
+// Get filename string without extension (uses static string)
+static const char *GetFileNameWithoutExt(const char *filePath)
+{
+    #define MAX_FILENAMEWITHOUTEXT_LENGTH   256
+
+    static char fileName[MAX_FILENAMEWITHOUTEXT_LENGTH] = { 0 };
+    memset(fileName, 0, MAX_FILENAMEWITHOUTEXT_LENGTH);
+
+    if (filePath != NULL) strcpy(fileName, GetFileName(filePath));   // Get filename with extension
+
+    int size = (int)strlen(fileName);   // Get size in bytes
+
+    for (int i = 0; (i < size) && (i < MAX_FILENAMEWITHOUTEXT_LENGTH); i++)
+    {
+        if (fileName[i] == '.')
+        {
+            // NOTE: We break on first '.' found
+            fileName[i] = '\0';
+            break;
+        }
+    }
+
+    return fileName;
 }
 
 // Load data from file into a buffer


### PR DESCRIPTION
NOTICE: THIS IS THE SAME COMMIT AS [#17](https://github.com/raysan5/raudio/pull/17) IN RAUDIO. I PUT THIS HERE TO HAVE BOTH REPOS SYNCED.

Hey,
While I updated raudio [#16](https://github.com/raysan5/raudio/pull/16), I also found some bugs & afterthoughts with "raudio.c".

First, as GetFileNameWithoutExt, GetFileName & strprbrk were linked to Raylib itself I had to add them to "raudio.c" under the "RAUDIO_STANDALONE" define for standalone mode to work. Point at which the functions were added:
- (15-04-2023) RadsammyT: "[[raudio] Rewritten ExportWaveAsCode() file saving to be more like rtextures ExportImageAsCode() (raysan5#3013)](https://github.com/sanyokdev/raylib/commit/e2da32e2daf2cf4de86cc1128a7b3ba66a1bab1c)"

Second, I use a lot compiler flags so it found that "SaveFileData" & "SaveFileText" in "raudio.c" were missing return values. Surprisingly a lot of variables inside "raudio.c" were actually using the values returned, that were never actually given.