### PR TITLE
[rmodels] Remove redundant call for disabling vertex color attribute

### DIFF
--- a/src/rmodels.c
+++ b/src/rmodels.c
@@ -1470,9 +1470,6 @@ void DrawMesh(Mesh mesh, Material material, Matrix transform)
         if (mesh.indices != NULL) rlEnableVertexBufferElement(mesh.vboId[6]);
     }
 
-    // WARNING: Disable vertex attribute color input if mesh can not provide that data (despite location being enabled in shader)
-    if (mesh.vboId[3] == 0) rlDisableVertexAttribute(material.shader.locs[SHADER_LOC_VERTEX_COLOR]);
-
     int eyeCount = 1;
     if (rlIsStereoRenderEnabled()) eyeCount = 2;
 
@@ -1690,9 +1687,6 @@ void DrawMeshInstanced(Mesh mesh, Material material, const Matrix *transforms, i
 
         if (mesh.indices != NULL) rlEnableVertexBufferElement(mesh.vboId[6]);
     }
-
-    // WARNING: Disable vertex attribute color input if mesh can not provide that data (despite location being enabled in shader)
-    if (mesh.vboId[3] == 0) rlDisableVertexAttribute(material.shader.locs[SHADER_LOC_VERTEX_COLOR]);
 
     int eyeCount = 1;
     if (rlIsStereoRenderEnabled()) eyeCount = 2;


### PR DESCRIPTION
This PR removes the call to `rlDisableVertexAttribute` for `SHADER_LOC_VERTEX_COLOR` in `DrawMesh` and `DrawMeshInstanced`, because it was being called in cases where this location is not set in the shader. This resulted in an invalid value (-1) being passed to `rlDisableVertexAttribute` which made an **OpenGL error `GL_INVALID_VALUE`**. 

Furthermore the same function is **already being called**  with correct checks (checking if location attribute is set and vboId[3]==0) few lines above (rmodels.c:1450 and rmodels.c:1671 in the original source).

This solves issue https://github.com/raysan5/raylib/issues/3841