### PR TITLE
Fix MeasureTextEx() height calculation

### DIFF
--- a/src/rtext.c
+++ b/src/rtext.c
@@ -1257,7 +1257,7 @@ Vector2 MeasureTextEx(Font font, const char *text, float fontSize, float spacing
     float textWidth = 0.0f;
     float tempTextWidth = 0.0f;     // Used to count longer text line width
 
-    float textHeight = (float)font.baseSize;
+    float textHeight = fontSize;
     float scaleFactor = fontSize/(float)font.baseSize;
 
     int letter = 0;                 // Current character
@@ -1294,7 +1294,7 @@ Vector2 MeasureTextEx(Font font, const char *text, float fontSize, float spacing
     if (tempTextWidth < textWidth) tempTextWidth = textWidth;
 
     textSize.x = tempTextWidth*scaleFactor + (float)((tempByteCounter - 1)*spacing);
-    textSize.y = textHeight*scaleFactor;
+    textSize.y = textHeight;
 
     return textSize;
 }


### PR DESCRIPTION
For multiline strings `MeasureTextEx()` is returning a much higher value than the actual text height.

Pretty much like `DrawTextEx()` this patch just increment `textLineSpacing` in the height when it sees `\n` and don't apply `scaleFactor` at the end.

Small program to simulate the issue:
```c
#include <stdlib.h>
#include "raylib.h"

int main(void) {
  InitWindow(200, 100, "MeasureTextEx");

  Font font = GetFontDefault();

  while (!WindowShouldClose()) {
    BeginDrawing();
    ClearBackground(WHITE);

    const char *text = "Some\nMultiline\nText";
    float fontSize = 20;
    float spacing = 5;

    SetTextLineSpacing(fontSize + 4);
    DrawTextEx(font, text, (Vector2){10, 10}, fontSize, spacing, BLACK);

    // draw red box around text
    Vector2 m = MeasureTextEx(font, text, fontSize, spacing);
    DrawRectangleLinesEx((Rectangle){10, 10, m.x, m.y}, 1, RED);

    EndDrawing();
  }

  CloseWindow();
  return 0;
}
```

Without the fix
![Screenshot 2024-01-31 at 5 40 00 PM](https://github.com/raysan5/raylib/assets/1334759/2a824eaa-3ffb-4240-aac0-06420eabdd42)

With the fix
![Screenshot 2024-01-31 at 5 39 25 PM](https://github.com/raysan5/raylib/assets/1334759/edad37c7-01ef-4d5b-a785-bc0382dd2ccf)
