### PR TITLE
Gamepad rumble support with SDL2

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -81,6 +81,7 @@
 #define MAX_GAMEPADS                    4       // Maximum number of gamepads supported
 #define MAX_GAMEPAD_AXIS                8       // Maximum number of axis supported (per gamepad)
 #define MAX_GAMEPAD_BUTTONS            32       // Maximum number of buttons supported (per gamepad)
+#define MAX_GAMEPAD_VIBRATION_TIME      2       // Maximum vibration time in seconds
 #define MAX_TOUCH_POINTS                8       // Maximum number of touch points supported
 #define MAX_KEY_PRESSED_QUEUE          16       // Maximum number of keys in the key input queue
 #define MAX_CHAR_PRESSED_QUEUE         16       // Maximum number of characters in the char input queue

--- a/src/config.h
+++ b/src/config.h
@@ -81,7 +81,7 @@
 #define MAX_GAMEPADS                    4       // Maximum number of gamepads supported
 #define MAX_GAMEPAD_AXIS                8       // Maximum number of axis supported (per gamepad)
 #define MAX_GAMEPAD_BUTTONS            32       // Maximum number of buttons supported (per gamepad)
-#define MAX_GAMEPAD_VIBRATION_TIME      2       // Maximum vibration time in seconds
+#define MAX_GAMEPAD_VIBRATION_TIME      2.0f    // Maximum vibration time in seconds
 #define MAX_TOUCH_POINTS                8       // Maximum number of touch points supported
 #define MAX_KEY_PRESSED_QUEUE          16       // Maximum number of keys in the key input queue
 #define MAX_CHAR_PRESSED_QUEUE         16       // Maximum number of characters in the char input queue

--- a/src/platforms/rcore_android.c
+++ b/src/platforms/rcore_android.c
@@ -613,6 +613,12 @@ int SetGamepadMappings(const char *mappings)
     return 0;
 }
 
+// Set gamepad vibration
+void SetGamepadVibration(int gamepad, float leftMotor, float rightMotor, float durationMs)
+{
+    TRACELOG(LOG_WARNING, "GamepadSetVibration() not implemented on target platform");
+}
+
 // Set mouse position XY
 void SetMousePosition(int x, int y)
 {

--- a/src/platforms/rcore_android.c
+++ b/src/platforms/rcore_android.c
@@ -614,7 +614,7 @@ int SetGamepadMappings(const char *mappings)
 }
 
 // Set gamepad vibration
-void SetGamepadVibration(int gamepad, float leftMotor, float rightMotor, float durationMs)
+void SetGamepadVibration(int gamepad, float leftMotor, float rightMotor)
 {
     TRACELOG(LOG_WARNING, "GamepadSetVibration() not implemented on target platform");
 }

--- a/src/platforms/rcore_desktop.c
+++ b/src/platforms/rcore_desktop.c
@@ -1051,7 +1051,7 @@ int SetGamepadMappings(const char *mappings)
 }
 
 // Set gamepad vibration
-void SetGamepadVibration(int gamepad, float leftMotor, float rightMotor, float durationMs)
+void SetGamepadVibration(int gamepad, float leftMotor, float rightMotor)
 {
     TRACELOG(LOG_WARNING, "GamepadSetVibration() not available on target platform");
 }

--- a/src/platforms/rcore_desktop.c
+++ b/src/platforms/rcore_desktop.c
@@ -1050,6 +1050,12 @@ int SetGamepadMappings(const char *mappings)
     return glfwUpdateGamepadMappings(mappings);
 }
 
+// Set gamepad vibration
+void SetGamepadVibration(int gamepad, float leftMotor, float rightMotor, float durationMs)
+{
+    TRACELOG(LOG_WARNING, "GamepadSetVibration() not available on target platform");
+}
+
 // Set mouse position XY
 void SetMousePosition(int x, int y)
 {

--- a/src/platforms/rcore_desktop_sdl.c
+++ b/src/platforms/rcore_desktop_sdl.c
@@ -949,7 +949,7 @@ void SetGamepadVibration(int gamepad, float leftMotor, float rightMotor)
 
     if (IsGamepadAvailable(gamepad))
     {
-        SDL_JoystickRumble(platform.gamepad[gamepad], (Uint16)(leftMotor*65535.0f), (Uint16)(rightMotor*65535.0f), MAX_GAMEPAD_VIBRATION_TIME*1000);
+        SDL_JoystickRumble(platform.gamepad[gamepad], (Uint16)(leftMotor*65535.0f), (Uint16)(rightMotor*65535.0f), (Uint32)(MAX_GAMEPAD_VIBRATION_TIME*1000.0f));
     }
 }
 

