### PR TITLE
[build.zig] Override config.h definitions

### DIFF
--- a/src/build.zig
+++ b/src/build.zig
@@ -28,6 +28,7 @@ pub fn addRaylib(b: *std.Build, target: std.Build.ResolvedTarget, optimize: std.
         .shared = options.shared,
         .linux_display_backend = options.linux_display_backend,
         .opengl_version = options.opengl_version,
+        .config = options.config,
     });
     const raylib = raylib_dep.artifact("raylib");
 
@@ -52,6 +53,53 @@ fn compileRaylib(b: *std.Build, target: std.Build.ResolvedTarget, optimize: std.
         "-DGL_SILENCE_DEPRECATION=199309L",
         "-fno-sanitize=undefined", // https://github.com/raysan5/raylib/issues/3674
     });
+    if (options.config) |config| {
+        const file = try std.fs.path.join(b.allocator, &.{ std.fs.path.dirname(@src().file) orelse ".", "config.h" });
+        defer b.allocator.free(file);
+        const content = try std.fs.cwd().readFileAlloc(b.allocator, file, std.math.maxInt(usize));
+        defer b.allocator.free(content);
+
+        var lines = std.mem.split(u8, content, "\n");
+        lines_loop: while (lines.next()) |line| {
+            if (!std.mem.startsWith(u8, line, "#define")) continue;
+
+            // Remove "#define " and add "-D" prefix
+            var flag = try std.fmt.allocPrint(b.allocator, "-D{s}", .{line[6..]});
+
+            // Skip if user is supplying the flag
+            var user_supplied_flags = std.mem.split(u8, config, " ");
+            while (user_supplied_flags.next()) |user_flag| {
+                // Flag could be -Dflag=1 or -Dflag
+                const skip_flag = user_flag[0 .. std.mem.lastIndexOf(u8, user_flag, "=") orelse user_flag.len];
+                if (std.mem.startsWith(u8, flag, skip_flag)) continue :lines_loop;
+            }
+
+            // Remove trailing comments
+            if (std.mem.indexOf(u8, flag, "/")) |comment_idx| {
+                flag = flag[0..comment_idx];
+                flag = try std.fmt.allocPrint(b.allocator, "{s}", .{std.mem.trim(u8, flag, " ")});
+            }
+
+            // Insert '=' after flag and remove spaces after equal
+            if (std.mem.indexOf(u8, flag, " ")) |startspaces_idx| {
+                flag[startspaces_idx] = '=';
+                // Remove spaces after equal
+                if (std.mem.lastIndexOf(u8, flag, " ")) |endspaces_idx| {
+                    const left = flag[0 .. startspaces_idx + 1];
+                    const right = flag[endspaces_idx + 1 ..];
+                    flag = try std.fmt.allocPrint(b.allocator, "{s}{s}", .{ left, right });
+                }
+            }
+
+            // Append default value from config.h to compile flags
+            try raylib_flags_arr.append(b.allocator, flag);
+        }
+        // Append config flags supplied by user to compile flags
+        try raylib_flags_arr.append(b.allocator, config);
+
+        try raylib_flags_arr.append(b.allocator, "-DEXTERNAL_CONFIG_FLAGS");
+    }
+
     if (options.shared) {
         try raylib_flags_arr.appendSlice(b.allocator, shared_flags);
     }
@@ -253,6 +301,7 @@ pub const Options = struct {
     shared: bool = false,
     linux_display_backend: LinuxDisplayBackend = .Both,
     opengl_version: OpenglVersion = .auto,
+    config: ?[]const u8 = null,
 
     raygui_dependency_name: []const u8 = "raygui",
 };
@@ -307,6 +356,7 @@ pub fn build(b: *std.Build) !void {
         .shared = b.option(bool, "shared", "Compile as shared library") orelse defaults.shared,
         .linux_display_backend = b.option(LinuxDisplayBackend, "linux_display_backend", "Linux display backend to use") orelse defaults.linux_display_backend,
         .opengl_version = b.option(OpenglVersion, "opengl_version", "OpenGL version to use") orelse defaults.opengl_version,
+        .config = b.option([]const u8, "config", "Compile with custom define macros overriding config.h") orelse null,
     };
 
     const lib = try compileRaylib(b, target, optimize, options);


### PR DESCRIPTION
### Overview
This PR introduces a new option allowing `build.zig` to override `config.h` settings using a simple string:
```zig
pub fn build(b: *std.Build) !void {
// ...
const config: []const u8 =
    "-DSUPPORT_FILEFORMAT_JPG -DSUPPORT_FILEFORMAT_PNG=0";

const raylib_dep = b.dependency("raylib", .{ .config = config });
// ...
}
```
This example enables support for the JPG format (disabled by default) and disables support for the PNG (enabled by default).

Two commits are present in the PR:
- the first allows for all definitions in `config.h` to be overriden, it has more cumbersome parsing since some definitions have different data types
- the second restricts the user to override only `SUPPORT_*` flags (which simplifies the implementation and you could possibly merge, given my assumptions are correct [below]).

