### PR TITLE
Add GenModelMipmaps() for generating mipmaps and setting filtering settings

### DIFF
--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1400,6 +1400,7 @@ RLAPI void UpdateTextureRec(Texture2D texture, Rectangle rec, const void *pixels
 
 // Texture configuration functions
 RLAPI void GenTextureMipmaps(Texture2D *texture);                                                        // Generate GPU mipmaps for a texture
+RLAPI void GenModelMipmaps(Model model);                                                                 // Generate GPU mipmaps for all textures used in a model, as well as enable appropriate texture filtering
 RLAPI void SetTextureFilter(Texture2D texture, int filter);                                              // Set texture scaling filter mode
 RLAPI void SetTextureWrap(Texture2D texture, int wrap);                                                  // Set texture wrapping mode
 

--- a/src/rtextures.c
+++ b/src/rtextures.c
@@ -4029,6 +4029,21 @@ void GenTextureMipmaps(Texture2D *texture)
     rlGenTextureMipmaps(texture->id, texture->width, texture->height, texture->format, &texture->mipmaps);
 }
 
+// Generate GPU mipmaps for all textures used in a model, as well
+// as enable appropriate texture filtering
+void GenModelMipmaps(Model model)
+{
+    for (int i = 0; i < model.materialCount; i++)
+    {
+        Material *material = &(model.materials[i]);
+        for (int m = 0; m < MAX_MATERIAL_MAPS; m++)
+        {
+            GenTextureMipmaps(&(material->maps[m].texture));
+            SetTextureFilter(material->maps[m].texture, TEXTURE_FILTER_TRILINEAR);
+        }
+    }
+}
+
 // Set texture scaling filter mode
 void SetTextureFilter(Texture2D texture, int filter)
 {


### PR DESCRIPTION
I was a bit surprised to find that a textured model loaded from (say) a glTF file did not use mipmaps automatically. The required code to generate and enable mipmaps isn't a lot, but seems to be an operation one would want to be easy to do. Hence this function.