### PR TITLE
Fixed LoadCodepoints returning a freed pointer when codepointCount is zero

### DIFF
--- a/src/rtext.c
+++ b/src/rtext.c
@@ -1892,8 +1892,7 @@ int *LoadCodepoints(const char *text, int *count)
     }
 
     // Re-allocate buffer to the actual number of codepoints loaded
-    int *temp = (int *)RL_REALLOC(codepoints, codepointCount*sizeof(int));
-    if (temp != NULL) codepoints = temp;
+    codepoints = (int *)RL_REALLOC(codepoints, codepointCount*sizeof(int));
 
     *count = codepointCount;
 


### PR DESCRIPTION
When calling `int *LoadCodepoints(const char *text, int *count)`. If the value of `codepointCount` is zero, the function returns a freed pointer.

It now returns null instead.