### PR TITLE
Fixed loading GLTF animations with 1 frame

### DIFF
--- a/src/rmodels.c
+++ b/src/rmodels.c
@@ -5368,7 +5368,7 @@ static bool GetPoseAtTimeGLTF(cgltf_accessor *input, cgltf_accessor *output, flo
         }
     }
 
-    float t = (time - tstart)/(tend - tstart);
+    float t = (time - tstart)/fmax((tend - tstart), EPSILON);
     t = (t < 0.0f)? 0.0f : t;
     t = (t > 1.0f)? 1.0f : t;
 
@@ -5506,7 +5506,7 @@ static ModelAnimation *LoadModelAnimationsGLTF(const char *fileName, int *animCo
                 strncpy(animations[i].name, animData.name, sizeof(animations[i].name));
                 animations[i].name[sizeof(animations[i].name) - 1] = '\0';
 
-                animations[i].frameCount = (int)(animDuration*1000.0f/GLTF_ANIMDELAY);
+                animations[i].frameCount = (int)(animDuration*1000.0f/GLTF_ANIMDELAY) + 1;
                 animations[i].framePoses = RL_MALLOC(animations[i].frameCount*sizeof(Transform *));
 
                 for (int j = 0; j < animations[i].frameCount; j++)


### PR DESCRIPTION
When I was working on my 3D project I found an issue that single frame animations (like T-Pose) are not loaded. Upon investigating the reason I realised that frame count calculated based on animation length (which is 0 apparently).

Using some basic combinatorics I added 1 at the end of frame count calculations. It is easy to think of a veeeery small animation (like 0.01 second) which still has to have minimum 2 frames. Animations with 0 length should have at least 1.

Also **fmax** is preventing NaN division result when **tend** and **tstart** are both 0.