### PR TITLE
[rcamera] Added missing CAMERA_CUSTOM check in  `UpdateCamera(Camera *camera, int mode)` function

### DIFF
--- a/src/rcamera.h
+++ b/src/rcamera.h
@@ -444,7 +444,8 @@ void UpdateCamera(Camera *camera, int mode)
     bool lockView = ((mode == CAMERA_FREE) || (mode == CAMERA_FIRST_PERSON) || (mode == CAMERA_THIRD_PERSON) || (mode == CAMERA_ORBITAL));
     bool rotateUp = false;
 
-    if (mode == CAMERA_ORBITAL)
+    if (mode == CAMERA_CUSTOM) {}
+    else if (mode == CAMERA_ORBITAL)
     {
         // Orbital can just orbit
         Matrix rotation = MatrixRotate(GetCameraUp(camera), CAMERA_ORBITAL_SPEED*GetFrameTime());


### PR DESCRIPTION
`rcamera.h` states that if `UpdateCamera()` is passed CAMERA_CUSTOM as an argument; the function  will do nothing. Source: https://github.com/raysan5/raylib/blob/master/src/rcamera.h#L120

However, the implementation of `UpdateCamera()`, has no checks to see if the mode passed is CAMERA_CUSTOM. 
https://github.com/raysan5/raylib/blob/master/src/rcamera.h#L438C6-L464



If `UpdateCamera` receives CAMERA_CUSTOM as argument; it will execute all the camera updating functions from lines 458 to 463.

This has the following effect:
https://github.com/raysan5/raylib/assets/65001595/a853549f-bb17-47af-b79b-ef2021d2ef12

After the patch is applied; this behavior changes:
https://github.com/raysan5/raylib/assets/65001595/121953c7-779c-4e41-9cbe-89f61abd9b00

Now `UpdateCamera()` won't modify the camera regardless of Mouse movement or keyboard movement (Which, is the intended behavior; right?)

This is the code that is used in the video:

```cpp
Camera3D camera {
    {0, 0, 5},
    {0, 0, 0},
    {0, 1, 0},
    90,
    CAMERA_PERSPECTIVE,
};

CameraMode mode = CAMERA_FREE;

int main(void)
{
    // Initialization
    //--------------------------------------------------------------------------------------
    const int screenWidth = 800;
    const int screenHeight = 450;

    InitWindow(screenWidth, screenHeight, "raylib CAMERA_CUSTOM");

    SetTargetFPS(60);   // Set our game to run at 60 frames-per-second
    //--------------------------------------------------------------------------------------

    // Main game loop
    while (!WindowShouldClose())    // Detect window close button or ESC key
    {
        UpdateCamera(&camera, mode); 

        BeginDrawing();

	  BeginMode3D(camera);


	  ClearBackground(RAYWHITE);
	  if (IsKeyPressed(KEY_T)) {
	      printf("\n");
	      printf("I am teleporting the camera and setting it to custom mode\n");
	      printf("\n");
	      mode = CAMERA_CUSTOM;
	      camera.position.x = 0;
	      camera.position.y = 5;
	      camera.position.z = 0;
	  }
	  DrawText(TextFormat("Score: %08i", 999), 200, 80, 20, RED);

	  DrawCube({0,0,0}, 4, 4, 4, BLUE);

	  EndMode3D();
        EndDrawing();
    }

    // De-Initialization
    //--------------------------------------------------------------------------------------
    CloseWindow();        // Close window and OpenGL context
    //--------------------------------------------------------------------------------------

    return 0;

}
```
PS: I am not mistaken; this would be the only/first use of CAMERA_CUSTOM in raylib. 


PS2: There's a difference in the comments in between `raylib.h` and `rcamera.h`. Is this intentional? Should I add another commit making them the same?
Rcamera (comment is slightly more verbose): https://github.com/raysan5/raylib/blob/master/src/rcamera.h#L120
Raylib (comment is more bare bones):  https://github.com/raysan5/raylib/blob/master/src/raylib.h#L916