### PR TITLE
Add CMake PLATFORM option for SDL

### DIFF
--- a/CMakeOptions.txt
+++ b/CMakeOptions.txt
@@ -2,7 +2,7 @@
 include(CMakeDependentOption)
 include(EnumOption)
 
-enum_option(PLATFORM "Desktop;Web;Android;Raspberry Pi;DRM" "Platform to build for.")
+enum_option(PLATFORM "Desktop;Web;Android;Raspberry Pi;DRM;SDL" "Platform to build for.")
 
 enum_option(OPENGL_VERSION "OFF;4.3;3.3;2.1;1.1;ES 2.0;ES 3.0" "Force a specific OpenGL Version?")
 

--- a/cmake/LibraryConfigurations.cmake
+++ b/cmake/LibraryConfigurations.cmake
@@ -91,6 +91,11 @@ elseif ("${PLATFORM}" MATCHES "DRM")
     endif ()
     set(LIBS_PRIVATE ${GLESV2} ${EGL} ${DRM} ${GBM} atomic pthread m dl)
 
+elseif ("${PLATFORM}" MATCHES "SDL")
+    find_package(SDL2 REQUIRED)
+    set(PLATFORM_CPP "PLATFORM_DESKTOP_SDL")
+    set(LIBS_PRIVATE SDL2::SDL2)
+
 endif ()
 
 if (NOT ${OPENGL_VERSION} MATCHES "OFF")


### PR DESCRIPTION
Adds a PLATFORM=SDL option to CMakeLists.txt, handled in LibraryConfigurations.cmake

Tested on Win 11 ARM64 (MSVC, vcpkg)