### PR TITLE
Zig build script - LazyPath.path has been deprecated, using b.path()

### DIFF
--- a/src/build.zig
+++ b/src/build.zig
@@ -204,7 +204,7 @@ fn compileRaylib(b: *std.Build, target: std.Build.ResolvedTarget, optimize: std.
             var dir = std.fs.openDirAbsolute(cache_include, std.fs.Dir.OpenDirOptions{ .access_sub_paths = true, .no_follow = true }) catch @panic("No emscripten cache. Generate it!");
             dir.close();
 
-            raylib.addIncludePath(.{ .path = cache_include });
+            raylib.addIncludePath(b.path(cache_include));
         },
         else => {
             @panic("Unsupported OS");


### PR DESCRIPTION
This works in zig 0.12 (current stable), LazyPath.path has been removed in zig 0.13 (development)

Currently building raylib is broken in 0.13, this change fixes that while not breaking building with current stable 0.12