### PR TITLE
Implement IsCursorOnScreen for PLATFORM_DESKTOP_SDL

### DIFF
--- a/src/platforms/rcore_desktop_sdl.c
+++ b/src/platforms/rcore_desktop_sdl.c
@@ -1108,11 +1108,17 @@ void PollInputEvents(void)
                         CORE.Window.currentFbo.height = height;
                         CORE.Window.resizedLastFrame = true;
                     } break;
+                    case SDL_WINDOWEVENT_ENTER:
+                    {
+                        CORE.Input.Mouse.cursorOnScreen = true;
+                    } break;
                     case SDL_WINDOWEVENT_LEAVE:
+                    {
+                        CORE.Input.Mouse.cursorOnScreen = false;
+                    } break;
                     case SDL_WINDOWEVENT_HIDDEN:
                     case SDL_WINDOWEVENT_MINIMIZED:
                     case SDL_WINDOWEVENT_FOCUS_LOST:
-                    case SDL_WINDOWEVENT_ENTER:
                     case SDL_WINDOWEVENT_SHOWN:
                     case SDL_WINDOWEVENT_FOCUS_GAINED:
                     case SDL_WINDOWEVENT_MAXIMIZED:


### PR DESCRIPTION
I did some testing and this seems to work okay, but it *is* different to GLFW. GLFW seems to lose "IsCursorOnScreen" for one frame upon pressing alt+tab over the window, without a different window covering it. SDL seems to have a more reasonable behavior for this case. Either way it's an edge case and I don't know the exact way to fix, likely requires internal GLFW changes.