### PR TITLE
FIX: can not compile generated code

### DIFF
--- a/src/rmodels.c
+++ b/src/rmodels.c
@@ -1874,10 +1874,7 @@ bool ExportMeshAsCode(Mesh mesh, const char *fileName)
     byteCount += sprintf(txtData + byteCount, "//                                                                                    //\n");
     byteCount += sprintf(txtData + byteCount, "////////////////////////////////////////////////////////////////////////////////////////\n\n");
 
-    // Get file name from path and convert variable name to uppercase
-    char varFileName[256] = { 0 };
-    strcpy(varFileName, GetFileNameWithoutExt(fileName));
-    for (int i = 0; varFileName[i] != '\0'; i++) if ((varFileName[i] >= 'a') && (varFileName[i] <= 'z')) { varFileName[i] = varFileName[i] - 32; }
+    const char *varFileName = GetFileIdentifier(fileName);
 
     // Add image information
     byteCount += sprintf(txtData + byteCount, "// Mesh basic information\n");

--- a/src/rtextures.c
+++ b/src/rtextures.c
@@ -852,10 +852,7 @@ bool ExportImageAsCode(Image image, const char *fileName)
     byteCount += sprintf(txtData + byteCount, "//                                                                                    //\n");
     byteCount += sprintf(txtData + byteCount, "////////////////////////////////////////////////////////////////////////////////////////\n\n");
 
-    // Get file name from path and convert variable name to uppercase
-    char varFileName[256] = { 0 };
-    strcpy(varFileName, GetFileNameWithoutExt(fileName));
-    for (int i = 0; varFileName[i] != '\0'; i++) if ((varFileName[i] >= 'a') && (varFileName[i] <= 'z')) { varFileName[i] = varFileName[i] - 32; }
+    const char *varFileName = GetFileIdentifier(fileName);
 
     // Add image information
     byteCount += sprintf(txtData + byteCount, "// Image data information\n");

--- a/src/utils.h
+++ b/src/utils.h
@@ -74,6 +74,8 @@ void InitAssetManager(AAssetManager *manager, const char *dataPath);   // Initia
 FILE *android_fopen(const char *fileName, const char *mode);           // Replacement for fopen() -> Read-only!
 #endif
 
+const char *GetFileIdentifier(const char *fileName);                   // Get identifier for file which is used in Export...AsCode functions (uses static string)
+
 #if defined(__cplusplus)
 }
 #endif


### PR DESCRIPTION
Problem: for files '123.png' and 'img-123.png' current `ExportDataAsCode` implementation produce uncompilable code, since `ExportDataAsCode` generates incorrect macro names: `123_DATA[_SIZE]` for `123.png` (macro name can't starts with digit) and `IMG-123_DATA[_SIZE]` for `ing-123.png` (macro name can't contains `'-'`). The correct С/C++ macro name should contain only `'_'`, letters, digits and not starts with a number. This PR converts all invalid characters to `'_'`, and, if necessary, adds an underscore `'_'` to the beginning of the macro name.