### PR TITLE
Allow raymath before raylib

### DIFF
--- a/examples/others/raymath_vector_angle.c
+++ b/examples/others/raymath_vector_angle.c
@@ -10,10 +10,9 @@
 *   Copyright (c) 2023 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
- 
-#include "raylib.h"
 
 #include "raymath.h"
+#include "raylib.h"
 
 //------------------------------------------------------------------------------------
 // Program main entry point
@@ -30,7 +29,7 @@ int main(void)
     Vector2 v0 = { screenWidth/2, screenHeight/2 };
     Vector2 v1 = Vector2Add(v0, (Vector2){ 100.0f, 80.0f });
     Vector2 v2 = { 0 };             // Updated with mouse position
-    
+
     float angle = 0.0f;             // Angle in degrees
     int angleMode = 0;              // 0-Vector2Angle(), 1-Vector2LineAngle()
 
@@ -45,12 +44,12 @@ int main(void)
         float startangle = 0.0f;
 
         if (angleMode == 0) startangle = -Vector2LineAngle(v0, v1)*RAD2DEG;
-        if (angleMode == 1) startangle = 0.0f; 
+        if (angleMode == 1) startangle = 0.0f;
 
         v2 = GetMousePosition();
 
         if (IsKeyPressed(KEY_SPACE)) angleMode = !angleMode;
-        
+
         if(angleMode == 0 && IsMouseButtonDown(MOUSE_BUTTON_RIGHT)) v1 = GetMousePosition();
 
         if (angleMode == 0)
@@ -73,12 +72,12 @@ int main(void)
         BeginDrawing();
 
             ClearBackground(RAYWHITE);
-            
+
             if (angleMode == 0)
             {
                 DrawText("MODE 0: Angle between V1 and V2", 10, 10, 20, BLACK);
                 DrawText("Right Click to Move V2", 10, 30, 20, DARKGRAY);
-                
+
                 DrawLineEx(v0, v1, 2.0f, BLACK);
                 DrawLineEx(v0, v2, 2.0f, RED);
 
@@ -87,13 +86,13 @@ int main(void)
             else if (angleMode == 1)
             {
                 DrawText("MODE 1: Angle formed by line V1 to V2", 10, 10, 20, BLACK);
-                
+
                 DrawLine(0, screenHeight/2, screenWidth, screenHeight/2, LIGHTGRAY);
                 DrawLineEx(v0, v2, 2.0f, RED);
 
                 DrawCircleSector(v0, 40.0f, startangle, startangle - angle, 32, Fade(GREEN, 0.6f));
             }
-            
+
             DrawText("v0", v0.x, v0.y, 10, DARKGRAY);
 
             // If the line from v0 to v1 would overlap the text, move it's position up 10
@@ -108,7 +107,7 @@ int main(void)
 
             DrawText("Press SPACE to change MODE", 460, 10, 20, DARKGRAY);
             DrawText(TextFormat("ANGLE: %2.2f", angle), 10, 70, 20, LIME);
-            
+
         EndDrawing();
         //----------------------------------------------------------------------------------
     }

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -158,11 +158,13 @@
 // this defines are very useful for internal check and avoid type (re)definitions
 #define RL_COLOR_TYPE
 #define RL_RECTANGLE_TYPE
+#ifndef RAYMATH_H
 #define RL_VECTOR2_TYPE
 #define RL_VECTOR3_TYPE
 #define RL_VECTOR4_TYPE
 #define RL_QUATERNION_TYPE
 #define RL_MATRIX_TYPE
+#endif // RAYMATH_H
 
 // Some Basic Colors
 // NOTE: Custom raylib color palette for amazing visuals on WHITE background
@@ -205,6 +207,7 @@
     #define RL_BOOL_TYPE
 #endif
 
+#ifndef RAYMATH_H
 // Vector2, 2 components
 typedef struct Vector2 {
     float x;                // Vector x component
@@ -236,6 +239,7 @@ typedef struct Matrix {
     float m2, m6, m10, m14; // Matrix third row (4 components)
     float m3, m7, m11, m15; // Matrix fourth row (4 components)
 } Matrix;
+#endif // RAYMATH_H
 
 // Color, 4 components, R8G8B8A8 (32bit)
 typedef struct Color {

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -852,7 +852,7 @@ void EndDrawing(void)
         #ifndef GIF_RECORD_FRAMERATE
         #define GIF_RECORD_FRAMERATE    10
         #endif
-        gifFrameCounter += GetFrameTime()*1000;
+        gifFrameCounter += (unsigned int)(GetFrameTime()*1000);
 
         // NOTE: We record one gif frame depending on the desired gif framerate
         if (gifFrameCounter > 1000/GIF_RECORD_FRAMERATE)

--- a/src/rlgl.h
+++ b/src/rlgl.h
@@ -3945,7 +3945,7 @@ void rlSetVertexAttribute(unsigned int index, int compSize, int type, bool norma
     // Additional types (depends on OpenGL version or extensions):
     //  - GL_HALF_FLOAT, GL_FLOAT, GL_DOUBLE, GL_FIXED,
     //  - GL_INT_2_10_10_10_REV, GL_UNSIGNED_INT_2_10_10_10_REV, GL_UNSIGNED_INT_10F_11F_11F_REV
-    glVertexAttribPointer(index, compSize, type, normalized, stride, (void *)offset);
+    glVertexAttribPointer(index, compSize, type, normalized, stride, (void *)((size_t)offset));
 #endif
 }
 

--- a/src/rmodels.c
+++ b/src/rmodels.c
@@ -5165,7 +5165,7 @@ static Model LoadGLTF(const char *fileName)
                             else TRACELOG(LOG_WARNING, "MODEL: [%s] Texcoords attribute data format not supported", fileName);
                         }
                         else TRACELOG(LOG_WARNING, "MODEL: [%s] Texcoords attribute data format not supported, use vec2 float", fileName);
-                    
+
                         int index = data->meshes[i].primitives[p].attributes[j].index;
                         if (index == 0) model.meshes[meshIndex].texcoords = texcoordPtr;
                         else if (index == 1) model.meshes[meshIndex].texcoords2 = texcoordPtr;
@@ -5549,7 +5549,7 @@ static bool GetPoseAtTimeGLTF(cgltf_interpolation_type interpolationType, cgltf_
         }
     }
 
