### PR TITLE
[rlgl] use GLint64 for glGetBufferParameteri64v

### DIFF
--- a/src/rlgl.h
+++ b/src/rlgl.h
@@ -4397,7 +4397,7 @@ void rlUpdateShaderBuffer(unsigned int id, const void *data, unsigned int dataSi
 // Get SSBO buffer size
 unsigned int rlGetShaderBufferSize(unsigned int id)
 {
-    long long size = 0;
+    GLint64 size = 0;
 
 #if defined(GRAPHICS_API_OPENGL_43)
     glBindBuffer(GL_SHADER_STORAGE_BUFFER, id);


### PR DESCRIPTION
Hi Ray,

When compiling raylib on Linux with `OPENGL_VERSION=4.3` the build fails because `GLint64` is defined as `long int` which is not the same type as `long long`. This will fix the issue while maintaining compatibility with Win32 where `long long` is equivalent to `GLint64`.