### PR TITLE
[rcore][desktop_glfw] Reviewed `ToggleFullScreen()`, `ToggleBorderlessWindowed()` and `FLAG_WINDOW_HIGHDPI` issues

### DIFF
--- a/src/platforms/rcore_desktop_glfw.c
+++ b/src/platforms/rcore_desktop_glfw.c
@@ -1726,8 +1726,8 @@ int InitPlatform(void)
         // We don't use `ToggleFullscreen()` directly because `CORE.Window.fullscreen` is already set to `true`,
         // and `ToggleFullscreen()` would think it is already in fullscreen mode.
 
-        bool result = _ActivateHardwareFullscreenMode(monitorIndex, CORE.Window.screen.width, CORE.Window.screen.height, GLFW_DONT_CARE);
-        if ( result == false )
+        bool _result = _ActivateHardwareFullscreenMode(monitorIndex, CORE.Window.screen.width, CORE.Window.screen.height, GLFW_DONT_CARE);
+        if ( _result == false )
         {
             TRACELOG(LOG_WARNING,"DISPLAY: failed to activate fullscreen mode.");
             // We don't close the window, nor terminate GLFW, nor interrupt the paltform intialization because it is just a warning.

--- a/src/platforms/rcore_desktop_glfw.c
+++ b/src/platforms/rcore_desktop_glfw.c
@@ -213,6 +213,9 @@ void ToggleBorderlessWindowed(void)
                 // Store screen position and size :
                 glfwGetWindowPos(platform.handle, &CORE.Window.previousPosition.x, &CORE.Window.previousPosition.y);
 
+                // GLFW 3.4 may trigger an error if platform like Wayland don't support setting or getting the position of the window
+                glfwGetError(NULL); // So we must clear this error
+
                 // We need to save the "render size" intead of the "screen size"
                 // because we might have FLAG_WINDOW_HIGHDPI enabled.
 
@@ -612,6 +615,9 @@ void SetWindowTitle(const char *title)
 void SetWindowPosition(int x, int y)
 {
     glfwSetWindowPos(platform.handle, x, y);
+
+    // GLFW 3.4 may trigger an error if platform like Wayland don't support setting or getting the position of the window
+    glfwGetError(NULL); // So we must clear this error
 }
 
 // Set monitor for the current window
@@ -649,6 +655,9 @@ void SetWindowMonitor(int monitor)
                 const int y = monitorWorkareaY + (monitorWorkareaHeight/2) - (screenHeight/2);
                 glfwSetWindowPos(platform.handle, x, y);
             }
+
+            // GLFW 3.4 may trigger an error if platform like Wayland don't support setting or getting the position of the window
+            glfwGetError(NULL); // So we must clear this error
         }
     }
     else TRACELOG(LOG_WARNING, "GLFW: Failed to find selected monitor");
@@ -778,6 +787,9 @@ int GetCurrentMonitor(void)
             glfwGetWindowPos(platform.handle, &wcx, &wcy);
             wcx += (int)CORE.Window.screen.width/2;
             wcy += (int)CORE.Window.screen.height/2;
+
+            // GLFW 3.4 may trigger an error if platform like Wayland don't support setting or getting the position of the window
+            glfwGetError(NULL); // So we must clear this error
 
             for (int i = 0; i < monitorCount; i++)
             {
@@ -947,6 +959,9 @@ Vector2 GetWindowPosition(void)
     int y = 0;
 
     glfwGetWindowPos(platform.handle, &x, &y);
+
+    // GLFW 3.4 may trigger an error if platform like Wayland don't support setting or getting the position of the window
+    glfwGetError(NULL); // So we must clear this error
 
     return (Vector2){ (float)x, (float)y };
 }
@@ -1573,6 +1588,9 @@ int InitPlatform(void)
                                                     //          This means that the desktop manager or GLFW might not be
                                                     //          able to fullfil this request and might change the position.
 
+    // GLFW 3.4 may trigger an error if platform like Wayland don't support setting or getting the position of the window
+    glfwGetError(NULL); // So we must clear this error
+
     // As our windowed window is almost ready, we can associate the OpenGL context to it :
 
     glfwMakeContextCurrent(platform.handle); // NOTE : from here, we must `glfwDestroyWindow()` before any `glfwTerminate()`
