### PR TITLE
[raudio] Improve AudioCallback (API breaking)

### DIFF
--- a/examples/audio/audio_mixed_processor.c
+++ b/examples/audio/audio_mixed_processor.c
@@ -21,7 +21,7 @@ static float averageVolume[400] = { 0.0f };   // Average volume history
 //------------------------------------------------------------------------------------
 // Audio processing function
 //------------------------------------------------------------------------------------
-void ProcessAudio(void *buffer, unsigned int frames)
+unsigned int ProcessAudio(void *buffer, unsigned int frames, void* userData)
 {
     float *samples = (float *)buffer;   // Samples internally stored as <float>s
     float average = 0.0f;               // Temporary average volume
@@ -41,6 +41,8 @@ void ProcessAudio(void *buffer, unsigned int frames)
     for (int i = 0; i < 399; i++) averageVolume[i] = averageVolume[i + 1];
 
     averageVolume[399] = average;         // Adding last average value
+
+    return frames;
 }
 
 //------------------------------------------------------------------------------------
@@ -57,7 +59,7 @@ int main(void)
 
     InitAudioDevice();              // Initialize audio device
 
-    AttachAudioMixedProcessor(ProcessAudio);
+    AttachAudioMixedProcessor(ProcessAudio, NULL);
 
     Music music = LoadMusicStream("resources/country.mp3");
     Sound sound = LoadSound("resources/coin.wav");

--- a/examples/audio/audio_raw_stream.c
+++ b/examples/audio/audio_raw_stream.c
@@ -35,7 +35,7 @@ float oldFrequency = 1.0f;
 float sineIdx = 0.0f;
 
 // Audio input processing callback
-void AudioInputCallback(void *buffer, unsigned int frames)
+unsigned int AudioInputCallback(void *buffer, unsigned int frames, void* userData)
 {
     audioFrequency = frequency + (audioFrequency - frequency)*0.95f;
 
@@ -48,6 +48,8 @@ void AudioInputCallback(void *buffer, unsigned int frames)
         sineIdx += incr;
         if (sineIdx > 1.0f) sineIdx -= 1.0f;
     }
+
+    return frames;
 }
 
 //------------------------------------------------------------------------------------
@@ -69,7 +71,7 @@ int main(void)
     // Init raw audio stream (sample rate: 44100, sample size: 16bit-short, channels: 1-mono)
     AudioStream stream = LoadAudioStream(44100, 16, 1);
 
-    SetAudioStreamCallback(stream, AudioInputCallback);
+    SetAudioStreamCallback(stream, AudioInputCallback, NULL);
 
     // Buffer for the single cycle waveform we are synthesizing
     short *data = (short *)malloc(sizeof(short)*MAX_SAMPLES);

--- a/examples/audio/audio_stream_effects.c
+++ b/examples/audio/audio_stream_effects.c
@@ -24,8 +24,8 @@ static unsigned int delayWriteIndex = 0;
 //------------------------------------------------------------------------------------
 // Module Functions Declaration
 //------------------------------------------------------------------------------------
-static void AudioProcessEffectLPF(void *buffer, unsigned int frames);   // Audio effect: lowpass filter
-static void AudioProcessEffectDelay(void *buffer, unsigned int frames); // Audio effect: delay
+static unsigned int AudioProcessEffectLPF(void *buffer, unsigned int frames, void* userData);   // Audio effect: lowpass filter
+static unsigned int AudioProcessEffectDelay(void *buffer, unsigned int frames, void* userData); // Audio effect: delay
 
 //------------------------------------------------------------------------------------
 // Program main entry point
@@ -85,7 +85,7 @@ int main(void)
         if (IsKeyPressed(KEY_F))
         {
             enableEffectLPF = !enableEffectLPF;
-            if (enableEffectLPF) AttachAudioStreamProcessor(music.stream, AudioProcessEffectLPF);
+            if (enableEffectLPF) AttachAudioStreamProcessor(music.stream, AudioProcessEffectLPF, NULL);
             else DetachAudioStreamProcessor(music.stream, AudioProcessEffectLPF);
         }
 
@@ -93,7 +93,7 @@ int main(void)
         if (IsKeyPressed(KEY_D))
         {
             enableEffectDelay = !enableEffectDelay;
-            if (enableEffectDelay) AttachAudioStreamProcessor(music.stream, AudioProcessEffectDelay);
+            if (enableEffectDelay) AttachAudioStreamProcessor(music.stream, AudioProcessEffectDelay, NULL);
             else DetachAudioStreamProcessor(music.stream, AudioProcessEffectDelay);
         }
         
@@ -143,7 +143,7 @@ int main(void)
 // Module Functions Definition
 //------------------------------------------------------------------------------------
 // Audio effect: lowpass filter
