### PR TITLE
[rcore] Fix GetKeyPressed for PLATFORM_DESKTOP_SDL

### DIFF
--- a/src/platforms/rcore_desktop_sdl.c
+++ b/src/platforms/rcore_desktop_sdl.c
@@ -1131,7 +1131,17 @@ void PollInputEvents(void)
             case SDL_KEYDOWN:
             {
                 KeyboardKey key = ConvertScancodeToKey(event.key.keysym.scancode);
-                if (key != KEY_NULL) CORE.Input.Keyboard.currentKeyState[key] = 1;
+
+                if (key != KEY_NULL) {
+                    // If key was up, add it to the key pressed queue
+                    if ((CORE.Input.Keyboard.currentKeyState[key] == 0) && (CORE.Input.Keyboard.keyPressedQueueCount < MAX_KEY_PRESSED_QUEUE))
+                    {
+                        CORE.Input.Keyboard.keyPressedQueue[CORE.Input.Keyboard.keyPressedQueueCount] = key;
+                        CORE.Input.Keyboard.keyPressedQueueCount++;
+                    }
+
+                    CORE.Input.Keyboard.currentKeyState[key] = 1;
+                }
 
                 if (event.key.repeat) CORE.Input.Keyboard.keyRepeatInFrame[key] = 1;
 
@@ -1153,14 +1163,6 @@ void PollInputEvents(void)
                 // NOTE: event.text.text data comes an UTF-8 text sequence but we register codepoints (int)
 
                 int codepointSize = 0;
-
-                // Check if there is space available in the key queue
-                if (CORE.Input.Keyboard.keyPressedQueueCount < MAX_KEY_PRESSED_QUEUE)
-                {
-                    // Add character (key) to the queue
-                    CORE.Input.Keyboard.keyPressedQueue[CORE.Input.Keyboard.keyPressedQueueCount] = GetCodepointNext(event.text.text, &codepointSize);
-                    CORE.Input.Keyboard.keyPressedQueueCount++;
-                }
 
                 // Check if there is space available in the queue
                 if (CORE.Input.Keyboard.charPressedQueueCount < MAX_CHAR_PRESSED_QUEUE)


### PR DESCRIPTION
The key handling in `PLATFORM_DESKTOP_SDL` was faulty in two ways, which led to `GetKeyPressed` returning incorrect data.

`CORE.Input.Keyboard.keyPressedQueue` was updated only on `SDL_TEXTINPUT`, meaning only text characters were registered as a pressed key, but not function keys (eg. tab, backspace...).

Also on such event, both `CORE.Input.Keyboard.keyPressedQueue` and `CORE.Input.Keyboard.charPressedQueue` were assigned the key's corresponding codepoint, when `CORE.Input.Keyboard.keyPressedQueue` should get the raylib keycode instead.

`CORE.Input.Keyboard.keyPressedQueue` is now updated on `SDL_KEYDOWN` event instead.
