### PR TITLE
Fix rlgl.h standalone/implementation

### DIFF
--- a/src/rlgl.h
+++ b/src/rlgl.h
@@ -4518,7 +4518,7 @@ Matrix rlGetMatrixTransform(void)
 }
 
 // Get internal projection matrix for stereo render (selected eye)
-RLAPI Matrix rlGetMatrixProjectionStereo(int eye)
+Matrix rlGetMatrixProjectionStereo(int eye)
 {
     Matrix mat = rlMatrixIdentity();
 #if defined(GRAPHICS_API_OPENGL_33) || defined(GRAPHICS_API_OPENGL_ES2)
@@ -4528,7 +4528,7 @@ RLAPI Matrix rlGetMatrixProjectionStereo(int eye)
 }
 
 // Get internal view offset matrix for stereo render (selected eye)
-RLAPI Matrix rlGetMatrixViewOffsetStereo(int eye)
+Matrix rlGetMatrixViewOffsetStereo(int eye)
 {
     Matrix mat = rlMatrixIdentity();
 #if defined(GRAPHICS_API_OPENGL_33) || defined(GRAPHICS_API_OPENGL_ES2)


### PR DESCRIPTION
Hello it's my first contribution to this project, i did found this error when compiling with #define RLGL_IMPLEMENTATION:
- The function rlGetMatrixProjectionStereo and rlGetMatrixViewOffsetStereo have RLAPI for the function declaration and cause error when compiling using RLGL_IMPLEMENTATION.