### PR TITLE
[raylib.h] Made comments on raylib.h match those present in rcamera.h

### DIFF
--- a/src/raylib.h
+++ b/src/raylib.h
@@ -913,11 +913,11 @@ typedef enum {
 
 // Camera system modes
 typedef enum {
-    CAMERA_CUSTOM = 0,              // Custom camera
-    CAMERA_FREE,                    // Free camera
-    CAMERA_ORBITAL,                 // Orbital camera
-    CAMERA_FIRST_PERSON,            // First person camera
-    CAMERA_THIRD_PERSON             // Third person camera
+    CAMERA_CUSTOM = 0,              // Camera custom, controlled by user (UpdateCamera() does nothing)
+    CAMERA_FREE,                    // Camera free mode
+    CAMERA_ORBITAL,                 // Camera orbital, around target, zoom supported
+    CAMERA_FIRST_PERSON,            // Camera first person
+    CAMERA_THIRD_PERSON             // Camera third person
 } CameraMode;
 
 // Camera projection


### PR DESCRIPTION
This is a follow up to this PR: https://github.com/raysan5/raylib/pull/3938

This would make the comments in `raylib.h` match the ones present in `rcamera.h`.

Here are the `rcamera.h` comments: https://github.com/raysan5/raylib/blob/master/src/rcamera.h#L119-L125