### PR TITLE
[rlgl] Rename near, far variables

### DIFF
--- a/src/rlgl.h
+++ b/src/rlgl.h
@@ -590,7 +590,7 @@ RLAPI void rlMultMatrixf(const float *matf);            // Multiply the current 
 RLAPI void rlFrustum(double left, double right, double bottom, double top, double znear, double zfar);
 RLAPI void rlOrtho(double left, double right, double bottom, double top, double znear, double zfar);
 RLAPI void rlViewport(int x, int y, int width, int height); // Set the viewport area
-RLAPI void rlSetClipPlanes(double near, double far);    // Set clip planes distances
+RLAPI void rlSetClipPlanes(double nearPlane, double farPlane);    // Set clip planes distances
 RLAPI double rlGetCullDistanceNear(void);               // Get cull plane distance near
 RLAPI double rlGetCullDistanceFar(void);                // Get cull plane distance far
 
@@ -1371,10 +1371,10 @@ void rlViewport(int x, int y, int width, int height)
 }
 
 // Set clip planes distances
-void rlSetClipPlanes(double near, double far)
+void rlSetClipPlanes(double nearPlane, double farPlane)
 {
-    rlCullDistanceNear = near;
-    rlCullDistanceFar = far;
+    rlCullDistanceNear = nearPlane;
+    rlCullDistanceFar = farPlane;
 }
 
 // Get cull plane distance near


### PR DESCRIPTION
Hi, I found a couple more instances of the `near` and `far` names being used in `rlgl.h`.

I don't really know if this could incure the same problem I found with `raymath.h`, but I tought it might be useful to also rename this one.

This relates to this old issue that mentions these names:
- https://github.com/raysan5/raylib/issues/243

I would also mention that I'm not yet using the suggested setup to select includes from `windows.h`, from here:
- https://github.com/raysan5/raylib/issues/1217

Which may fix most of this kind of issues, should anyone incur in the same warnings as [in here.](https://www.reddit.com/r/raylib/comments/1d8m52k/question_why_does_including_raymathh_make_my/)