-static void AudioProcessEffectLPF(void *buffer, unsigned int frames)
+static unsigned int AudioProcessEffectLPF(void *buffer, unsigned int frames, void* userData)
 {
     static float low[2] = { 0.0f, 0.0f };
     static const float cutoff = 70.0f / 44100.0f; // 70 Hz lowpass filter
@@ -161,10 +161,12 @@ static void AudioProcessEffectLPF(void *buffer, unsigned int frames)
         bufferData[i] = low[0];
         bufferData[i + 1] = low[1];
     }
+
+    return frames;
 }
 
 // Audio effect: delay
-static void AudioProcessEffectDelay(void *buffer, unsigned int frames)
+static unsigned int AudioProcessEffectDelay(void *buffer, unsigned int frames, void* userData)
 {
     for (unsigned int i = 0; i < frames*2; i += 2)
     {
@@ -180,4 +182,6 @@ static void AudioProcessEffectDelay(void *buffer, unsigned int frames)
         delayBuffer[delayWriteIndex++] = ((float *)buffer)[i + 1];
         if (delayWriteIndex == delayBufferSize) delayWriteIndex = 0;
     }
+
+    return frames;
 }

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1602,7 +1602,7 @@ RLAPI RayCollision GetRayCollisionQuad(Ray ray, Vector3 p1, Vector3 p2, Vector3 
 //------------------------------------------------------------------------------------
 // Audio Loading and Playing Functions (Module: audio)
 //------------------------------------------------------------------------------------
-typedef void (*AudioCallback)(void *bufferData, unsigned int frames);
+typedef unsigned int (*AudioCallback)(void *bufferData, unsigned int frames, void* userData);
 
 // Audio device management functions
 RLAPI void InitAudioDevice(void);                                     // Initialize audio device and context
@@ -1670,16 +1670,17 @@ RLAPI void PauseAudioStream(AudioStream stream);                      // Pause a
 RLAPI void ResumeAudioStream(AudioStream stream);                     // Resume audio stream
 RLAPI bool IsAudioStreamPlaying(AudioStream stream);                  // Check if audio stream is playing
 RLAPI void StopAudioStream(AudioStream stream);                       // Stop audio stream
+RLAPI void SetAudioStreamLooping(AudioStream stream, bool loop);      // Turn looping on or off
 RLAPI void SetAudioStreamVolume(AudioStream stream, float volume);    // Set volume for audio stream (1.0 is max level)
 RLAPI void SetAudioStreamPitch(AudioStream stream, float pitch);      // Set pitch for audio stream (1.0 is base level)
 RLAPI void SetAudioStreamPan(AudioStream stream, float pan);          // Set pan for audio stream (0.5 is centered)
 RLAPI void SetAudioStreamBufferSizeDefault(int size);                 // Default size for new audio streams
-RLAPI void SetAudioStreamCallback(AudioStream stream, AudioCallback callback); // Audio thread callback to request new data
+RLAPI void SetAudioStreamCallback(AudioStream stream, AudioCallback callback, void* userData); // Audio thread callback to request new data
 
-RLAPI void AttachAudioStreamProcessor(AudioStream stream, AudioCallback processor); // Attach audio stream processor to stream, receives the samples as 'float'
+RLAPI void AttachAudioStreamProcessor(AudioStream stream, AudioCallback processor, void* userData); // Attach audio stream processor to stream, receives the samples as 'float'
 RLAPI void DetachAudioStreamProcessor(AudioStream stream, AudioCallback processor); // Detach audio stream processor from stream
 
-RLAPI void AttachAudioMixedProcessor(AudioCallback processor); // Attach audio stream processor to the entire audio pipeline, receives the samples as 'float'
+RLAPI void AttachAudioMixedProcessor(AudioCallback processor, void* userData); // Attach audio stream processor to the entire audio pipeline, receives the samples as 'float'
 RLAPI void DetachAudioMixedProcessor(AudioCallback processor); // Detach audio stream processor from the entire audio pipeline
 
 #if defined(__cplusplus)


### PR DESCRIPTION
**Changes in this PR**

- **AudioCallback Signature Update:** Changes the signature of `AudioCallback` to return the number of frames processed by the callback. This is useful when `AudioStream` looping is disabled, and fewer than the requested frames have been copied to the output buffer. Additionally, a `void* userData` argument has been added to associate custom data with the `AudioStream`, simplifying the creation of custom audio data loaders.

- **API Signature Changes:** The signatures of `SetAudioStreamCallback`, `AttachAudioStreamProcessor`, and `AttachAudioMixedProcessor` have been updated to accept an additional `void* userData` argument, which is forwarded to the corresponding callback.

- **New Function to enable/disable looping:** A new function, `SetAudioStreamLooping`, has been added to enable toggling looping on and off.

- **Example Updates:** Examples using the mentioned API functions have been updated to reflect the new signatures.