### PR TITLE
Fix ExportDataAsCode not considering some characters for variable name

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -316,7 +316,11 @@ bool ExportDataAsCode(const unsigned char *data, int dataSize, const char *fileN
     // Get file name from path and convert variable name to uppercase
     char varFileName[256] = { 0 };
     strcpy(varFileName, GetFileNameWithoutExt(fileName));
-    for (int i = 0; varFileName[i] != '\0'; i++) if ((varFileName[i] >= 'a') && (varFileName[i] <= 'z')) { varFileName[i] = varFileName[i] - 32; }
+    for (int i = 0; varFileName[i] != '\0'; i++)
+    {
+        if ((varFileName[i] >= 'a') && (varFileName[i] <= 'z')) varFileName[i] = varFileName[i] - 32;
+        else if (varFileName[i] == '.' || varFileName[i] == '-' || varFileName[i] == '?' || varFileName[i] == '!') varFileName[i] = '_';
+    }
 
     byteCount += sprintf(txtData + byteCount, "#define %s_DATA_SIZE     %i\n\n", varFileName, dataSize);
 


### PR DESCRIPTION
With a `fileName` argument like `my-image.png.h`, the output inside `my-image.png.h` looks like this:
```c
#define MY-IMAGE.PNG_DATA_SIZE     119076

static unsigned char MY-IMAGE.PNG_DATA[MY-IMAGE.PNG_DATA_SIZE] = ...
```
This commit checks if characters such as `-`, `.`, `?` and `!` are present in `varFileName` and replaces them with `_`, so `my-image.png.h` would be
```c
#define MY_IMAGE_PNG_DATA_SIZE     119076

static unsigned char MY_IMAGE_PNG_DATA[MY_IMAGE_PNG_DATA_SIZE] = ...
```