### PR TITLE
Fix the link error of examples, cmake error, and charset error

### DIFF
--- a/cmake/AddIfFlagCompiles.cmake
+++ b/cmake/AddIfFlagCompiles.cmake
@@ -9,4 +9,7 @@ function(add_if_flag_compiles flag)
     set(outcome "compiles")
   endif()
   message(STATUS "Testing if ${flag} can be used -- ${outcome}")
+  # It must be manually removed from the cache; otherwise, the check won't be re-evalated
+  # https://cmake.org/cmake/help/latest/module/CheckCCompilerFlag.html
+  unset(COMPILER_HAS_THOSE_TOGGLES CACHE)
 endfunction()

--- a/cmake/CompilerFlags.cmake
+++ b/cmake/CompilerFlags.cmake
@@ -11,6 +11,12 @@ add_if_flag_compiles(-Werror=implicit-function-declaration CMAKE_C_FLAGS)
 # Allows some casting of pointers without generating a warning
 add_if_flag_compiles(-fno-strict-aliasing CMAKE_C_FLAGS)
 
+# Set the charset of input files and executable files as utf-8
+# Since the default charset of MSVC is not utf-8
+if(CMAKE_C_COMPILER_ID STREQUAL "MSVC")
+    add_if_flag_compiles(-utf-8 CMAKE_C_FLAGS)
+endif()
+
 if (ENABLE_MSAN AND ENABLE_ASAN)
     # MSAN and ASAN both work on memory - ASAN does more things
     MESSAGE(WARNING "Compiling with both AddressSanitizer and MemorySanitizer is not recommended")

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -142,5 +142,8 @@ foreach (example_source ${example_sources})
     endif ()
 endforeach ()
 
+# Need glfw implemention for glfw3.h
+target_sources(rlgl_standalone PRIVATE ${CMAKE_SOURCE_DIR}/src/rglfw.c)
+
 # Copy all of the resource files to the destination
 file(COPY ${example_resources} DESTINATION "resources/")

--- a/examples/others/raylib_opengl_interop.c
+++ b/examples/others/raylib_opengl_interop.c
@@ -38,6 +38,9 @@
             #include <OpenGL/gl3.h>     // OpenGL 3 library for OSX
             #include <OpenGL/gl3ext.h>  // OpenGL 3 extensions library for OSX
         #else
+            #if defined(_WIN32) && defined(_MSC_VER)
+                #define GLAD_IMPLEMENTATION  // Need self-implementation for MSVC
+            #endif
             #include "glad.h"       // Required for: OpenGL functionality 
         #endif
         #define GLSL_VERSION            330


### PR DESCRIPTION
fixes #3818 

Fix the link error of `raylib_opengl_interop` and `rlgl_standalone` by adding function implementation.
Set utf-8 as default charset for MSVC; otherwise, there would be an error when encoding `text_codepoints_loading.c`.
Fix the error `add_if_flag_compiles` by removing cache in `AddIfFlagCompiles.cmake`.