### PR TITLE
[rcamera.h] cleaned away unused macros in rcamera.h

### DIFF
--- a/src/rcamera.h
+++ b/src/rcamera.h
@@ -202,17 +202,9 @@ RLAPI Matrix GetCameraProjectionMatrix(Camera* camera, float aspect);
 
 // Camera mouse movement sensitivity
 #define CAMERA_MOUSE_MOVE_SENSITIVITY                   0.003f     // TODO: it should be independant of framerate
-#define CAMERA_MOUSE_SCROLL_SENSITIVITY                 1.5f
 
+// Camera orbital speed in CAMERA_ORBITAL mode
 #define CAMERA_ORBITAL_SPEED                            0.5f       // Radians per second
-
-
-#define CAMERA_FIRST_PERSON_STEP_TRIGONOMETRIC_DIVIDER  8.0f
-#define CAMERA_FIRST_PERSON_STEP_DIVIDER                30.0f
-#define CAMERA_FIRST_PERSON_WAVING_DIVIDER              200.0f
-
-// PLAYER (used by camera)
-#define PLAYER_MOVEMENT_SENSITIVITY                     20.0f
 
 //----------------------------------------------------------------------------------
 // Types and Structures Definition


### PR DESCRIPTION
I assume these were accidentally left in. they were made in the redesign https://github.com/raysan5/raylib/pull/2563 but the macros were used in the finished pull. I guess a new redesign since then rendered the macros useless.