### PR TITLE
[build] Add build flags for optional image format support in build.zig

### DIFF
--- a/src/build.zig
+++ b/src/build.zig
@@ -70,6 +70,55 @@ fn compileRaylib(b: *std.Build, target: std.Build.ResolvedTarget, optimize: std.
         });
     raylib.linkLibC();
 
+    // support_fileformat_bmp
+    if (options.support_fileformat_bmp) {
+        raylib.defineCMacro("SUPPORT_FILEFORMAT_BMP", "1");
+    }
+    // support_fileformat_tga
+    if (options.support_fileformat_tga) {
+        raylib.defineCMacro("SUPPORT_FILEFORMAT_TGA", "1");
+    }
+    // support_fileformat_jpg
+    if (options.support_fileformat_jpg) {
+        raylib.defineCMacro("SUPPORT_FILEFORMAT_JPG", "1");
+    }
+    // support_fileformat_qoi
+    if (options.support_fileformat_qoi) {
+        raylib.defineCMacro("SUPPORT_FILEFORMAT_QOI", "1");
+    }
+    // support_fileformat_psd
+    if (options.support_fileformat_psd) {
+        raylib.defineCMacro("SUPPORT_FILEFORMAT_PSD", "1");
+    }
+    // support_fileformat_hdr
+    if (options.support_fileformat_hdr) {
+        raylib.defineCMacro("SUPPORT_FILEFORMAT_HDR", "1");
+    }
+    // support_fileformat_pic
+    if (options.support_fileformat_pic) {
+        raylib.defineCMacro("SUPPORT_FILEFORMAT_PIC", "1");
+    }
+    // support_fileformat_ktx
+    if (options.support_fileformat_ktx) {
+        raylib.defineCMacro("SUPPORT_FILEFORMAT_KTX", "1");
+    }
+    // support_fileformat_astc
+    if (options.support_fileformat_astc) {
+        raylib.defineCMacro("SUPPORT_FILEFORMAT_ASTC", "1");
+    }
+    // support_fileformat_pkm
+    if (options.support_fileformat_pkm) {
+        raylib.defineCMacro("SUPPORT_FILEFORMAT_PKM", "1");
+    }
+    // support_fileformat_pvr
+    if (options.support_fileformat_pvr) {
+        raylib.defineCMacro("SUPPORT_FILEFORMAT_PVR", "1");
+    }
+    // support_fileformat_svg
+    if (options.support_fileformat_svg) {
+        raylib.defineCMacro("SUPPORT_FILEFORMAT_SVG", "1");
+    }
+
     // No GLFW required on PLATFORM_DRM
     if (!options.platform_drm) {
         raylib.addIncludePath(b.path("src/external/glfw/include"));
@@ -118,9 +167,8 @@ fn compileRaylib(b: *std.Build, target: std.Build.ResolvedTarget, optimize: std.
                 raylib.addLibraryPath(.{ .cwd_relative = "/usr/lib" });
                 raylib.addIncludePath(.{ .cwd_relative = "/usr/include" });
                 if (options.linux_display_backend == .X11 or options.linux_display_backend == .Both) {
-
-                        raylib.defineCMacro("_GLFW_X11", null);
-                        raylib.linkSystemLibrary("X11");
+                    raylib.defineCMacro("_GLFW_X11", null);
+                    raylib.linkSystemLibrary("X11");
                 }
 
                 if (options.linux_display_backend == .Wayland or options.linux_display_backend == .Both) {
@@ -253,6 +301,26 @@ pub const Options = struct {
     shared: bool = false,
     linux_display_backend: LinuxDisplayBackend = .Both,
     opengl_version: OpenglVersion = .auto,
+
+    // enable format support:
+    // these are enabled by default
+    // support_fileformat_png: bool = true,
+    // support_fileformat_dds: bool = true,
+    // support_fileformat_gif: bool = true,
+
+    // these are optional
+    support_fileformat_bmp: bool = false,
+    support_fileformat_tga: bool = false,
+    support_fileformat_jpg: bool = false,
+    support_fileformat_qoi: bool = true,
+    support_fileformat_psd: bool = false,
+    support_fileformat_hdr: bool = false,
+    support_fileformat_pic: bool = false,
+    support_fileformat_ktx: bool = false,
+    support_fileformat_astc: bool = false,
+    support_fileformat_pkm: bool = false,
+    support_fileformat_pvr: bool = false,
+    support_fileformat_svg: bool = false,
 
     raygui_dependency_name: []const u8 = "raygui",
 };

--- a/src/build.zig
+++ b/src/build.zig
@@ -28,6 +28,20 @@ pub fn addRaylib(b: *std.Build, target: std.Build.ResolvedTarget, optimize: std.
         .shared = options.shared,
         .linux_display_backend = options.linux_display_backend,
         .opengl_version = options.opengl_version,
+
+        // supported file format options:
+        .support_fileformat_bmp = options.support_fileformat_bmp,
+        .support_fileformat_tga = options.support_fileformat_tga,
+        .support_fileformat_jpg = options.support_fileformat_jpg,
+        .support_fileformat_qoi = options.support_fileformat_qoi,
+        .support_fileformat_psd = options.support_fileformat_psd,
+        .support_fileformat_hdr = options.support_fileformat_hdr,
+        .support_fileformat_pic = options.support_fileformat_pic,
+        .support_fileformat_ktx = options.support_fileformat_ktx,
+        .support_fileformat_astc = options.support_fileformat_astc,
+        .support_fileformat_pkm = options.support_fileformat_pkm,
+        .support_fileformat_pvr = options.support_fileformat_pvr,
+        .support_fileformat_svg = options.support_fileformat_svg,
     });
     const raylib = raylib_dep.artifact("raylib");
 
@@ -69,6 +83,11 @@ fn compileRaylib(b: *std.Build, target: std.Build.ResolvedTarget, optimize: std.
             .optimize = optimize,
         });
     raylib.linkLibC();
+
+    // No GLFW required on PLATFORM_DRM
+    if (!options.platform_drm) {
+        raylib.addIncludePath(b.path("src/external/glfw/include"));
+    }
 
     // support_fileformat_bmp
     if (options.support_fileformat_bmp) {
@@ -117,11 +136,6 @@ fn compileRaylib(b: *std.Build, target: std.Build.ResolvedTarget, optimize: std.
     // support_fileformat_svg
     if (options.support_fileformat_svg) {
         raylib.defineCMacro("SUPPORT_FILEFORMAT_SVG", "1");
-    }
-
-    // No GLFW required on PLATFORM_DRM
-    if (!options.platform_drm) {
-        raylib.addIncludePath(b.path("src/external/glfw/include"));
     }
 
     var c_source_files = try std.ArrayList([]const u8).initCapacity(b.allocator, 2);
@@ -375,6 +389,20 @@ pub fn build(b: *std.Build) !void {
         .shared = b.option(bool, "shared", "Compile as shared library") orelse defaults.shared,
         .linux_display_backend = b.option(LinuxDisplayBackend, "linux_display_backend", "Linux display backend to use") orelse defaults.linux_display_backend,
         .opengl_version = b.option(OpenglVersion, "opengl_version", "OpenGL version to use") orelse defaults.opengl_version,
+
+        // supported image file format flags
+        .support_fileformat_bmp = b.option(bool, "support_fileformat_bmp", "support for fileformat bmp") orelse false,
+        .support_fileformat_tga = b.option(bool, "support_fileformat_tga", "support for fileformat tga") orelse false,
+        .support_fileformat_jpg = b.option(bool, "support_fileformat_jpg", "support for fileformat jpg") orelse false,
+        .support_fileformat_qoi = b.option(bool, "support_fileformat_qoi", "support for fileformat qoi") orelse false,
+        .support_fileformat_psd = b.option(bool, "support_fileformat_psd", "support for fileformat psd") orelse false,
+        .support_fileformat_hdr = b.option(bool, "support_fileformat_hdr", "support for fileformat hdr") orelse false,
+        .support_fileformat_pic = b.option(bool, "support_fileformat_pic", "support for fileformat pic") orelse false,
+        .support_fileformat_ktx = b.option(bool, "support_fileformat_ktx", "support for fileformat ktx") orelse false,
+        .support_fileformat_astc = b.option(bool, "support_fileformat_astc", "support for fileformat astc") orelse false,
+        .support_fileformat_pkm = b.option(bool, "support_fileformat_pkm", "support for fileformat pkm") orelse false,
+        .support_fileformat_pvr = b.option(bool, "support_fileformat_pvr", "support for fileformat pvr") orelse false,
+        .support_fileformat_svg = b.option(bool, "support_fileformat_svg", "support for fileformat svg") orelse false,
     };
 
     const lib = try compileRaylib(b, target, optimize, options);


### PR DESCRIPTION
problem: 
no option to easily enable file format support like .svg, .jpg... in the build.zig options.

solution: 
add options like support_fileformat_bmp to build.zig. 
these default to false but when set to true the compile step will define the respective macro.

positive : 
user has the option to select image file format support in zig build

negative : 
if default options change one must also revisit the build.zig and apply the respective changes.


