### PR TITLE
[rshapes]Circle line collision function

### DIFF
--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1295,6 +1295,7 @@ RLAPI bool CheckCollisionPointTriangle(Vector2 point, Vector2 p1, Vector2 p2, Ve
 RLAPI bool CheckCollisionPointPoly(Vector2 point, Vector2 *points, int pointCount);                      // Check if point is within a polygon described by array of vertices
 RLAPI bool CheckCollisionLines(Vector2 startPos1, Vector2 endPos1, Vector2 startPos2, Vector2 endPos2, Vector2 *collisionPoint); // Check the collision between two lines defined by two points each, returns collision point by reference
 RLAPI bool CheckCollisionPointLine(Vector2 point, Vector2 p1, Vector2 p2, int threshold);                // Check if point belongs to line created between two points [p1] and [p2] with defined margin in pixels [threshold]
+RLAPI bool CheckCollisionCircleLine(Vector2 center, float radius, Vector2 p1, Vector2 p2);
 RLAPI Rectangle GetCollisionRec(Rectangle rec1, Rectangle rec2);                                         // Get collision rectangle for two rectangles collision
 
 //------------------------------------------------------------------------------------

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1295,7 +1295,7 @@ RLAPI bool CheckCollisionPointTriangle(Vector2 point, Vector2 p1, Vector2 p2, Ve
 RLAPI bool CheckCollisionPointPoly(Vector2 point, Vector2 *points, int pointCount);                      // Check if point is within a polygon described by array of vertices
 RLAPI bool CheckCollisionLines(Vector2 startPos1, Vector2 endPos1, Vector2 startPos2, Vector2 endPos2, Vector2 *collisionPoint); // Check the collision between two lines defined by two points each, returns collision point by reference
 RLAPI bool CheckCollisionPointLine(Vector2 point, Vector2 p1, Vector2 p2, int threshold);                // Check if point belongs to line created between two points [p1] and [p2] with defined margin in pixels [threshold]
-RLAPI bool CheckCollisionCircleLine(Vector2 center, float radius, Vector2 p1, Vector2 p2);
+RLAPI bool CheckCollisionCircleLine(Vector2 center, float radius, Vector2 p1, Vector2 p2);               // Check if circle collides with a line created betweeen two points [p1] and [p2]
 RLAPI Rectangle GetCollisionRec(Rectangle rec1, Rectangle rec2);                                         // Get collision rectangle for two rectangles collision
 
 //------------------------------------------------------------------------------------

--- a/src/rshapes.c
+++ b/src/rshapes.c
@@ -2315,6 +2315,41 @@ bool CheckCollisionPointLine(Vector2 point, Vector2 p1, Vector2 p2, int threshol
     return collision;
 }
 
+RLAPI bool CheckCollisionCircleLine(Vector2 center, float radius, Vector2 p1, Vector2 p2)
+{
+    // get length of line
+    float dx = p1.x - p2.x;
+    float dy = p1.y - p2.y;
+    float length_sqr = ((dx * dx) + (dy * dy));
+
+    // dot product
+    float dotProduct = (((center.x - p1.x) * (p2.x - p1.x)) + ((center.y - p1.y) * (p2.y - p1.y))) / (length_sqr);
+
+    if (dotProduct > 1.0f)
+    {
+        dotProduct = 1.0f;
+    }
+    else if (dotProduct < 0.0f)
+    {
+        dotProduct = 0.0f;
+    }
+
+    // closest point on line
+    float closeX = p1.x - (dotProduct * (dx));
+    float closeY = p1.y - (dotProduct * (dy));
+
+    Vector2 close = { closeX, closeY };
+
+    //distnce from circle to closest point
+
+    dx = closeX - center.x;
+    dy = closeY - center.y;
+    float distance_sqr = ((dx * dx) + (dy * dy));
+
+    if (distance_sqr <= radius * radius) return true;
+    return false;
+}
+
 // Get collision rectangle for two rectangles collision
 Rectangle GetCollisionRec(Rectangle rec1, Rectangle rec2)
 {

--- a/src/rshapes.c
+++ b/src/rshapes.c
@@ -2335,8 +2335,7 @@ RLAPI bool CheckCollisionCircleLine(Vector2 center, float radius, Vector2 p1, Ve
     float dy2 = (p1.y - (dotProduct * (dy))) - center.y;
     float distance_sqr = ((dx2 * dx2) + (dy2 * dy2));
 
-    if (distance_sqr <= radius * radius) return true;
-    return false;
+    return (distance_sqr <= radius * radius);
 }
 
 // Get collision rectangle for two rectangles collision

--- a/src/rshapes.c
+++ b/src/rshapes.c
@@ -2317,12 +2317,9 @@ bool CheckCollisionPointLine(Vector2 point, Vector2 p1, Vector2 p2, int threshol
 
 RLAPI bool CheckCollisionCircleLine(Vector2 center, float radius, Vector2 p1, Vector2 p2)
 {
-    // get length of line
     float dx = p1.x - p2.x;
     float dy = p1.y - p2.y;
     float length_sqr = ((dx * dx) + (dy * dy));
-
-    // dot product
     float dotProduct = (((center.x - p1.x) * (p2.x - p1.x)) + ((center.y - p1.y) * (p2.y - p1.y))) / (length_sqr);
 
     if (dotProduct > 1.0f)
@@ -2334,17 +2331,9 @@ RLAPI bool CheckCollisionCircleLine(Vector2 center, float radius, Vector2 p1, Ve
         dotProduct = 0.0f;
     }
 
-    // closest point on line
-    float closeX = p1.x - (dotProduct * (dx));
-    float closeY = p1.y - (dotProduct * (dy));
-
-    Vector2 close = { closeX, closeY };
-
-    //distnce from circle to closest point
-
-    dx = closeX - center.x;
-    dy = closeY - center.y;
-    float distance_sqr = ((dx * dx) + (dy * dy));
+    float dx2 = (p1.x - (dotProduct * (dx))) - center.x;
+    float dy2 = (p1.y - (dotProduct * (dy))) - center.y;
+    float distance_sqr = ((dx2 * dx2) + (dy2 * dy2));
 
     if (distance_sqr <= radius * radius) return true;
     return false;

--- a/src/rshapes.c
+++ b/src/rshapes.c
@@ -2320,17 +2320,17 @@ RLAPI bool CheckCollisionCircleLine(Vector2 center, float radius, Vector2 p1, Ve
 {
     float dx = p1.x - p2.x;
     float dy = p1.y - p2.y;
+
+    if ((fabsf(dx) + fabsf(dy)) <= FLT_EPSILON)
+    {
+        return CheckCollisionCircles(p1, 0, center, radius);
+    }
+
     float lengthSQ = ((dx * dx) + (dy * dy));
     float dotProduct = (((center.x - p1.x) * (p2.x - p1.x)) + ((center.y - p1.y) * (p2.y - p1.y))) / (lengthSQ);
 
-    if (dotProduct > 1.0f)
-    {
-        dotProduct = 1.0f;
-    }
-    else if (dotProduct < 0.0f)
-    {
-        dotProduct = 0.0f;
-    }
+    if (dotProduct > 1.0f) dotProduct = 1.0f;
+    else if (dotProduct < 0.0f) dotProduct = 0.0f;
 
     float dx2 = (p1.x - (dotProduct * (dx))) - center.x;
     float dy2 = (p1.y - (dotProduct * (dy))) - center.y;

--- a/src/rshapes.c
+++ b/src/rshapes.c
@@ -2320,8 +2320,8 @@ RLAPI bool CheckCollisionCircleLine(Vector2 center, float radius, Vector2 p1, Ve
 {
     float dx = p1.x - p2.x;
     float dy = p1.y - p2.y;
-    float length_sqr = ((dx * dx) + (dy * dy));
-    float dotProduct = (((center.x - p1.x) * (p2.x - p1.x)) + ((center.y - p1.y) * (p2.y - p1.y))) / (length_sqr);
+    float lengthSQ = ((dx * dx) + (dy * dy));
+    float dotProduct = (((center.x - p1.x) * (p2.x - p1.x)) + ((center.y - p1.y) * (p2.y - p1.y))) / (lengthSQ);
 
     if (dotProduct > 1.0f)
     {
@@ -2334,9 +2334,9 @@ RLAPI bool CheckCollisionCircleLine(Vector2 center, float radius, Vector2 p1, Ve
 
     float dx2 = (p1.x - (dotProduct * (dx))) - center.x;
     float dy2 = (p1.y - (dotProduct * (dy))) - center.y;
-    float distance_sqr = ((dx2 * dx2) + (dy2 * dy2));
+    float distanceSQ = ((dx2 * dx2) + (dy2 * dy2));
 
-    return (distance_sqr <= radius * radius);
+    return (distanceSQ <= radius * radius);
 }
 
 // Get collision rectangle for two rectangles collision

--- a/src/rshapes.c
+++ b/src/rshapes.c
@@ -2315,6 +2315,7 @@ bool CheckCollisionPointLine(Vector2 point, Vector2 p1, Vector2 p2, int threshol
     return collision;
 }
 
+// Check if circle collides with a line created betweeen two points [p1] and [p2]
 RLAPI bool CheckCollisionCircleLine(Vector2 center, float radius, Vector2 p1, Vector2 p2)
 {
     float dx = p1.x - p2.x;


### PR DESCRIPTION
Added a function to check collision between a line defined by p1, p2 and a circle defined by its position and radius. This code is tested in https://github.com/kai-z99/raylib/blob/circleLineDev/examples/shapes/shapes_collision_area.c

This function is intended to a standalone collision detection function as well as possibly a helper function for a polygon-circle collision function.

The algorithm is based on https://www.jeffreythompson.org/collision-detection/line-circle.php

It is also similar to this one: https://github.com/raysan5/raylib/pull/4000 (which is closed)

![Screenshot 2024-05-29 213049](https://github.com/raysan5/raylib/assets/147789796/5e6217f4-e2a9-4573-ae88-13933a2e35f7)
![Screenshot 2024-05-29 213032](https://github.com/raysan5/raylib/assets/147789796/6c819fdf-cd19-46c4-941e-18a253dc5120)
![Screenshot 2024-05-29 213011](https://github.com/raysan5/raylib/assets/147789796/4a0af823-13ca-4a64-835e-8d925998a0e0)

