### PR TITLE
[examples] Fix PBR and Shadowmap example shaders for GLSL 1.20

### DIFF
--- a/examples/shaders/resources/shaders/glsl120/pbr.fs
+++ b/examples/shaders/resources/shaders/glsl120/pbr.fs
@@ -1,7 +1,5 @@
 #version 120
 
-precision mediump float;
-
 #define MAX_LIGHTS              4
 #define LIGHT_DIRECTIONAL       0
 #define LIGHT_POINT             1
@@ -17,12 +15,12 @@ struct Light {
 };
 
 // Input vertex attributes (from vertex shader)
-varying in vec3 fragPosition;
-varying in vec2 fragTexCoord;
-varying in vec4 fragColor;
-varying in vec3 fragNormal;
-varying in vec4 shadowPos;
-varying in mat3 TBN;
+varying vec3 fragPosition;
+varying vec2 fragTexCoord;
+varying vec4 fragColor;
+varying vec3 fragNormal;
+varying vec4 shadowPos;
+varying mat3 TBN;
 
 
 // Input uniform values

--- a/examples/shaders/resources/shaders/glsl120/shadowmap.fs
+++ b/examples/shaders/resources/shaders/glsl120/shadowmap.fs
@@ -1,15 +1,13 @@
 #version 120
 
-precision mediump float;
-
 // This shader is based on the basic lighting shader
 // This only supports one light, which is directional, and it (of course) supports shadows
 
 // Input vertex attributes (from vertex shader)
-varying in vec3 fragPosition;
-varying in vec2 fragTexCoord;
+varying vec3 fragPosition;
+varying vec2 fragTexCoord;
 //varying in vec4 fragColor;
-varying in vec3 fragNormal;
+varying vec3 fragNormal;
 
 // Input uniform values
 uniform sampler2D texture0;


### PR DESCRIPTION
Removed presicion mediump float because it is for GLES, and not desktop GL.
also removed 'in' that are in a multitude of lines, because someone when porting it didn't remove it and didn't test it.

Tested on `Mesa Mobile Intel® GM45 Express Chipset (CTG) (0x2a42)`

it works.