### PR TITLE
[rcore] `InitWindow()` should check `InitPlatform()` returned value

### DIFF
--- a/src/platforms/rcore_template.c
+++ b/src/platforms/rcore_template.c
@@ -476,7 +476,7 @@ int InitPlatform(void)
     if (platform.device == EGL_NO_DISPLAY)
     {
         TRACELOG(LOG_WARNING, "DISPLAY: Failed to initialize EGL device");
-        return false;
+        return -1;
     }
 
     // Initialize the EGL device connection
@@ -484,7 +484,7 @@ int InitPlatform(void)
     {
         // If all of the calls to eglInitialize returned EGL_FALSE then an error has occurred.
         TRACELOG(LOG_WARNING, "DISPLAY: Failed to initialize EGL device");
-        return false;
+        return -1;
     }
 
     // Get an appropriate EGL framebuffer configuration

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -631,10 +631,10 @@ void InitWindow(int width, int height, const char *title)
 
     // Initialize platform
     //--------------------------------------------------------------
-    if ( InitPlatform() != 0 )
+    int result = InitPlatform();
+    if (result == -1 )
     {
         TRACELOG(LOG_ERROR, "Platform backend: Window initialization failed.");
-        CORE.Window.ready = false;
         return;
     }
     //--------------------------------------------------------------

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -631,7 +631,12 @@ void InitWindow(int width, int height, const char *title)
 
     // Initialize platform
     //--------------------------------------------------------------
-    InitPlatform();
+    if ( InitPlatform() != 0 )
+    {
+        TRACELOG(LOG_ERROR, "Platform backend: Window initialization failed.");
+        CORE.Window.ready = false;
+        return;
+    }
     //--------------------------------------------------------------
 
     // Initialize rlgl default data (buffers and shaders)

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -632,7 +632,7 @@ void InitWindow(int width, int height, const char *title)
     // Initialize platform
     //--------------------------------------------------------------
     int result = InitPlatform();
-    if (result == -1 )
+    if (result == -1)
     {
         TRACELOG(LOG_ERROR, "Platform backend: Window initialization failed.");
         return;


### PR DESCRIPTION
In case `PlatformInit()` fails, `InitWindow()` should quit properly and set `CORE.Window.ready = false`.

Also fix `rcore_template.c` which returned `false` instead of `-1`, as `false` might be defined to `0` in `raylib.h`.

Note that if the user forget to check `IsWindowReady()` before continuing, the program might still crash in a segfault if `InitPlatform()` failed.

@raysan5 : could we change `void InitWindow()` to `bool InitWindow()` instead of hoping the user think about checking `IsWindowReady()` in case of `InitPlatform()` failure ?