--- a/src/platforms/rcore_desktop_sdl.c
+++ b/src/platforms/rcore_desktop_sdl.c
@@ -938,6 +938,15 @@ int SetGamepadMappings(const char *mappings)
     return SDL_GameControllerAddMapping(mappings);
 }
 
+// Set gamepad vibration
+void SetGamepadVibration(int gamepad, float leftMotor, float rightMotor, float durationMs)
+{
+    if (IsGamepadAvailable(gamepad))
+    {
+        SDL_JoystickRumble(platform.gamepad[gamepad], (Uint16)(leftMotor*0xFFFF), (Uint16)(rightMotor*0xFFFF), durationMs);
+    }
+}
+
 // Set mouse position XY
 void SetMousePosition(int x, int y)
 {

--- a/src/platforms/rcore_desktop_sdl.c
+++ b/src/platforms/rcore_desktop_sdl.c
@@ -939,11 +939,17 @@ int SetGamepadMappings(const char *mappings)
 }
 
 // Set gamepad vibration
-void SetGamepadVibration(int gamepad, float leftMotor, float rightMotor, float durationMs)
+void SetGamepadVibration(int gamepad, float leftMotor, float rightMotor)
 {
+    //Limit input values to between 0.0f and 1.0f
+    leftMotor  = (0.0f > leftMotor)  ? 0.0f : leftMotor;
+    rightMotor = (0.0f > rightMotor) ? 0.0f : rightMotor;
+    leftMotor  = (1.0f < leftMotor)  ? 1.0f : leftMotor;
+    rightMotor = (1.0f < rightMotor) ? 1.0f : rightMotor;
+
     if (IsGamepadAvailable(gamepad))
     {
-        SDL_JoystickRumble(platform.gamepad[gamepad], (Uint16)(leftMotor*0xFFFF), (Uint16)(rightMotor*0xFFFF), durationMs);
+        SDL_JoystickRumble(platform.gamepad[gamepad], (Uint16)(leftMotor*65535.0f), (Uint16)(rightMotor*65535.0f), MAX_GAMEPAD_VIBRATION_TIME*1000);
     }
 }
 

--- a/src/platforms/rcore_drm.c
+++ b/src/platforms/rcore_drm.c
@@ -520,7 +520,7 @@ int SetGamepadMappings(const char *mappings)
 }
 
 // Set gamepad vibration
-void SetGamepadVibration(int gamepad, float leftMotor, float rightMotor, float durationMs)
+void SetGamepadVibration(int gamepad, float leftMotor, float rightMotor)
 {
     TRACELOG(LOG_WARNING, "GamepadSetVibration() not implemented on target platform");
 }

--- a/src/platforms/rcore_drm.c
+++ b/src/platforms/rcore_drm.c
@@ -519,6 +519,12 @@ int SetGamepadMappings(const char *mappings)
     return 0;
 }
 
+// Set gamepad vibration
+void SetGamepadVibration(int gamepad, float leftMotor, float rightMotor, float durationMs)
+{
+    TRACELOG(LOG_WARNING, "GamepadSetVibration() not implemented on target platform");
+}
+
 // Set mouse position XY
 void SetMousePosition(int x, int y)
 {

--- a/src/platforms/rcore_web.c
+++ b/src/platforms/rcore_web.c
@@ -851,7 +851,7 @@ int SetGamepadMappings(const char *mappings)
 }
 
 // Set gamepad vibration
-void SetGamepadVibration(int gamepad, float leftMotor, float rightMotor, float durationMs)
+void SetGamepadVibration(int gamepad, float leftMotor, float rightMotor)
 {
     TRACELOG(LOG_WARNING, "GamepadSetVibration() not implemented on target platform");
 }

