### PR TITLE
[parser] Don't crash for files that don't end in newlines

### DIFF
--- a/parser/raylib_parser.c
+++ b/parser/raylib_parser.c
@@ -1243,7 +1243,7 @@ static char **GetTextLines(const char *buffer, int length, int *linesCount)
         while ((bufferPtr[index] == ' ') || (bufferPtr[index] == '\t')) index++;
 
         int j = 0;
-        while (bufferPtr[index + j] != '\n')
+        while (bufferPtr[index + j] != '\n' && bufferPtr[index + j] != '\0')
         {
             lines[i][j] = bufferPtr[index + j];
             j++;


### PR DESCRIPTION
The parser assumes all lines end in newlines, but sometimes this isn't true. Check for a null terminator along with '\n' when stripping leading spaces.