### PR TITLE
Use builtin_clz for clang on windows

### DIFF
--- a/src/external/sinfl.h
+++ b/src/external/sinfl.h
@@ -171,7 +171,7 @@ extern int zsinflate(void *out, int cap, const void *in, int size);
 
 static int
 sinfl_bsr(unsigned n) {
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && !defined(__clang__)
   _BitScanReverse(&n, n);
   return n;
 #elif defined(__GNUC__) || defined(__clang__)


### PR DESCRIPTION
Clang on windows defines both _MSC_VER and __clang__ for compatibility reason. The logic in sinfl.h selects the MSVC buitlin which clang only understands in clang-cl compatibility mode. If compiled with regular clang _MSC_VER is defined but the _BitScanReverse builtin is not recognised. This leads to the following warning during compilation:
```
In file included from ../raylib/src\rcore.c:141:
../raylib/src/external/sinfl.h:175:19: warning: incompatible pointer types passing 'unsigned int *' to parameter of type
      'unsigned long *' [-Wincompatible-pointer-types]
  175 |   _BitScanReverse(&n, n);
      |                   ^~
```

This PR fixes that by selecting the __builtin_clz builtin if __clang__ is defined.