### PR TITLE
[raudio] check audio device state early

### DIFF
--- a/src/raudio.c
+++ b/src/raudio.c
@@ -927,6 +927,12 @@ Sound LoadSoundFromWave(Wave wave)
 
     if (wave.data != NULL)
     {
+        if (ma_device_get_state(&AUDIO.System.device) == ma_device_state_uninitialized)
+        {
+            TRACELOG(LOG_WARNING, "SOUND: Audio device uninitialized");
+            return sound;
+        }
+
         // When using miniaudio we need to do our own mixing
         // To simplify this we need convert the format of each sound to be consistent with
         // the format used to open the playback AUDIO.System.device. We can do this two ways:


### PR DESCRIPTION
I was getting "frame count" warning message, but the real reason was that I forgot to call `InitAudioDevice()`. I feel that having this check early would better describe the problem.