### PR TITLE
Enable include reordering

### DIFF
--- a/parser/output/raylib_api.json
+++ b/parser/output/raylib_api.json
@@ -91,48 +91,6 @@
       "description": ""
     },
     {
-      "name": "RL_COLOR_TYPE",
-      "type": "GUARD",
-      "value": "",
-      "description": ""
-    },
-    {
-      "name": "RL_RECTANGLE_TYPE",
-      "type": "GUARD",
-      "value": "",
-      "description": ""
-    },
-    {
-      "name": "RL_VECTOR2_TYPE",
-      "type": "GUARD",
-      "value": "",
-      "description": ""
-    },
-    {
-      "name": "RL_VECTOR3_TYPE",
-      "type": "GUARD",
-      "value": "",
-      "description": ""
-    },
-    {
-      "name": "RL_VECTOR4_TYPE",
-      "type": "GUARD",
-      "value": "",
-      "description": ""
-    },
-    {
-      "name": "RL_QUATERNION_TYPE",
-      "type": "GUARD",
-      "value": "",
-      "description": ""
-    },
-    {
-      "name": "RL_MATRIX_TYPE",
-      "type": "GUARD",
-      "value": "",
-      "description": ""
-    },
-    {
       "name": "LIGHTGRAY",
       "type": "COLOR",
       "value": "CLITERAL(Color){ 200, 200, 200, 255 }",
@@ -295,6 +253,48 @@
       "description": ""
     },
     {
+      "name": "RL_VECTOR2_TYPE",
+      "type": "GUARD",
+      "value": "",
+      "description": ""
+    },
+    {
+      "name": "RL_VECTOR3_TYPE",
+      "type": "GUARD",
+      "value": "",
+      "description": ""
+    },
+    {
+      "name": "RL_VECTOR4_TYPE",
+      "type": "GUARD",
+      "value": "",
+      "description": ""
+    },
+    {
+      "name": "RL_QUATERNION_TYPE",
+      "type": "GUARD",
+      "value": "",
+      "description": ""
+    },
+    {
+      "name": "RL_MATRIX_TYPE",
+      "type": "GUARD",
+      "value": "",
+      "description": ""
+    },
+    {
+      "name": "RL_COLOR_TYPE",
+      "type": "GUARD",
+      "value": "",
+      "description": ""
+    },
+    {
+      "name": "RL_RECTANGLE_TYPE",
+      "type": "GUARD",
+      "value": "",
+      "description": ""
+    },
+    {
       "name": "MOUSE_LEFT_BUTTON",
       "type": "UNKNOWN",
       "value": "MOUSE_BUTTON_LEFT",
@@ -335,6 +335,12 @@
       "type": "UNKNOWN",
       "value": "SHADER_LOC_MAP_METALNESS",
       "description": ""
+    },
+    {
+      "name": "GetMouseRay",
+      "type": "UNKNOWN",
+      "value": "GetScreenToWorldRay",
+      "description": "Compatibility hack for previous raylib versions"
     }
   ],
   "structs": [
@@ -3873,12 +3879,12 @@
     },
     {
       "name": "GetScreenToWorldRay",
-      "description": "Get a ray trace from mouse position",
+      "description": "Get a ray trace from screen position (i.e mouse)",
       "returnType": "Ray",
       "params": [
         {
           "type": "Vector2",
-          "name": "mousePosition"
+          "name": "position"
         },
         {
           "type": "Camera",
@@ -3888,12 +3894,12 @@
     },
     {
       "name": "GetScreenToWorldRayEx",
-      "description": "Get a ray trace from mouse position in a viewport",
+      "description": "Get a ray trace from screen position (i.e mouse) in a viewport",
       "returnType": "Ray",
       "params": [
         {
           "type": "Vector2",
-          "name": "mousePosition"
+          "name": "position"
         },
         {
           "type": "Camera",

--- a/parser/output/raylib_api.lua
+++ b/parser/output/raylib_api.lua
@@ -91,48 +91,6 @@ return {
       description = ""
     },
     {
-      name = "RL_COLOR_TYPE",
-      type = "GUARD",
-      value = "",
-      description = ""
-    },
-    {
-      name = "RL_RECTANGLE_TYPE",
-      type = "GUARD",
-      value = "",
-      description = ""
-    },
-    {
-      name = "RL_VECTOR2_TYPE",
-      type = "GUARD",
-      value = "",
-      description = ""
-    },
-    {
-      name = "RL_VECTOR3_TYPE",
-      type = "GUARD",
-      value = "",
-      description = ""
-    },
-    {
-      name = "RL_VECTOR4_TYPE",
-      type = "GUARD",
-      value = "",
-      description = ""
-    },
-    {
-      name = "RL_QUATERNION_TYPE",
-      type = "GUARD",
-      value = "",
-      description = ""
-    },
-    {
-      name = "RL_MATRIX_TYPE",
-      type = "GUARD",
-      value = "",
-      description = ""
-    },
-    {
       name = "LIGHTGRAY",
       type = "COLOR",
       value = "CLITERAL(Color){ 200, 200, 200, 255 }",
@@ -295,6 +253,48 @@ return {
       description = ""
     },
     {
+      name = "RL_VECTOR2_TYPE",
+      type = "GUARD",
+      value = "",
+      description = ""
+    },
+    {
+      name = "RL_VECTOR3_TYPE",
+      type = "GUARD",
+      value = "",
+      description = ""
+    },
+    {
+      name = "RL_VECTOR4_TYPE",
+      type = "GUARD",
+      value = "",
+      description = ""
+    },
+    {
+      name = "RL_QUATERNION_TYPE",
+      type = "GUARD",
+      value = "",
+      description = ""
+    },
+    {
+      name = "RL_MATRIX_TYPE",
+      type = "GUARD",
+      value = "",
+      description = ""
+    },
+    {
+      name = "RL_COLOR_TYPE",
+      type = "GUARD",
+      value = "",
+      description = ""
+    },
+    {
+      name = "RL_RECTANGLE_TYPE",
+      type = "GUARD",
+      value = "",
+      description = ""
+    },
+    {
       name = "MOUSE_LEFT_BUTTON",
       type = "UNKNOWN",
       value = "MOUSE_BUTTON_LEFT",
@@ -335,6 +335,12 @@ return {
       type = "UNKNOWN",
       value = "SHADER_LOC_MAP_METALNESS",
       description = ""
+    },
+    {
+      name = "GetMouseRay",
+      type = "UNKNOWN",
+      value = "GetScreenToWorldRay",
+      description = "Compatibility hack for previous raylib versions"
     }
   },
   structs = {
@@ -3636,19 +3642,19 @@ return {
     },
     {
       name = "GetScreenToWorldRay",
-      description = "Get a ray trace from mouse position",
+      description = "Get a ray trace from screen position (i.e mouse)",
       returnType = "Ray",
       params = {
-        {type = "Vector2", name = "mousePosition"},
+        {type = "Vector2", name = "position"},
         {type = "Camera", name = "camera"}
       }
     },
     {
       name = "GetScreenToWorldRayEx",
-      description = "Get a ray trace from mouse position in a viewport",
+      description = "Get a ray trace from screen position (i.e mouse) in a viewport",
       returnType = "Ray",
       params = {
-        {type = "Vector2", name = "mousePosition"},
+        {type = "Vector2", name = "position"},
         {type = "Camera", name = "camera"},
         {type = "float", name = "width"},
         {type = "float", name = "height"}

--- a/parser/output/raylib_api.txt
+++ b/parser/output/raylib_api.txt
@@ -1,5 +1,5 @@
 
-Defines found: 56
+Defines found: 57
 
 Define 001: RAYLIB_H
   Name: RAYLIB_H
@@ -76,173 +76,173 @@ Define 015: CLITERAL(type)
   Type: MACRO
   Value: type
   Description: 
-Define 016: RL_COLOR_TYPE
-  Name: RL_COLOR_TYPE
-  Type: GUARD
-  Value: 
-  Description: 
-Define 017: RL_RECTANGLE_TYPE
-  Name: RL_RECTANGLE_TYPE
-  Type: GUARD
-  Value: 
-  Description: 
-Define 018: RL_VECTOR2_TYPE
-  Name: RL_VECTOR2_TYPE
-  Type: GUARD
-  Value: 
-  Description: 
-Define 019: RL_VECTOR3_TYPE
-  Name: RL_VECTOR3_TYPE
-  Type: GUARD
-  Value: 
-  Description: 
-Define 020: RL_VECTOR4_TYPE
-  Name: RL_VECTOR4_TYPE
-  Type: GUARD
-  Value: 
-  Description: 
-Define 021: RL_QUATERNION_TYPE
-  Name: RL_QUATERNION_TYPE
-  Type: GUARD
-  Value: 
-  Description: 
-Define 022: RL_MATRIX_TYPE
-  Name: RL_MATRIX_TYPE
-  Type: GUARD
-  Value: 
-  Description: 
-Define 023: LIGHTGRAY
+Define 016: LIGHTGRAY
   Name: LIGHTGRAY
   Type: COLOR
   Value: CLITERAL(Color){ 200, 200, 200, 255 }
   Description: Light Gray
-Define 024: GRAY
+Define 017: GRAY
   Name: GRAY
   Type: COLOR
   Value: CLITERAL(Color){ 130, 130, 130, 255 }
   Description: Gray
-Define 025: DARKGRAY
+Define 018: DARKGRAY
   Name: DARKGRAY
   Type: COLOR
   Value: CLITERAL(Color){ 80, 80, 80, 255 }
   Description: Dark Gray
-Define 026: YELLOW
+Define 019: YELLOW
   Name: YELLOW
   Type: COLOR
   Value: CLITERAL(Color){ 253, 249, 0, 255 }
   Description: Yellow
-Define 027: GOLD
+Define 020: GOLD
   Name: GOLD
   Type: COLOR
   Value: CLITERAL(Color){ 255, 203, 0, 255 }
   Description: Gold
-Define 028: ORANGE
+Define 021: ORANGE
   Name: ORANGE
   Type: COLOR
   Value: CLITERAL(Color){ 255, 161, 0, 255 }
   Description: Orange
-Define 029: PINK
+Define 022: PINK
   Name: PINK
   Type: COLOR
   Value: CLITERAL(Color){ 255, 109, 194, 255 }
   Description: Pink
-Define 030: RED
+Define 023: RED
   Name: RED
   Type: COLOR
   Value: CLITERAL(Color){ 230, 41, 55, 255 }
   Description: Red
-Define 031: MAROON
+Define 024: MAROON
   Name: MAROON
   Type: COLOR
   Value: CLITERAL(Color){ 190, 33, 55, 255 }
   Description: Maroon
-Define 032: GREEN
+Define 025: GREEN
   Name: GREEN
   Type: COLOR
   Value: CLITERAL(Color){ 0, 228, 48, 255 }
   Description: Green
-Define 033: LIME
+Define 026: LIME
   Name: LIME
   Type: COLOR
   Value: CLITERAL(Color){ 0, 158, 47, 255 }
   Description: Lime
-Define 034: DARKGREEN
+Define 027: DARKGREEN
   Name: DARKGREEN
   Type: COLOR
   Value: CLITERAL(Color){ 0, 117, 44, 255 }
   Description: Dark Green
-Define 035: SKYBLUE
+Define 028: SKYBLUE
   Name: SKYBLUE
   Type: COLOR
   Value: CLITERAL(Color){ 102, 191, 255, 255 }
   Description: Sky Blue
-Define 036: BLUE
+Define 029: BLUE
   Name: BLUE
   Type: COLOR
   Value: CLITERAL(Color){ 0, 121, 241, 255 }
   Description: Blue
-Define 037: DARKBLUE
+Define 030: DARKBLUE
   Name: DARKBLUE
   Type: COLOR
   Value: CLITERAL(Color){ 0, 82, 172, 255 }
   Description: Dark Blue
-Define 038: PURPLE
+Define 031: PURPLE
   Name: PURPLE
   Type: COLOR
   Value: CLITERAL(Color){ 200, 122, 255, 255 }
   Description: Purple
-Define 039: VIOLET
+Define 032: VIOLET
   Name: VIOLET
   Type: COLOR
   Value: CLITERAL(Color){ 135, 60, 190, 255 }
   Description: Violet
-Define 040: DARKPURPLE
+Define 033: DARKPURPLE
   Name: DARKPURPLE
   Type: COLOR
   Value: CLITERAL(Color){ 112, 31, 126, 255 }
   Description: Dark Purple
-Define 041: BEIGE
+Define 034: BEIGE
   Name: BEIGE
   Type: COLOR
   Value: CLITERAL(Color){ 211, 176, 131, 255 }
   Description: Beige
-Define 042: BROWN
+Define 035: BROWN
   Name: BROWN
   Type: COLOR
   Value: CLITERAL(Color){ 127, 106, 79, 255 }
   Description: Brown
-Define 043: DARKBROWN
+Define 036: DARKBROWN
   Name: DARKBROWN
   Type: COLOR
   Value: CLITERAL(Color){ 76, 63, 47, 255 }
   Description: Dark Brown
-Define 044: WHITE
+Define 037: WHITE
   Name: WHITE
   Type: COLOR
   Value: CLITERAL(Color){ 255, 255, 255, 255 }
   Description: White
-Define 045: BLACK
+Define 038: BLACK
   Name: BLACK
   Type: COLOR
   Value: CLITERAL(Color){ 0, 0, 0, 255 }
   Description: Black
-Define 046: BLANK
+Define 039: BLANK
   Name: BLANK
   Type: COLOR
   Value: CLITERAL(Color){ 0, 0, 0, 0 }
   Description: Blank (Transparent)
-Define 047: MAGENTA
+Define 040: MAGENTA
   Name: MAGENTA
   Type: COLOR
   Value: CLITERAL(Color){ 255, 0, 255, 255 }
   Description: Magenta
-Define 048: RAYWHITE
+Define 041: RAYWHITE
   Name: RAYWHITE
   Type: COLOR
   Value: CLITERAL(Color){ 245, 245, 245, 255 }
   Description: My own White (raylib logo)
-Define 049: RL_BOOL_TYPE
+Define 042: RL_BOOL_TYPE
   Name: RL_BOOL_TYPE
+  Type: GUARD
+  Value: 
+  Description: 
+Define 043: RL_VECTOR2_TYPE
+  Name: RL_VECTOR2_TYPE
+  Type: GUARD
+  Value: 
+  Description: 
+Define 044: RL_VECTOR3_TYPE
+  Name: RL_VECTOR3_TYPE
+  Type: GUARD
+  Value: 
+  Description: 
+Define 045: RL_VECTOR4_TYPE
+  Name: RL_VECTOR4_TYPE
+  Type: GUARD
+  Value: 
+  Description: 
+Define 046: RL_QUATERNION_TYPE
+  Name: RL_QUATERNION_TYPE
+  Type: GUARD
+  Value: 
+  Description: 
+Define 047: RL_MATRIX_TYPE
+  Name: RL_MATRIX_TYPE
+  Type: GUARD
+  Value: 
+  Description: 
+Define 048: RL_COLOR_TYPE
+  Name: RL_COLOR_TYPE
+  Type: GUARD
+  Value: 
+  Description: 
+Define 049: RL_RECTANGLE_TYPE
+  Name: RL_RECTANGLE_TYPE
   Type: GUARD
   Value: 
   Description: 
@@ -281,6 +281,11 @@ Define 056: SHADER_LOC_MAP_SPECULAR
   Type: UNKNOWN
   Value: SHADER_LOC_MAP_METALNESS
   Description: 
+Define 057: GetMouseRay
+  Name: GetMouseRay
+  Type: UNKNOWN
+  Value: GetScreenToWorldRay
+  Description: Compatibility hack for previous raylib versions
 
 Structures found: 34
 
@@ -1424,14 +1429,14 @@ Function 083: UnloadShader() (1 input parameters)
 Function 084: GetScreenToWorldRay() (2 input parameters)
   Name: GetScreenToWorldRay
   Return type: Ray
-  Description: Get a ray trace from mouse position
-  Param[1]: mousePosition (type: Vector2)
+  Description: Get a ray trace from screen position (i.e mouse)
+  Param[1]: position (type: Vector2)
   Param[2]: camera (type: Camera)
 Function 085: GetScreenToWorldRayEx() (4 input parameters)
   Name: GetScreenToWorldRayEx
   Return type: Ray
-  Description: Get a ray trace from mouse position in a viewport
-  Param[1]: mousePosition (type: Vector2)
+  Description: Get a ray trace from screen position (i.e mouse) in a viewport
+  Param[1]: position (type: Vector2)
   Param[2]: camera (type: Camera)
   Param[3]: width (type: float)
   Param[4]: height (type: float)

--- a/parser/output/raylib_api.xml
+++ b/parser/output/raylib_api.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="Windows-1252" ?>
 <raylibAPI>
-    <Defines count="56">
+    <Defines count="57">
         <Define name="RAYLIB_H" type="GUARD" value="" desc="" />
         <Define name="RAYLIB_VERSION_MAJOR" type="INT" value="5" desc="" />
         <Define name="RAYLIB_VERSION_MINOR" type="INT" value="1" desc="" />
@@ -16,13 +16,6 @@
         <Define name="RL_REALLOC(ptr,sz)" type="MACRO" value="realloc(ptr,sz)" desc="" />
         <Define name="RL_FREE(ptr)" type="MACRO" value="free(ptr)" desc="" />
         <Define name="CLITERAL(type)" type="MACRO" value="type" desc="" />
-        <Define name="RL_COLOR_TYPE" type="GUARD" value="" desc="" />
-        <Define name="RL_RECTANGLE_TYPE" type="GUARD" value="" desc="" />
-        <Define name="RL_VECTOR2_TYPE" type="GUARD" value="" desc="" />
-        <Define name="RL_VECTOR3_TYPE" type="GUARD" value="" desc="" />
-        <Define name="RL_VECTOR4_TYPE" type="GUARD" value="" desc="" />
-        <Define name="RL_QUATERNION_TYPE" type="GUARD" value="" desc="" />
-        <Define name="RL_MATRIX_TYPE" type="GUARD" value="" desc="" />
         <Define name="LIGHTGRAY" type="COLOR" value="CLITERAL(Color){ 200, 200, 200, 255 }" desc="Light Gray" />
         <Define name="GRAY" type="COLOR" value="CLITERAL(Color){ 130, 130, 130, 255 }" desc="Gray" />
         <Define name="DARKGRAY" type="COLOR" value="CLITERAL(Color){ 80, 80, 80, 255 }" desc="Dark Gray" />
@@ -50,6 +43,13 @@
         <Define name="MAGENTA" type="COLOR" value="CLITERAL(Color){ 255, 0, 255, 255 }" desc="Magenta" />
         <Define name="RAYWHITE" type="COLOR" value="CLITERAL(Color){ 245, 245, 245, 255 }" desc="My own White (raylib logo)" />
         <Define name="RL_BOOL_TYPE" type="GUARD" value="" desc="" />
+        <Define name="RL_VECTOR2_TYPE" type="GUARD" value="" desc="" />
+        <Define name="RL_VECTOR3_TYPE" type="GUARD" value="" desc="" />
+        <Define name="RL_VECTOR4_TYPE" type="GUARD" value="" desc="" />
+        <Define name="RL_QUATERNION_TYPE" type="GUARD" value="" desc="" />
+        <Define name="RL_MATRIX_TYPE" type="GUARD" value="" desc="" />
+        <Define name="RL_COLOR_TYPE" type="GUARD" value="" desc="" />
+        <Define name="RL_RECTANGLE_TYPE" type="GUARD" value="" desc="" />
         <Define name="MOUSE_LEFT_BUTTON" type="UNKNOWN" value="MOUSE_BUTTON_LEFT" desc="" />
         <Define name="MOUSE_RIGHT_BUTTON" type="UNKNOWN" value="MOUSE_BUTTON_RIGHT" desc="" />
         <Define name="MOUSE_MIDDLE_BUTTON" type="UNKNOWN" value="MOUSE_BUTTON_MIDDLE" desc="" />
@@ -57,6 +57,7 @@
         <Define name="MATERIAL_MAP_SPECULAR" type="UNKNOWN" value="MATERIAL_MAP_METALNESS" desc="" />
         <Define name="SHADER_LOC_MAP_DIFFUSE" type="UNKNOWN" value="SHADER_LOC_MAP_ALBEDO" desc="" />
         <Define name="SHADER_LOC_MAP_SPECULAR" type="UNKNOWN" value="SHADER_LOC_MAP_METALNESS" desc="" />
+        <Define name="GetMouseRay" type="UNKNOWN" value="GetScreenToWorldRay" desc="Compatibility hack for previous raylib versions" />
     </Defines>
     <Structs count="34">
         <Struct name="Vector2" fieldCount="2" desc="Vector2, 2 components">
@@ -902,12 +903,12 @@
         <Function name="UnloadShader" retType="void" paramCount="1" desc="Unload shader from GPU memory (VRAM)">
             <Param type="Shader" name="shader" desc="" />
         </Function>
-        <Function name="GetScreenToWorldRay" retType="Ray" paramCount="2" desc="Get a ray trace from mouse position">
-            <Param type="Vector2" name="mousePosition" desc="" />
+        <Function name="GetScreenToWorldRay" retType="Ray" paramCount="2" desc="Get a ray trace from screen position (i.e mouse)">
+            <Param type="Vector2" name="position" desc="" />
             <Param type="Camera" name="camera" desc="" />
         </Function>
-        <Function name="GetScreenToWorldRayEx" retType="Ray" paramCount="4" desc="Get a ray trace from mouse position in a viewport">
-            <Param type="Vector2" name="mousePosition" desc="" />
+        <Function name="GetScreenToWorldRayEx" retType="Ray" paramCount="4" desc="Get a ray trace from screen position (i.e mouse) in a viewport">
+            <Param type="Vector2" name="position" desc="" />
             <Param type="Camera" name="camera" desc="" />
             <Param type="float" name="width" desc="" />
             <Param type="float" name="height" desc="" />

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -152,18 +152,6 @@
     #error "C++11 or later is required. Add -std=c++11"
 #endif
 
-// NOTE: We set some defines with some data types declared by raylib
-// Other modules (raymath, rlgl) also require some of those types, so,
-// to be able to use those other modules as standalone (not depending on raylib)
-// this defines are very useful for internal check and avoid type (re)definitions
-#define RL_COLOR_TYPE
-#define RL_RECTANGLE_TYPE
-#define RL_VECTOR2_TYPE
-#define RL_VECTOR3_TYPE
-#define RL_VECTOR4_TYPE
-#define RL_QUATERNION_TYPE
-#define RL_MATRIX_TYPE
-
 // Some Basic Colors
 // NOTE: Custom raylib color palette for amazing visuals on WHITE background
 #define LIGHTGRAY  CLITERAL(Color){ 200, 200, 200, 255 }   // Light Gray
@@ -198,26 +186,40 @@
 // Structures Definition
 //----------------------------------------------------------------------------------
 // Boolean type
-#if (defined(__STDC__) && __STDC_VERSION__ >= 199901L) || (defined(_MSC_VER) && _MSC_VER >= 1800)
+#if defined(__cplusplus)
+// Do nothing. `bool` is fundamental type.
+#elif (defined(__STDC__) && __STDC_VERSION__ >= 199901L) || (defined(_MSC_VER) && _MSC_VER >= 1800)
     #include <stdbool.h>
-#elif !defined(__cplusplus) && !defined(bool)
+#elif !defined(bool)
     typedef enum bool { false = 0, true = !false } bool;
     #define RL_BOOL_TYPE
 #endif
 
+// TODO(marco): Improve wording.
+// Note: The following types have its own define guards because they are
+// redefined in other files. So it's here to avoid redefinition in other file
+// and to enable header inclusion reordering.
+
+#if !defined(RL_VECTOR2_TYPE)
 // Vector2, 2 components
 typedef struct Vector2 {
     float x;                // Vector x component
     float y;                // Vector y component
 } Vector2;
+#define RL_VECTOR2_TYPE
+#endif
 
+#if !defined(RL_VECTOR3_TYPE)
 // Vector3, 3 components
 typedef struct Vector3 {
     float x;                // Vector x component
     float y;                // Vector y component
     float z;                // Vector z component
 } Vector3;
+#define RL_VECTOR3_TYPE
+#endif
 
+#if !defined(RL_VECTOR4_TYPE)
 // Vector4, 4 components
 typedef struct Vector4 {
     float x;                // Vector x component
@@ -225,10 +227,16 @@ typedef struct Vector4 {
     float z;                // Vector z component
     float w;                // Vector w component
 } Vector4;
+#define RL_VECTOR4_TYPE
+#endif
 
+#if !defined(RL_QUATERNION_TYPE)
 // Quaternion, 4 components (Vector4 alias)
 typedef Vector4 Quaternion;
+#define RL_QUATERNION_TYPE
+#endif
 
+#if !defined(RL_MATRIX_TYPE)
 // Matrix, 4x4 components, column major, OpenGL style, right-handed
 typedef struct Matrix {
     float m0, m4, m8, m12;  // Matrix first row (4 components)
@@ -236,7 +244,10 @@ typedef struct Matrix {
     float m2, m6, m10, m14; // Matrix third row (4 components)
     float m3, m7, m11, m15; // Matrix fourth row (4 components)
 } Matrix;
+#define RL_MATRIX_TYPE
+#endif
 
+#if !defined(RL_COLOR_TYPE)
 // Color, 4 components, R8G8B8A8 (32bit)
 typedef struct Color {
     unsigned char r;        // Color red value
@@ -244,7 +255,11 @@ typedef struct Color {
     unsigned char b;        // Color blue value
     unsigned char a;        // Color alpha value
 } Color;
+#define RL_COLOR_TYPE
+#endif
 
+
+#if !defined(RL_RECTANGLE_TYPE)
 // Rectangle, 4 components
 typedef struct Rectangle {
     float x;                // Rectangle top-left corner position x
@@ -252,6 +267,8 @@ typedef struct Rectangle {
     float width;            // Rectangle width
     float height;           // Rectangle height
 } Rectangle;
+#define RL_RECTANGLE_TYPE
+#endif
 
 // Image, pixel data stored in CPU memory (RAM)
 typedef struct Image {

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -195,10 +195,12 @@
     #define RL_BOOL_TYPE
 #endif
 
-// TODO(marco): Improve wording.
-// Note: The following types have its own define guards because they are
-// redefined in other files. So it's here to avoid redefinition in other file
-// and to enable header inclusion reordering.
+// NOTE: In the following types we set some defines with some data types
+// declared by raylib's other modules (raymath, rlgl), they also require some of
+// those types, so, to be able to use those other modules as standalone (not
+// depending on raylib), add include guard to be able to include the headers in
+// any order, these defines are useful for internal checks and to avoid type
+// redefinitions.
 
 #if !defined(RL_VECTOR2_TYPE)
 // Vector2, 2 components


### PR DESCRIPTION
The purpose of this is for us to be able to do the following:

```c
#include <raymath.h>
#include <rlgl.h>
#include <raylib.h>
```

Right now the only possibility is to include `raylib.h` first.