### PR TITLE
[rshapes] Give CheckCollisionPointCircle() its own implementation

### DIFF
--- a/src/rshapes.c
+++ b/src/rshapes.c
@@ -2179,7 +2179,6 @@ bool CheckCollisionPointCircle(Vector2 point, Vector2 center, float radius)
     return collision;
 }
 
-
 // Check if point is inside a triangle defined by three points (p1, p2, p3)
 bool CheckCollisionPointTriangle(Vector2 point, Vector2 p1, Vector2 p2, Vector2 p3)
 {

--- a/src/rshapes.c
+++ b/src/rshapes.c
@@ -2172,10 +2172,13 @@ bool CheckCollisionPointCircle(Vector2 point, Vector2 center, float radius)
 {
     bool collision = false;
 
-    collision = CheckCollisionCircles(point, 0, center, radius);
+    float distanceSquared = (point.x - center.x) * (point.x - center.x) + (point.y - center.y) * (point.y - center.y);
+
+    collision = distanceSquared <= radius * radius;
 
     return collision;
 }
+
 
 // Check if point is inside a triangle defined by three points (p1, p2, p3)
 bool CheckCollisionPointTriangle(Vector2 point, Vector2 p1, Vector2 p2, Vector2 p3)


### PR DESCRIPTION
Originally, CheckCollisionPointCircle() calls CheckCollisionCircles() with a circle radius 0. This change simplifies and gives this function its own implementation without relying on another function call.