### PR TITLE
Do not use "nanosleep" on windows at all (PLATFORM_DESKTOP_RGFW)

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -592,12 +592,12 @@ endif
 ifeq ($(PLATFORM),PLATFORM_DESKTOP_RGFW)
     ifeq ($(PLATFORM_OS),WINDOWS)
         # Libraries for Windows desktop compilation
-        LDLIBS = ..\src\libraylib.a -lgdi32 -lwinmm -lopengl32
+        LDLIBS = -lgdi32 -lwinmm -lopengl32
     endif
     ifeq ($(PLATFORM_OS),LINUX)
         # Libraries for Debian GNU/Linux desktop compipling
         # NOTE: Required packages: libegl1-mesa-dev
-        LDLIBS = ../src/libraylib.a -lGL -lX11 -lXrandr -lXinerama -lXi -lXxf86vm -lXcursor -lm -lpthread -ldl -lrt
+        LDLIBS = -lGL -lX11 -lXrandr -lXinerama -lXi -lXcursor -lm -lpthread -ldl -lrt
 
         # Explicit link to libc
         ifeq ($(RAYLIB_LIBTYPE),SHARED)
@@ -608,10 +608,9 @@ ifeq ($(PLATFORM),PLATFORM_DESKTOP_RGFW)
         LDLIBS += -latomic
     endif
     ifeq ($(PLATFORM_OS),OSX)
-        # Libraries for Debian GNU/Linux desktop compiling
+        # Libraries for Debian MacOS desktop compiling
         # NOTE: Required packages: libegl1-mesa-dev
-        LDLIBS = ../src/libraylib.a -lm 
-        LDLIBS += -framework Foundation -framework AppKit -framework OpenGL -framework CoreVideo
+        LDLIBS += -lm -framework Foundation -framework AppKit -framework OpenGL -framework CoreVideo
     endif
 endif
 

--- a/src/external/RGFW.h
+++ b/src/external/RGFW.h
@@ -2753,8 +2753,8 @@ typedef struct { i32 x, y; } RGFW_vector;
 						4,
 						&actualType,
 						&actualFormat,
-						&count,
-						&bytesAfter,
+						(unsigned long*) &count,
+						(unsigned long*) &bytesAfter,
 						(u8**) &formats);
 				} else {
 					formats = (Atom*) RGFW_MALLOC(E.xclient.data.l[2] + E.xclient.data.l[3] + E.xclient.data.l[4]);
@@ -3002,7 +3002,6 @@ typedef struct { i32 x, y; } RGFW_vector;
 			win->src.winArgs &= ~RGFW_MOUSE_CHANGED;
 		}
 
-			RGFW_vector mouse = RGFW_getGlobalMousePoint();
 			if (win->src.winArgs & RGFW_HOLD_MOUSE && win->event.inFocus && win->event.type == RGFW_mousePosChanged) {
 				RGFW_window_moveMouse(win, RGFW_VECTOR(win->r.x + (win->r.w / 2), win->r.y + (win->r.h / 2)));
 				
@@ -6074,7 +6073,7 @@ static HMODULE wglinstance = NULL;
 	}
 
 	void RGFW_sleep(u32 ms) {
-#ifndef _MSC_VER
+#ifndef RGFW_WINDOWS
 		struct timespec time;
 		time.tv_sec = 0;
 		time.tv_nsec = ms * 1000;


### PR DESCRIPTION
An issue was found the RGFW platform while a user was trying to create bindings wherein mingw did not define `nanosleep`.

It turns out I was wrong in assuming that all distros of mingw support `nanosleep`. 
This fixes the issue by never using nanosleep when compiling for windows. 

Source issue: https://github.com/ColleagueRiley/RGFW/issues/13