### PR TITLE
[build.zig] Fix FileNotFound: .../src/raylib.h

### DIFF
--- a/src/build.zig
+++ b/src/build.zig
@@ -258,12 +258,12 @@ pub fn build(b: *std.Build) !void {
 
     const lib = try addRaylib(b, target, optimize, options);
 
-    installHeaderVersioned(lib, "src/raylib.h", "raylib.h");
-    installHeaderVersioned(lib, "src/raymath.h", "raymath.h");
-    installHeaderVersioned(lib, "src/rlgl.h", "rlgl.h");
+    installHeaderVersioned(b, lib, "src/raylib.h", "raylib.h");
+    installHeaderVersioned(b, lib, "src/raymath.h", "raymath.h");
+    installHeaderVersioned(b, lib, "src/rlgl.h", "rlgl.h");
 
     if (options.raygui) {
-        installHeaderVersioned(lib, "../raygui/src/raygui.h", "raygui.h");
+        installHeaderVersioned(b, lib, "../raygui/src/raygui.h", "raygui.h");
     }
 
     b.installArtifact(lib);
@@ -297,12 +297,16 @@ fn addCSourceFilesVersioned(
 }
 
 fn installHeaderVersioned(
+    b: *std.Build,
     lib: *std.Build.Step.Compile,
     source: []const u8,
     dest: []const u8,
 ) void {
     if (comptime builtin.zig_version.minor >= 12) {
-        lib.installHeader(.{ .path = source }, dest);
+        lib.installHeader(.{ .src_path = .{
+            .owner = b,
+            .sub_path = source,
+        } }, dest);
     } else {
         lib.installHeader(source, dest);
     }


### PR DESCRIPTION
I'm getting an error when attempting to build using the latest raylib and Zig master (0.12.0-dev.3635+786876c05):
```
zig build -Dtarget=wasm32-emscripten
install
└─ install raylib failure
error: unable to update file from '.../src/raylib.h' to '.../zig-out/include/raylib.h': FileNotFound
Build Summary: 15/17 steps succeeded; 1 failed (disable with --summary none)
install transitive failure
└─ install raylib failure
error: the following build command failed with exit code 1:
.../zig-cache/o/8c0437471634c5f3da2ba2e71966fe50/build /home/vscode/.zvm/master/zig / .../zig-cache /home/vscode/.cache/zig --seed 0xbfa3d8ae -Z33b99a15b162f409 -Dtarget=wasm32-emscripten
```

As far as I can tell this isn't resolved by #3913 so I'm submitting this request.

To resolve I updated the LazyPath that raylib is importing its headers from with the current `std.Build` specified as the owner.