### PR TITLE
Add very little sanitization to indentifier names in ExportDataAsCode()

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -313,10 +313,16 @@ bool ExportDataAsCode(const unsigned char *data, int dataSize, const char *fileN
     byteCount += sprintf(txtData + byteCount, "//                                                                                    //\n");
     byteCount += sprintf(txtData + byteCount, "////////////////////////////////////////////////////////////////////////////////////////\n\n");
 
-    // Get file name from path and convert variable name to uppercase
+    // Get file name from path
     char varFileName[256] = { 0 };
     strcpy(varFileName, GetFileNameWithoutExt(fileName));
-    for (int i = 0; varFileName[i] != '\0'; i++) if ((varFileName[i] >= 'a') && (varFileName[i] <= 'z')) { varFileName[i] = varFileName[i] - 32; }
+    for (int i = 0; varFileName[i] != '\0'; i++)
+    {
+        // Convert variable name to uppercase
+        if ((varFileName[i] >= 'a') && (varFileName[i] <= 'z')) { varFileName[i] = varFileName[i] - 32; }
+        // Replace '-' (non valid character for C identifier with '_')
+        if (varFileName[i] == '-') { varFileName[i] = '_'; }
+    }
 
     byteCount += sprintf(txtData + byteCount, "#define %s_DATA_SIZE     %i\n\n", varFileName, dataSize);
 


### PR DESCRIPTION
Hello, I decided to add this little sanitization for the '-' characater to the exported identifiers since find it quite useful for me and may help to other raylib users that use '-' in their file names.

Without this change any exported data to a file name containing the character would not compile since it's not a valid character for identifiers, I could have added more characters to be replaced ('@', '#', '%', etc) but i don't think they are really used for the use cases of `ExportDataAsCode()`.

Thanks for your time ❤️  