### PR TITLE
Optimization to DrawSphereEx()

### DIFF
--- a/src/rmodels.c
+++ b/src/rmodels.c
@@ -436,16 +436,16 @@ void DrawSphereEx(Vector3 centerPos, float radius, int rings, int slices, Color 
             float *sinring;
             float *cosslice;
             float *sinslice;
-            cosring = (float *)RL_CALLOC(rings + 2, sizeof(float));
-            sinring = (float *)RL_CALLOC(rings + 2, sizeof(float));
-            cosslice = (float *)RL_CALLOC(slices, sizeof(float));
-            sinslice = (float *)RL_CALLOC(slices, sizeof(float));
-            for (int i = 0; i < (rings + 2); i++)
+            cosring = (float *)RL_CALLOC(rings + 2 + 1, sizeof(float));
+            sinring = (float *)RL_CALLOC(rings + 2 + 1, sizeof(float));
+            cosslice = (float *)RL_CALLOC(slices + 1, sizeof(float));
+            sinslice = (float *)RL_CALLOC(slices + 1, sizeof(float));
+            for (int i = 0; i < (rings + 2 + 1); i++)
             {
                 cosring[i] = cosf(DEG2RAD*(270 + (180.0f/(rings + 1))*i)); // Precalculate position on unit circle required for each ring
                 sinring[i] = sinf(DEG2RAD*(270 + (180.0f/(rings + 1))*i));
             }
-            for (int j = 0; j < slices; j++)
+            for (int j = 0; j < slices + 1; j++)
             {
                 cosslice[j] = cosf(DEG2RAD*(360.0f*j/slices)); // Precalculate position on unit circle required for each slice
                 sinslice[j] = sinf(DEG2RAD*(360.0f*j/slices));

--- a/src/rmodels.c
+++ b/src/rmodels.c
@@ -433,24 +433,24 @@ void DrawSphereEx(Vector3 centerPos, float radius, int rings, int slices, Color 
             rlColor4ub(color.r, color.g, color.b, color.a);
 
             float *cosring;
-			float *sinring;
-			float *cosslice;
-			float *sinslice;
-			cosring = (float *)RL_CALLOC(rings + 2, sizeof(float));
-			sinring = (float *)RL_CALLOC(rings + 2, sizeof(float));
-			cosslice = (float *)RL_CALLOC(slices, sizeof(float));
-			sinslice = (float *)RL_CALLOC(slices, sizeof(float));
-			for (int i = 0; i < (rings + 2); i++)
+            float *sinring;
+            float *cosslice;
+            float *sinslice;
+            cosring = (float *)RL_CALLOC(rings + 2, sizeof(float));
+            sinring = (float *)RL_CALLOC(rings + 2, sizeof(float));
+            cosslice = (float *)RL_CALLOC(slices, sizeof(float));
+            sinslice = (float *)RL_CALLOC(slices, sizeof(float));
+            for (int i = 0; i < (rings + 2); i++)
             {
-				cosring[i] = cosf(DEG2RAD*(270 + (180.0f/(rings + 1))*i)); // Precalculate position on unit circle required for each ring
-				sinring[i] = sinf(DEG2RAD*(270 + (180.0f/(rings + 1))*i));
-			}
-			for (int j = 0; j < slices; j++)
-			{
-				cosslice[j] = cosf(DEG2RAD*(360.0f*j/slices)); // Precalculate position on unit circle required for each slice
-				sinslice[j] = sinf(DEG2RAD*(360.0f*j/slices));
-			}
-
+                cosring[i] = cosf(DEG2RAD*(270 + (180.0f/(rings + 1))*i)); // Precalculate position on unit circle required for each ring
+                sinring[i] = sinf(DEG2RAD*(270 + (180.0f/(rings + 1))*i));
+            }
+            for (int j = 0; j < slices; j++)
+            {
+                cosslice[j] = cosf(DEG2RAD*(360.0f*j/slices)); // Precalculate position on unit circle required for each slice
+                sinslice[j] = sinf(DEG2RAD*(360.0f*j/slices));
+            }
+            
             for (int i = 0; i < (rings + 2); i++)
             {
                 for (int j = 0; j < slices; j++)
@@ -458,7 +458,7 @@ void DrawSphereEx(Vector3 centerPos, float radius, int rings, int slices, Color 
                     rlVertex3f(cosring[i]*sinslice[j], sinring[i], cosring[i]*cosslice[j]);
                     rlVertex3f(cosring[i+1]*sinslice[j+1], sinring[i+1], cosring[i+1]*cosslice[j+1]);
                     rlVertex3f(cosring[i+1]*sinslice[j], sinring[i+1], cosring[i+1]*cosslice[j]);
-
+            
                     rlVertex3f(cosring[i]*sinslice[j], sinring[i], cosring[i]*cosslice[j]);
                     rlVertex3f(cosring[i]*sinslice[j+1], sinring[i], cosring[i]*cosslice[j+1]);
                     rlVertex3f(cosring[i+1]*sinslice[j+1], sinring[i+1], cosring[i+1]*cosslice[j+1]);

--- a/src/rmodels.c
+++ b/src/rmodels.c
@@ -432,29 +432,36 @@ void DrawSphereEx(Vector3 centerPos, float radius, int rings, int slices, Color 
         rlBegin(RL_TRIANGLES);
             rlColor4ub(color.r, color.g, color.b, color.a);
 
+            float *cosring;
+			float *sinring;
+			float *cosslice;
+			float *sinslice;
+			cosring = (float *)RL_CALLOC(rings + 2, sizeof(float));
+			sinring = (float *)RL_CALLOC(rings + 2, sizeof(float));
+			cosslice = (float *)RL_CALLOC(slices, sizeof(float));
+			sinslice = (float *)RL_CALLOC(slices, sizeof(float));
+			for (int i = 0; i < (rings + 2); i++)
+            {
+				cosring[i] = cosf(DEG2RAD*(270 + (180.0f/(rings + 1))*i)); // Precalculate position on unit circle required for each ring
+				sinring[i] = sinf(DEG2RAD*(270 + (180.0f/(rings + 1))*i));
+			}
+			for (int j = 0; j < slices; j++)
+			{
+				cosslice[j] = cosf(DEG2RAD*(360.0f*j/slices)); // Precalculate position on unit circle required for each slice
+				sinslice[j] = sinf(DEG2RAD*(360.0f*j/slices));
+			}
+
             for (int i = 0; i < (rings + 2); i++)
             {
                 for (int j = 0; j < slices; j++)
                 {
-                    rlVertex3f(cosf(DEG2RAD*(270 + (180.0f/(rings + 1))*i))*sinf(DEG2RAD*(360.0f*j/slices)),
-                               sinf(DEG2RAD*(270 + (180.0f/(rings + 1))*i)),
-                               cosf(DEG2RAD*(270 + (180.0f/(rings + 1))*i))*cosf(DEG2RAD*(360.0f*j/slices)));
-                    rlVertex3f(cosf(DEG2RAD*(270 + (180.0f/(rings + 1))*(i + 1)))*sinf(DEG2RAD*(360.0f*(j + 1)/slices)),
-                               sinf(DEG2RAD*(270 + (180.0f/(rings + 1))*(i + 1))),
-                               cosf(DEG2RAD*(270 + (180.0f/(rings + 1))*(i + 1)))*cosf(DEG2RAD*(360.0f*(j + 1)/slices)));
-                    rlVertex3f(cosf(DEG2RAD*(270 + (180.0f/(rings + 1))*(i + 1)))*sinf(DEG2RAD*(360.0f*j/slices)),
-                               sinf(DEG2RAD*(270 + (180.0f/(rings + 1))*(i + 1))),
-                               cosf(DEG2RAD*(270 + (180.0f/(rings + 1))*(i + 1)))*cosf(DEG2RAD*(360.0f*j/slices)));
+                    rlVertex3f(cosring[i]*sinslice[j], sinring[i], cosring[i]*cosslice[j]);
+                    rlVertex3f(cosring[i+1]*sinslice[j+1], sinring[i+1], cosring[i+1]*cosslice[j+1]);
+                    rlVertex3f(cosring[i+1]*sinslice[j], sinring[i+1], cosring[i+1]*cosslice[j]);
 
-                    rlVertex3f(cosf(DEG2RAD*(270 + (180.0f/(rings + 1))*i))*sinf(DEG2RAD*(360.0f*j/slices)),
-                               sinf(DEG2RAD*(270 + (180.0f/(rings + 1))*i)),
-                               cosf(DEG2RAD*(270 + (180.0f/(rings + 1))*i))*cosf(DEG2RAD*(360.0f*j/slices)));
-                    rlVertex3f(cosf(DEG2RAD*(270 + (180.0f/(rings + 1))*(i)))*sinf(DEG2RAD*(360.0f*(j + 1)/slices)),
-                               sinf(DEG2RAD*(270 + (180.0f/(rings + 1))*(i))),
-                               cosf(DEG2RAD*(270 + (180.0f/(rings + 1))*(i)))*cosf(DEG2RAD*(360.0f*(j + 1)/slices)));
-                    rlVertex3f(cosf(DEG2RAD*(270 + (180.0f/(rings + 1))*(i + 1)))*sinf(DEG2RAD*(360.0f*(j + 1)/slices)),
-                               sinf(DEG2RAD*(270 + (180.0f/(rings + 1))*(i + 1))),
-                               cosf(DEG2RAD*(270 + (180.0f/(rings + 1))*(i + 1)))*cosf(DEG2RAD*(360.0f*(j + 1)/slices)));
+                    rlVertex3f(cosring[i]*sinslice[j], sinring[i], cosring[i]*cosslice[j]);
+                    rlVertex3f(cosring[i]*sinslice[j+1], sinring[i], cosring[i]*cosslice[j+1]);
+                    rlVertex3f(cosring[i+1]*sinslice[j+1], sinring[i+1], cosring[i+1]*cosslice[j+1]);
                 }
             }
         rlEnd();


### PR DESCRIPTION
Removed unnecessary cos/sin usage in DrawSphereEx(). For a sphere with 16 rings and 16 slices (as with DrawSphere()), 8640 cos/sin calls pre-optimization are reduced to 72.

Benchmark (1000 spheres):
`// gcc main.c -o main.exe -I ./include -L ./lib -lraylib -lgdi32 -lwinmm

#include <stdio.h>
#include <string.h>
#include <stdbool.h>
#include <assert.h>

#include "raylib.h"
#include "raymath.h"

Camera3D camera = {
	.position = (Vector3){-50.0f,50.0f,-50.0f},
	.target = (Vector3){22.5f,22.5f,22.5f},
	.up = (Vector3){0,1,0},
	.fovy = 70.0f,
	.projection = CAMERA_PERSPECTIVE,
};

int main(int argc, char** argv) {
	InitWindow(1280, 720, "DrawSphere benchmark");
	
	int density = 10; // density^3 = number of rendered spheres
	float scale = 50.0f;
	float cameraspeed = 15.0f;
	
	while (!WindowShouldClose()) {
		float deltatime = GetFrameTime();
		printf("%f\n", deltatime);
		
		Vector3 camerafacing = Vector3Normalize(Vector3Subtract(camera.target, camera.position));
		
		if (IsKeyDown(KEY_W)) {
		camera.position = Vector3Add(camera.position, Vector3Scale(camerafacing, cameraspeed*deltatime));
		}
		if (IsKeyDown(KEY_S)) {
			camera.position = Vector3Add(camera.position, Vector3Scale(camerafacing, -cameraspeed*deltatime));
		}
		if (IsKeyDown(KEY_A)) {
			camera.position = Vector3Add(camera.position, Vector3Scale(Vector3Normalize(Vector3CrossProduct(camerafacing, camera.up)), -cameraspeed*deltatime));
		}
		if (IsKeyDown(KEY_D)) {
			camera.position = Vector3Add(camera.position, Vector3Scale(Vector3Normalize(Vector3CrossProduct(camerafacing, camera.up)), cameraspeed*deltatime));
		}
		
		BeginDrawing();
		ClearBackground(RAYWHITE);
			BeginMode3D(camera);
				for (int i = 0; i < density; i++) {
					for (int j = 0; j < density; j++) {
						for (int k = 0; k < density; k++) {
							Color color = (Color){255-i*20, 255-j*20, k*20, 255};
							DrawSphere((Vector3){i*scale/density,j*scale/density,k*scale/density}, 1.0f, color);
						}
					}
				}
			EndMode3D();
			DrawFPS(10,10);
		EndDrawing();
	}
	
	CloseWindow();
	
	return 0;
};`

I compiled raylib (mingw32-make, static, Release) without and with the optimization. On my machine, the above benchmark gives a 75 ms frametime without, 50 ms with the optimization.