### PR TITLE
[rtextures][rlgl] Implement UpdateImageFromTexture

### DIFF
--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1305,6 +1305,7 @@ RLAPI Image LoadImageAnim(const char *fileName, int *frames);                   
 RLAPI Image LoadImageAnimFromMemory(const char *fileType, const unsigned char *fileData, int dataSize, int *frames); // Load image sequence from memory buffer
 RLAPI Image LoadImageFromMemory(const char *fileType, const unsigned char *fileData, int dataSize);      // Load image from memory buffer, fileType refers to extension: i.e. '.png'
 RLAPI Image LoadImageFromTexture(Texture2D texture);                                                     // Load image from GPU texture data
+RLAPI void UpdateImageFromTexture(Image *image, Texture2D texture);                                      // Load image from GPU texture data into existing image
 RLAPI Image LoadImageFromScreen(void);                                                                   // Load image from screen buffer and (screenshot)
 RLAPI bool IsImageReady(Image image);                                                                    // Check if an image is ready
 RLAPI void UnloadImage(Image image);                                                                     // Unload image from CPU memory (RAM)

--- a/src/rtextures.c
+++ b/src/rtextures.c
@@ -678,6 +678,33 @@ Image LoadImageFromTexture(Texture2D texture)
     return image;
 }
 
+// Update image from GPU texture data
+// NOTE: Compressed texture formats not supported
+// Size and format of the texture and image must match
+void UpdateImageFromTexture(Image *image, Texture2D texture)
+{
+    if (image->data == NULL)
+    {
+        *image = LoadImageFromTexture(texture);
+        return;
+    }
+    if (image->format >= PIXELFORMAT_COMPRESSED_DXT1_RGB)
+    {
+        TRACELOG(LOG_WARNING, "TEXTURE: [ID %i] Failed to retrieve compressed pixel data", texture.id);
+        return;
+    }
+    if (image->width != texture.width || image->height != texture.height || image->format != texture.format)
+    {
+        TRACELOG(LOG_WARNING, "TEXTURE: [ID %i] Failed to retrieve pixel data, image didn't match texture", texture.id);
+        return;
+    }
+
+    if (rlReadTexturePixelsIntoBuffer(texture.id, texture.width, texture.height, texture.format, image->data))
+    {
+        TRACELOG(LOG_INFO, "TEXTURE: [ID %i] Pixel data retrieved successfully", texture.id);
+    }
+}
+
 // Load image from screen buffer and (screenshot)
 Image LoadImageFromScreen(void)
 {


### PR DESCRIPTION
I've added ability to update existing image from a texture. The functions in rtextures.c and rlgl.h are pretty much copies of existing functions that create a new image but they use the provided image buffer instead.

I wanted this functionality since my project needs to read rendered pixels in real time for external use and I wanted to avoid allocating memory every frame.

I have successfully tested the addition on GNU/Linux. I don't have access to other systems to do other tests.

Please let me know if any adjustments need to be done. Thank you.

Purrie.