### PR TITLE
[build.zig] Fix Zig emscripten build

### DIFF
--- a/src/build.zig
+++ b/src/build.zig
@@ -198,13 +198,15 @@ fn compileRaylib(b: *std.Build, target: std.Build.ResolvedTarget, optimize: std.
                 @panic("Pass '--sysroot \"$EMSDK/upstream/emscripten\"'");
             }
 
-            const cache_include = std.fs.path.join(b.allocator, &.{ b.sysroot.?, "cache", "sysroot", "include" }) catch @panic("Out of memory");
-            defer b.allocator.free(cache_include);
-
-            var dir = std.fs.openDirAbsolute(cache_include, std.fs.Dir.OpenDirOptions{ .access_sub_paths = true, .no_follow = true }) catch @panic("No emscripten cache. Generate it!");
-            dir.close();
-
-            raylib.addIncludePath(b.path(cache_include));
+            if (comptime builtin.zig_version.minor > 12) {
+                var dir = std.fs.cwd().openDir(cache_include, std.fs.Dir.OpenDirOptions{ .access_sub_paths = true, .no_follow = true }) catch @panic("No emscripten cache. Generate it!");
+                dir.close();
+                raylib.addIncludePath(b.path(cache_include));
+            } else {
+                var dir = std.fs.openDirAbsolute(cache_include, std.fs.Dir.OpenDirOptions{ .access_sub_paths = true, .no_follow = true }) catch @panic("No emscripten cache. Generate it!");
+                dir.close();
+                raylib.addIncludePath(.{ .path = cache_include });
+            }
         },
         else => {
             @panic("Unsupported OS");

--- a/src/build.zig
+++ b/src/build.zig
@@ -198,6 +198,9 @@ fn compileRaylib(b: *std.Build, target: std.Build.ResolvedTarget, optimize: std.
                 @panic("Pass '--sysroot \"$EMSDK/upstream/emscripten\"'");
             }
 
+            const cache_include = std.fs.path.join(b.allocator, &.{ b.sysroot.?, "cache", "sysroot", "include" }) catch @panic("Out of memory");
+            defer b.allocator.free(cache_include);
+
             if (comptime builtin.zig_version.minor > 12) {
                 var dir = std.fs.cwd().openDir(cache_include, std.fs.Dir.OpenDirOptions{ .access_sub_paths = true, .no_follow = true }) catch @panic("No emscripten cache. Generate it!");
                 dir.close();


### PR DESCRIPTION
This pull request fixes #4010. In Zig's master branch the path to the emsdk headers must be a relative path, as mentioned https://github.com/ziglang/zig/pull/19623. Previously, in versions >= 0.12, this path was absolute.

This fix splits the code based on the current Zig version. If the current version is greater than 0.12.0 then we use a relative path and otherwise we use an absolute path. _**If upgrading to Zig's master branch this is a breaking change and the path supplied for the `--sysroot` must be relative to Zig's build directory.**_