### PR TITLE
[raudio] Add 24 bits samples support for FLAC format

### DIFF
--- a/src/raudio.c
+++ b/src/raudio.c
@@ -1428,7 +1428,9 @@ Music LoadMusicStream(const char *fileName)
         {
             music.ctxType = MUSIC_AUDIO_FLAC;
             music.ctxData = ctxFlac;
-            music.stream = LoadAudioStream(ctxFlac->sampleRate, ctxFlac->bitsPerSample, ctxFlac->channels);
+            int sampleSize = ctxFlac->bitsPerSample;
+            if (ctxFlac->bitsPerSample == 24) sampleSize = 16;   // Forcing conversion to s16 on UpdateMusicStream()
+            music.stream = LoadAudioStream(ctxFlac->sampleRate, sampleSize, ctxFlac->channels);
             music.frameCount = (unsigned int)ctxFlac->totalPCMFrameCount;
             music.looping = true;   // Looping enabled by default
             musicLoaded = true;


### PR DESCRIPTION
If you enable SUPPORT_FILEFORMAT_FLAC some FLAC files don't play correctly. Specifically with sample size 24 bits. Here is a small example to reproduce the bug [flac_bug.zip](https://github.com/user-attachments/files/15798781/flac_bug.zip). The song sounds choppy.

I looked around the source code and found that WAV hardcodes the conversion of 24 bits samples to 16 bits ones. So I applied the same approach to FLAC and it seems to fix the issue. Submitting it as a PR in case it's useful for anybody else.

Please let me know if this is not the right way to do that.