### PR TITLE
Fix parsing of empty parentheses

### DIFF
--- a/parser/raylib_parser.c
+++ b/parser/raylib_parser.c
@@ -1006,8 +1006,14 @@ int main(int argc, char* argv[])
             {
                 funcEnd = c + 2;
 
-                // Check if previous word is void
-                if ((linePtr[c - 4] == 'v') && (linePtr[c - 3] == 'o') && (linePtr[c - 2] == 'i') && (linePtr[c - 1] == 'd')) break;
+                // Check if there are no parameters
+                if ((funcEnd - funcParamsStart == 2) ||
+                    ((linePtr[c - 4] == 'v') &&
+                     (linePtr[c - 3] == 'o') &&
+                     (linePtr[c - 2] == 'i') &&
+                     (linePtr[c - 1] == 'd'))) {
+                  break;
+                }
 
                 // Get parameter type + name, extract info
                 char funcParamTypeName[128] = { 0 };


### PR DESCRIPTION
This fix allows to parse `()` like `(void)` in the function parameters.
Another way to fix is to add `void` into following lines:
https://github.com/raysan5/raylib/blob/f62202198e35161a9fe394a14bbd1a7c655107ad/src/rlgl.h#L594-L595 these lines are from the commit: https://github.com/raysan5/raylib/commit/4b0e25d3af79ce4c5cd94e8279473764d969cca3