### PR TITLE
Change sanitization check for `ExportDataAsCode`

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -320,6 +320,7 @@ bool ExportDataAsCode(const unsigned char *data, int dataSize, const char *fileN
     {
         // Convert variable name to uppercase
         if ((varFileName[i] >= 'a') && (varFileName[i] <= 'z')) { varFileName[i] = varFileName[i] - 32; }
+        // Replace non valid character for C identifier with '_'
         else if (varFileName[i] == '.' || varFileName[i] == '-' || varFileName[i] == '?' || varFileName[i] == '!' || varFileName[i] == '+') { varFileName[i] = '_'; }
     }
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -48,7 +48,6 @@
 #include <stdio.h>                      // Required for: FILE, fopen(), fseek(), ftell(), fread(), fwrite(), fprintf(), vprintf(), fclose()
 #include <stdarg.h>                     // Required for: va_list, va_start(), va_end()
 #include <string.h>                     // Required for: strcpy(), strcat()
-#include <ctype.h>                      // Required for: isalnum()
 
 //----------------------------------------------------------------------------------
 // Defines and Macros
@@ -321,8 +320,7 @@ bool ExportDataAsCode(const unsigned char *data, int dataSize, const char *fileN
     {
         // Convert variable name to uppercase
         if ((varFileName[i] >= 'a') && (varFileName[i] <= 'z')) { varFileName[i] = varFileName[i] - 32; }
-        // Replace non valid character for C identifier with '_'
-        if (!isalnum(varFileName[i])) { varFileName[i] = '_'; }
+        else if (varFileName[i] == '.' || varFileName[i] == '-' || varFileName[i] == '?' || varFileName[i] == '!' || varFileName[i] == '+') { varFileName[i] = '_'; }
     }
 
     byteCount += sprintf(txtData + byteCount, "#define %s_DATA_SIZE     %i\n\n", varFileName, dataSize);

--- a/src/utils.c
+++ b/src/utils.c
@@ -48,6 +48,7 @@
 #include <stdio.h>                      // Required for: FILE, fopen(), fseek(), ftell(), fread(), fwrite(), fprintf(), vprintf(), fclose()
 #include <stdarg.h>                     // Required for: va_list, va_start(), va_end()
 #include <string.h>                     // Required for: strcpy(), strcat()
+#include <ctype.h>                      // Required for: isalnum()
 
 //----------------------------------------------------------------------------------
 // Defines and Macros
@@ -320,8 +321,8 @@ bool ExportDataAsCode(const unsigned char *data, int dataSize, const char *fileN
     {
         // Convert variable name to uppercase
         if ((varFileName[i] >= 'a') && (varFileName[i] <= 'z')) { varFileName[i] = varFileName[i] - 32; }
-        // Replace '-' (non valid character for C identifier with '_')
-        if (varFileName[i] == '-') { varFileName[i] = '_'; }
+        // Replace non valid character for C identifier with '_'
+        if (!isalnum(varFileName[i])) { varFileName[i] = '_'; }
     }
 
     byteCount += sprintf(txtData + byteCount, "#define %s_DATA_SIZE     %i\n\n", varFileName, dataSize);


### PR DESCRIPTION
I opted to use `isalnum` function since it should handle most cases. It cannot however handle cases of files beginning with numbers.