@@ -2071,6 +2089,9 @@ static bool _ActivateHardwareFullscreenMode(int monitorIndex, int desiredWidth, 
     // Store previous window position and size (in case we exit fullscreen)
     glfwGetWindowPos(platform.handle, &CORE.Window.previousPosition.x, &CORE.Window.previousPosition.y);
 
+    // GLFW 3.4 may trigger an error if platform like Wayland don't support setting or getting the position of the window.
+    glfwGetError(NULL); // So we must clear this error
+
     // If `FLAG_RESCALE_CONTENT` is enabled, we might be rescaling the "screen" when rendering it.
     // So we need to remember the size the "render" viewport, not the size of the screen.
     // And anyway, if `FLAG_RESCALE_CONTENT` is disabled (backward compatibility mode), the hardware fullscreen
@@ -2129,9 +2150,9 @@ static bool _ActivateHardwareFullscreenMode(int monitorIndex, int desiredWidth, 
     glfwSetWindowMonitor(platform.handle, monitor, 0, 0, mode->width, mode->height, mode->refreshRate);
 
     const char *errorMessage;
-    int result = glfwGetError(&errorMessage);
+    int _result = glfwGetError(&errorMessage);
 
-    if (result != GLFW_NO_ERROR)
+    if (_result != GLFW_NO_ERROR)
     {
         TRACELOG(LOG_ERROR, "DISPLAY: GLFW failed to activate requested fullscreen mode.");
 

--- a/src/platforms/rcore_desktop_glfw.c
+++ b/src/platforms/rcore_desktop_glfw.c
@@ -1410,6 +1410,12 @@ int InitPlatform(void)
     // REF: https://github.com/raysan5/raylib/issues/1554
     glfwSetJoystickCallback(NULL);
 
+    // By default, when a fullscreen window looses focus, GLFW iconifies it and restores the desktop monitor resolution.
+    // This default behavior can be emulated on user's side with a simple code : `if ( ! IsWindowFocused() ) MinimizeWindow();`
+    // So we disable this GLFW default behavior and let the user decides by themself the behavior of their program :
+    glfwWindowHint(GLFW_AUTO_ICONIFY, GLFW_FALSE);
+
+
     GLFWmonitor *monitor = NULL;
     if (CORE.Window.fullscreen)
     {
@@ -1484,11 +1490,7 @@ int InitPlatform(void)
         // No-fullscreen window creation
         bool requestWindowedFullscreen = (CORE.Window.screen.height == 0) && (CORE.Window.screen.width == 0);
 
-        // If we are windowed fullscreen, ensures that window does not minimize when focus is lost.
-        // This hinting code will not work if the user already specified the correct monitor dimensions;
-        // at this point we don't know the monitor's dimensions. (Though, how did the user then?)
-        if (requestWindowedFullscreen) glfwWindowHint(GLFW_AUTO_ICONIFY, 0);
-
+       
         // Default to at least one pixel in size, as creation with a zero dimension is not allowed.
         int creationWidth = CORE.Window.screen.width != 0 ? CORE.Window.screen.width : 1;
         int creationHeight = CORE.Window.screen.height != 0 ? CORE.Window.screen.height : 1;

--- a/src/platforms/rcore_desktop_glfw.c
+++ b/src/platforms/rcore_desktop_glfw.c
@@ -220,8 +220,8 @@ void ToggleBorderlessWindowed(void)
                 glfwSetWindowMonitor(platform.handle, monitors[monitor], 0, 0, mode->width, mode->height, mode->refreshRate);
 
                 // Let's not wait for GLFW to call WindowSizeCallback to update these values :
-                CORE.Window.screen.width = mode->width ;
-                CORE.Window.screen.height = mode->height ;
+                CORE.Window.screen.width = mode->width;
+                CORE.Window.screen.height = mode->height;
 
                 // Refocus window
                 glfwFocusWindow(platform.handle);
@@ -231,16 +231,16 @@ void ToggleBorderlessWindowed(void)
             else
             {
                 // Return previous screen size and position
-                int prevPosX = CORE.Window.previousPosition.x ;
-                int prevPosY = CORE.Window.previousPosition.y ;
-                int prevWidth = CORE.Window.previousScreen.width ;
-                int prevHeight = CORE.Window.previousScreen.height ;
+                int prevPosX = CORE.Window.previousPosition.x;
+                int prevPosY = CORE.Window.previousPosition.y;
+                int prevWidth = CORE.Window.previousScreen.width;
+                int prevHeight = CORE.Window.previousScreen.height;
 
-                glfwSetWindowMonitor(platform.handle, NULL, prevPosX , prevPosY, prevWidth, prevHeight, GLFW_DONT_CARE);
+                glfwSetWindowMonitor(platform.handle, NULL, prevPosX, prevPosY, prevWidth, prevHeight, GLFW_DONT_CARE);
 
                 // Let's not wait for GLFW to call WindowSizeCallback to update these values :
-                CORE.Window.screen.width = prevWidth ;
-                CORE.Window.screen.height = prevHeight ;
+                CORE.Window.screen.width = prevWidth;
+                CORE.Window.screen.height = prevHeight;
 
                 // Refocus window
                 glfwFocusWindow(platform.handle);

--- a/src/platforms/rcore_desktop_glfw.c
+++ b/src/platforms/rcore_desktop_glfw.c
@@ -216,22 +216,12 @@ void ToggleBorderlessWindowed(void)
                 if (!wasOnFullscreen) glfwGetWindowPos(platform.handle, &CORE.Window.previousPosition.x, &CORE.Window.previousPosition.y);
                 CORE.Window.previousScreen = CORE.Window.screen;
 
-                // Set undecorated and topmost modes and flags
-                glfwSetWindowAttrib(platform.handle, GLFW_DECORATED, GLFW_FALSE);
-                CORE.Window.flags |= FLAG_WINDOW_UNDECORATED;
-                glfwSetWindowAttrib(platform.handle, GLFW_FLOATING, GLFW_TRUE);
-                CORE.Window.flags |= FLAG_WINDOW_TOPMOST;
+                // Ask fullscreen window :
+                glfwSetWindowMonitor(platform.handle, monitors[monitor], 0, 0, mode->width, mode->height, mode->refreshRate);
 
-                // Get monitor position and size
-                int monitorPosX = 0;
-                int monitorPosY = 0;
-                glfwGetMonitorPos(monitors[monitor], &monitorPosX, &monitorPosY);
-                const int monitorWidth = mode->width;
-                const int monitorHeight = mode->height;
-
-                // Set screen position and size
-                glfwSetWindowPos(platform.handle, monitorPosX, monitorPosY);
-                glfwSetWindowSize(platform.handle, monitorWidth, monitorHeight);
+                // Let's not wait for GLFW to call WindowSizeCallback to update these values :
+                CORE.Window.screen.width = mode->width ;
+                CORE.Window.screen.height = mode->height ;
 
                 // Refocus window
                 glfwFocusWindow(platform.handle);
@@ -240,16 +230,17 @@ void ToggleBorderlessWindowed(void)
             }
             else
             {
-                // Remove topmost and undecorated modes and flags
-                glfwSetWindowAttrib(platform.handle, GLFW_FLOATING, GLFW_FALSE);
-                CORE.Window.flags &= ~FLAG_WINDOW_TOPMOST;
-                glfwSetWindowAttrib(platform.handle, GLFW_DECORATED, GLFW_TRUE);
-                CORE.Window.flags &= ~FLAG_WINDOW_UNDECORATED;
-
                 // Return previous screen size and position
-                // NOTE: The order matters here, it must set size first, then set position, otherwise the screen will be positioned incorrectly
-                glfwSetWindowSize(platform.handle,  CORE.Window.previousScreen.width, CORE.Window.previousScreen.height);
-                glfwSetWindowPos(platform.handle, CORE.Window.previousPosition.x, CORE.Window.previousPosition.y);
+                int prevPosX = CORE.Window.previousPosition.x ;
+                int prevPosY = CORE.Window.previousPosition.y ;
+                int prevWidth = CORE.Window.previousScreen.width ;
+                int prevHeight = CORE.Window.previousScreen.height ;
+
+                glfwSetWindowMonitor(platform.handle, NULL, prevPosX , prevPosY, prevWidth, prevHeight, GLFW_DONT_CARE);
+
+                // Let's not wait for GLFW to call WindowSizeCallback to update these values :
+                CORE.Window.screen.width = prevWidth ;
+                CORE.Window.screen.height = prevHeight ;
 
                 // Refocus window
                 glfwFocusWindow(platform.handle);

--- a/src/platforms/rcore_desktop_glfw.c
+++ b/src/platforms/rcore_desktop_glfw.c
@@ -778,6 +778,8 @@ int GetCurrentMonitor(void)
             // this is probably an overengineered solution for a very side case
             // trying to match SDL behaviour
 
+            // NOTE : this won't work with Wayland because it does not allow to know the window position
+
             int closestDist = 0x7FFFFFFF;
 
             // Window center position
@@ -1515,19 +1517,14 @@ int InitPlatform(void)
 
     if (invalidWindowSizeRequested) 
     {
-        // If the user requested an invalid screen resolution
-        // it may be because they did not know the size of the display. 
-        // Also, they may provide only an invalid width or height. 
-        // For instance, `InitWindow(800,0)` could be interpreted as a desire to automatically set the
-        // height of the window the same as the height of the display.
-        // So we fill the blanks with the now known display dimensions :
+        // For backward compatibility purpose, an invalid window size is interpreted as a requestBorderlessWindowed.
+        // The `FLAG_BORDERLESS_WINDOWED_MODE` flag will be set when `ToggleBorderlessWindowed()` will be called later
+        // once we're done setting up the window.
+        // For now, we must give an arbitrary valid size to this window.
+        // This is the size the window will have if restored from fullscreen mode.
 
-        // TODO : NOTE the expected bahavior should be discussed an formalized with the community or the maintainer, 
-        // because it could also be interpreted as the desire to set a windowed window with a height or width same as
-        // the available desktop area.
-
-        if (CORE.Window.screen.width <= 0) CORE.Window.screen.width = mode->width;
-        if (CORE.Window.screen.height <= 0) CORE.Window.screen.height = mode->height;
+        CORE.Window.screen.width = mode->width*3/4;
+        CORE.Window.screen.height = mode->height*3/4;
     }
 
     // If the user did not requestWindowHDPI, the size of the frameBuffer is the same as the requested screen size :

--- a/src/platforms/rcore_desktop_glfw.c
+++ b/src/platforms/rcore_desktop_glfw.c
@@ -144,6 +144,15 @@ bool WindowShouldClose(void)
 // Toggle fullscreen mode
 void ToggleFullscreen(void)
 {
+    if (IsWindowState(FLAG_BORDERLESS_WINDOWED_MODE))
+    {
+        // We can't go straighforward from one fullscreen mode to an other
+        // there needs to be at least one loop between them
+        // so we just toggle the currently active fullscreen mode and leave.
+        ToggleBorderlessWindowed();
+        return;
+    }
+
     if (!CORE.Window.fullscreen)
     {
         // Store previous window position (in case we exit fullscreen)
@@ -201,13 +210,13 @@ void ToggleFullscreen(void)
 // Toggle borderless windowed mode
 void ToggleBorderlessWindowed(void)
 {
-    // Leave fullscreen before attempting to set borderless windowed mode and get screen position from it
-    bool wasOnFullscreen = false;
     if (CORE.Window.fullscreen)
     {
-        CORE.Window.previousPosition = CORE.Window.position;
+        // We can't go straighforward from one fullscreen mode to an other
+        // there needs to be at least one loop between them
+        // so we just toggle the currently active fullscreen mode and leave.
         ToggleFullscreen();
-        wasOnFullscreen = true;
+        return;
     }
 
     const int monitor = GetCurrentMonitor();
@@ -222,9 +231,8 @@ void ToggleBorderlessWindowed(void)
         {
             if (!IsWindowState(FLAG_BORDERLESS_WINDOWED_MODE))
             {
-                // Store screen position and size
-                // NOTE: If it was on fullscreen, screen position was already stored, so skip setting it here
-                if (!wasOnFullscreen) glfwGetWindowPos(platform.handle, &CORE.Window.previousPosition.x, &CORE.Window.previousPosition.y);
+                // Store screen position and size :
+                glfwGetWindowPos(platform.handle, &CORE.Window.previousPosition.x, &CORE.Window.previousPosition.y);
 
                 // We need to save the "render size" intead of the "screen size"
                 // because we might have FLAG_WINDOW_HIGHDPI enabled.

--- a/src/platforms/rcore_desktop_glfw.c
+++ b/src/platforms/rcore_desktop_glfw.c
@@ -1410,7 +1410,7 @@ int InitPlatform(void)
     // REF: https://github.com/raysan5/raylib/issues/1554
     glfwSetJoystickCallback(NULL);
 
-    // By default, when a fullscreen window looses focus, GLFW iconifies it and restores the desktop monitor resolution.
+    // By default, when a fullscreen window loses focus, GLFW iconifies it and restores the desktop monitor resolution.
     // This default behavior can be emulated on user's side with a simple code : `if ( ! IsWindowFocused() ) MinimizeWindow();`
     // So we disable this GLFW default behavior and let the user decides by themself the behavior of their program :
     glfwWindowHint(GLFW_AUTO_ICONIFY, GLFW_FALSE);
@@ -1560,15 +1560,18 @@ int InitPlatform(void)
         {
             // NOTE: On APPLE and Wayland platforms system should manage window/input scaling and also framebuffer scaling.
             // Framebuffer scaling should be activated with: glfwWindowHint(GLFW_SCALE_FRAMEBUFFER, GLFW_TRUE);
-    #if !defined(__APPLE__) && !defined(_GLFW_WAYLAND)
-            glfwGetFramebufferSize(platform.handle, &fbWidth, &fbHeight);
+    #if !defined(__APPLE__) 
+            if ( glfwGetPlatform() != GLFW_PLATFORM_WAYLAND )
+            {
+                glfwGetFramebufferSize(platform.handle, &fbWidth, &fbHeight);
 
-            // Screen scaling matrix is required in case desired screen area is different from display area
-            CORE.Window.screenScale = MatrixScale((float)fbWidth/CORE.Window.screen.width, (float)fbHeight/CORE.Window.screen.height, 1.0f);
+                // Screen scaling matrix is required in case desired screen area is different from display area
+                CORE.Window.screenScale = MatrixScale((float)fbWidth/CORE.Window.screen.width, (float)fbHeight/CORE.Window.screen.height, 1.0f);
 
-            // Mouse input scaling for the new screen size
-            // TODO FIXME does Wayland requires mouse scaling too ?
-            SetMouseScale((float)CORE.Window.screen.width/fbWidth, (float)CORE.Window.screen.height/fbHeight);
+                // Mouse input scaling for the new screen size
+                // TODO FIXME does Wayland requires mouse scaling too ?
+                SetMouseScale((float)CORE.Window.screen.width/fbWidth, (float)CORE.Window.screen.height/fbHeight);
+            }
     #endif
         }
 
@@ -1705,11 +1708,11 @@ static void WindowSizeCallback(GLFWwindow *window, int width, int height)
     CORE.Window.currentFbo.height = height;
     CORE.Window.resizedLastFrame = true;
 
-#if defined(__APPLE__) || defined(_GLFW_WAYLAND)
+#if defined(__APPLE__) 
     CORE.Window.screen.width = width;
     CORE.Window.screen.height = height;
 #else
-    if ((CORE.Window.flags & FLAG_WINDOW_HIGHDPI) > 0)
+    if ( ((CORE.Window.flags & FLAG_WINDOW_HIGHDPI) > 0 ) && (glfwGetPlatform() != GLFW_PLATFORM_WAYLAND) )
     {
         Vector2 windowScaleDPI = GetWindowScaleDPI();
 

--- a/src/platforms/rcore_desktop_glfw.c
+++ b/src/platforms/rcore_desktop_glfw.c
@@ -1024,8 +1024,23 @@ Vector2 GetWindowPosition(void)
 // Get window scale DPI factor for current monitor
 Vector2 GetWindowScaleDPI(void)
 {
-    Vector2 scale = {0};
-    glfwGetWindowContentScale(platform.handle, &scale.x, &scale.y);
+    Vector2 scale = {1.0, 1.0};
+
+    // On platforms, like Wayland, the window and its frameBuffer are automatically rescaled
+    // according to the current DPI scale of the display on which the window is visible, 
+    // `glfwGetWindowContentScale()` will always return `{1.0, 1.0}`, because there is no need
+    // for the applciation to apply any DPI rescaling by itself.
+    // So, to keep consistency among all supported platforms, if `FLAG_WINDOW_HIGHDPI` is enabled
+    // we ignore the value returned by `glfwGetWindowContentScale()` and return `{1.0, 1.0}` instead.
+    // Same if we are in an hardware/exclusive fullscreen mode.
+
+    if (!IsWindowState(FLAG_WINDOW_HIGHDPI) && !CORE.Window.fullscreen) 
+    {
+        // We only need to know the DPI scale of the display if we want to rescale our UI and texts manually by code.
+
+        glfwGetWindowContentScale(platform.handle, &scale.x, &scale.y);
+    }
+
     return scale;
 }
 

--- a/src/platforms/rcore_desktop_glfw.c
+++ b/src/platforms/rcore_desktop_glfw.c
@@ -190,7 +190,14 @@ void ToggleFullscreen(void)
             CORE.Window.previousScreen.width = renderingWidth;
             CORE.Window.previousScreen.height = renderingHeight;
 
+            // GLFW will pick the best monitor resolution it can find for the size of rendering :
+            // TODO pick the resolution ourself and try to rescale and center with black borders
             glfwSetWindowMonitor(platform.handle, monitor, 0, 0, renderingWidth, renderingHeight, GLFW_DONT_CARE);
+
+            // GLFW will call WindowSizeCallback too late after EndDrawing()
+            // Let's call it already so the user can access updated values without further delay :
+            const GLFWvidmode *mode = glfwGetVideoMode( monitor	);
+            WindowSizeCallback(platform.handle, mode->width, mode->height);
         }
 
     }
@@ -199,7 +206,12 @@ void ToggleFullscreen(void)
         CORE.Window.fullscreen = false;
         CORE.Window.flags &= ~FLAG_FULLSCREEN_MODE;
 
+        // Ask GLFW to restore the window and the previous monitor resolution :
         glfwSetWindowMonitor(platform.handle, NULL, CORE.Window.previousPosition.x, CORE.Window.previousPosition.y, CORE.Window.previousScreen.width, CORE.Window.previousScreen.height, GLFW_DONT_CARE);
+
+        // GLFW will call WindowSizeCallback too late after EndDrawing()
+        // Let's call it already so the user can access updated values without further delay :
+        WindowSizeCallback(platform.handle, CORE.Window.previousScreen.width, CORE.Window.previousScreen.height);
     }
 
     // Try to enable GPU V-Sync, so frames are limited to screen refresh rate (60Hz -> 60 FPS)
@@ -246,9 +258,9 @@ void ToggleBorderlessWindowed(void)
                 // Ask fullscreen window :
                 glfwSetWindowMonitor(platform.handle, monitors[monitor], 0, 0, mode->width, mode->height, mode->refreshRate);
 
-                // Let's not wait for GLFW to call WindowSizeCallback to update these values :
-                CORE.Window.screen.width = mode->width;
-                CORE.Window.screen.height = mode->height;
+                // GLFW will call WindowSizeCallback too late after EndDrawing()
+                // Let's call it already so the user can access updated values without further delay :
+                WindowSizeCallback(platform.handle, mode->width, mode->height);
 
                 // Refocus window
                 glfwFocusWindow(platform.handle);
@@ -265,9 +277,9 @@ void ToggleBorderlessWindowed(void)
 
                 glfwSetWindowMonitor(platform.handle, NULL, prevPosX, prevPosY, prevWidth, prevHeight, GLFW_DONT_CARE);
 
-                // Let's not wait for GLFW to call WindowSizeCallback to update these values :
-                CORE.Window.screen.width = prevWidth;
-                CORE.Window.screen.height = prevHeight;
+                // GLFW will call WindowSizeCallback too late after EndDrawing()
+                // Let's call it already so the user can access updated values without further delay :
+                WindowSizeCallback(platform.handle, prevWidth, prevHeight);
 
                 // Refocus window
                 glfwFocusWindow(platform.handle);

--- a/src/platforms/rcore_desktop_glfw.c
+++ b/src/platforms/rcore_desktop_glfw.c
@@ -1339,7 +1339,11 @@ int InitPlatform(void)
         glfwWindowHint(GLFW_SCALE_TO_MONITOR, GLFW_TRUE); // Only has effect on Windows and X11
         glfwWindowHint(GLFW_SCALE_FRAMEBUFFER, GLFW_TRUE); // Only has effect on MacOS and Wayland
     }
-    else glfwWindowHint(GLFW_SCALE_TO_MONITOR, GLFW_FALSE);
+    else 
+    {
+        glfwWindowHint(GLFW_SCALE_TO_MONITOR, GLFW_FALSE);
+        glfwWindowHint(GLFW_SCALE_FRAMEBUFFER, GLFW_FALSE);
+    }
 
     // Mouse passthrough
     if ((CORE.Window.flags & FLAG_WINDOW_MOUSE_PASSTHROUGH) > 0) glfwWindowHint(GLFW_MOUSE_PASSTHROUGH, GLFW_TRUE);

--- a/src/platforms/rcore_desktop_glfw.c
+++ b/src/platforms/rcore_desktop_glfw.c
@@ -628,7 +628,7 @@ void SetWindowMonitor(int monitor)
 
     if ((monitor >= 0) && (monitor < monitorCount))
     {
-        if (CORE.Window.fullscreen)
+        if ((CORE.Window.fullscreen) || IsWindowState(FLAG_BORDERLESS_WINDOWED_MODE))
         {
             TRACELOG(LOG_INFO, "GLFW: Selected fullscreen monitor: [%i] %s", monitor, glfwGetMonitorName(monitors[monitor]));
 

--- a/src/platforms/rcore_desktop_glfw.c
+++ b/src/platforms/rcore_desktop_glfw.c
@@ -130,7 +130,10 @@ static void _SetupFramebuffer(int frameBufferWidth, int frameBufferHeight, bool 
 static bool _ActivateHardwareFullscreenMode(int monitorIndex, int desiredWidth, int desiredHeight, int desiredRefreshRate); 
 static void _DeactivateHardwareFullscreenMode();
 
-static void _SetupMouseScaleAndOffset(); // Update mouse scale and offset according to current viewport
+static void _SetupPlatformMouseScaleAndOffset(); // Update mouse scale and offset according to current viewport
+
+static void _SetPlatformMouseOffset(int offsetX, int offsetY);
+static void _SetPlatformMouseScale(float scaleX, float scaleY);
 
 //----------------------------------------------------------------------------------
 // Module Functions Declaration
@@ -1900,12 +1903,22 @@ static void WindowSizeCallback(GLFWwindow *window, int frameBufferWidth, int fra
     // We have to rescale and offset the mouse coordinate system 
     // so that it always matches the offset and scale of the "screen" surface
 
-    _SetupMouseScaleAndOffset();
+    _SetupPlatformMouseScaleAndOffset();
 
     // NOTE: Postprocessing texture is not scaled to new size
 }
 
-static void _SetupMouseScaleAndOffset()
+static void _SetPlatformMouseOffset(int offsetX, int offsetY)
+{
+    CORE.Input.Mouse.platformOffset = (Vector2){ (float)offsetX, (float)offsetY };
+}
+
+static void _SetPlatformMouseScale(float scaleX, float scaleY)
+{
+    CORE.Input.Mouse.platformScale = (Vector2){ scaleX, scaleY };
+}
+
+static void _SetupPlatformMouseScaleAndOffset()
 {
     // Depending the current viewport and setup, we have to rescale and offset the mouse coordinate system
     // returned by Raylib's mouse API functions.
@@ -1913,24 +1926,25 @@ static void _SetupMouseScaleAndOffset()
     // TODO : test __APPLE__ special case, @SoloByte mission
  
 #if defined(__APPLE__)
-    SetMouseScale(1.0, 1.0);
+    _SetPlatformMouseScale(1.0, 1.0); //!\ We don't use the user's side SetMouseScale()
 #else
     if (IsWindowState(FLAG_RESCALE_CONTENT) || (glfwGetPlatform() != GLFW_PLATFORM_WAYLAND))
     {
         float mouseScaleX = (float)CORE.Window.screen.width/(float)CORE.Window.render.width;
         float mouseScaleY = (float)CORE.Window.screen.height/(float)CORE.Window.render.height;
-        SetMouseScale(mouseScaleX, mouseScaleY);
+        
+        _SetPlatformMouseScale(mouseScaleX, mouseScaleY); //!\ We don't use the user's side SetMouseScale()
     }
     else
     {
-        SetMouseScale(1.0, 1.0);
+        _SetPlatformMouseScale(1.0, 1.0); //!\ We don't use the user's side SetMouseScale()
     }
 #endif
 
     float mouseOffsetX = -0.5f*CORE.Window.renderOffset.x;
     float mouseOffsetY = -0.5f*CORE.Window.renderOffset.y;
 
-    SetMouseOffset( mouseOffsetX , mouseOffsetY );
+    _SetPlatformMouseOffset(mouseOffsetX, mouseOffsetY); //!\ We don't use the user's side SetMouseOffset()
 }
 
 

--- a/src/platforms/rcore_desktop_glfw.c
+++ b/src/platforms/rcore_desktop_glfw.c
@@ -1160,9 +1160,9 @@ void SetMousePosition(int x, int y)
 
     // Update the metrics :
 
-    CORE.Input.Mouse.currentPosition = (Vector2){ mouseX, mouseY };
     CORE.Input.Mouse.previousPosition = CORE.Input.Mouse.currentPosition;
-
+    CORE.Input.Mouse.currentPosition = (Vector2){ mouseX, mouseY };
+  
     // And we're done :
 
     glfwSetCursorPos(platform.handle, mouseX, mouseY);

--- a/src/platforms/rcore_desktop_glfw.c
+++ b/src/platforms/rcore_desktop_glfw.c
@@ -1026,17 +1026,18 @@ Vector2 GetWindowScaleDPI(void)
 {
     Vector2 scale = {1.0, 1.0};
 
-    // On platforms, like Wayland, the window and its frameBuffer are automatically rescaled
+    // On platforms like Wayland, the window and its frameBuffer are automatically rescaled
     // according to the current DPI scale of the display on which the window is visible, 
     // `glfwGetWindowContentScale()` will always return `{1.0, 1.0}`, because there is no need
-    // for the applciation to apply any DPI rescaling by itself.
-    // So, to keep consistency among all supported platforms, if `FLAG_WINDOW_HIGHDPI` is enabled
+    // for the application to apply any DPI rescaling by itself.
+    // So, to keep consistency between all supported platforms, if `FLAG_WINDOW_HIGHDPI` is enabled
     // we ignore the value returned by `glfwGetWindowContentScale()` and return `{1.0, 1.0}` instead.
     // Same if we are in an hardware/exclusive fullscreen mode.
 
     if (!IsWindowState(FLAG_WINDOW_HIGHDPI) && !CORE.Window.fullscreen) 
     {
-        // We only need to know the DPI scale of the display if we want to rescale our UI and texts manually by code.
+        // We only need to know the DPI scale of the display if we have to rescale our UI and texts manually by code.
+        // TODO @SoloByte __APPLE__ test mission
 
         glfwGetWindowContentScale(platform.handle, &scale.x, &scale.y);
     }

--- a/src/platforms/rcore_desktop_glfw.c
+++ b/src/platforms/rcore_desktop_glfw.c
@@ -170,7 +170,7 @@ void ToggleFullscreen(void)
             CORE.Window.fullscreen = true;
             CORE.Window.flags |= FLAG_FULLSCREEN_MODE;
 
-            // We need to save the "render size" intead of the "screen size"
+            // We need to save the "size at which the content of the window is rendered"
             // because we might have FLAG_WINDOW_HIGHDPI enabled.
 
             int renderWidth  = GetRenderWidth();

--- a/src/platforms/rcore_desktop_glfw.c
+++ b/src/platforms/rcore_desktop_glfw.c
@@ -147,7 +147,7 @@ void ToggleFullscreen(void)
     if (!CORE.Window.fullscreen)
     {
         // Store previous window position (in case we exit fullscreen)
-        glfwGetWindowPos(platform.handle, &CORE.Window.position.x, &CORE.Window.position.y);
+        glfwGetWindowPos(platform.handle, &CORE.Window.previousPosition.x, &CORE.Window.previousPosition.y);
 
         int monitorCount = 0;
         int monitorIndex = GetCurrentMonitor();
@@ -156,6 +156,11 @@ void ToggleFullscreen(void)
         // Use current monitor, so we correctly get the display the window is on
         GLFWmonitor *monitor = (monitorIndex < monitorCount)? monitors[monitorIndex] : NULL;
 
+        // The size at which the content of the window shall be rendered 
+        // taking into account the DPI scaling if FLAG_WINDOW_HIGHDPI is set :
+        int renderingWidth  = GetRenderWidth();
+        int renderingHeight = GetRenderHeight();
+
         if (monitor == NULL)
         {
             TRACELOG(LOG_WARNING, "GLFW: Failed to get monitor");
@@ -163,7 +168,7 @@ void ToggleFullscreen(void)
             CORE.Window.fullscreen = false;
             CORE.Window.flags &= ~FLAG_FULLSCREEN_MODE;
 
-            glfwSetWindowMonitor(platform.handle, NULL, 0, 0, CORE.Window.screen.width, CORE.Window.screen.height, GLFW_DONT_CARE);
+            // There is nothing more to do. Just leave the window where it is.
         }
         else
         {
@@ -173,13 +178,10 @@ void ToggleFullscreen(void)
             // We need to save the "size at which the content of the window is rendered"
             // because we might have FLAG_WINDOW_HIGHDPI enabled.
 
-            int renderWidth  = GetRenderWidth();
-            int renderHeight = GetRenderHeight();
+            CORE.Window.previousScreen.width = renderingWidth;
+            CORE.Window.previousScreen.height = renderingHeight;
 
-            CORE.Window.previousScreen.width = renderWidth;
-            CORE.Window.previousScreen.height =  renderHeight;
-
-            glfwSetWindowMonitor(platform.handle, monitor, 0, 0, renderWidth, renderHeight, GLFW_DONT_CARE);
+            glfwSetWindowMonitor(platform.handle, monitor, 0, 0, renderingWidth, renderingHeight, GLFW_DONT_CARE);
         }
 
     }
@@ -188,7 +190,7 @@ void ToggleFullscreen(void)
         CORE.Window.fullscreen = false;
         CORE.Window.flags &= ~FLAG_FULLSCREEN_MODE;
 
-        glfwSetWindowMonitor(platform.handle, NULL, CORE.Window.position.x, CORE.Window.position.y, CORE.Window.previousScreen.width, CORE.Window.previousScreen.height, GLFW_DONT_CARE);
+        glfwSetWindowMonitor(platform.handle, NULL, CORE.Window.previousPosition.x, CORE.Window.previousPosition.y, CORE.Window.previousScreen.width, CORE.Window.previousScreen.height, GLFW_DONT_CARE);
     }
 
     // Try to enable GPU V-Sync, so frames are limited to screen refresh rate (60Hz -> 60 FPS)

--- a/src/platforms/rcore_desktop_glfw.c
+++ b/src/platforms/rcore_desktop_glfw.c
@@ -418,6 +418,14 @@ void SetWindowState(unsigned int flags)
         glfwGetFramebufferSize(platform.handle, &fbWidth, &fbHeight);
         WindowSizeCallback(platform.handle, fbWidth, fbHeight);
     }
+
+    // State change: FLAG_TEXT_LINEAR_FILTER
+    if (((CORE.Window.flags & FLAG_TEXT_LINEAR_FILTER) != (flags & FLAG_TEXT_LINEAR_FILTER)) && ((flags & FLAG_TEXT_LINEAR_FILTER) > 0))
+    {
+        CORE.Window.flags |= FLAG_TEXT_LINEAR_FILTER;
+        rlTextureParameters(GetFontDefault().texture.id, RL_TEXTURE_MIN_FILTER, RL_TEXTURE_FILTER_LINEAR);
+        rlTextureParameters(GetFontDefault().texture.id, RL_TEXTURE_MAG_FILTER, RL_TEXTURE_FILTER_LINEAR);
+    }
 }
 
 // Clear window configuration state flags
@@ -540,6 +548,14 @@ void ClearWindowState(unsigned int flags)
         int fbHeight;
         glfwGetFramebufferSize(platform.handle, &fbWidth, &fbHeight);
         WindowSizeCallback(platform.handle, fbWidth, fbHeight);
+    }
+
+    // State change: FLAG_TEXT_LINEAR_FILTER
+    if (((CORE.Window.flags & FLAG_TEXT_LINEAR_FILTER) > 0) && ((flags & FLAG_TEXT_LINEAR_FILTER) > 0))
+    {
+        CORE.Window.flags &= ~FLAG_TEXT_LINEAR_FILTER;
+        rlTextureParameters(GetFontDefault().texture.id, RL_TEXTURE_MIN_FILTER, RL_TEXTURE_FILTER_NEAREST);
+        rlTextureParameters(GetFontDefault().texture.id, RL_TEXTURE_MAG_FILTER, RL_TEXTURE_FILTER_NEAREST);
     }
 }
 

--- a/src/platforms/rcore_desktop_glfw.c
+++ b/src/platforms/rcore_desktop_glfw.c
@@ -172,7 +172,7 @@ void ToggleFullscreen(void)
 
         if (monitor == NULL)
         {
-            TRACELOG(LOG_WARNING, "GLFW: Failed to get monitor");
+            TRACELOG(LOG_WARNING, "GLFW: ToggleFullscreen() failed to get monitor");
 
             CORE.Window.fullscreen = false;
             CORE.Window.flags &= ~FLAG_FULLSCREEN_MODE;
@@ -213,6 +213,9 @@ void ToggleFullscreen(void)
         // Let's call it already so the user can access updated values without further delay :
         WindowSizeCallback(platform.handle, CORE.Window.previousScreen.width, CORE.Window.previousScreen.height);
     }
+
+    // Refocus window
+    glfwFocusWindow(platform.handle);
 
     // Try to enable GPU V-Sync, so frames are limited to screen refresh rate (60Hz -> 60 FPS)
     // NOTE: V-Sync can be enabled by graphic driver configuration

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -531,22 +531,25 @@ typedef struct AutomationEventList {
 // NOTE: Every bit registers one state (use it with bit masks)
 // By default all flags are set to 0
 typedef enum {
-    FLAG_VSYNC_HINT         = 0x00000040,   // Set to try enabling V-Sync on GPU
-    FLAG_FULLSCREEN_MODE    = 0x00000002,   // Set to run program in fullscreen
-    FLAG_WINDOW_RESIZABLE   = 0x00000004,   // Set to allow resizable window
-    FLAG_WINDOW_UNDECORATED = 0x00000008,   // Set to disable window decoration (frame and buttons)
-    FLAG_WINDOW_HIDDEN      = 0x00000080,   // Set to hide window
-    FLAG_WINDOW_MINIMIZED   = 0x00000200,   // Set to minimize window (iconify)
-    FLAG_WINDOW_MAXIMIZED   = 0x00000400,   // Set to maximize window (expanded to monitor)
-    FLAG_WINDOW_UNFOCUSED   = 0x00000800,   // Set to window non focused
-    FLAG_WINDOW_TOPMOST     = 0x00001000,   // Set to window always on top
-    FLAG_WINDOW_ALWAYS_RUN  = 0x00000100,   // Set to allow windows running while minimized
-    FLAG_WINDOW_TRANSPARENT = 0x00000010,   // Set to allow transparent framebuffer
-    FLAG_WINDOW_HIGHDPI     = 0x00002000,   // Set to support HighDPI
-    FLAG_WINDOW_MOUSE_PASSTHROUGH = 0x00004000, // Set to support mouse passthrough, only supported when FLAG_WINDOW_UNDECORATED
-    FLAG_BORDERLESS_WINDOWED_MODE = 0x00008000, // Set to run program in borderless windowed mode
-    FLAG_MSAA_4X_HINT       = 0x00000020,   // Set to try enabling MSAA 4X
-    FLAG_INTERLACED_HINT    = 0x00010000    // Set to try enabling interlaced video format (for V3D)
+    FLAG_VSYNC_HINT               = 0x00000040,   // Set to try enabling V-Sync on GPU
+    FLAG_FULLSCREEN_MODE          = 0x00000002,   // Set to run program in fullscreen
+    FLAG_WINDOW_RESIZABLE         = 0x00000004,   // Set to allow resizable window
+    FLAG_WINDOW_UNDECORATED       = 0x00000008,   // Set to disable window decoration (frame and buttons)
+    FLAG_WINDOW_HIDDEN            = 0x00000080,   // Set to hide window
+    FLAG_WINDOW_MINIMIZED         = 0x00000200,   // Set to minimize window (iconify)
+    FLAG_WINDOW_MAXIMIZED         = 0x00000400,   // Set to maximize window (expanded to monitor)
+    FLAG_WINDOW_UNFOCUSED         = 0x00000800,   // Set to window non focused
+    FLAG_WINDOW_TOPMOST           = 0x00001000,   // Set to window always on top
+    FLAG_WINDOW_ALWAYS_RUN        = 0x00000100,   // Set to allow windows running while minimized
+    FLAG_WINDOW_TRANSPARENT       = 0x00000010,   // Set to allow transparent framebuffer
+    FLAG_WINDOW_HIGHDPI           = 0x00002000,   // Set to support HighDPI
+    FLAG_WINDOW_MOUSE_PASSTHROUGH = 0x00004000,   // Set to support mouse passthrough, only supported when FLAG_WINDOW_UNDECORATED
+    FLAG_BORDERLESS_WINDOWED_MODE = 0x00008000,   // Set to run program in borderless windowed mode
+    FLAG_MSAA_4X_HINT             = 0x00000020,   // Set to try enabling MSAA 4X
+    FLAG_INTERLACED_HINT          = 0x00010000,   // Set to try enabling interlaced video format (for V3D)
+
+    // Experimental WIP flags :
+    FLAG_RESCALE_CONTENT          = 0x10000000    // (GLFW desktop platform) Set to rescale the content of the window when the window is resized or fullscreened
 } ConfigFlags;
 
 // Trace log level

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -549,7 +549,9 @@ typedef enum {
     FLAG_INTERLACED_HINT          = 0x00010000,   // Set to try enabling interlaced video format (for V3D)
 
     // Experimental WIP flags :
-    FLAG_RESCALE_CONTENT          = 0x10000000    // (GLFW desktop platform) Set to rescale the content of the window when the window is resized or fullscreened
+    FLAG_RESCALE_CONTENT          = 0x10000000,   // Set to rescale the content of the window when the window is resized or fullscreened
+    FLAG_TEXT_LINEAR_FILTER       = 0x20000000,   // Set to force the linear texture filter of the text font
+    FLAG_RESCALE_CONTENT_LINEAR   = 0x30000000    // Set both bits of `FLAG_RESCALE_CONTENT` and `FLAG_TEXT_LINEAR_FILTER`
 } ConfigFlags;
 
 // Trace log level

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -683,6 +683,10 @@ void InitWindow(int width, int height, const char *title)
         // RL_TEXTURE_FILTER_LINEAR - tex filter: BILINEAR, no mipmaps
         rlTextureParameters(GetFontDefault().texture.id, RL_TEXTURE_MIN_FILTER, RL_TEXTURE_FILTER_LINEAR);
         rlTextureParameters(GetFontDefault().texture.id, RL_TEXTURE_MAG_FILTER, RL_TEXTURE_FILTER_LINEAR);
+
+        // As of 2024-07-24, to keep backward compatibility, `FLAG_WINDOW_HIGHDPI` does not contain the 
+        // bit of `FLAG_TEXT_LINEAR_FILTER`, so we add it here for forward compatibility. TODO remove once deprecated.
+        CORE.Window.flags |= FLAG_TEXT_LINEAR_FILTER;
     }
 #endif
 

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -283,6 +283,8 @@ typedef struct CoreData {
         Size screenMax;                     // Screen maximum width and height (for resizable window)
         Matrix screenScale;                 // Matrix to scale screen (framebuffer rendering)
 
+        int lastAssociatedMonitorIndex;     // Contains the last monitor index selected using `SetWindowMonitor()` (required by Wayland backend)
+
         char **dropFilepaths;               // Store dropped files paths pointers (provided by GLFW)
         unsigned int dropFileCount;         // Count dropped files strings
 

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -677,7 +677,7 @@ void InitWindow(int width, int height, const char *title)
     #endif
 #endif
 #if defined(SUPPORT_MODULE_RTEXT) && defined(SUPPORT_DEFAULT_FONT)
-    if ((CORE.Window.flags & FLAG_WINDOW_HIGHDPI) > 0)
+    if (((CORE.Window.flags & FLAG_WINDOW_HIGHDPI) > 0) || ((CORE.Window.flags & FLAG_TEXT_LINEAR_FILTER) > 0))
     {
         // Set default font texture filter for HighDPI (blurry)
         // RL_TEXTURE_FILTER_LINEAR - tex filter: BILINEAR, no mipmaps

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -639,12 +639,7 @@ void InitWindow(int width, int height, const char *title)
 
     // Initialize platform
     //--------------------------------------------------------------
-    if ( InitPlatform() != 0 )
-    {
-        TRACELOG(LOG_ERROR, "Platform backend: Window initialization failed.");
-        CORE.Window.ready = false;
-        return;
-    }
+    InitPlatform();
     //--------------------------------------------------------------
 
     // Initialize rlgl default data (buffers and shaders)
@@ -3511,7 +3506,7 @@ static void RecordAutomationEvent(void)
         currentEventList->events[currentEventList->count].frame = CORE.Time.frameCounter;
         currentEventList->events[currentEventList->count].type = INPUT_MOUSE_WHEEL_MOTION;
         currentEventList->events[currentEventList->count].params[0] = (int)CORE.Input.Mouse.currentWheelMove.x;
-        currentEventList->events[currentEventList->count].params[1] = (int)CORE.Input.Mouse.currentWheelMove.y;;
+        currentEventList->events[currentEventList->count].params[1] = (int)CORE.Input.Mouse.currentWheelMove.y;
         currentEventList->events[currentEventList->count].params[2] = 0;
 
         TRACELOG(LOG_INFO, "AUTOMATION: Frame: %i | Event type: INPUT_MOUSE_WHEEL_MOTION | Event parameters: %i, %i, %i", currentEventList->events[currentEventList->count].frame, currentEventList->events[currentEventList->count].params[0], currentEventList->events[currentEventList->count].params[1], currentEventList->events[currentEventList->count].params[2]);


### PR DESCRIPTION
## dont merge it yet

# You can test this PR again, code updated with new pipeline.

----

1) should fix most issues related to `ToggleFullScreen()`, `ToggleBorderlessWindowed()` and `FLAG_WINDOW_HIGHDPI`

2) use a custom implementation of `SetupFramebuffer()` without affecting other platform backends and without changing `rcore.c` (**edit:** well, i had to add some changes to `rcore.c` but they should not impact other platforms)

3) adds a new experimental `FLAG_RESCALE_CONTENT` that keeps the size of what you requested in `InitWindow()` and rescale and center it with borders. (so if you requested a 500x500 drawing surface, you'll allways have 500x500 drawing surface rescaled with the same aspect ratio that always fits inside the window or fullscreen window). [see screen capture here](https://github.com/raysan5/raylib/pull/4151#issuecomment-2235951225)

---

Need confirmations and testing on :
- [ ] MacOs <-- (i don't have access to this system)
- [ ] Windows + WLS ? (i won't bother install WLS on my Windows machines, so if one of you use that, you'll be welcome to test)
- [ ] GNOME 3
- [ ]  Non-ubuntu Linux distro with Wayland based desktop
- [x] Ubuntu + Wayland <--- functional 
- [x]  Ubuntu + Wayland + Xwayland <--- functional, but less reliable than true X11 or full Wayland
- [x] Linux + X11 (Cinnamon desktop)
- [x] Linux + X11 (MATE desktop)
- [x] Windows 11 - using [Msys2 + UCRT64](https://www.msys2.org/docs/environments/)
- [x] Windows 10 - using Msys2 + UCRT64 

I posted a minimal test source code in a message below. Press B for borderless fullscreen, and F for hardware fullscreen.

:warning: If you have VirtualBox running at the same time on your computer, it is recommend to close it when testing. (i found that it could interfere with fullscreen mode on my computer. I don't know what cause that.)

---
Here is a list of the concerned issues :
- #3872
- #3972
- #4149
- #4145
- 
---

thanks to @SoloByte and to @paulmelis for their help and efforts to solve this issue
(but i'd need you to test again the new update of this PR)