### PR TITLE
[rtextures] fix buffer overflow on loading .svg file

### DIFF
--- a/src/rtextures.c
+++ b/src/rtextures.c
@@ -353,6 +353,14 @@ Image LoadImageSvg(const char *fileNameOrString, int width, int height)
         {
             fileData = LoadFileData(fileNameOrString, &dataSize);
             isSvgStringValid = true;
+
+            // make sure that fileData is a NULL terminated String
+            // as required by nsvgParse()
+            if (fileData[dataSize-1] != '\0')
+            {
+                fileData = RL_REALLOC(fileData, dataSize+1);
+                fileData[dataSize] = '\0';
+            }
         }
         else
         {


### PR DESCRIPTION
simple fix for #4185 

Makes sure the input to `nsvgParse()` function is NULL terminated, to avoid buffer overflow