### PR TITLE
Fix GetCameraRight

### DIFF
--- a/src/rcamera.h
+++ b/src/rcamera.h
@@ -243,7 +243,7 @@ Vector3 GetCameraRight(Camera *camera)
     Vector3 forward = GetCameraForward(camera);
     Vector3 up = GetCameraUp(camera);
 
-    return Vector3CrossProduct(forward, up);
+    return Vector3Normalize(Vector3CrossProduct(forward, up));
 }
 
 // Moves the camera in its forward direction


### PR DESCRIPTION
Before this PR `GetCameraRight` was returning non-normalized vector, which caused some issues (for example, with CAMERA_FREE), this PR fixes this issue by normalizing return vector.