### PR TITLE
Fix examples linking with CMake and -DPLATFORM=SDL

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -131,6 +131,9 @@ foreach (example_source ${example_sources})
     add_executable(${example_name} ${example_source})
 
     target_link_libraries(${example_name} raylib)
+    if (NOT WIN32)
+        target_link_libraries(${example_name} m)
+    endif()
 
     string(REGEX MATCH ".*/.*/" resources_dir ${example_source})
     string(APPEND resources_dir "resources")


### PR DESCRIPTION
Currently, every example fails linking likeso:

[  3%] Linking C executable audio_mixed_processor
/usr/bin/ld: ../raylib/libraylib.a(raudio.c.o): undefined reference to symbol 'exp@@GLIBC_2.29' /usr/bin/ld: /usr/lib/libm.so.6: error adding symbols: DSO missing from command line collect2: error: ld returned 1 exit status

Apparently, linking libm explicitly is the solution.