### PR TITLE
[rlgl] Add rlCullDistance variables/getters and rlSetClipPlanes function

### DIFF
--- a/examples/models/models_skybox.c
+++ b/examples/models/models_skybox.c
@@ -208,7 +208,7 @@ static TextureCubemap GenTextureCubemap(Shader shader, Texture2D panorama, int s
     rlEnableShader(shader.id);
 
     // Define projection matrix and send it to shader
-    Matrix matFboProjection = MatrixPerspective(90.0*DEG2RAD, 1.0, RL_CULL_DISTANCE_NEAR, RL_CULL_DISTANCE_FAR);
+    Matrix matFboProjection = MatrixPerspective(90.0*DEG2RAD, 1.0, rlGetCullDistanceNear(), rlGetCullDistanceFar());
     rlSetUniformMatrix(shader.locs[SHADER_LOC_MATRIX_PROJECTION], matFboProjection);
 
     // Define view matrix for every side of the cubemap

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -992,10 +992,10 @@ void BeginMode3D(Camera camera)
     if (camera.projection == CAMERA_PERSPECTIVE)
     {
         // Setup perspective projection
-        double top = RL_CULL_DISTANCE_NEAR*tan(camera.fovy*0.5*DEG2RAD);
+        double top = rlGetCullDistanceNear()*tan(camera.fovy*0.5*DEG2RAD);
         double right = top*aspect;
 
-        rlFrustum(-right, right, -top, top, RL_CULL_DISTANCE_NEAR, RL_CULL_DISTANCE_FAR);
+        rlFrustum(-right, right, -top, top, rlGetCullDistanceNear(), rlGetCullDistanceFar());
     }
     else if (camera.projection == CAMERA_ORTHOGRAPHIC)
     {
@@ -1003,7 +1003,7 @@ void BeginMode3D(Camera camera)
         double top = camera.fovy/2.0;
         double right = top*aspect;
 
-        rlOrtho(-right, right, -top,top, RL_CULL_DISTANCE_NEAR, RL_CULL_DISTANCE_FAR);
+        rlOrtho(-right, right, -top,top, rlGetCullDistanceNear(), rlGetCullDistanceFar());
     }
 
     rlMatrixMode(RL_MODELVIEW);     // Switch back to modelview matrix
@@ -1207,7 +1207,7 @@ VrStereoConfig LoadVrStereoConfig(VrDeviceInfo device)
 
         // Compute camera projection matrices
         float projOffset = 4.0f*lensShift;      // Scaled to projection space coordinates [-1..1]
-        Matrix proj = MatrixPerspective(fovy, aspect, RL_CULL_DISTANCE_NEAR, RL_CULL_DISTANCE_FAR);
+        Matrix proj = MatrixPerspective(fovy, aspect, rlGetCullDistanceNear(), rlGetCullDistanceFar());
 
         config.projection[0] = MatrixMultiply(proj, MatrixTranslate(projOffset, 0.0f, 0.0f));
         config.projection[1] = MatrixMultiply(proj, MatrixTranslate(-projOffset, 0.0f, 0.0f));
@@ -1446,7 +1446,7 @@ Ray GetScreenToWorldRayEx(Vector2 position, Camera camera, int width, int height
     if (camera.projection == CAMERA_PERSPECTIVE)
     {
         // Calculate projection matrix from perspective
-        matProj = MatrixPerspective(camera.fovy*DEG2RAD, ((double)width/(double)height), RL_CULL_DISTANCE_NEAR, RL_CULL_DISTANCE_FAR);
+        matProj = MatrixPerspective(camera.fovy*DEG2RAD, ((double)width/(double)height), rlGetCullDistanceNear(), rlGetCullDistanceFar());
     }
     else if (camera.projection == CAMERA_ORTHOGRAPHIC)
     {
@@ -1533,7 +1533,7 @@ Vector2 GetWorldToScreenEx(Vector3 position, Camera camera, int width, int heigh
     if (camera.projection == CAMERA_PERSPECTIVE)
     {
         // Calculate projection matrix from perspective
-        matProj = MatrixPerspective(camera.fovy*DEG2RAD, ((double)width/(double)height), RL_CULL_DISTANCE_NEAR, RL_CULL_DISTANCE_FAR);
+        matProj = MatrixPerspective(camera.fovy*DEG2RAD, ((double)width/(double)height), rlGetCullDistanceNear(), rlGetCullDistanceFar());
     }
     else if (camera.projection == CAMERA_ORTHOGRAPHIC)
     {
@@ -1542,7 +1542,7 @@ Vector2 GetWorldToScreenEx(Vector3 position, Camera camera, int width, int heigh
         double right = top*aspect;
 
         // Calculate projection matrix from orthographic
-        matProj = MatrixOrtho(-right, right, -top, top, RL_CULL_DISTANCE_NEAR, RL_CULL_DISTANCE_FAR);
+        matProj = MatrixOrtho(-right, right, -top, top, rlGetCullDistanceNear(), rlGetCullDistanceFar());
     }
 
     // Calculate view matrix from camera look at (and transpose it)

--- a/src/rlgl.h
+++ b/src/rlgl.h
@@ -558,6 +558,10 @@ typedef enum {
 extern "C" {            // Prevents name mangling of functions
 #endif
 
+RLAPI void rlSetClipPlanes(double near, double far);
+RLAPI double rlGetCullDistanceNear();
+RLAPI double rlGetCullDistanceFar();
+
 RLAPI void rlMatrixMode(int mode);                      // Choose the current matrix to be transformed
 RLAPI void rlPushMatrix(void);                          // Push the current matrix to stack
 RLAPI void rlPopMatrix(void);                           // Pop latest inserted matrix from stack
@@ -1062,6 +1066,10 @@ typedef void *(*rlglLoadProc)(const char *name);   // OpenGL extension functions
 //----------------------------------------------------------------------------------
 // Global Variables Definition
 //----------------------------------------------------------------------------------
+
+static double rlCullDistanceNear = RL_CULL_DISTANCE_NEAR;
+static double rlCullDistanceFar = RL_CULL_DISTANCE_FAR;
+
 #if defined(GRAPHICS_API_OPENGL_33) || defined(GRAPHICS_API_OPENGL_ES2)
 static rlglData RLGL = { 0 };
 #endif  // GRAPHICS_API_OPENGL_33 || GRAPHICS_API_OPENGL_ES2
@@ -1098,6 +1106,22 @@ static Matrix rlMatrixMultiply(Matrix left, Matrix right);  // Multiply two matr
 //----------------------------------------------------------------------------------
 // Module Functions Definition - Matrix operations
 //----------------------------------------------------------------------------------
+
+void rlSetClipPlanes(double near, double far)
+{
+	rlCullDistanceNear = near;
+	rlCullDistanceFar = far;
+}
+
+double rlGetCullDistanceFar()
+{
+	return rlCullDistanceFar;
+}
+
+double rlGetCullDistanceNear()
+{
+	return rlCullDistanceNear;
+}
 
 #if defined(GRAPHICS_API_OPENGL_11)
 // Fallback to OpenGL 1.1 function calls


### PR DESCRIPTION
**NOTE**: The PR at the moment is just a proof-of-concept to show the scale of modifications necessary to make this happen. Should it be reviewed well i will add the utils for `rlClipDistanceNear` and fix any use of `RL_CULL_DISTANCE*`, for example in the camera. Also i am not too sure about the name, when "cull" when "clip"

## Reasoning

As discussed on discord [here](https://discord.com/channels/426912293134270465/1227696407389933649) and then mentioned [here](https://discord.com/channels/426912293134270465/426912531429457930/1227712810679799888) the current `CULL_DISTANCE`s are hardcoded and require a full recompile to change.

By adding static `rlCullDistance` globals and accessor function we can make this a runtime configurable value.

## Overview:

The current `RL_CULL_DISTANCE_` remain as configuration of the initial cull distances. New code may include:
- Static variables:
  - `rlCullDistanceFar`
  - `rlCullDistanceNear`
- Accessors:
  - `rlGetClipPlaneNear()`
  - `rlGetClipPlaneFar()`
  - `rlGetDefaultClipPlaneNear()`
  - `rlGetDefaultClipPlaneFar()` 
- Setters:
  - `rlSetClipPlanes(double near, double far)`
  - `rlSetClipPlaneNear(double value)`
  - `rlSetClipPlaneFar(double value)`
  - `rlResetClipPlanes()`

## Example
[Screencast from 2024-04-11 11-11-42.webm](https://github.com/raysan5/raylib/assets/69913906/1682b898-0bb0-4fdd-8ae0-89b9b327e1bd)
