### PR TITLE
[rcore] Fix `GetFileNameWithoutExt()`

### DIFF
--- a/src/rcore.c
+++ b/src/rcore.c
@@ -1946,26 +1946,17 @@ const char *GetFileName(const char *filePath)
 // Get filename string without extension (uses static string)
 const char *GetFileNameWithoutExt(const char *filePath)
 {
-    #define MAX_FILENAMEWITHOUTEXT_LENGTH   256
-
-    static char fileName[MAX_FILENAMEWITHOUTEXT_LENGTH] = { 0 };
-    memset(fileName, 0, MAX_FILENAMEWITHOUTEXT_LENGTH);
-
-    if (filePath != NULL) strcpy(fileName, GetFileName(filePath));   // Get filename with extension
-
-    int size = (int)strlen(fileName);   // Get size in bytes
-
-    for (int i = 0; (i < size) && (i < MAX_FILENAMEWITHOUTEXT_LENGTH); i++)
+    const char *filename = GetFileName(filePath);
+    int pos = TextLength(filename);
+    for(int i = pos; i>0; i--)
     {
-        if (fileName[i] == '.')
+        if(filename[i] == '.')
         {
-            // NOTE: We break on first '.' found
-            fileName[i] = '\0';
+            pos = i;
             break;
         }
     }
-
-    return fileName;
+    return TextSubtext(filename,0,pos);
 }
 
 // Get directory for a given filePath

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -1948,14 +1948,15 @@ const char *GetFileNameWithoutExt(const char *filePath)
 {
     if (filePath != NULL)
     {
-        const char *fileName = GetFileName(filePath); // Get filename without path
-        for (int i = (int)strlen(fileName); i>0; i--) // Reverse search
+        const char *fileName = GetFileName(filePath); // Get filename.ext without path
+        for (int i = (int)strlen(fileName); i>0; i--) // Reverse search '.'
         {
             if (fileName[i] == '.')
             {
                 return TextSubtext(fileName,0,i);
             }
         }
+        return fileName; // Extension not found
     }
     return "\0";
 }

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -1946,17 +1946,21 @@ const char *GetFileName(const char *filePath)
 // Get filename string without extension (uses static string)
 const char *GetFileNameWithoutExt(const char *filePath)
 {
-    const char *fileName = GetFileName(filePath);
-    int pos = (int)strlen(fileName);
-    for(int i = pos; i>0; i--)
+    if (filePath != NULL)
     {
-        if(fileName[i] == '.')
+        const char *fileName = GetFileName(filePath);
+        int pos = (int)strlen(fileName);
+        for(int i = pos; i>0; i--)
         {
-            pos = i;
-            break;
+            if(fileName[i] == '.')
+            {
+                pos = i;
+                break;
+            }
         }
+        return TextSubtext(fileName,0,pos);
     }
-    return TextSubtext(fileName,0,pos);
+    return "";
 }
 
 // Get directory for a given filePath

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -1959,6 +1959,7 @@ const char *GetFileNameWithoutExt(const char *filePath)
         {
             if (fileName[i] == '.')
             {
+                // NOTE: We break on first '.' found
                 fileName[i] = '\0';
                 break;
             }

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -1949,7 +1949,7 @@ const char *GetFileNameWithoutExt(const char *filePath)
     if (filePath != NULL)
     {
         const char *fileName = GetFileName(filePath); // Get filename without path
-        for (int i = (int)strlen(fileName); i>0; i--) // reverse search
+        for (int i = (int)strlen(fileName); i>0; i--) // Reverse search
         {
             if (fileName[i] == '.')
             {

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -1953,7 +1953,11 @@ const char *GetFileNameWithoutExt(const char *filePath)
         {
             if (fileName[i] == '.')
             {
-                return TextSubtext(fileName,0,i);
+                char rfileName[i];
+                strncpy(rfileName, fileName,i);
+                rfileName[i] = '\0';
+                const char* rrfileName = rfileName;
+                return rrfileName;
             }
         }
         return fileName; // Extension not found

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -1950,7 +1950,7 @@ const char *GetFileNameWithoutExt(const char *filePath)
     int pos = (int)strlen(fileName);
     for(int i = pos; i>0; i--)
     {
-        if(filename[i] == '.')
+        if(fileName[i] == '.')
         {
             pos = i;
             break;

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -1948,17 +1948,14 @@ const char *GetFileNameWithoutExt(const char *filePath)
 {
     if (filePath != NULL)
     {
-        const char *fileName = GetFileName(filePath); // get filename without path
-        int pos = (int)strlen(fileName); // get filename lenght
-        for (int i = pos; i>0; i--)
+        const char *fileName = GetFileName(filePath); // Get filename without path
+        for (int i = (int)strlen(fileName); i>0; i--) // reverse search
         {
             if (fileName[i] == '.')
             {
-                pos = i;
-                break;
+                return TextSubtext(fileName,0,i);
             }
         }
-        return TextSubtext(fileName,0,pos);
     }
     return "\0";
 }

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -1948,8 +1948,8 @@ const char *GetFileNameWithoutExt(const char *filePath)
 {
     if (filePath != NULL)
     {
-        const char *fileName = GetFileName(filePath);
-        int pos = (int)strlen(fileName);
+        const char *fileName = GetFileName(filePath); // get filename without path
+        int pos = (int)strlen(fileName); // get filename lenght
         for (int i = pos; i>0; i--)
         {
             if (fileName[i] == '.')
@@ -1960,7 +1960,7 @@ const char *GetFileNameWithoutExt(const char *filePath)
         }
         return TextSubtext(fileName,0,pos);
     }
-    return "";
+    return "\0";
 }
 
 // Get directory for a given filePath

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -1946,23 +1946,25 @@ const char *GetFileName(const char *filePath)
 // Get filename string without extension (uses static string)
 const char *GetFileNameWithoutExt(const char *filePath)
 {
+    #define MAX_FILENAMEWITHOUTEXT_LENGTH 256
+    
+    static char fileName[MAX_FILENAMEWITHOUTEXT_LENGTH] = { 0 };
+    memset(fileName, 0, MAX_FILENAMEWITHOUTEXT_LENGTH);
+
     if (filePath != NULL)
     {
-        const char *fileName = GetFileName(filePath); // Get filename.ext without path
-        for (int i = (int)strlen(fileName); i>0; i--) // Reverse search '.'
+        strcpy(fileName, GetFileName(filePath)); // Get filename.ext without path
+        int size = (int)strlen(fileName); // Get size in bytes
+        for (int i = size; i>0; i--) // Reverse search '.'
         {
             if (fileName[i] == '.')
             {
-                char rfileName[i];
-                strncpy(rfileName, fileName,i);
-                rfileName[i] = '\0';
-                const char* rrfileName = rfileName;
-                return rrfileName;
+                fileName[i] = '\0';
+                break;
             }
         }
-        return fileName; // Extension not found
     }
-    return "\0";
+    return fileName;
 }
 
 // Get directory for a given filePath

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -1946,8 +1946,8 @@ const char *GetFileName(const char *filePath)
 // Get filename string without extension (uses static string)
 const char *GetFileNameWithoutExt(const char *filePath)
 {
-    const char *filename = GetFileName(filePath);
-    int pos = TextLength(filename);
+    const char *fileName = GetFileName(filePath);
+    int pos = (int)strlen(fileName);
     for(int i = pos; i>0; i--)
     {
         if(filename[i] == '.')
@@ -1956,7 +1956,7 @@ const char *GetFileNameWithoutExt(const char *filePath)
             break;
         }
     }
-    return TextSubtext(filename,0,pos);
+    return TextSubtext(fileName,0,pos);
 }
 
 // Get directory for a given filePath

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -1950,9 +1950,9 @@ const char *GetFileNameWithoutExt(const char *filePath)
     {
         const char *fileName = GetFileName(filePath);
         int pos = (int)strlen(fileName);
-        for(int i = pos; i>0; i--)
+        for (int i = pos; i>0; i--)
         {
-            if(fileName[i] == '.')
+            if (fileName[i] == '.')
             {
                 pos = i;
                 break;


### PR DESCRIPTION
```c
puts( GetFileNameWithoutExt("dir/file.name.zip") ); 
// out : "file"
```
[with fix]
```c
puts( GetFileNameWithoutExt("dir/file.name.zip") );
// out : "file.name"
```
Use reverse search '.' for remove extension.