### PR TITLE
[rmodels] Initial work to correctly handle the node hierarchy in a glTF file

### DIFF
--- a/src/rmodels.c
+++ b/src/rmodels.c
@@ -4969,9 +4969,14 @@ static Model LoadGLTF(const char *fileName)
             cgltf_mesh *mesh = node->mesh;
             if (!mesh)
                 continue;
-            primitivesCount += mesh->primitives_count;
+
+            for (unsigned int p = 0; p < mesh->primitives_count; p++)
+            {
+                if (mesh->primitives[p].type == cgltf_primitive_type_triangles)
+                    primitivesCount++;
+            }
         }
-        TRACELOG(LOG_DEBUG, "    > Primitives count based on hierarchy: %i", primitivesCount);
+        TRACELOG(LOG_DEBUG, "    > Primitives (triangles only) count based on hierarchy : %i", primitivesCount);
 
         // Load our model data: meshes and materials
         model.meshCount = primitivesCount;


### PR DESCRIPTION
Having to use glTF files without node hierarchies and without transformations applied to the meshes is really a big limitation. Also, the current handling is not really correct, as it completely ignores the node hierarchy and thus might lead to meshes not getting instanced more than once. 

This patch adds using the nodes in the glTF file to drive the process of creating meshes, instead of only processing the list of meshes and ignoring the node hierarchy. Transforms defined in the nodes (including parent-child effects) are applied to the vertices/normals/tangents of the meshes in the leafs. A separate raylib Mesh is generated for each leaf node (and still generates one Mesh per primitive in a glTF mesh).

Static meshes with more complex hierarchy in terms of parenting and object transforms seem to work fine in my tests. 

Haven't tried any glTF files with animations yet, but those are almost certainly broken. It's also the part where I don't know off-hand how to handle that, so any tips on what is currently going on with respect to bones and animation are appreciated.

Btw, scenes in the glTF files are also ignored (which can contain subsets of nodes, and thus meshes), but that's something I ignore here as well.