### PR TITLE
[rmodels] `LoadBoneInfoGLTF()`, add check for animation name being NULL

### DIFF
--- a/src/rmodels.c
+++ b/src/rmodels.c
@@ -4864,7 +4864,7 @@ static BoneInfo *LoadBoneInfoGLTF(cgltf_skin skin, int *boneCount)
     for (unsigned int i = 0; i < skin.joints_count; i++)
     {
         cgltf_node node = *skin.joints[i];
-        strncpy(bones[i].name, node.name, sizeof(bones[i].name));
+        if (node.name != NULL) strncpy(bones[i].name, node.name, sizeof(bones[i].name));
 
         // Find parent bone index
         unsigned int parentIndex = -1;


### PR DESCRIPTION
Same issue described here https://github.com/raysan5/raylib/pull/4037 with this model https://github.com/KhronosGroup/glTF-Sample-Models/blob/main/2.0/BrainStem/glTF-Binary/BrainStem.glb