### PR TITLE
[rcore][desktop_glfw] Set AUTO_ICONIFY flag to false per default

### DIFF
--- a/src/platforms/rcore_desktop_glfw.c
+++ b/src/platforms/rcore_desktop_glfw.c
@@ -1275,6 +1275,12 @@ int InitPlatform(void)
     //glfwWindowHint(GLFW_CLIENT_API, GLFW_OPENGL_API); // OpenGL API to use. Alternative: GLFW_OPENGL_ES_API
     //glfwWindowHint(GLFW_AUX_BUFFERS, 0);          // Number of auxiliar buffers
 
+    //Disable GlFW auto iconify behaviour
+    //Auto Iconify automatically minimizes (iconifies) the window if the window loses focus
+    //additionally auto iconify restores the hardware resolution of the monitor if the window that loses focus is a fullscreen window
+    glfwWindowHint(GLFW_AUTO_ICONIFY, 0); 
+
+
     // Check window creation flags
     if ((CORE.Window.flags & FLAG_FULLSCREEN_MODE) > 0) CORE.Window.fullscreen = true;
 
@@ -1453,11 +1459,6 @@ int InitPlatform(void)
     {
         // No-fullscreen window creation
         bool requestWindowedFullscreen = (CORE.Window.screen.height == 0) && (CORE.Window.screen.width == 0);
-
-        // If we are windowed fullscreen, ensures that window does not minimize when focus is lost.
-        // This hinting code will not work if the user already specified the correct monitor dimensions;
-        // at this point we don't know the monitor's dimensions. (Though, how did the user then?)
-        if (requestWindowedFullscreen) glfwWindowHint(GLFW_AUTO_ICONIFY, 0);
 
         // Default to at least one pixel in size, as creation with a zero dimension is not allowed.
         int creationWidth = CORE.Window.screen.width != 0 ? CORE.Window.screen.width : 1;

--- a/src/platforms/rcore_desktop_glfw.c
+++ b/src/platforms/rcore_desktop_glfw.c
@@ -1275,11 +1275,10 @@ int InitPlatform(void)
     //glfwWindowHint(GLFW_CLIENT_API, GLFW_OPENGL_API); // OpenGL API to use. Alternative: GLFW_OPENGL_ES_API
     //glfwWindowHint(GLFW_AUX_BUFFERS, 0);          // Number of auxiliar buffers
 
-    //Disable GlFW auto iconify behaviour
-    //Auto Iconify automatically minimizes (iconifies) the window if the window loses focus
-    //additionally auto iconify restores the hardware resolution of the monitor if the window that loses focus is a fullscreen window
+    // Disable GlFW auto iconify behaviour
+    // Auto Iconify automatically minimizes (iconifies) the window if the window loses focus
+    // additionally auto iconify restores the hardware resolution of the monitor if the window that loses focus is a fullscreen window
     glfwWindowHint(GLFW_AUTO_ICONIFY, 0); 
-
 
     // Check window creation flags
     if ((CORE.Window.flags & FLAG_FULLSCREEN_MODE) > 0) CORE.Window.fullscreen = true;


### PR DESCRIPTION
Previously `AUTO_ICONIFY` was only disabled if the user requested a Fullscreen window from the start. After that, changing this behavior on the user side was impossible, even when changing to a Fullscreen window.

The `AUTO_ICONIFY` causes problems on macOS. On macOS, if the window is minimized because of `AUTO_ICONIFY` then the only way to restore it is to click on the icon in the dock. In other words, when `AUTO_ICONIFY` is enabled alt/cmd-tabbing through Windows does not work correctly. On Windows, it works even when `AUTO_ICONIFY` is enabled.

Additionally, if a raylib window is in Fullscreen mode on another monitor the `AUTO_ICONIFY` behavior is a problem because the user might want the window to stay on the monitor even if it loses focus. (problem on all OS's)

`AUTO_ICONIFY` also restores the monitor hardware resolution if a fullscreen window loses focus. (is a good thing mostly but causes an issue with multiple monitors, see point above)

I set it to false per default on all operating systems to maintain consistency. The  `AUTO_ICONIFY` behavior can be implemented by the user if needed:

```c
void update()
{
	handleInput();

	bool currentWindowFocus = IsWindowFocused();
	if (currentWindowFocus != previousWindowFocus)
	{
		onFocusChanged(currentWindowFocus);
		previousWindowFocus = currentWindowFocus;
	}

}

void onFocusChanged(bool newFocus)
{
	if (newFocus == false) //window lost focus
	{
		if (IsWindowFullscreen())
		{
			wasFullscreen = true; //used for restoring fullscreen when window gains focus again
			ToggleFullscreen();
			MinimizeWindow();
		}
		else
		{
			if (!IsWindowMinimized()) MinimizeWindow();
		}
	}
	else // window gained focus
	{
		RestoreWindow();
		if (wasFullscreen) 
		{
			wasFullscreen = false;
			ToggleFullscreen();
		}
	}
}
```

---


### If wanted/needed there are some other options to go about this:

1. I only set the `AUTO_ICONIFY` flag to false per default on macOS. (this creates problems because the behavior is different on different platforms but has the advantage that nothing changes for Windows/Linux users) 
2. There is a way to set the `AUTO_ICONIFY` flag on the user side (like with other flags but I don't know how other backends handle this behavior)
3. `AUTO_ICONIFY` is set to false per default and it is only set to true whenever fullscreen mode is activated. It is set to false again once fullscreen is exited.

---

### Another example that just caused me problems with the `AUTO_ICONIFY` flag on Windows:
I wanted to make a screenshot of a raylib window for another PR using the Snipping Tool app. With the `AUTO_ICONIFY` flag enabled I could not do that because every time I focused the window of the snipping tool to make a screenshot the raylib window automatically minimized... So I am really for just disabling it.