### PR TITLE
Fix CMake SDL build for rlgl_standalone

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -145,5 +145,11 @@ foreach (example_source ${example_sources})
     endif ()
 endforeach ()
 
+# For SDL, have rlgl_standalone link the glfw dependency.
+if ("${PLATFORM}" STREQUAL "SDL")
+    find_package(glfw3 3.3 REQUIRED)
+    target_link_libraries(rlgl_standalone glfw)
+endif()
+
 # Copy all of the resource files to the destination
 file(COPY ${example_resources} DESTINATION "resources/")


### PR DESCRIPTION
The `rlgl_standalone` example depends on having glfw. On the SDL build, glfw is not embedded directly, so we'll have to link it.
