### PR TITLE
[cmake] Disable SDL rlgl_standalone example

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -113,10 +113,13 @@ elseif ("${PLATFORM}" STREQUAL "DRM")
     list(REMOVE_ITEM example_sources ${CMAKE_CURRENT_SOURCE_DIR}/others/rlgl_standalone.c)
     list(REMOVE_ITEM example_sources ${CMAKE_CURRENT_SOURCE_DIR}/others/raylib_opengl_interop.c)
 
-elseif ("${PLATFORM}" STREQUAL "SDL")
+endif ()
+
+# The rlgl_standalone example only targets desktop, without shared libraries.
+if (BUILD_SHARED_LIBS OR NOT ${PLATFORM} MATCHES "Desktop")
     list(REMOVE_ITEM example_sources ${CMAKE_CURRENT_SOURCE_DIR}/others/rlgl_standalone.c)
 
-endif ()
+endif()
 
 include_directories(BEFORE SYSTEM others/external/include)
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -113,6 +113,9 @@ elseif ("${PLATFORM}" STREQUAL "DRM")
     list(REMOVE_ITEM example_sources ${CMAKE_CURRENT_SOURCE_DIR}/others/rlgl_standalone.c)
     list(REMOVE_ITEM example_sources ${CMAKE_CURRENT_SOURCE_DIR}/others/raylib_opengl_interop.c)
 
+elseif ("${PLATFORM}" STREQUAL "SDL")
+    list(REMOVE_ITEM example_sources ${CMAKE_CURRENT_SOURCE_DIR}/others/rlgl_standalone.c)
+
 endif ()
 
 include_directories(BEFORE SYSTEM others/external/include)
@@ -144,12 +147,6 @@ foreach (example_source ${example_sources})
         set_target_properties(${example_name} PROPERTIES LINK_FLAGS "--preload-file ${resources_dir}")
     endif ()
 endforeach ()
-
-# For SDL, have rlgl_standalone link the glfw dependency.
-if ("${PLATFORM}" STREQUAL "SDL")
-    find_package(glfw3 3.3 REQUIRED)
-    target_link_libraries(rlgl_standalone glfw)
-endif()
 
 # Copy all of the resource files to the destination
 file(COPY ${example_resources} DESTINATION "resources/")


### PR DESCRIPTION
Follows up from #3860 to completely disable the SDL build for rlgl_standalone in CMake.

cc @Peter0x44 