### PR TITLE
[rcore][desktop_glfw] Keeping CORE.Window.position properly in sync with glfw window position

### DIFF
--- a/src/platforms/rcore_desktop_glfw.c
+++ b/src/platforms/rcore_desktop_glfw.c
@@ -618,8 +618,9 @@ void SetWindowMonitor(int monitor)
         {
             TRACELOG(LOG_INFO, "GLFW: Selected monitor: [%i] %s", monitor, glfwGetMonitorName(monitors[monitor]));
 
-            const int screenWidth = CORE.Window.screen.width;
-            const int screenHeight = CORE.Window.screen.height;
+            // Here the render width has to be used again in case high dpi flag is enabled
+            const int screenWidth = CORE.Window.render.width;
+            const int screenHeight = CORE.Window.render.height;
             int monitorWorkareaX = 0;
             int monitorWorkareaY = 0;
             int monitorWorkareaWidth = 0;

--- a/src/platforms/rcore_desktop_glfw.c
+++ b/src/platforms/rcore_desktop_glfw.c
@@ -1572,12 +1572,17 @@ int InitPlatform(void)
         int monitorWidth = 0;
         int monitorHeight = 0;
         glfwGetMonitorWorkarea(monitor, &monitorX, &monitorY, &monitorWidth, &monitorHeight);
-
-        int posX = monitorX + (monitorWidth - (int)CORE.Window.screen.width)/2;
-        int posY = monitorY + (monitorHeight - (int)CORE.Window.screen.height)/2;
+        
+        // Here CORE.Window.render.width/height should be used instead of CORE.Window.screen.width/height to center the window correctly when the high dpi flag is enabled.
+        int posX = monitorX + (monitorWidth - (int)CORE.Window.render.width)/2;
+        int posY = monitorY + (monitorHeight - (int)CORE.Window.render.height)/2;
         if (posX < monitorX) posX = monitorX;
         if (posY < monitorY) posY = monitorY;
         SetWindowPosition(posX, posY);
+
+        // Update CORE.Window.position here so it is correct from the start
+        CORE.Window.position.x = posX;
+        CORE.Window.position.y = posY;
     }
 
     // Load OpenGL extensions

--- a/src/platforms/rcore_desktop_glfw.c
+++ b/src/platforms/rcore_desktop_glfw.c
@@ -181,6 +181,10 @@ void ToggleFullscreen(void)
         CORE.Window.flags &= ~FLAG_FULLSCREEN_MODE;
 
         glfwSetWindowMonitor(platform.handle, NULL, CORE.Window.previousPosition.x, CORE.Window.previousPosition.y, CORE.Window.screen.width, CORE.Window.screen.height, GLFW_DONT_CARE);
+
+        // we update the window position right away
+        CORE.Window.position.x = CORE.Window.previousPosition.x;
+        CORE.Window.position.y = CORE.Window.previousPosition.y;
     }
 
     // Try to enable GPU V-Sync, so frames are limited to screen refresh rate (60Hz -> 60 FPS)
@@ -256,6 +260,9 @@ void ToggleBorderlessWindowed(void)
                 glfwFocusWindow(platform.handle);
 
                 CORE.Window.flags &= ~FLAG_BORDERLESS_WINDOWED_MODE;
+
+                CORE.Window.position.x = CORE.Window.previousPosition.x;
+                CORE.Window.position.y = CORE.Window.previousPosition.y;
             }
         }
         else TRACELOG(LOG_WARNING, "GLFW: Failed to find video mode for selected monitor");

--- a/src/platforms/rcore_desktop_glfw.c
+++ b/src/platforms/rcore_desktop_glfw.c
@@ -195,7 +195,7 @@ void ToggleBorderlessWindowed(void)
     bool wasOnFullscreen = false;
     if (CORE.Window.fullscreen)
     {
-        //fullscreen already saves previous position so it does not need to be set here again
+        // fullscreen already saves the previous position so it does not need to be set here again
         ToggleFullscreen();
         wasOnFullscreen = true;
     }
@@ -593,7 +593,7 @@ void SetWindowTitle(const char *title)
 // Set window position on screen (windowed mode)
 void SetWindowPosition(int x, int y)
 {
-    //update core window position as well
+    // Update CORE.Window.position as well
     CORE.Window.position.x = x;
     CORE.Window.position.y = y;
     glfwSetWindowPos(platform.handle, x, y);
@@ -1688,6 +1688,7 @@ static void WindowSizeCallback(GLFWwindow *window, int width, int height)
 }
 static void WindowPosCallback(GLFWwindow* window, int x, int y)
 {
+    // Set current window position
     CORE.Window.position.x = x;
     CORE.Window.position.y = y;
 }


### PR DESCRIPTION
CORE.Window.position is now properly kept in sync with the glfw window position.
- WindowPosCallback added
- SetWindowPos now updates CORE.Window.position as well
- Fullscreen & Borderless Fullscreen now properly user CORE.Window.position for setting CORE.Window.prevposition

Those changes should not change any behavior other than fixing `ToggleFullscreen()` not restoring the window to the correct previous window position. 

---

FYI: There will be another PR for fixing the remaining problems with fullscreen & borderless fullscreen
- restoring window size correctly and using already existing CORE.Window.prevscreen for it
- BorderlessFullscreen using glfw SetWindowMonitor function as well to fix borderless fullscreen on macOS
- some small misc fixes.