### PR TITLE
Fix window not initializing on primary monitor on GLFW backend

### DIFF
--- a/src/platforms/rcore_desktop.c
+++ b/src/platforms/rcore_desktop.c
@@ -1518,10 +1518,16 @@ int InitPlatform(void)
     else 
     {
         // Try to center window on screen but avoiding window-bar outside of screen
-        int posX = GetMonitorWidth(GetCurrentMonitor())/2 - CORE.Window.screen.width/2;
-        int posY = GetMonitorHeight(GetCurrentMonitor())/2 - CORE.Window.screen.height/2;
-        if (posX < 0) posX = 0;
-        if (posY < 0) posY = 0;
+        int monitorX = 0;
+        int monitorY = 0;
+        int monitorWidth = 0;
+        int monitorHeight = 0;
+        glfwGetMonitorWorkarea(monitor, &monitorX, &monitorY, &monitorWidth, &monitorHeight);
+
+        int posX = monitorX + (monitorWidth - CORE.Window.screen.width)/2;
+        int posY = monitorY + (monitorHeight - CORE.Window.screen.height)/2;
+        if (posX < monitorX) posX = monitorX;
+        if (posY < monitorY) posY = monitorY;
         SetWindowPosition(posX, posY);
     }
 


### PR DESCRIPTION
The way the current code worked was by calling `GetCurrentMonitor()`, which would always return the monitor at position (0,0). This isn't the primary monitor on all platforms, on Linux in particular it isn't the case.

This isn't the case on the SDL backend, after calling `InitWindow()` the window would always show up on the primary monitor. Even on the GLFW backend, if the full screen flag was set it would attempt to put it on the primary monitor as it would call `glfwGetPrimaryMonitor()` to do it, so for consistency's sake we should do it on windowed mode too.