### PR TITLE
Update `Makefile`

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -316,7 +316,7 @@ endif
 #  -D_GNU_SOURCE            access to lots of nonstandard GNU/Linux extension functions
 #  -Werror=pointer-arith    catch unportable code that does direct arithmetic on void pointers
 #  -fno-strict-aliasing     jar_xm.h does shady stuff (breaks strict aliasing)
-CFLAGS = -Wall -D_GNU_SOURCE -D$(PLATFORM) -D$(GRAPHICS) -Wno-missing-braces -Werror=pointer-arith -fno-strict-aliasing $(CUSTOM_CFLAGS)
+CFLAGS = -Wall -D_GNU_SOURCE -D$(PLATFORM) -D$(GRAPHICS) -Wno-missing-braces -Werror=pointer-arith -fno-strict-aliasing
 
 ifneq ($(RAYLIB_CONFIG_FLAGS), NONE)
     CFLAGS += -DEXTERNAL_CONFIG_FLAGS $(RAYLIB_CONFIG_FLAGS)
@@ -448,6 +448,8 @@ ifeq ($(PLATFORM),PLATFORM_DESKTOP)
         endif
     endif
 endif
+
+CFLAGS += $(CUSTOM_CFLAGS)
 
 # Define include paths for required headers: INCLUDE_PATHS
 # NOTE: Several external required libraries (stb and others)


### PR DESCRIPTION
Since the flag `CUSTOM_CFLAGS` should allow users customize things, in particular the optimization level, I figured it should come after other default ones.

Based on: "If you use multiple -O options, with or without level numbers, the last such option is the one that is effective."

Source: https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html