### PR TITLE
[build.zig] Drop support for 0.11.0 and use more idiomatic build script code

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1,7 +1,11 @@
 const std = @import("std");
 const raylib = @import("src/build.zig");
 
-// This has been tested to work with zig 0.11.0 and zig 0.12.0-dev.3632+7fb5a0b18
+// This has been tested to work with zig 0.12.0
 pub fn build(b: *std.Build) !void {
     try raylib.build(b);
 }
+
+// expose helper functions to user's build.zig
+pub const addRaylib = raylib.addRaylib;
+pub const addRaygui = raylib.addRaygui;

--- a/examples/build.zig
+++ b/examples/build.zig
@@ -1,24 +1,14 @@
 const std = @import("std");
 const builtin = @import("builtin");
 
-// This has been tested to work with zig 0.11.0 (67709b6, Aug 4 2023) and zig 0.12.0-dev.2075+f5978181e (Jan 8 2024)
-//
-// anytype is used here to preserve compatibility, in 0.12.0dev the std.zig.CrossTarget type
-// was reworked into std.Target.Query and std.Build.ResolvedTarget. Using anytype allows
-// us to accept both CrossTarget and ResolvedTarget and act accordingly in getOsTagVersioned.
-fn add_module(comptime module: []const u8, b: *std.Build, target: anytype, optimize: std.builtin.OptimizeMode) !*std.Build.Step {
-    if (comptime builtin.zig_version.minor >= 12 and @TypeOf(target) != std.Build.ResolvedTarget) {
-        @compileError("Expected 'std.Build.ResolvedTarget' for argument 2 'target' in 'add_module', found '" ++ @typeName(@TypeOf(target)) ++ "'");
-    } else if (comptime builtin.zig_version.minor == 11 and @TypeOf(target) != std.zig.CrossTarget) {
-        @compileError("Expected 'std.zig.CrossTarget' for argument 2 'target' in 'add_module', found '" ++ @typeName(@TypeOf(target)) ++ "'");
-    }
-
-    if (getOsTagVersioned(target) == .emscripten) {
+// This has been tested to work with zig 0.12.0
+fn add_module(comptime module: []const u8, b: *std.Build, target: std.Build.ResolvedTarget, optimize: std.builtin.OptimizeMode) !*std.Build.Step {
+    if (target.result.os.tag == .emscripten) {
         @panic("Emscripten building via Zig unsupported");
     }
 
     const all = b.step(module, "All " ++ module ++ " examples");
-    var dir = try openIterableDirVersioned(std.fs.cwd(), module);
+    var dir = try std.fs.cwd().openDir(module, .{ .iterate = true });
     defer if (comptime builtin.zig_version.minor >= 12) dir.close();
 
     var iter = dir.iterate();
@@ -29,7 +19,7 @@ fn add_module(comptime module: []const u8, b: *std.Build, target: anytype, optim
         const path = try std.fs.path.join(b.allocator, &.{ module, entry.name });
 
         // zig's mingw headers do not include pthread.h
-        if (std.mem.eql(u8, "core_loading_thread", name) and getOsTagVersioned(target) == .windows) continue;
+        if (std.mem.eql(u8, "core_loading_thread", name) and target.result.os.tag == .windows) continue;
 
         const exe = b.addExecutable(.{
             .name = name,
@@ -38,7 +28,7 @@ fn add_module(comptime module: []const u8, b: *std.Build, target: anytype, optim
         });
         exe.addCSourceFile(.{ .file = .{ .path = path }, .flags = &.{} });
         exe.linkLibC();
-        exe.addObjectFile(switch (getOsTagVersioned(target)) {
+        exe.addObjectFile(switch (target.result.os.tag) {
             .windows => .{ .path = "../zig-out/lib/raylib.lib" },
             .linux => .{ .path = "../zig-out/lib/libraylib.a" },
             .macos => .{ .path = "../zig-out/lib/libraylib.a" },
@@ -50,7 +40,7 @@ fn add_module(comptime module: []const u8, b: *std.Build, target: anytype, optim
         exe.addIncludePath(.{ .path = "../src/external" });
         exe.addIncludePath(.{ .path = "../src/external/glfw/include" });
 
-        switch (getOsTagVersioned(target)) {
+        switch (target.result.os.tag) {
             .windows => {
                 exe.linkSystemLibrary("winmm");
                 exe.linkSystemLibrary("gdi32");
@@ -116,20 +106,4 @@ pub fn build(b: *std.Build) !void {
     all.dependOn(try add_module("shapes", b, target, optimize));
     all.dependOn(try add_module("text", b, target, optimize));
     all.dependOn(try add_module("textures", b, target, optimize));
-}
-
-fn getOsTagVersioned(target: anytype) std.Target.Os.Tag {
-    if (comptime builtin.zig_version.minor >= 12) {
-        return target.result.os.tag;
-    } else {
-        return target.getOsTag();
-    }
-}
-
-fn openIterableDirVersioned(dir: std.fs.Dir, path: []const u8) !(if (builtin.zig_version.minor >= 12) std.fs.Dir else std.fs.IterableDir) {
-    if (comptime builtin.zig_version.minor >= 12) {
-        return dir.openDir(path, .{ .iterate = true });
-    } else {
-        return dir.openIterableDir(path, .{});
-    }
 }

--- a/examples/build.zig
+++ b/examples/build.zig
@@ -26,19 +26,19 @@ fn add_module(comptime module: []const u8, b: *std.Build, target: std.Build.Reso
             .target = target,
             .optimize = optimize,
         });
-        exe.addCSourceFile(.{ .file = .{ .path = path }, .flags = &.{} });
+        exe.addCSourceFile(.{ .file = b.path(path), .flags = &.{} });
         exe.linkLibC();
         exe.addObjectFile(switch (target.result.os.tag) {
-            .windows => .{ .path = "../zig-out/lib/raylib.lib" },
-            .linux => .{ .path = "../zig-out/lib/libraylib.a" },
-            .macos => .{ .path = "../zig-out/lib/libraylib.a" },
-            .emscripten => .{ .path = "../zig-out/lib/libraylib.a" },
+            .windows => b.path("../zig-out/lib/raylib.lib"),
+            .linux => b.path("../zig-out/lib/libraylib.a"),
+            .macos => b.path("../zig-out/lib/libraylib.a"),
+            .emscripten => b.path("../zig-out/lib/libraylib.a"),
             else => @panic("Unsupported OS"),
         });
 
-        exe.addIncludePath(.{ .path = "../src" });
-        exe.addIncludePath(.{ .path = "../src/external" });
-        exe.addIncludePath(.{ .path = "../src/external/glfw/include" });
+        exe.addIncludePath(b.path("../src"));
+        exe.addIncludePath(b.path("../src/external"));
+        exe.addIncludePath(b.path("../src/external/glfw/include"));
 
         switch (target.result.os.tag) {
             .windows => {

--- a/src/build.zig
+++ b/src/build.zig
@@ -211,6 +211,7 @@ fn compileRaylib(b: *std.Build, target: std.Build.ResolvedTarget, optimize: std.
     return raylib;
 }
 
+/// This function does not need to be called if you passed .raygui = true to addRaylib
 pub fn addRaygui(b: *std.Build, raylib: *std.Build.Step.Compile, raygui_dep: *std.Build.Dependency) void {
     if (raylib_flags_arr.items.len == 0) {
         @panic(


### PR DESCRIPTION
With the release of zig 0.12.0, supporting 0.11.0 is no longer necessary.

Changes:
+ remove all 0.11.0 compatibility functions
+ remove most LazyPath `.path` variants
  + I didn't touch emscripten, I don't know if it's relative or absolute
+ change all absolute paths to use `.cwd_relative`
+ only use the builder's allocator
+ have local dependencies use the package manager
+ make adding raygui more flexible
+ use zig-cache for generated wayland files

## Upgrade path for local dependencies:

`build.zig.zon`:
```diff
.dependencies = .{
+  .raylib = .{ // the dependency name "raylib" can be overridden in addRaylib's options with .raylib_dependency_name
+    .path = "path/to/raylib",
+  },
+  .raygui = .{ // the dependency name "raygui" can be overridden in addRaylib's options with .raygui_dependency_name
+    .path = "path/to/raygui",
+  },
}
```

`build.zig` for local/remote dependency:
```diff
- const raylib_build = @import("path/to/raylib/src/build.zig");
+ const raylib_build = @import("raylib");

  const raylib = try raylib_build.addRaylib(b, target, optimize, .{
    .raygui = true, // if true, there has to be a .raygui dependency in build.zig.zon (dependency name can be overidden with .raygui_dependency_name)
  });
- exe.addIncludePath(.{ .path = "raylib/src" });
  exe.linkLibrary(raylib);
```

Alternative method:
```zig
const raylib_dep = b.dependency("raylib", .{
  .target = target,
  .optimize = optimize,
});
const raylib = raylib_dep.artifact("raylib");

const raygui_dep = b.dependency("raygui", .{});
raylib_build.addRaygui(b, raylib, raygui_dep);

exe.linkLibrary(raylib);
```