### PR TITLE
Remove all uses of deps/mingw

### DIFF
--- a/examples/build.zig
+++ b/examples/build.zig
@@ -55,7 +55,6 @@ fn add_module(comptime module: []const u8, b: *std.Build, target: anytype, optim
                 exe.linkSystemLibrary("winmm");
                 exe.linkSystemLibrary("gdi32");
                 exe.linkSystemLibrary("opengl32");
-                exe.addIncludePath(.{ .path = "external/glfw/deps/mingw" });
 
                 exe.defineCMacro("PLATFORM_DESKTOP", null);
             },

--- a/src/Makefile
+++ b/src/Makefile
@@ -438,7 +438,7 @@ INCLUDE_PATHS = -I.
 
 # Define additional directories containing required header files
 ifeq ($(PLATFORM),PLATFORM_DESKTOP)
-    INCLUDE_PATHS += -Iexternal/glfw/include -Iexternal/glfw/deps/mingw
+    INCLUDE_PATHS += -Iexternal/glfw/include
     ifeq ($(PLATFORM_OS),BSD)
         INCLUDE_PATHS += -I/usr/local/include
     endif
@@ -447,7 +447,7 @@ ifeq ($(PLATFORM),PLATFORM_DESKTOP_SDL)
     INCLUDE_PATHS += -I$(SDL_INCLUDE_PATH)
 endif
 ifeq ($(PLATFORM),PLATFORM_WEB)
-    INCLUDE_PATHS += -Iexternal/glfw/include -Iexternal/glfw/deps/mingw
+    INCLUDE_PATHS += -Iexternal/glfw/include
 endif
 ifeq ($(PLATFORM),PLATFORM_DRM)
     INCLUDE_PATHS += -I/usr/include/libdrm

--- a/src/build.zig
+++ b/src/build.zig
@@ -97,7 +97,6 @@ pub fn addRaylib(b: *std.Build, target: anytype, optimize: std.builtin.OptimizeM
             raylib.linkSystemLibrary("winmm");
             raylib.linkSystemLibrary("gdi32");
             raylib.linkSystemLibrary("opengl32");
-            raylib.addIncludePath(.{ .path = "external/glfw/deps/mingw" });
 
             raylib.defineCMacro("PLATFORM_DESKTOP", null);
         },


### PR DESCRIPTION
The purpose of this directory in GLFW is to provide some headers that "mingw.org" doesn't. Raylib has long been unable to build with mingw.org due to using certain symbols that aren't exposed in their headers. (_ftelli64 and _access, among others.). Mingw-w64 already has the necessary headers included, and doesn't need any of these external implementations. For some reason, this also causes the following error when building with Visual Studio's clang:

clang  -c rglfw.c -Wall -D_GNU_SOURCE -DPLATFORM_DESKTOP -DGRAPHICS_API_OPENGL_33 -Wno-missing-braces -Werror=pointer-arith -fno-strict-aliasing  -std=c99 -O1 -Werror=implicit-function-declaration -I. -Iexternal/glfw/include -Iexternal/glfw/deps/mingw In file included from rglfw.c:61:
In file included from ./external/glfw/src/init.c:30: In file included from ./external/glfw/src/internal.h:331: In file included from ./external/glfw/src/platform.h:31: In file included from ./external/glfw/src/win32_platform.h:70: external/glfw/deps/mingw\xinput.h:227:26: error: a parameter list without types is only allowed in a function definition
  227 | void WINAPI XInputEnable(WINBOOL);
      |

If the last -Iexternal/glfw/deps/mingw is removed, the build works fine.

So, this workaround causes other problems, while not actually helping raylib.

https://github.com/glfw/glfw/blob/0bb605cd797e4d63709495f4074ec59362064ab4/src/CMakeLists.txt#L272-L279

GLFW's CMakeLists.txt first checks if either dinput.h or xinput.h are provided by the toolchain, before telling the compiler to search for headers in that directory. For EVERY compiler that can build raylib, this is true.

In summary: This directory causes issues when building with some compilers, and every toolchain that needs this workaround can't build raylib anyway.