### PR TITLE
Organizing the drm backend to only use one api to allow for more devices

### DIFF
--- a/src/platforms/rcore_drm.c
+++ b/src/platforms/rcore_drm.c
@@ -1080,7 +1080,7 @@ static void InitKeyboard(void)
     int result = ioctl(STDIN_FILENO, KDGKBMODE, &platform.defaultKeyboardMode);
 
     // In case of failure, it could mean a remote keyboard is used (SSH)
-    if (result < 0) TRACELOG(LOG_WARNING, "RPI: Failed to change keyboard mode, an SSH keyboard is probably used");
+    if (result < 0) TRACELOG(LOG_WARNING, "DRM: Failed to change keyboard mode, an SSH keyboard is probably used");
     else
     {
         // Reconfigure keyboard mode to get:
@@ -1264,7 +1264,7 @@ static void InitEvdevInput(void)
 
         closedir(directory);
     }
-    else TRACELOG(LOG_WARNING, "RPI: Failed to open linux event directory: %s", DEFAULT_EVDEV_PATH);
+    else TRACELOG(LOG_WARNING, "DRM: Failed to open linux event directory: %s", DEFAULT_EVDEV_PATH);
 }
 
 // Identifies a input device and configures it for use if appropriate
@@ -1286,7 +1286,7 @@ static void ConfigureEvdevDevice(char *device)
     int fd = open(device, O_RDONLY | O_NONBLOCK);
     if (fd < 0)
     {
-        TRACELOG(LOG_WARNING, "Failed to open input device: %s", device);
+        TRACELOG(LOG_WARNING, "DRM: Failed to open input device: %s", device);
         return;
     }
 
@@ -1519,7 +1519,7 @@ static void PollKeyboardEvents(void)
 
                     if (CORE.Input.Keyboard.currentKeyState[CORE.Input.Keyboard.exitKey] == 1) CORE.Window.shouldClose = true;
 
-                    TRACELOGD("KEY_%s ScanCode: %4i KeyCode: %4i", (event.value == 0)? "UP" : "DOWN", event.code, keycode);
+                    TRACELOGD("DRM: KEY_%s ScanCode: %4i KeyCode: %4i", (event.value == 0)? "UP" : "DOWN", event.code, keycode);
                 }
             }
         }
@@ -1544,7 +1544,7 @@ static void PollGamepadEvents(void)
             {
                 if (event.code >= MAX_GAMEPAD_BUTTONS) return;
 
-                TRACELOG(LOG_DEBUG, "Gamepad %i button: %i, value: %i", i, event.code, event.value);
+                TRACELOG(LOG_DEBUG, "DRM: Gamepad %i button: %i, value: %i", i, event.code, event.value);
 
                 // 1 - button pressed, 0 - button released
                 CORE.Input.Gamepad.currentButtonState[i][event.code] = event.value;
@@ -1556,7 +1556,7 @@ static void PollGamepadEvents(void)
             {
                 if (event.code >= MAX_GAMEPAD_AXIS) return;
 
-                TRACELOG(LOG_DEBUG, "Gamepad %i axis: %i, value: %i", i, platform.gamepadAbsAxisMap[i][event.code], event.value);
+                TRACELOG(LOG_DEBUG, "DRM: Gamepad %i axis: %i, value: %i", i, platform.gamepadAbsAxisMap[i][event.code], event.value);
 
                 if (event.type == EV_REL) CORE.Input.Gamepad.axisState[i][event.code] += (float)event.value;
                 else

--- a/src/platforms/rcore_drm.c
+++ b/src/platforms/rcore_drm.c
@@ -1558,15 +1558,11 @@ static void PollGamepadEvents(void)
 
                 TRACELOG(LOG_DEBUG, "DRM: Gamepad %i axis: %i, value: %i", i, platform.gamepadAbsAxisMap[i][event.code], event.value);
 
-                if (event.type == EV_REL) CORE.Input.Gamepad.axisState[i][event.code] += (float)event.value;
-                else
-                {
-                    int min = platform.gamepadAbsAxisRange[i][event.code][0];
-                    int range = platform.gamepadAbsAxisRange[i][event.code][1];
+                int min = platform.gamepadAbsAxisRange[i][event.code][0];
+                int range = platform.gamepadAbsAxisRange[i][event.code][1];
 
-                    // NOTE: Scaling of event.value to get values between -1..1
-                    CORE.Input.Gamepad.axisState[i][platform.gamepadAbsAxisMap[i][event.code]] = (2 * (float)(event.value - min) / range) - 1;
-                }
+                // NOTE: Scaling of event.value to get values between -1..1
+                CORE.Input.Gamepad.axisState[i][platform.gamepadAbsAxisMap[i][event.code]] = (2 * (float)(event.value - min) / range) - 1;
             }
         }
     }

