### PR TITLE
[rcore] fix gamepad axis movement and its automation event recording

### DIFF
--- a/src/rcore.c
+++ b/src/rcore.c
@@ -2949,15 +2949,10 @@ int GetGamepadAxisCount(int gamepad)
     return CORE.Input.Gamepad.axisCount[gamepad];
 }
 
-static float GetGamepadAxisMovementDefault(int axis)
-{
-    return (axis == GAMEPAD_AXIS_LEFT_TRIGGER || axis == GAMEPAD_AXIS_RIGHT_TRIGGER) ? -1.0f : 0.0f;
-}
-
 // Get axis movement vector for a gamepad
 float GetGamepadAxisMovement(int gamepad, int axis)
 {
-    float value = GetGamepadAxisMovementDefault(axis);
+    float value = (axis == GAMEPAD_AXIS_LEFT_TRIGGER || axis == GAMEPAD_AXIS_RIGHT_TRIGGER)? -1.0f : 0.0f;
 
     if ((gamepad < MAX_GAMEPADS) && CORE.Input.Gamepad.ready[gamepad] && (axis < MAX_GAMEPAD_AXIS)) {
         float movement = value < 0.0f ? CORE.Input.Gamepad.axisState[gamepad][axis] : fabs(CORE.Input.Gamepad.axisState[gamepad][axis]);
@@ -3608,7 +3603,8 @@ static void RecordAutomationEvent(void)
         for (int axis = 0; axis < MAX_GAMEPAD_AXIS; axis++)
         {
             // Event type: INPUT_GAMEPAD_AXIS_MOTION
-            if (GetGamepadAxisMovement(gamepad, axis) != GetGamepadAxisMovementDefault(axis))
+            float defaultMovement = (axis == GAMEPAD_AXIS_LEFT_TRIGGER || axis == GAMEPAD_AXIS_RIGHT_TRIGGER)? -1.0f : 0.0f;
+            if (GetGamepadAxisMovement(gamepad, axis) != defaultMovement)
             {
                 currentEventList->events[currentEventList->count].frame = CORE.Time.frameCounter;
                 currentEventList->events[currentEventList->count].type = INPUT_GAMEPAD_AXIS_MOTION;


### PR DESCRIPTION
While working with Automation Events, I recognized that my gamepad input was not recorded correctly. Negative axis movements (e.g. stick going left/up) weren't recorded at all.

Furthermore, `GetGamepadAxisMovement` seems to snap trigger axis values to 0.0 if they are in the region [-0.1, 0.1]. I think the delta/drift check was intended to ignore values in between the range [-1.0, -0.9] instead (since -1.0 is the default state for triggers).

This PR addresses both of these issues.

**Remark:**
With my changes `GetGamepadAxisMovement` always returns the default value for each axis, even if a gamepad is not attached. This makes more sense in my opinion, but it is a behavior change for triggers.
Please let me know if you don't want that, and I'll change it back to always return 0.0 if the gamepad isn't available.