### PR TITLE
fix(cmake): infer CMAKE_MODULE_PATH in super-build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ cmake_policy(SET CMP0054 NEW)
 
 # Directory for easier includes
 # Anywhere you see include(...) you can check <root>/cmake for that file
-set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
 # RAYLIB_IS_MAIN determines whether the project is being used from root
 # or if it is added as a dependency (through add_subdirectory for example).
@@ -40,7 +40,7 @@ add_subdirectory(src raylib)
 # Uninstall target
 if(NOT TARGET uninstall)
   configure_file(
-    "${CMAKE_MODULE_PATH}/Uninstall.cmake"
+    "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Uninstall.cmake"
     "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
     IMMEDIATE @ONLY)
 


### PR DESCRIPTION
Raylib as a library should not override the `CMAKE_MODULE_PATH' variable. This is the way it is used in [glfw](https://github.com/raysan5/raylib/blob/5.0/src/external/glfw/CMakeLists.txt#L62).

As it also depends on `find_package()` calls which expect system-wide installed dependencies, this prevents you from using custom `Find<target>.cmake` files to build them in-source.

In CMake this is a bit hacky, but in e.g. meson this is natively supported [behavior](https://mesonbuild.com/External-Project-module.html).