### PR TITLE
[GLFW] No longer set the RL_TEXTURE_FILTER_LINEAR when high dpi flag is enabled

### DIFF
--- a/src/rcore.c
+++ b/src/rcore.c
@@ -668,15 +668,7 @@ void InitWindow(int width, int height, const char *title)
     SetShapesTexture(texture, (Rectangle){ 0.0f, 0.0f, 1.0f, 1.0f });    // WARNING: Module required: rshapes
     #endif
 #endif
-#if defined(SUPPORT_MODULE_RTEXT) && defined(SUPPORT_DEFAULT_FONT)
-    if ((CORE.Window.flags & FLAG_WINDOW_HIGHDPI) > 0)
-    {
-        // Set default font texture filter for HighDPI (blurry)
-        // RL_TEXTURE_FILTER_LINEAR - tex filter: BILINEAR, no mipmaps
-        rlTextureParameters(GetFontDefault().texture.id, RL_TEXTURE_MIN_FILTER, RL_TEXTURE_FILTER_LINEAR);
-        rlTextureParameters(GetFontDefault().texture.id, RL_TEXTURE_MAG_FILTER, RL_TEXTURE_FILTER_LINEAR);
-    }
-#endif
+
 
     CORE.Time.frameCounter = 0;
     CORE.Window.shouldClose = false;


### PR DESCRIPTION
I am not sure why this was done in the first place. If I am missing something here and there is a good reason for doing this, please tell me.

Right now when the font texture filter is set to linear when the high dpi flag is enabled the default font looks very blurry.
The screenshots were made on a 4k monitor on Windows 11 with the `HIGH_DPI `flag enabled.


## Linear Filter Enabled / Before I changed it (Blurry)
![raylib-default-font-linear-filter-enabled](https://github.com/user-attachments/assets/8039083e-bc5a-4e5a-8378-357b3645d258)


## Linear Filter Disabled / How it looks now with the changes (Not Blurry)
![raylib-default-font-linear-filter-disabled](https://github.com/user-attachments/assets/a9acaf16-2017-461d-ae73-d3b18f1f7207)
