### PR TITLE
[rmodels] Read uninitialized values in GenMeshTangents() - fix bounding case

### DIFF
--- a/src/rmodels.c
+++ b/src/rmodels.c
@@ -3436,7 +3436,11 @@ void GenMeshTangents(Mesh *mesh)
     Vector3 *tan1 = (Vector3 *)RL_MALLOC(mesh->vertexCount*sizeof(Vector3));
     Vector3 *tan2 = (Vector3 *)RL_MALLOC(mesh->vertexCount*sizeof(Vector3));
 
-    assert(mesh->vertexCount % 3 == 0);
+    if (mesh->vertexCount % 3 != 0)
+    {
+        TRACELOG(LOG_WARNING, "MESH: vertexCount expected to be a multiple of 3. Expect uninitialized values.");
+    }
+
     for (int i = 0; i <= mesh->vertexCount - 3; i += 3)
     {
         // Get triangle vertices

--- a/src/rmodels.c
+++ b/src/rmodels.c
@@ -3436,7 +3436,8 @@ void GenMeshTangents(Mesh *mesh)
     Vector3 *tan1 = (Vector3 *)RL_MALLOC(mesh->vertexCount*sizeof(Vector3));
     Vector3 *tan2 = (Vector3 *)RL_MALLOC(mesh->vertexCount*sizeof(Vector3));
 
-    for (int i = 0; i < mesh->vertexCount - 3; i += 3)
+    assert(mesh->vertexCount % 3 == 0);
+    for (int i = 0; i <= mesh->vertexCount - 3; i += 3)
     {
         // Get triangle vertices
         Vector3 v1 = { mesh->vertices[(i + 0)*3 + 0], mesh->vertices[(i + 0)*3 + 1], mesh->vertices[(i + 0)*3 + 2] };


### PR DESCRIPTION
reference to issue: https://github.com/raysan5/raylib/issues/3998

Fix the problem where last 3 values are uninitialized in GenMeshTangents(). Also give a warning when this function will generate uninitialized values.

