### PR TITLE
[platform_desktop] fixed issue with GetScreenWidth/GetScreenHeight

### DIFF
--- a/src/platforms/rcore_desktop.c
+++ b/src/platforms/rcore_desktop.c
@@ -666,6 +666,9 @@ void SetWindowMaxSize(int width, int height)
 // Set window dimensions
 void SetWindowSize(int width, int height)
 {
+    CORE.Window.screen.width = width;
+    CORE.Window.screen.height = height;
+
     glfwSetWindowSize(platform.handle, width, height);
 }
 


### PR DESCRIPTION
There is a known issue that people are having where `GetScreenWidth`/`GetScreenHeight` are returning incorrect values. It only uses the one set during initialization and does not work if you change the screen size. I believe this section of code is missing, and I copied the format from `SetWindowMaxSize` directly above it

`PLATFORM_DEKSTOP_SDL` does the same thing: https://github.com/raysan5/raylib/blob/master/src/platforms/rcore_desktop_sdl.c#L661

Note: I don't know about `CORE.Window.render.width`/height or where that one should be added (definitely a separate PR) but it has the same problem and i believe same solution

https://github.com/raysan5/raylib/issues/3763
https://github.com/raysan5/raylib/discussions/3764