### PR TITLE
[rmodels] Fix aspect ratio calculation in `DrawBillboardPro`

### DIFF
--- a/src/rmodels.c
+++ b/src/rmodels.c
@@ -3584,8 +3584,8 @@ void DrawBillboardRec(Camera camera, Texture2D texture, Rectangle source, Vector
 
 void DrawBillboardPro(Camera camera, Texture2D texture, Rectangle source, Vector3 position, Vector3 up, Vector2 size, Vector2 origin, float rotation, Color tint)
 {
-    // NOTE: Billboard size will maintain source rectangle aspect ratio, size will represent billboard width
-    Vector2 sizeRatio = { size.x*fabsf((float)source.width/source.height), size.y };
+    // NOTE: Billboard size will maintain source rectangle aspect ratio, so "size.x" is effectively ignored.
+    Vector2 sizeRatio = { size.y * fabsf((float)source.width/source.height), size.y };
 
     Matrix matView = MatrixLookAt(camera.position, camera.target, camera.up);
 


### PR DESCRIPTION
Hello! Not sure if I misunderstood the code/API, but I believe the aspect ratio correction in `DrawBillboardPro` is incorrect. I would expect it to calculate `sizeRatio` such that `sizeRatio.x / sizeRatio.y == source.width / source.height`, or in other words match the aspect ratio of `source`. The current code is definitely not doing that. I was writing some custom 3D text rendering using the billboard functions and the sizing was very confusing and unexpected.

Hehe, I see this was brought up in https://github.com/raysan5/raylib/issues/2494 before but still seems off. I think the suggested fix was incorrect.

**NOTE** - I am also concerned people are relying on incorrect behavior currently and this change will affect them. I actually have some code that would be affected, and I can't think of an alternative. Basically, I would like to draw billboards that are a flat color, without any texture. What I was doing is using a texture that was a 1x1 white pixel, but if the aspect ratio is forced to match the texture, I won't be able to draw anything flatter than a square 😢  maybe a new API is in order? Will think about specific suggestions...

*EDIT: tbh, I think there should just be a version of this API that doesn't modify `size` behind the scenes and will stretch the texture, if that's what you want.*