### PR TITLE
Fix building of raylib_opengl_interop on PLATFORM_DESKTOP_SDL

### DIFF
--- a/examples/others/raylib_opengl_interop.c
+++ b/examples/others/raylib_opengl_interop.c
@@ -26,7 +26,7 @@
 
 #include "raylib.h"
 
-#if defined(PLATFORM_DESKTOP)
+#if defined(PLATFORM_DESKTOP) || defined(PLATFORM_DESKTOP_SDL)
     #if defined(GRAPHICS_API_OPENGL_ES2)
         #include "glad_gles2.h"       // Required for: OpenGL functionality 
         #define glGenVertexArrays glGenVertexArraysOES


### PR DESCRIPTION
I tested this with CMake. I don't know if the examples makefile currently handles this case.
The resulting executable runs and produces the expected output.

NOTE: testing this PR depends on #3825, otherwise this example won't even link due to the issue that PR resolves.

Though I hope it's trivial enough that there aren't problems I missed.