### PR TITLE
[rtext] Don't return default font if LoadFontEx fails

### DIFF
--- a/src/rtext.c
+++ b/src/rtext.c
@@ -394,7 +394,6 @@ Font LoadFontEx(const char *fileName, int fontSize, int *codepoints, int codepoi
 
         UnloadFileData(fileData);
     }
-    else font = GetFontDefault();
 
     return font;
 }


### PR DESCRIPTION
It is currently impossible to check a font loaded successfully with IsFontReady because LoadFontEx will always return a valid font.

DrawTextEx has this check:
if (font.texture.id == 0) font = GetFontDefault();  // Security check in case of not valid font

So anyone relying on the default font as a fallback for fonts failing to load should still be covered.