### Thoughts
- Issue #3516 suggested the `addConfigHeader` function, but I haven't found a way to use it. My logic mimics what has been done for CMake: parse `config.h` to retrieve default values and override them with the ones provided by user, then inhibit `config.h` by supplying `-DEXTERNAL_CONFIG_FLAGS`
- In CMake for what I can gather only the SUPPORT flags are handled, therefore my second commit (99307a4d5573498e469f59dc2a7e1cce45bbde36). I was thinking that after `-DEXTERNAL_CONFIG_FLAGS` all the other flags wouldn't be set, but it seems everything is redefined if needed in the various source file (**is this assumption correct?**).
<details>

<summary>I used a command to find references to all NON-SUPPORT flags (all are redefined elsewhere except CONFIG_H)</summary>

```sh
> cat src/config.h | grep -Eo "^#define \w+" | cut -d" " -f2 | grep --invert SUPPORT | parallel --tag grep -Erni \"#define {}\" --exclude=config.h --before-context=1 \| wc -l | column -t
CONFIG_H                                     0
MAX_FILEPATH_CAPACITY                        2
MAX_FILEPATH_LENGTH                          4
MAX_KEYBOARD_KEYS                            2
MAX_MOUSE_BUTTONS                            2
MAX_GAMEPADS                                 2
MAX_GAMEPAD_BUTTONS                          2
MAX_GAMEPAD_AXIS                             2
MAX_GAMEPAD_VIBRATION_TIME                   2
MAX_CHAR_PRESSED_QUEUE                       2
MAX_TOUCH_POINTS                             8
MAX_KEY_PRESSED_QUEUE                        2
MAX_AUTOMATION_EVENTS                        2
MAX_DECOMPRESSION_SIZE                       2
RL_DEFAULT_BATCH_BUFFERS                     8
RL_DEFAULT_BATCH_DRAWCALLS                   8
RL_DEFAULT_BATCH_MAX_TEXTURE_UNITS           8
RL_MAX_MATRIX_STACK_SIZE                     8
RL_MAX_SHADER_LOCATIONS                      8
RL_CULL_DISTANCE_NEAR                        8
RL_CULL_DISTANCE_FAR                         8
RL_DEFAULT_SHADER_ATTRIB_LOCATION_POSITION   2
RL_DEFAULT_SHADER_ATTRIB_LOCATION_TEXCOORD   5
RL_DEFAULT_SHADER_ATTRIB_LOCATION_NORMAL     2
RL_DEFAULT_SHADER_ATTRIB_LOCATION_COLOR      2
RL_DEFAULT_SHADER_ATTRIB_LOCATION_TEXCOORD2  2
RL_DEFAULT_SHADER_ATTRIB_LOCATION_TANGENT    2
RL_DEFAULT_SHADER_ATTRIB_NAME_POSITION       5
RL_DEFAULT_SHADER_ATTRIB_NAME_TEXCOORD       11
RL_DEFAULT_SHADER_ATTRIB_NAME_NORMAL         5
RL_DEFAULT_SHADER_ATTRIB_NAME_COLOR          5
RL_DEFAULT_SHADER_ATTRIB_NAME_TANGENT        5
RL_DEFAULT_SHADER_ATTRIB_NAME_TEXCOORD2      5
RL_DEFAULT_SHADER_UNIFORM_NAME_VIEW          5
RL_DEFAULT_SHADER_UNIFORM_NAME_PROJECTION    5
RL_DEFAULT_SHADER_UNIFORM_NAME_MVP           5
RL_DEFAULT_SHADER_UNIFORM_NAME_NORMAL        5
RL_DEFAULT_SHADER_UNIFORM_NAME_MODEL         5
RL_DEFAULT_SHADER_UNIFORM_NAME_COLOR         5
RL_DEFAULT_SHADER_SAMPLER2D_NAME_TEXTURE0    5
RL_DEFAULT_SHADER_SAMPLER2D_NAME_TEXTURE1    5
RL_DEFAULT_SHADER_SAMPLER2D_NAME_TEXTURE2    5
MAX_TEXT_BUFFER_LENGTH                       5
SPLINE_SEGMENT_DIVISIONS                     2
MAX_TEXTSPLIT_COUNT                          5
MAX_MATERIAL_MAPS                            2
MAX_MESH_VERTEX_BUFFERS                      2
AUDIO_DEVICE_FORMAT                          2
AUDIO_DEVICE_SAMPLE_RATE                     2
AUDIO_DEVICE_CHANNELS                        2
MAX_AUDIO_BUFFER_POOL_CHANNELS               2
MAX_TRACELOG_MSG_LENGTH                      2
```
</details>

- Zig doesn't have a standard regex support, the parsing is done manually in my code
- In the second commit I added lines to trim whitespace, they are not really needed given the current state of `config.h` **should I remove them?** and assume the formatting will always be the same
- Should I remove the comments?
- I think after we decide the correct implementation I will have to rebase the commits to have a single one

Thank you for considering my PR :)