### PR TITLE
[rmodels] Fix out of bounds error in GenMeshTangents for loop.

### DIFF
--- a/src/rmodels.c
+++ b/src/rmodels.c
@@ -3431,7 +3431,7 @@ void GenMeshTangents(Mesh *mesh)
     Vector3 *tan1 = (Vector3 *)RL_MALLOC(mesh->vertexCount*sizeof(Vector3));
     Vector3 *tan2 = (Vector3 *)RL_MALLOC(mesh->vertexCount*sizeof(Vector3));
 
-    for (int i = 0; i < mesh->vertexCount; i += 3)
+    for (int i = 0; i < mesh->vertexCount - 3; i += 3)
     {
         // Get triangle vertices
         Vector3 v1 = { mesh->vertices[(i + 0)*3 + 0], mesh->vertices[(i + 0)*3 + 1], mesh->vertices[(i + 0)*3 + 2] };


### PR DESCRIPTION
Found a bug in the GenMeshTangents function when calling it with a generated plane mesh. Pointers to tan1 and tan2 go out of bounds since the int i would increment up to vertexCount instead of vertexCount - 3.