### PR TITLE
Fixed typo in a comment (#3816)

### DIFF
--- a/examples/textures/textures_image_generation.c
+++ b/examples/textures/textures_image_generation.c
@@ -13,7 +13,7 @@
 
 #include "raylib.h"
 
-#define NUM_TEXTURES  9      // Currently we have 8 generation algorithms but some are have multiple purposes (Linear and Square Gradients)
+#define NUM_TEXTURES  9      // Currently we have 8 generation algorithms but some have multiple purposes (Linear and Square Gradients)
 
 //------------------------------------------------------------------------------------
 // Program main entry point


### PR DESCRIPTION
Fixed a grammatical error by removing "are" to change `... but some are have multiple purposes ...` to `... but some have multiple purposes ...` in `textures/textures_image_generation`