### PR TITLE
[rmodels] Multiplication of colors in `DrawModelEx` which can be simplified

### DIFF
--- a/src/rmodels.c
+++ b/src/rmodels.c
@@ -3546,10 +3546,10 @@ void DrawModelEx(Model model, Vector3 position, Vector3 rotationAxis, float rota
         Color color = model.materials[model.meshMaterial[i]].maps[MATERIAL_MAP_DIFFUSE].color;
 
         Color colorTint = WHITE;
-        colorTint.r = (unsigned char)((color.r*tint.r)/255);
-        colorTint.g = (unsigned char)((color.g*tint.g)/255);
-        colorTint.b = (unsigned char)((color.b*tint.b)/255);
-        colorTint.a = (unsigned char)((color.a*tint.a)/255);
+        colorTint.r = (unsigned char)(((int)color.r*(int)tint.r)/255);
+        colorTint.g = (unsigned char)(((int)color.g*(int)tint.g)/255);
+        colorTint.b = (unsigned char)(((int)color.b*(int)tint.b)/255);
+        colorTint.a = (unsigned char)(((int)color.a*(int)tint.a)/255);
 
         model.materials[model.meshMaterial[i]].maps[MATERIAL_MAP_DIFFUSE].color = colorTint;
         DrawMesh(model.meshes[i], model.materials[model.meshMaterial[i]], model.transform);

--- a/src/rmodels.c
+++ b/src/rmodels.c
@@ -3546,10 +3546,10 @@ void DrawModelEx(Model model, Vector3 position, Vector3 rotationAxis, float rota
         Color color = model.materials[model.meshMaterial[i]].maps[MATERIAL_MAP_DIFFUSE].color;
 
         Color colorTint = WHITE;
-        colorTint.r = (unsigned char)((((float)color.r/255.0f)*((float)tint.r/255.0f))*255.0f);
-        colorTint.g = (unsigned char)((((float)color.g/255.0f)*((float)tint.g/255.0f))*255.0f);
-        colorTint.b = (unsigned char)((((float)color.b/255.0f)*((float)tint.b/255.0f))*255.0f);
-        colorTint.a = (unsigned char)((((float)color.a/255.0f)*((float)tint.a/255.0f))*255.0f);
+        colorTint.r = (unsigned char)((color.r*tint.r)/255);
+        colorTint.g = (unsigned char)((color.g*tint.g)/255);
+        colorTint.b = (unsigned char)((color.b*tint.b)/255);
+        colorTint.a = (unsigned char)((color.a*tint.a)/255);
 
         model.materials[model.meshMaterial[i]].maps[MATERIAL_MAP_DIFFUSE].color = colorTint;
         DrawMesh(model.meshes[i], model.materials[model.meshMaterial[i]], model.transform);


### PR DESCRIPTION
The multiplication of colors in `DrawModelEx` can be simplified by performing 4 integer divisions rather than 8 float conversions/divisions.