### PR TITLE
[raudio] Fix 3664: crash in raudio from multithreading issues

### DIFF
--- a/src/raudio.c
+++ b/src/raudio.c
@@ -1050,7 +1050,6 @@ void UpdateSound(Sound sound, const void *data, int frameCount)
     {
         StopAudioBuffer(sound.stream.buffer);
 
-        // TODO: May want to lock/unlock this since this data buffer is read at mixing time
         memcpy(sound.stream.buffer->data, data, frameCount*ma_get_bytes_per_frame(sound.stream.buffer->converter.formatIn, sound.stream.buffer->converter.channelsIn));
     }
 }

--- a/src/raudio.c
+++ b/src/raudio.c
@@ -1888,7 +1888,7 @@ void UpdateMusicStream(Music music)
     // Check both sub-buffers to check if they require refilling
     for (int i = 0; i < 2; i++)
     {
-        if ((music.stream.buffer != NULL) && !music.stream.buffer->isSubBufferProcessed[i]) continue; // No refilling required, move to next sub-buffer
+        if (!music.stream.buffer->isSubBufferProcessed[i]) continue; // No refilling required, move to next sub-buffer
 
         unsigned int framesLeft = music.frameCount - music.stream.buffer->framesProcessed;  // Frames left to be processed
         unsigned int framesToStream = 0;                 // Total frames to be streamed

--- a/src/raudio.c
+++ b/src/raudio.c
@@ -612,8 +612,8 @@ void UnloadAudioBuffer(AudioBuffer *buffer)
 {
     if (buffer != NULL)
     {
-        ma_data_converter_uninit(&buffer->converter, NULL);
         UntrackAudioBuffer(buffer);
+        ma_data_converter_uninit(&buffer->converter, NULL);
         RL_FREE(buffer->data);
         RL_FREE(buffer);
     }

--- a/src/raudio.c
+++ b/src/raudio.c
@@ -1037,8 +1037,8 @@ void UnloadSoundAlias(Sound alias)
     // Untrack and unload just the sound buffer, not the sample data, it is shared with the source for the alias
     if (alias.stream.buffer != NULL)
     {
-        ma_data_converter_uninit(&alias.stream.buffer->converter, NULL);
         UntrackAudioBuffer(alias.stream.buffer);
+        ma_data_converter_uninit(&alias.stream.buffer->converter, NULL);
         RL_FREE(alias.stream.buffer);
     }
 }


### PR DESCRIPTION
This pull request fixes #3664 .

However, it fixes things slightly different than originally thought/intended.

The triggering issue with `UpdateMusicStream()` was in as much mitigated by removing the entire hack code, as it was a no-op. See [comment for details](https://github.com/raysan5/raylib/issues/3664#issuecomment-2044458367).

Included changes:
* Remove hack from `UpdateMusicStream()` and `PlayMusicStream()`
* Add mutex lock/unlock to all functions called from main thread that share buffer member access
  * This required separation of some of the functions, as they are called from both threads and mutex is not re-entrant. Suffix `InLockedState` was added to indicate this.
* Fix for cleanup of order of buffer/converter; Initialisation sets up converter, then tracks buffer - deinit must do inverse

I could run all the audio examples and play with them. Still, this is only a small test for a change like this. Please review carefully.