-    float duration = fmax((tend - tstart), EPSILON);
+    float duration = fmaxf((tend - tstart), EPSILON);
     float t = (time - tstart)/duration;
     t = (t < 0.0f)? 0.0f : t;
     t = (t > 1.0f)? 1.0f : t;

--- a/src/rshapes.c
+++ b/src/rshapes.c
@@ -815,17 +815,17 @@ void DrawRectangleLines(int posX, int posY, int width, int height, Color color)
 {
     rlBegin(RL_LINES);
         rlColor4ub(color.r, color.g, color.b, color.a);
-        rlVertex2f(posX, posY);
-        rlVertex2f(posX + width, posY + 1);
+        rlVertex2f((float)posX, (float)posY);
+        rlVertex2f((float)(posX + width), (float)(posY + 1));
 
-        rlVertex2f(posX + width, posY + 1);
-        rlVertex2f(posX + width, posY + height);
+        rlVertex2f((float)(posX + width), (float)(posY + 1));
+        rlVertex2f((float)(posX + width), (float)(posY + height));
 
-        rlVertex2f(posX + width, posY + height);
-        rlVertex2f(posX + 1, posY + height);
+        rlVertex2f((float)(posX + width), (float)(posY + height));
+        rlVertex2f((float)(posX + 1), (float)(posY + height));
 
-        rlVertex2f(posX + 1, posY + height);
-        rlVertex2f(posX + 1, posY + 1);
+        rlVertex2f((float)(posX + 1), (float)(posY + height));
+        rlVertex2f((float)(posX + 1), (float)(posY + 1));
     rlEnd();
 }
 

--- a/src/rtext.c
+++ b/src/rtext.c
@@ -1166,7 +1166,7 @@ void DrawTextEx(Font font, const char *text, Vector2 position, float fontSize, f
         if (codepoint == '\n')
         {
             // NOTE: Line spacing is a global variable, use SetTextLineSpacing() to setup
-            textOffsetY += (fontSize + textLineSpacing);
+            textOffsetY += (int)(fontSize + textLineSpacing);
             textOffsetX = 0.0f;
         }
         else
@@ -1237,7 +1237,7 @@ void DrawTextCodepoints(Font font, const int *codepoints, int codepointCount, Ve
         if (codepoints[i] == '\n')
         {
             // NOTE: Line spacing is a global variable, use SetTextLineSpacing() to setup
-            textOffsetY += (fontSize + textLineSpacing);
+            textOffsetY += (int)(fontSize + textLineSpacing);
             textOffsetX = 0.0f;
         }
         else

--- a/src/rtextures.c
+++ b/src/rtextures.c
@@ -311,15 +311,15 @@ Image LoadImageRaw(const char *fileName, int width, int height, int format, int 
     int dataSize = 0;
     unsigned char *fileData = LoadFileData(fileName, &dataSize);
 
-    if (fileData != NULL)
+    if (fileData != NULL && dataSize > 0)
     {
         unsigned char *dataPtr = fileData;
         unsigned int size = GetPixelDataSize(width, height, format);
 
-        if (size <= dataSize)   // Security check
+        if (size <= (unsigned int)dataSize)   // Security check
         {
             // Offset file data to expected raw image by header size
-            if ((headerSize > 0) && ((headerSize + size) <= dataSize)) dataPtr += headerSize;
+            if ((headerSize > 0) && ((headerSize + size) <= (unsigned int)dataSize)) dataPtr += headerSize;
 
             image.data = RL_MALLOC(size);      // Allocate required memory in bytes
             memcpy(image.data, dataPtr, size); // Copy required data to image
@@ -697,8 +697,8 @@ Image LoadImageFromScreen(void)
     Vector2 scale = GetWindowScaleDPI();
     Image image = { 0 };
 
-    image.width = GetScreenWidth()*scale.x;
-    image.height = GetScreenHeight()*scale.y;
+    image.width = (int)(GetScreenWidth()*scale.x);
+    image.height = (int)(GetScreenHeight()*scale.y);
     image.mipmaps = 1;
     image.format = PIXELFORMAT_UNCOMPRESSED_R8G8B8A8;
     image.data = rlReadScreenPixels(image.width, image.height);


### PR DESCRIPTION
In one of my projects, it'd be really useful to allow the `raymath.h` header to be included before `raylib.h`. Currently this is not possible without throwing errors regarding types already being defined before `raylib.h` encounters them.

This PR adds some `#ifdef` brackets around the definitions so that `raymath.h` can define them if it was included first. It also fixes a number of MSVC warnings in various code files. I didn't go through the examples to fix warnings there because there are a lot, and I though it'd make this PR very noisy. You might want to double check that the casts make sense, particularly the one from `int` to `size_t` to `void*` - I think it should be fine since that'd essentially be what the compiler is doing underneath, but best to check.