### PR TITLE
Remove GLFW mouse passthrough hack and increase GLFW version in CMake

### DIFF
--- a/cmake/GlfwImport.cmake
+++ b/cmake/GlfwImport.cmake
@@ -1,8 +1,8 @@
 
 if(USE_EXTERNAL_GLFW STREQUAL "ON")
-    find_package(glfw3 3.3.3 REQUIRED)
+    find_package(glfw3 3.4 REQUIRED)
 elseif(USE_EXTERNAL_GLFW STREQUAL "IF_POSSIBLE")
-    find_package(glfw3 3.3.3 QUIET)
+    find_package(glfw3 3.4 QUIET)
 endif()
 if (glfw3_FOUND)
     set(LIBS_PRIVATE ${LIBS_PRIVATE} glfw)

--- a/src/platforms/rcore_desktop.c
+++ b/src/platforms/rcore_desktop.c
@@ -85,15 +85,6 @@
 #endif
 
 //----------------------------------------------------------------------------------
-// Defines and Macros
-//----------------------------------------------------------------------------------
-// TODO: HACK: Added flag if not provided by GLFW when using external library
-// Latest GLFW release (GLFW 3.3.8) does not implement this flag, it was added for 3.4.0-dev
-#if !defined(GLFW_MOUSE_PASSTHROUGH)
-    #define GLFW_MOUSE_PASSTHROUGH      0x0002000D
-#endif
-
-//----------------------------------------------------------------------------------
 // Types and Structures Definition
 //----------------------------------------------------------------------------------
 typedef struct {


### PR DESCRIPTION
With the ``GLFW_MOUSE_PASSTHROUGH`` constant now available in GLFW 3.4, this hack is no longer necessary.