### PR TITLE
[PLATFORM DESKTOP] Use relative mouse mode when cursor is disabled

### DIFF
--- a/src/platforms/rcore_desktop.c
+++ b/src/platforms/rcore_desktop.c
@@ -972,6 +972,9 @@ void EnableCursor(void)
     // Set cursor position in the middle
     SetMousePosition(CORE.Window.screen.width/2, CORE.Window.screen.height/2);
 
+    if (glfwRawMouseMotionSupported())
+        glfwSetInputMode(platform.handle, GLFW_RAW_MOUSE_MOTION, GLFW_FALSE);
+
     CORE.Input.Mouse.cursorHidden = false;
 }
 
@@ -982,6 +985,9 @@ void DisableCursor(void)
 
     // Set cursor position in the middle
     SetMousePosition(CORE.Window.screen.width/2, CORE.Window.screen.height/2);
+
+    if (glfwRawMouseMotionSupported())
+        glfwSetInputMode(platform.handle, GLFW_RAW_MOUSE_MOTION, GLFW_TRUE);
 
     CORE.Input.Mouse.cursorHidden = true;
 }


### PR DESCRIPTION
When the cursor is disabled we need to put GLFW in relative mouse motion mode. If we don't some platforms (linux) can get drift in the mouse position. 

This PR sets the GLFW mode when we disable/enable the cursor.