### PR TITLE
[rtextures] Fix Undefined behaviour in ColorToInt

### DIFF
--- a/src/rtextures.c
+++ b/src/rtextures.c
@@ -4510,9 +4510,7 @@ Color Fade(Color color, float alpha)
 // Get hexadecimal value for a Color
 int ColorToInt(Color color)
 {
-    int result = (((int)color.r << 24) | ((int)color.g << 16) | ((int)color.b << 8) | (int)color.a);
-
-    return result;
+    return (int)(((unsigned)color.r << 24) | ((unsigned)color.g << 16) | ((unsigned)color.b << 8) | color.a);
 }
 
 // Get color normalized as float [0..1]


### PR DESCRIPTION
If the red value is too large, the right shift operator leads to overflow in the signed int. Closes issue #3987. The cast to int afterward is not UB, only implementation-defined behaviour. See #3987.