### PR TITLE
Fix a dependance of rtexture to rtext

### DIFF
--- a/src/rtextures.c
+++ b/src/rtextures.c
@@ -1213,6 +1213,7 @@ Image GenImageText(int width, int height, const char *text)
 {
     Image image = { 0 };
 
+#ifdef SUPPORT_MODULE_RTEXT
     int textLength = TextLength(text);
     int imageViewSize = width*height;
 
@@ -1223,6 +1224,10 @@ Image GenImageText(int width, int height, const char *text)
     image.mipmaps = 1;
 
     memcpy(image.data, text, (textLength > imageViewSize)? imageViewSize : textLength);
+#else
+    TRACELOG(LOG_WARNING, "IMAGE: GenImageText() requires module: rtext");
+    image = GenImageColor(width, height, BLACK);     // Generating placeholder black image rectangle
+#endif
 
     return image;
 }


### PR DESCRIPTION
Building raylib with `rtextures=ON, rtext=OFF` currently does not work, giving a link error as it can not find `TextLength()`.

This PR fixes this by adding a tracelog warning and returning a black placeholder instead.