### PR TITLE
[examples] Use logarithmic scaling for 2d examples with zoom functionality

### DIFF
--- a/examples/core/core_2d_camera_mouse_zoom.c
+++ b/examples/core/core_2d_camera_mouse_zoom.c
@@ -63,10 +63,9 @@ int main ()
             camera.target = mouseWorldPos;
 
             // Zoom increment
-            const float zoomIncrement = 0.125f;
-
-            camera.zoom += (wheel*zoomIncrement);
-            if (camera.zoom < zoomIncrement) camera.zoom = zoomIncrement;
+            float scaleFactor = 1.0f + (0.25f * fabsf(wheel));
+            if (wheel < 0) scaleFactor = 1.0f / scaleFactor;
+            camera.zoom = Clamp(camera.zoom * scaleFactor, 0.125, 64);
         }
 
         //----------------------------------------------------------------------------------


### PR DESCRIPTION
Makes zoom increments feel more natural. Otherwise, increments can feel too small when zoomed in, or too big when zoomed out.