--- a/src/platforms/rcore_drm.c
+++ b/src/platforms/rcore_drm.c
@@ -1542,7 +1542,7 @@ static void PollGamepadEvents(void)
         {
             if (event.type == EV_KEY)
             {
-                if (event.code >= MAX_GAMEPAD_BUTTONS) return;
+                if (event.code >= MAX_GAMEPAD_BUTTONS) continue;
 
                 TRACELOG(LOG_DEBUG, "DRM: Gamepad %i button: %i, value: %i", i, event.code, event.value);
 
@@ -1554,7 +1554,7 @@ static void PollGamepadEvents(void)
             }
             else if (event.type == EV_ABS)
             {
-                if (event.code >= MAX_GAMEPAD_AXIS) return;
+                if (event.code >= MAX_GAMEPAD_AXIS) continue;
 
                 TRACELOG(LOG_DEBUG, "DRM: Gamepad %i axis: %i, value: %i", i, platform.gamepadAbsAxisMap[i][event.code], event.value);
 


### PR DESCRIPTION
## Notes
- Sorry for the awfully long single commit, the way I developed this, that was the only way
- This PR is kind of a WIP and maybe even a XY problem
- Theses changes are theoretically breaking
---

## The Problem
So I'm currently using a raspberry pi and a small display plus a rotary encoder to built a little device. I'm using raylib for the software, because of the direct drm support, so I can avoid X11. Problem is: raylib doesn't support rotary encoders when selecting `PLATFORM_DRM`. This is because rotary encoders basically either have one relative or one absolute axis, but the way `rcore_drm.c` is detecting devices doesn't allow for that, it required at least two axes.

## Approaching the solution
So the problem now is how one classifies the different kind of input devices into the categories raylib exposes. (This isn't standardized, you probably know that). The `rotary-encoder` linux driver allows for either one absolute axis or one relative axis. Absolute axes are annoying, because rotary-encoders don't have a physical stop, so you always have to deal with weird wrapping issues. Relative axes are annoying, because gamepads don't typically have a relative axes (and thus raylibs API doesn't really allow for it ....). I *for now* decided on an absolute axis.

## What this PR changes
- The old thread code is removed, because this wasn't used anymore and thus has no reason to exist (There were also some errors, like the file descriptors not getting closed)
- The stdio keyboard is now not getting initialized if `SUPPORT_SSH_KEYBOARD_RPI` isn't set
- The gamepads are now handled using the evdev API and not joydev/joystick API as that API is old and the new other one gives us more control over what is a gamepad
- The detection of evdev devices has been changed to take account for the gamepads. This would be the breaking change. It also allows for single axis devices now. (The only thing that's more restrictive now is keyboards now require more than just a SPACE key)
- The polling has been factored out into separate functions

## Open Problems
- What is USE_LAST_TOUCH_DEVICE supposed to do? As it is definitely not doing anything currently (see comment)
- Should single relative axis devices be allowed? Should they be gamepads?
- What about other devices like accelerometers, etc. ? Maybe a separate special IO API?