### PR TITLE
check for vcvarsall.bat normally before guessing pre-defined paths

### DIFF
--- a/projects/scripts/build-windows.bat
+++ b/projects/scripts/build-windows.bat
@@ -27,7 +27,11 @@ REM (Prevents calling vcvarsall every time you run this script)
 WHERE cl >nul 2>nul
 IF %ERRORLEVEL% == 0 goto READ_ARGS
 REM Activate the msvc build environment if cl isn't available yet
-IF EXIST "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" (
+REM Check if vcvarsall.bat is visible (possibly through system path) before checking common paths
+WHERE /Q vcvarsall.bat
+IF NOT ERRORLEVEL 1 (
+  set VC_INIT=vcvarsall.bat
+) ELSE IF EXIST "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" (
   set VC_INIT="C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat"
 ) ELSE IF EXIST "C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\VC\Auxiliary\Build\vcvarsall.bat" (
   set VC_INIT="C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\VC\Auxiliary\Build\vcvarsall.bat"


### PR DESCRIPTION
Some people (like me) may have the path to their *vcvarsall.bat* in their system path. This will check for it and just use it directly if available before using the pre-defined directories.