### PR TITLE
Fix DRM cross-compile without sysroot

### DIFF
--- a/cmake/LibraryConfigurations.cmake
+++ b/cmake/LibraryConfigurations.cmake
@@ -43,7 +43,7 @@ if (${PLATFORM} MATCHES "Desktop")
         if ("${OPENGL_LIBRARIES}" STREQUAL "")
             set(OPENGL_LIBRARIES "GL")
         endif ()
-        
+
         set(LIBS_PRIVATE m atomic pthread ${OPENGL_LIBRARIES} ${OSS_LIBRARY})
 
         if ("${CMAKE_SYSTEM_NAME}" MATCHES "(Net|Open)BSD")
@@ -86,7 +86,7 @@ elseif ("${PLATFORM}" MATCHES "DRM")
     find_library(DRM drm)
     find_library(GBM gbm)
 
-    if (NOT CMAKE_CROSSCOMPILING)
+    if (NOT CMAKE_CROSSCOMPILING OR NOT CMAKE_SYSROOT)
         include_directories(/usr/include/libdrm)
     endif ()
     set(LIBS_PRIVATE ${GLESV2} ${EGL} ${DRM} ${GBM} atomic pthread m dl)


### PR DESCRIPTION
Encountering `/usr/include/xf86drm.h:40:10: fatal error: drm.h: No such file or directory`
when doing a cross-compile I found that
```
cmake -DCMAKE_C_FLAGS=-I/usr/include/libdrm …
```
is needed. Some digging revealed that in my case #1717 spoils the libdrm includes.

The unexpected and different situation here: I'm doing a cross-compile on a multi-arch image.
I.e. I run an arm-linux-gnueabihf compiler on aarch64 and the armhf libs are installed side-by-side with the arm64 libs -- no need for a sysroot.

I propose to only drop the libdrm include path if a sysroot is actually used.