### PR TITLE
[build] Fix Zig raygui build when using addRaygui externally

### DIFF
--- a/src/build.zig
+++ b/src/build.zig
@@ -216,6 +216,7 @@ fn compileRaylib(b: *std.Build, target: std.Build.ResolvedTarget, optimize: std.
         },
     }
 
+    raylib.addIncludePath(b.path("src"));
     raylib.root_module.addCSourceFiles(.{
         .root = b.path("src"),
         .files = c_source_files.items,


### PR DESCRIPTION
When `addRaygui` is used from an external build, for example in a bindings project, the build of a generated `raygui.c` fails with "raylib.h not found" error from the compiler.

I've traced this down to a raylib step not adding its `src/` to the shared list of include paths using `addIncludePath` but relying on `addCSourceFiles` `.root` to provide the implicit include path for raylib proper's own files.

If raygui is later added to the step the compiler won't know where to look for `raylib.h` and friends and will fail to build.

This change simply adds raylib's `src/` to the include path list.