### PR TITLE
[build.zig] Make emscripten build compatible with Zig 0.13.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,6 +104,7 @@ GRTAGS
 GTAGS
 
 # Zig programming language
+.zig-cache/
 zig-cache/
 zig-out/
 build/

--- a/src/build.zig
+++ b/src/build.zig
@@ -207,15 +207,9 @@ fn compileRaylib(b: *std.Build, target: std.Build.ResolvedTarget, optimize: std.
             const cache_include = std.fs.path.join(b.allocator, &.{ b.sysroot.?, "cache", "sysroot", "include" }) catch @panic("Out of memory");
             defer b.allocator.free(cache_include);
 
-            if (comptime builtin.zig_version.minor > 12) {
-                var dir = std.fs.cwd().openDir(cache_include, std.fs.Dir.OpenDirOptions{ .access_sub_paths = true, .no_follow = true }) catch @panic("No emscripten cache. Generate it!");
-                dir.close();
-                raylib.addIncludePath(b.path(cache_include));
-            } else {
-                var dir = std.fs.openDirAbsolute(cache_include, std.fs.Dir.OpenDirOptions{ .access_sub_paths = true, .no_follow = true }) catch @panic("No emscripten cache. Generate it!");
-                dir.close();
-                raylib.addIncludePath(.{ .path = cache_include });
-            }
+            var dir = std.fs.openDirAbsolute(cache_include, std.fs.Dir.OpenDirOptions{ .access_sub_paths = true, .no_follow = true }) catch @panic("No emscripten cache. Generate it!");
+            dir.close();
+            raylib.addIncludePath(.{ .cwd_relative = cache_include });
         },
         else => {
             @panic("Unsupported OS");


### PR DESCRIPTION
When attempting to export a project for the web with emscripten and Zig 0.13.0, I would get the following error:
```
std.debug.panic("sub_path is expected to be relative to the build root, but was this absolute path: '{s}'. It is best avoid absolute paths, but if you must, it is supported by LazyPath.cwd_relative", .{
                       ^
raylib/src/build.zig:213:45: 0x11dd8dd in compileRaylib (build)
                raylib.addIncludePath(b.path(cache_include));
``` 

The proposed change has shown to work for both Zig versions 0.12.0 and 0.13.0.

Also added `.zig-cache/` to .gitignore, as the name of the cache folder gets changed in 0.13.0