### PR TITLE
[rcore] Draft: OpenGL 4.6 Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ features
   - **NO external dependencies**, all required libraries are [bundled into raylib](https://github.com/raysan5/raylib/tree/master/src/external)
   - Multiple platforms supported: **Windows, Linux, MacOS, RPI, Android, HTML5... and more!**
   - Written in plain C code (C99) using PascalCase/camelCase notation
-  - Hardware accelerated with OpenGL (**1.1, 2.1, 3.3, 4.3, ES 2.0, ES 3.0**)
+  - Hardware accelerated with OpenGL (**1.1, 2.1, 3.3, 4.3, 4.6, ES 2.0, ES 3.0**)
   - **Unique OpenGL abstraction layer** (usable as standalone module): [rlgl](https://github.com/raysan5/raylib/blob/master/src/rlgl.h)
   - Multiple **Fonts** formats supported (TTF, OTF, Image fonts, AngelCode fonts)
   - Multiple texture formats supported, including **compressed formats** (DXT, ETC, ASTC)

--- a/src/platforms/rcore_desktop.c
+++ b/src/platforms/rcore_desktop.c
@@ -1350,6 +1350,19 @@ int InitPlatform(void)
         glfwWindowHint(GLFW_OPENGL_DEBUG_CONTEXT, GLFW_TRUE);   // Enable OpenGL Debug Context
 #endif
     }
+    else if (rlGetVersion() == RL_OPENGL_46)
+    {
+        glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 4);          // Choose OpenGL major version (just hint)
+        glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 6);          // Choose OpenGL minor version (just hint)
+        glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
+        glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GLFW_FALSE);
+#if defined(RLGL_ENABLE_OPENGL_DEBUG_CONTEXT)
+        glfwWindowHint(GLFW_OPENGL_DEBUG_CONTEXT, GLFW_TRUE);   // Enable OpenGL Debug Context
+#endif
+#if defined(RLGL_ENABLE_NOERROR_CONTEXT)
+        glfwWindowHint(GLFW_CONTEXT_NO_ERROR, GLFW_TRUE);
+#endif
+    }
     else if (rlGetVersion() == RL_OPENGL_ES_20)                 // Request OpenGL ES 2.0 context
     {
         glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 2);

--- a/src/platforms/rcore_desktop.c
+++ b/src/platforms/rcore_desktop.c
@@ -1269,6 +1269,15 @@ int InitPlatform(void)
     // Check window creation flags
     if ((CORE.Window.flags & FLAG_FULLSCREEN_MODE) > 0) CORE.Window.fullscreen = true;
 
+    if(CORE.Window.flags & FLAG_NOERROR_CONTEXT)
+    {
+      if(rlGetVersion() == RL_OPENGL_46)
+      {
+        TRACELOG(LOG_INFO, "CONTEXT: Trying to enable NOERROR context");
+        glfwWindowHint(GLFW_CONTEXT_NO_ERROR, GLFW_TRUE);
+      }else TRACELOG(LOG_WARNING, "NOERROR contexts are only supported in OpenGL 4.6");
+    }
+
     if ((CORE.Window.flags & FLAG_WINDOW_HIDDEN) > 0) glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE); // Visible window
     else glfwWindowHint(GLFW_VISIBLE, GLFW_TRUE);     // Window initially hidden
 
@@ -1358,9 +1367,6 @@ int InitPlatform(void)
         glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GLFW_FALSE);
 #if defined(RLGL_ENABLE_OPENGL_DEBUG_CONTEXT)
         glfwWindowHint(GLFW_OPENGL_DEBUG_CONTEXT, GLFW_TRUE);   // Enable OpenGL Debug Context
