### PR TITLE
[build] zig: run examples from their directories

### DIFF
--- a/examples/build.zig
+++ b/examples/build.zig
@@ -75,6 +75,7 @@ fn add_module(comptime module: []const u8, b: *std.Build, target: std.Build.Reso
         const install_cmd = b.addInstallArtifact(exe, .{});
 
         const run_cmd = b.addRunArtifact(exe);
+        run_cmd.cwd = b.path(module);
         run_cmd.step.dependOn(&install_cmd.step);
 
         const run_step = b.step(name, name);


### PR DESCRIPTION
This way, when we run an example using the `zig build [example_name]` command, it will be able to find the resource folder associated with that section.