### PR TITLE
[web] Fix undesired scrollbars on shell files

### DIFF
--- a/src/minshell.html
+++ b/src/minshell.html
@@ -34,8 +34,12 @@
     <link rel="shortcut icon" href="https://www.raylib.com/favicon.ico">
 
     <style>
-        body { margin: 0px; }
-        canvas.emscripten { border: 0px none; background-color: black; }
+        body { 
+          margin: 0px; 
+          overflow: hidden; 
+          background-color: black;
+        }
+        canvas.emscripten { border: 0px none; background-color: black;}
     </style>
     <script type='text/javascript' src="https://cdn.jsdelivr.net/gh/eligrey/FileSaver.js/dist/FileSaver.min.js"> </script>
     <script type='text/javascript'>

--- a/src/shell.html
+++ b/src/shell.html
@@ -141,6 +141,11 @@ jwE50AGjLCVuS8Yt4H7OgZLKK5EKOsLviEWJSL/+0uMi7gLUSBseYwqEbXvSHCec1CJvZPyHCmYQffaB
       }
 
       #output {
+        border-left: 0px none;
+        border-right: 0px none;
+        border-bottom: 0px none;
+        padding-left: 0;
+        padding-right: 0;
         width: 100%;
         height: 140px;
         margin: 0 auto;


### PR DESCRIPTION
While testing my game, I noticed scrollbars were visible when compiling with minshell.html. First, I thought my RenderTexture was not scaling correctly on the web. After some tests, I discovered that a small change to the minshell.html file completely fixes the problem.

The issue has already been described [here](https://github.com/raysan5/raylib/issues/3231#issuecomment-1713026923).

And even the solution has already been described [here](https://github.com/raysan5/raylib/issues/3231#issuecomment-1713043728) but not merged.

I also added `background-color: black` to the body so that areas not rendered (happens when resizing the window or when not scaling the game) are black instead of white, which I assume should be the default.

Then I checked shell.html and found that it always shows a horizontal scrollbar, even with no RenderTexture scaling. This can also be fixed directly on the shell.html file.

So hopefully these changes make the shell files behave as expected.

## Tests

(For minshell.html I used a modified version of core_basic_window that scales using a RenderTexture)

minshell.html before:
![minshell html before](https://github.com/raysan5/raylib/assets/140563347/b8f9f3da-4698-4ae7-b839-78c40ff1b921)

minshell.html after:
![minshell html after](https://github.com/raysan5/raylib/assets/140563347/b932844b-f9ed-4fb5-8bf9-cbd303eea35f)

shell.html before:
![shell html before](https://github.com/raysan5/raylib/assets/140563347/382cf52a-5ecf-4d2f-a134-570384e215ba)

shell.html after:
![shell html after](https://github.com/raysan5/raylib/assets/140563347/bc433eef-03d1-49be-a12f-ba1956ba92a5)