### PR TITLE
[rtextures] Fix LoadImageFromScreen scaling

### DIFF
--- a/src/rtextures.c
+++ b/src/rtextures.c
@@ -681,10 +681,11 @@ Image LoadImageFromTexture(Texture2D texture)
 // Load image from screen buffer and (screenshot)
 Image LoadImageFromScreen(void)
 {
+    Vector2 scale = GetWindowScaleDPI();
     Image image = { 0 };
 
-    image.width = GetScreenWidth();
-    image.height = GetScreenHeight();
+    image.width = GetScreenWidth()*scale.x;
+    image.height = GetScreenHeight()*scale.y;
     image.mipmaps = 1;
     image.format = PIXELFORMAT_UNCOMPRESSED_R8G8B8A8;
     image.data = rlReadScreenPixels(image.width, image.height);


### PR DESCRIPTION
Before this PR, LoadImageFromScreen was not applying the scale DPI to both width and height. After this PR, the behaviour of LoadImageFromScreen is the same as TakeScreenshot, but returns an image instead. Not sure if this is the appropriate fix, but this was what I was expecting when calling the function. If there needs to be adjustments such as calling ImageResize to get the current width and height instead of the scaled one, let me know.