### PR TITLE
[rshapes] Optimize CheckCollisionCircles

### DIFF
--- a/src/rshapes.c
+++ b/src/rshapes.c
@@ -2233,9 +2233,10 @@ bool CheckCollisionCircles(Vector2 center1, float radius1, Vector2 center2, floa
     float dx = center2.x - center1.x;      // X distance between centers
     float dy = center2.y - center1.y;      // Y distance between centers
 
-    float distance = sqrtf(dx*dx + dy*dy); // Distance between centers
+    float distanceSquared = dx * dx + dy * dy; // Distance between centers squared
+    float radiusSum = radius1 + radius2;
 
-    if (distance <= (radius1 + radius2)) collision = true;
+    collision = (distanceSquared <= (radiusSum * radiusSum));
 
     return collision;
 }


### PR DESCRIPTION
Avoid unnecessary square root calculation in CheckCollisionCircles

Tested in this branch:
https://github.com/kai-z99/raylib/blob/circlecollisionopt/examples/shapes/shapes_collision_area.c

![ss2](https://github.com/raysan5/raylib/assets/147789796/50d1cfe6-ade5-49bf-97d0-30c870118eaa)
![ss1](https://github.com/raysan5/raylib/assets/147789796/dacb0a1d-7a40-497a-9edb-483d333e09fc)