--- a/src/platforms/rcore_web.c
+++ b/src/platforms/rcore_web.c
@@ -850,6 +850,12 @@ int SetGamepadMappings(const char *mappings)
     return 0;
 }
 
+// Set gamepad vibration
+void SetGamepadVibration(int gamepad, float leftMotor, float rightMotor, float durationMs)
+{
+    TRACELOG(LOG_WARNING, "GamepadSetVibration() not implemented on target platform");
+}
+
 // Set mouse position XY
 void SetMousePosition(int x, int y)
 {

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1162,17 +1162,17 @@ RLAPI int GetCharPressed(void);                               // Get char presse
 RLAPI void SetExitKey(int key);                               // Set a custom key to exit program (default is ESC)
 
 // Input-related functions: gamepads
-RLAPI bool IsGamepadAvailable(int gamepad);                                                          // Check if a gamepad is available
-RLAPI const char *GetGamepadName(int gamepad);                                                       // Get gamepad internal name id
-RLAPI bool IsGamepadButtonPressed(int gamepad, int button);                                          // Check if a gamepad button has been pressed once
-RLAPI bool IsGamepadButtonDown(int gamepad, int button);                                             // Check if a gamepad button is being pressed
-RLAPI bool IsGamepadButtonReleased(int gamepad, int button);                                         // Check if a gamepad button has been released once
-RLAPI bool IsGamepadButtonUp(int gamepad, int button);                                               // Check if a gamepad button is NOT being pressed
-RLAPI int GetGamepadButtonPressed(void);                                                             // Get the last gamepad button pressed
-RLAPI int GetGamepadAxisCount(int gamepad);                                                          // Get gamepad axis count for a gamepad
-RLAPI float GetGamepadAxisMovement(int gamepad, int axis);                                           // Get axis movement value for a gamepad axis
-RLAPI int SetGamepadMappings(const char *mappings);                                                  // Set internal gamepad mappings (SDL_GameControllerDB)
-RLAPI void SetGamepadVibration(int gamepad, float leftMotor, float rightMotor, float durationMs);    // Set gamepad vibration for both motors
+RLAPI bool IsGamepadAvailable(int gamepad);                                        // Check if a gamepad is available
+RLAPI const char *GetGamepadName(int gamepad);                                     // Get gamepad internal name id
+RLAPI bool IsGamepadButtonPressed(int gamepad, int button);                        // Check if a gamepad button has been pressed once
+RLAPI bool IsGamepadButtonDown(int gamepad, int button);                           // Check if a gamepad button is being pressed
+RLAPI bool IsGamepadButtonReleased(int gamepad, int button);                       // Check if a gamepad button has been released once
+RLAPI bool IsGamepadButtonUp(int gamepad, int button);                             // Check if a gamepad button is NOT being pressed
+RLAPI int GetGamepadButtonPressed(void);                                           // Get the last gamepad button pressed
+RLAPI int GetGamepadAxisCount(int gamepad);                                        // Get gamepad axis count for a gamepad
+RLAPI float GetGamepadAxisMovement(int gamepad, int axis);                         // Get axis movement value for a gamepad axis
+RLAPI int SetGamepadMappings(const char *mappings);                                // Set internal gamepad mappings (SDL_GameControllerDB)
+RLAPI void SetGamepadVibration(int gamepad, float leftMotor, float rightMotor);    // Set gamepad vibration for both motors
 
 // Input-related functions: mouse
 RLAPI bool IsMouseButtonPressed(int button);                  // Check if a mouse button has been pressed once

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1162,16 +1162,17 @@ RLAPI int GetCharPressed(void);                               // Get char presse
 RLAPI void SetExitKey(int key);                               // Set a custom key to exit program (default is ESC)
 
 // Input-related functions: gamepads
-RLAPI bool IsGamepadAvailable(int gamepad);                   // Check if a gamepad is available
-RLAPI const char *GetGamepadName(int gamepad);                // Get gamepad internal name id
-RLAPI bool IsGamepadButtonPressed(int gamepad, int button);   // Check if a gamepad button has been pressed once
-RLAPI bool IsGamepadButtonDown(int gamepad, int button);      // Check if a gamepad button is being pressed
-RLAPI bool IsGamepadButtonReleased(int gamepad, int button);  // Check if a gamepad button has been released once
-RLAPI bool IsGamepadButtonUp(int gamepad, int button);        // Check if a gamepad button is NOT being pressed
-RLAPI int GetGamepadButtonPressed(void);                      // Get the last gamepad button pressed
-RLAPI int GetGamepadAxisCount(int gamepad);                   // Get gamepad axis count for a gamepad
-RLAPI float GetGamepadAxisMovement(int gamepad, int axis);    // Get axis movement value for a gamepad axis
-RLAPI int SetGamepadMappings(const char *mappings);           // Set internal gamepad mappings (SDL_GameControllerDB)
+RLAPI bool IsGamepadAvailable(int gamepad);                                                          // Check if a gamepad is available
+RLAPI const char *GetGamepadName(int gamepad);                                                       // Get gamepad internal name id
+RLAPI bool IsGamepadButtonPressed(int gamepad, int button);                                          // Check if a gamepad button has been pressed once
+RLAPI bool IsGamepadButtonDown(int gamepad, int button);                                             // Check if a gamepad button is being pressed
+RLAPI bool IsGamepadButtonReleased(int gamepad, int button);                                         // Check if a gamepad button has been released once
+RLAPI bool IsGamepadButtonUp(int gamepad, int button);                                               // Check if a gamepad button is NOT being pressed
+RLAPI int GetGamepadButtonPressed(void);                                                             // Get the last gamepad button pressed
+RLAPI int GetGamepadAxisCount(int gamepad);                                                          // Get gamepad axis count for a gamepad
+RLAPI float GetGamepadAxisMovement(int gamepad, int axis);                                           // Get axis movement value for a gamepad axis
+RLAPI int SetGamepadMappings(const char *mappings);                                                  // Set internal gamepad mappings (SDL_GameControllerDB)
+RLAPI void SetGamepadVibration(int gamepad, float leftMotor, float rightMotor, float durationMs);    // Set gamepad vibration for both motors
 
 // Input-related functions: mouse
 RLAPI bool IsMouseButtonPressed(int button);                  // Check if a mouse button has been pressed once

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -224,6 +224,9 @@ __declspec(dllimport) int __stdcall WideCharToMultiByte(unsigned int cp, unsigne
 #ifndef MAX_GAMEPAD_BUTTONS
     #define MAX_GAMEPAD_BUTTONS           32        // Maximum number of buttons supported (per gamepad)
 #endif
+#ifndef MAX_GAMEPAD_BUTTONS
+    #define MAX_GAMEPAD_VIBRATION_TIME     2.0f     // Maximum vibration time in seconds
+#endif
 #ifndef MAX_TOUCH_POINTS
     #define MAX_TOUCH_POINTS               8        // Maximum number of touch points supported
 #endif

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -224,7 +224,7 @@ __declspec(dllimport) int __stdcall WideCharToMultiByte(unsigned int cp, unsigne
 #ifndef MAX_GAMEPAD_BUTTONS
     #define MAX_GAMEPAD_BUTTONS           32        // Maximum number of buttons supported (per gamepad)
 #endif
-#ifndef MAX_GAMEPAD_BUTTONS
+#ifndef MAX_GAMEPAD_VIBRATION_TIME
     #define MAX_GAMEPAD_VIBRATION_TIME     2.0f     // Maximum vibration time in seconds
 #endif
 #ifndef MAX_TOUCH_POINTS


### PR DESCRIPTION
As discussed in issue https://github.com/raysan5/raylib/issues/3815, I added a function `SetGamepadVibration(int gamepad, float leftMotor, float rightMotor)`. I also added a new define, `MAX_GAMEPAD_VIBRATION_TIME 2.0f` to control the maximum duration of the vibration. When the user sends `SetGamepadVibration(gamepad, float 0.0f, float 0.0f)`, it cancels the vibration. Otherwise it continues on for MAX_GAMEPAD_VIBRATION_TIME. 

It seems to work well on my end with an 8BitDo Pro 2 controller set both to Nintendo Switch Pro and Xbox One modes. Perhaps the max time could be changed to something else, but 2 seconds seem to be fine.

Currently the function is set as not returning a value, the SDL function returns -1 if rumble isn't supported on the controller. Should something like that be returned from the SetGamepadVibration function as well? 