### PR TITLE
Warning on invalid image data

### DIFF
--- a/src/rtextures.c
+++ b/src/rtextures.c
@@ -505,12 +505,12 @@ Image LoadImageFromMemory(const char *fileType, const unsigned char *fileData, i
     // Security check for input data
     if ((fileData == NULL) || (dataSize == 0))
     {
-        TRACELOG(LOG_ERROR, "IMAGE: Invalid file data");
+        TRACELOG(LOG_WARNING, "IMAGE: Invalid file data");
         return image;
     }
     if (fileType == NULL)
     {
-        TRACELOG(LOG_ERROR, "IMAGE: Missing file extension");
+        TRACELOG(LOG_WARNING, "IMAGE: Missing file extension");
         return image;
     }
 

--- a/src/rtextures.c
+++ b/src/rtextures.c
@@ -503,9 +503,14 @@ Image LoadImageFromMemory(const char *fileType, const unsigned char *fileData, i
     Image image = { 0 };
 
     // Security check for input data
-    if ((fileType == NULL) || (fileData == NULL) || (dataSize == 0))
+    if ((fileData == NULL) || (dataSize == 0))
     {
         TRACELOG(LOG_ERROR, "IMAGE: Invalid file data");
+        return image;
+    }
+    if (fileType == NULL)
+    {
+        TRACELOG(LOG_ERROR, "IMAGE: Missing file extension");
         return image;
     }
 

--- a/src/rtextures.c
+++ b/src/rtextures.c
@@ -503,7 +503,11 @@ Image LoadImageFromMemory(const char *fileType, const unsigned char *fileData, i
     Image image = { 0 };
 
     // Security check for input data
-    if ((fileType == NULL) || (fileData == NULL) || (dataSize == 0)) return image;
+    if ((fileType == NULL) || (fileData == NULL) || (dataSize == 0))
+    {
+        TRACELOG(LOG_ERROR, "IMAGE: Invalid file data");
+        return image;
+    }
 
     if ((false)
 #if defined(SUPPORT_FILEFORMAT_PNG)


### PR DESCRIPTION
Added some log warnings.
LoadImage will call with NULL fileType if file extension is missing.