### PR TITLE
add warning log multiple of 4

### DIFF
--- a/src/external/rl_gputex.h
+++ b/src/external/rl_gputex.h
@@ -171,6 +171,10 @@ void *rl_load_dds_from_memory(const unsigned char *file_data, unsigned int file_
 
             *width = header->width;
             *height = header->height;
+
+            if (*width % 4 != 0) LOG("WARNING: IMAGE: DDS file width must be multiple of 4. Image will not display correctly");
+            if (*height % 4 != 0) LOG("WARNING: IMAGE: DDS file height must be multiple of 4. Image will not display correctly");
+
             image_pixel_size = header->width*header->height;
 
             if (header->mipmap_count == 0) *mips = 1;   // Parameter not used


### PR DESCRIPTION
Conversation taken from https://github.com/raysan5/raylib/issues/3962

Tried to match the LOG format from other ones in the file

Tested to make sure the issue was the correct reason
Tested to make sure the warning displays

It's a long-known issue on Unity and such https://forum.unity.com/threads/crunch-compression-width-height-multiple-of-4-issue.538306/