### PR TITLE
rmodels.c, `LoadImageFromCgltfImage()` : fix base64 padding support

### DIFF
--- a/src/rmodels.c
+++ b/src/rmodels.c
@@ -4815,9 +4815,9 @@ static Image LoadImageFromCgltfImage(cgltf_image *cgltfImage, const char *texPat
             else
             {
                 int base64Size = (int)strlen(cgltfImage->uri + i + 1);
-                while (cgltfImage->uri[i+base64Size] == '=') base64Size--; // remove optional paddings
-                int numberOfEncodedBits = base64Size * 6 - (base64Size * 6) % 8 ; // ignore extra bits
-                int outSize = numberOfEncodedBits / 8 ; // actual encoded bytes
+                while (cgltfImage->uri[i + base64Size] == '=') base64Size--; // remove optional paddings
+                int numberOfEncodedBits = base64Size*6 - (base64Size*6) % 8 ; // ignore extra bits
+                int outSize = numberOfEncodedBits/8 ; // actual encoded bytes
                 void *data = NULL;
 
                 cgltf_options options = { 0 };

--- a/src/rmodels.c
+++ b/src/rmodels.c
@@ -4815,9 +4815,9 @@ static Image LoadImageFromCgltfImage(cgltf_image *cgltfImage, const char *texPat
             else
             {
                 int base64Size = (int)strlen(cgltfImage->uri + i + 1);
-                while (cgltfImage->uri[i + base64Size] == '=') base64Size--; // remove optional paddings
-                int numberOfEncodedBits = base64Size*6 - (base64Size*6) % 8 ; // ignore extra bits
-                int outSize = numberOfEncodedBits/8 ; // actual encoded bytes
+                while (cgltfImage->uri[i + base64Size] == '=') base64Size--;    // Ignore optional paddings
+                int numberOfEncodedBits = base64Size*6 - (base64Size*6) % 8 ;   // Encoded bits minus extra bits, so it becomes a multiple of 8 bits
+                int outSize = numberOfEncodedBits/8 ;                           // Actual encoded bytes
                 void *data = NULL;
 
                 cgltf_options options = { 0 };

--- a/src/rmodels.c
+++ b/src/rmodels.c
@@ -4815,8 +4815,8 @@ static Image LoadImageFromCgltfImage(cgltf_image *cgltfImage, const char *texPat
             else
             {
                 int base64Size = (int)strlen(cgltfImage->uri + i + 1);
-                while( cgltfImage->uri[ i + base64Size ] == '=' ) base64Size--; // remove optional paddings
-                int numberOfEncodedBits = base64Size * 6 - ( base64Size * 6 ) % 8 ; // ignore extra bits
+                while (cgltfImage->uri[i+base64Size] == '=') base64Size--; // remove optional paddings
+                int numberOfEncodedBits = base64Size * 6 - (base64Size * 6) % 8 ; // ignore extra bits
                 int outSize = numberOfEncodedBits / 8 ; // actual encoded bytes
                 void *data = NULL;
 

--- a/src/rmodels.c
+++ b/src/rmodels.c
@@ -4815,7 +4815,9 @@ static Image LoadImageFromCgltfImage(cgltf_image *cgltfImage, const char *texPat
             else
             {
                 int base64Size = (int)strlen(cgltfImage->uri + i + 1);
-                int outSize = 3*(base64Size/4);         // TODO: Consider padding (-numberOfPaddingCharacters)
+                while( cgltfImage->uri[ i + base64Size ] == '=' ) base64Size--; // remove optional paddings
+                int numberOfEncodedBits = base64Size * 6 - ( base64Size * 6 ) % 8 ; // ignore extra bits
+                int outSize = numberOfEncodedBits / 8 ; // actual encoded bytes
                 void *data = NULL;
 
                 cgltf_options options = { 0 };


### PR DESCRIPTION
This should fix the issue related to `.gltf` embeded textures in base64 format, by ignoring the optional `=` padding and calculating the data size in bytes correctly.

Before this patch, `cgltf_load_buffer_base64()` would fail, and the `.gltf`model would not load embedded textures.

Should not interfere with pending https://github.com/raysan5/raylib/pull/4107