### PR TITLE
Fix fragPosition using wrong matrix in lighting_instancing.vs

### DIFF
--- a/examples/shaders/resources/shaders/glsl330/lighting_instancing.vs
+++ b/examples/shaders/resources/shaders/glsl330/lighting_instancing.vs
@@ -22,15 +22,12 @@ out vec3 fragNormal;
 
 void main()
 {
-    // Compute MVP for current instance
-    mat4 mvpi = mvp*instanceTransform;
-
     // Send vertex attributes to fragment shader
-    fragPosition = vec3(mvpi*vec4(vertexPosition, 1.0));
+    fragPosition = vec3(instanceTransform*vec4(vertexPosition, 1.0));
     fragTexCoord = vertexTexCoord;
     //fragColor = vertexColor;
     fragNormal = normalize(vec3(matNormal*vec4(vertexNormal, 1.0)));
 
-    // Calculate final vertex position
-    gl_Position = mvpi*vec4(vertexPosition, 1.0);
+    // Calculate final vertex position, note that we multiply mvp by instanceTransform
+    gl_Position = mvp*instanceTransform*vec4(vertexPosition, 1.0);
 }


### PR DESCRIPTION
fragPosition was multiplied by mvp*instanceTransform, but it should only be multiplied by instanceTransform. Compare to lighting.vs, there we only use mvp for gl_Position, but matModel for the fragPosition.