-#endif
-#if defined(RLGL_ENABLE_NOERROR_CONTEXT)
-        glfwWindowHint(GLFW_CONTEXT_NO_ERROR, GLFW_TRUE);
 #endif
     }
     else if (rlGetVersion() == RL_OPENGL_ES_20)                 // Request OpenGL ES 2.0 context

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -546,7 +546,8 @@ typedef enum {
     FLAG_WINDOW_MOUSE_PASSTHROUGH = 0x00004000, // Set to support mouse passthrough, only supported when FLAG_WINDOW_UNDECORATED
     FLAG_BORDERLESS_WINDOWED_MODE = 0x00008000, // Set to run program in borderless windowed mode
     FLAG_MSAA_4X_HINT       = 0x00000020,   // Set to try enabling MSAA 4X
-    FLAG_INTERLACED_HINT    = 0x00010000    // Set to try enabling interlaced video format (for V3D)
+    FLAG_INTERLACED_HINT    = 0x00010000,   // Set to try enabling interlaced video format (for V3D)
+    FLAG_NOERROR_CONTEXT    = 0x00020000    // Set to try enabling NOERROR context (OpenGL 4.6 only)
 } ConfigFlags;
 
 // Trace log level

--- a/src/rlgl.h
+++ b/src/rlgl.h
@@ -25,6 +25,7 @@
 *       #define GRAPHICS_API_OPENGL_21
 *       #define GRAPHICS_API_OPENGL_33
 *       #define GRAPHICS_API_OPENGL_43
+*       #define GRAPHICS_API_OPENGL_46
 *       #define GRAPHICS_API_OPENGL_ES2
 *       #define GRAPHICS_API_OPENGL_ES3
 *           Use selected OpenGL graphics backend, should be supported by platform
@@ -150,6 +151,7 @@
     !defined(GRAPHICS_API_OPENGL_21) && \
     !defined(GRAPHICS_API_OPENGL_33) && \
     !defined(GRAPHICS_API_OPENGL_43) && \
+    !defined(GRAPHICS_API_OPENGL_46) && \
     !defined(GRAPHICS_API_OPENGL_ES2) && \
     !defined(GRAPHICS_API_OPENGL_ES3)
         #define GRAPHICS_API_OPENGL_33
@@ -166,6 +168,9 @@
     #if defined(GRAPHICS_API_OPENGL_43)
         #undef GRAPHICS_API_OPENGL_43
     #endif
+    #if defined(GRAPHICS_API_OPENGL_46)
+        #undef GRAPHICS_API_OPENGL_46
+    #endif
     #if defined(GRAPHICS_API_OPENGL_ES2)
         #undef GRAPHICS_API_OPENGL_ES2
     #endif
@@ -179,6 +184,11 @@
 
 // OpenGL 4.3 uses OpenGL 3.3 Core functionality
 #if defined(GRAPHICS_API_OPENGL_43)
+    #define GRAPHICS_API_OPENGL_33
+#endif
+
+// OpenGL 4.6 uses OpenGL 3.3 Core functionality
+#if defined(GRAPHICS_API_OPENGL_46)
     #define GRAPHICS_API_OPENGL_33
 #endif
 
@@ -414,6 +424,7 @@ typedef enum {
     RL_OPENGL_21,               // OpenGL 2.1 (GLSL 120)
     RL_OPENGL_33,               // OpenGL 3.3 (GLSL 330)
     RL_OPENGL_43,               // OpenGL 4.3 (using GLSL 330)
+    RL_OPENGL_46,               // OpenGL 4.6 (using GLSL 330)
     RL_OPENGL_ES_20,            // OpenGL ES 2.0 (GLSL 100)
     RL_OPENGL_ES_30             // OpenGL ES 3.0 (GLSL 300 es)
 } rlGlVersion;
@@ -2589,6 +2600,8 @@ int rlGetVersion(void)
     glVersion = RL_OPENGL_43;
 #elif defined(GRAPHICS_API_OPENGL_33)
     glVersion = RL_OPENGL_33;
+#elif defined(GRAPHICS_API_OPENGL_46)
+    glVersion = RL_OPENGL_46;
 #endif
 #if defined(GRAPHICS_API_OPENGL_ES3)
     glVersion = RL_OPENGL_ES_30;


### PR DESCRIPTION
This pull request is a draft for adding OpenGL 4.6 support in Raylib.

OpenGL 4.6 offers additional features such as DSA, SPIR-V and NOERROR context.

I currently implemented basic support for opengl46 context creation and a config flag for enabling noerror context.

DSA implentations of rlgl functions are not yet implemented. The first part of rlgl where i plan to add DSA support is the batching system.

Testing was only done on Linux with Mesa and Nvidia 550.

 
