### PR TITLE
Fix examples warnings for macos

### DIFF
--- a/examples/models/models_first_person_maze.c
+++ b/examples/models/models_first_person_maze.c
@@ -34,7 +34,6 @@ int main(void)
     camera.up = (Vector3){ 0.0f, 1.0f, 0.0f };          // Camera up vector (rotation towards target)
     camera.fovy = 45.0f;                                // Camera field-of-view Y
     camera.projection = CAMERA_PERSPECTIVE;             // Camera projection type
-    Vector3 position = { 0.0f, 0.0f, 0.0f };            // Set model position
 
     Image imMap = LoadImage("resources/cubicmap.png");      // Load cubicmap image (RAM)
     Texture2D cubicmap = LoadTextureFromImage(imMap);       // Convert image to texture to display (VRAM)

--- a/examples/others/raylib_opengl_interop.c
+++ b/examples/others/raylib_opengl_interop.c
@@ -35,6 +35,7 @@
         #define GLSL_VERSION            100
     #else
         #if defined(__APPLE__)
+            #define GL_SILENCE_DEPRECATION // Silence Opengl API deprecation warnings 
             #include <OpenGL/gl3.h>     // OpenGL 3 library for OSX
             #include <OpenGL/gl3ext.h>  // OpenGL 3 extensions library for OSX
         #else

--- a/examples/text/text_codepoints_loading.c
+++ b/examples/text/text_codepoints_loading.c
@@ -60,7 +60,6 @@ int main(void)
     bool showFontAtlas = false;
 
     int codepointSize = 0;
-    int codepoint = 0;
     char *ptr = text;
 
     SetTargetFPS(60);               // Set our game to run at 60 frames-per-second
@@ -77,13 +76,13 @@ int main(void)
         if (IsKeyPressed(KEY_RIGHT))
         {
             // Get next codepoint in string and move pointer
-            codepoint = GetCodepointNext(ptr, &codepointSize);
+            GetCodepointNext(ptr, &codepointSize);
             ptr += codepointSize;
         }
         else if (IsKeyPressed(KEY_LEFT))
         {
             // Get previous codepoint in string and move pointer
-            codepoint = GetCodepointPrevious(ptr, &codepointSize);
+            GetCodepointPrevious(ptr, &codepointSize);
             ptr -= codepointSize;
         }
         //----------------------------------------------------------------------------------


### PR DESCRIPTION
Fix the below warnings in examples for macos (version 14.3.1, clang 14):

others/raylib_opengl_interop.c:158:5: warning: 'glDeleteVertexArrays' is deprecated: first deprecated in macOS 10.14 - OpenGL API deprecated. (Define GL_SILENCE_DEPRECATION to silence these warnings) [-Wdeprecated-declarations]
    glDeleteVertexArrays(1, &vao);

models/models_first_person_maze.c:37:13: warning: unused variable 'position' [-Wunused-variable]
    Vector3 position = { 0.0f, 0.0f, 0.0f };            // Set model position

text/text_codepoints_loading.c:63:9: warning: variable 'codepoint' set but not used [-Wunused-but-set-variable]
    int codepoint = 0;
