### PR TITLE
[build.zig] pass the real build.zig file

### DIFF
--- a/src/build.zig
+++ b/src/build.zig
@@ -9,9 +9,14 @@ comptime {
 // get the flags a second time when adding raygui
 var raylib_flags_arr: std.ArrayListUnmanaged([]const u8) = .{};
 
+/// we're not inside the actual build script recognized by the
+/// zig build system; use this type where one would otherwise
+/// use `@This()` when inside the actual entrypoint file.
+const BuildScript = @import("../build.zig");
+
 // This has been tested with zig version 0.12.0
 pub fn addRaylib(b: *std.Build, target: std.Build.ResolvedTarget, optimize: std.builtin.OptimizeMode, options: Options) !*std.Build.Step.Compile {
-    const raylib_dep = b.dependencyFromBuildZig(@This(), .{
+    const raylib_dep = b.dependencyFromBuildZig(BuildScript, .{
         .target = target,
         .optimize = optimize,
         .raudio = options.raudio,


### PR DESCRIPTION
Many apologies, #4109 was not thoroughly tested enough to catch this blunder.

`@This()` was naively passed to `dependencyFromBuildZig` while inside a file that is not actually the build file, causing a panic when actually used. Passing `@import("../build.zig")` fixes this.