### PR TITLE
[rtextures] Promote calculation to long long in GetPixelDataSize() to allow for larger image sizes

### DIFF
--- a/src/rtextures.c
+++ b/src/rtextures.c
@@ -5403,7 +5403,9 @@ int GetPixelDataSize(int width, int height, int format)
         default: break;
     }
 
-    dataSize = width*height*bpp/8;  // Total data size in bytes
+    // Total data size in bytes
+    // NOTE: promote to long long during calculation to avoid overflows before dividing by 8
+    dataSize = width*height*(long long)bpp/8;
 
     // Most compressed formats works on 4x4 blocks,
     // if texture is smaller, minimum dataSize is 8 or 16


### PR DESCRIPTION
Fix to allow working with image sizes >= 8192 x 8192 x 32bit by promoting calculation of image sizes to long long during calculation.
Without fix GetPixelDataSize() yields a negative result due to an int overflow with image sizes >= 8192 x 8192 x 32bit.
Fix allows for sizes up to ~23k x 23k x 32bit without overflowing the size int.
