### PR TITLE
Changed raylib.h to improve tooltips in modern IDEs

### DIFF
--- a/src/raylib.h
+++ b/src/raylib.h
@@ -935,11 +935,16 @@ typedef enum {
 
 // Callbacks to hook some internal functions
 // WARNING: These callbacks are intended for advanced users
-typedef void (*TraceLogCallback)(int logLevel, const char *text, va_list args);  // Logging: Redirect trace log messages
-typedef unsigned char *(*LoadFileDataCallback)(const char *fileName, int *dataSize);    // FileIO: Load binary data
-typedef bool (*SaveFileDataCallback)(const char *fileName, void *data, int dataSize);   // FileIO: Save binary data
-typedef char *(*LoadFileTextCallback)(const char *fileName);            // FileIO: Load text data
-typedef bool (*SaveFileTextCallback)(const char *fileName, char *text); // FileIO: Save text data
+// Logging: Redirect trace log messages
+typedef void (*TraceLogCallback)(int logLevel, const char *text, va_list args);
+// FileIO: Load binary data
+typedef unsigned char *(*LoadFileDataCallback)(const char *fileName, int *dataSize);
+// FileIO: Save binary data
+typedef bool (*SaveFileDataCallback)(const char *fileName, void *data, int dataSize);
+// FileIO: Load text data
+typedef char *(*LoadFileTextCallback)(const char *fileName);
+// FileIO: Save text data
+typedef bool (*SaveFileTextCallback)(const char *fileName, char *text);
 
 //------------------------------------------------------------------------------------
 // Global Variables Definition
@@ -955,267 +960,497 @@ extern "C" {            // Prevents name mangling of functions
 #endif
 
 // Window-related functions
-RLAPI void InitWindow(int width, int height, const char *title);  // Initialize window and OpenGL context
-RLAPI void CloseWindow(void);                                     // Close window and unload OpenGL context
-RLAPI bool WindowShouldClose(void);                               // Check if application should close (KEY_ESCAPE pressed or windows close icon clicked)
-RLAPI bool IsWindowReady(void);                                   // Check if window has been initialized successfully
-RLAPI bool IsWindowFullscreen(void);                              // Check if window is currently fullscreen
-RLAPI bool IsWindowHidden(void);                                  // Check if window is currently hidden (only PLATFORM_DESKTOP)
-RLAPI bool IsWindowMinimized(void);                               // Check if window is currently minimized (only PLATFORM_DESKTOP)
-RLAPI bool IsWindowMaximized(void);                               // Check if window is currently maximized (only PLATFORM_DESKTOP)
-RLAPI bool IsWindowFocused(void);                                 // Check if window is currently focused (only PLATFORM_DESKTOP)
-RLAPI bool IsWindowResized(void);                                 // Check if window has been resized last frame
-RLAPI bool IsWindowState(unsigned int flag);                      // Check if one specific window flag is enabled
-RLAPI void SetWindowState(unsigned int flags);                    // Set window configuration state using flags (only PLATFORM_DESKTOP)
-RLAPI void ClearWindowState(unsigned int flags);                  // Clear window configuration state flags
-RLAPI void ToggleFullscreen(void);                                // Toggle window state: fullscreen/windowed (only PLATFORM_DESKTOP)
-RLAPI void ToggleBorderlessWindowed(void);                        // Toggle window state: borderless windowed (only PLATFORM_DESKTOP)
-RLAPI void MaximizeWindow(void);                                  // Set window state: maximized, if resizable (only PLATFORM_DESKTOP)
-RLAPI void MinimizeWindow(void);                                  // Set window state: minimized, if resizable (only PLATFORM_DESKTOP)
-RLAPI void RestoreWindow(void);                                   // Set window state: not minimized/maximized (only PLATFORM_DESKTOP)
-RLAPI void SetWindowIcon(Image image);                            // Set icon for window (single image, RGBA 32bit, only PLATFORM_DESKTOP)
-RLAPI void SetWindowIcons(Image *images, int count);              // Set icon for window (multiple images, RGBA 32bit, only PLATFORM_DESKTOP)
-RLAPI void SetWindowTitle(const char *title);                     // Set title for window (only PLATFORM_DESKTOP and PLATFORM_WEB)
-RLAPI void SetWindowPosition(int x, int y);                       // Set window position on screen (only PLATFORM_DESKTOP)
-RLAPI void SetWindowMonitor(int monitor);                         // Set monitor for the current window
-RLAPI void SetWindowMinSize(int width, int height);               // Set window minimum dimensions (for FLAG_WINDOW_RESIZABLE)
-RLAPI void SetWindowMaxSize(int width, int height);               // Set window maximum dimensions (for FLAG_WINDOW_RESIZABLE)
-RLAPI void SetWindowSize(int width, int height);                  // Set window dimensions
-RLAPI void SetWindowOpacity(float opacity);                       // Set window opacity [0.0f..1.0f] (only PLATFORM_DESKTOP)
-RLAPI void SetWindowFocused(void);                                // Set window focused (only PLATFORM_DESKTOP)
-RLAPI void *GetWindowHandle(void);                                // Get native window handle
-RLAPI int GetScreenWidth(void);                                   // Get current screen width
-RLAPI int GetScreenHeight(void);                                  // Get current screen height
-RLAPI int GetRenderWidth(void);                                   // Get current render width (it considers HiDPI)
-RLAPI int GetRenderHeight(void);                                  // Get current render height (it considers HiDPI)
-RLAPI int GetMonitorCount(void);                                  // Get number of connected monitors
-RLAPI int GetCurrentMonitor(void);                                // Get current connected monitor
-RLAPI Vector2 GetMonitorPosition(int monitor);                    // Get specified monitor position
-RLAPI int GetMonitorWidth(int monitor);                           // Get specified monitor width (current video mode used by monitor)
-RLAPI int GetMonitorHeight(int monitor);                          // Get specified monitor height (current video mode used by monitor)
-RLAPI int GetMonitorPhysicalWidth(int monitor);                   // Get specified monitor physical width in millimetres
-RLAPI int GetMonitorPhysicalHeight(int monitor);                  // Get specified monitor physical height in millimetres
-RLAPI int GetMonitorRefreshRate(int monitor);                     // Get specified monitor refresh rate
-RLAPI Vector2 GetWindowPosition(void);                            // Get window position XY on monitor
-RLAPI Vector2 GetWindowScaleDPI(void);                            // Get window scale DPI factor
-RLAPI const char *GetMonitorName(int monitor);                    // Get the human-readable, UTF-8 encoded name of the specified monitor
-RLAPI void SetClipboardText(const char *text);                    // Set clipboard text content
-RLAPI const char *GetClipboardText(void);                         // Get clipboard text content
-RLAPI void EnableEventWaiting(void);                              // Enable waiting for events on EndDrawing(), no automatic event polling
-RLAPI void DisableEventWaiting(void);                             // Disable waiting for events on EndDrawing(), automatic events polling
+
+// Initialize window and OpenGL context
+RLAPI void InitWindow(int width, int height, const char *title);
+// Close window and unload OpenGL context
+RLAPI void CloseWindow(void);
+// Check if application should close (KEY_ESCAPE pressed or windows close icon clicked)
+RLAPI bool WindowShouldClose(void);
+// Check if window has been initialized successfully
+RLAPI bool IsWindowReady(void);
+// Check if window is currently fullscreen
+RLAPI bool IsWindowFullscreen(void);
+// Check if window is currently hidden (only PLATFORM_DESKTOP)
+RLAPI bool IsWindowHidden(void);
+// Check if window is currently minimized (only PLATFORM_DESKTOP)
+RLAPI bool IsWindowMinimized(void);
+// Check if window is currently maximized (only PLATFORM_DESKTOP)
+RLAPI bool IsWindowMaximized(void);
+// Check if window is currently focused (only PLATFORM_DESKTOP)
+RLAPI bool IsWindowFocused(void);
+// Check if window has been resized last frame
+RLAPI bool IsWindowResized(void);
+// Check if one specific window flag is enabled
+RLAPI bool IsWindowState(unsigned int flag);
+// Set window configuration state using flags (only PLATFORM_DESKTOP)
+RLAPI void SetWindowState(unsigned int flags);
+// Clear window configuration state flags
+RLAPI void ClearWindowState(unsigned int flags);
+// Toggle window state: fullscreen/windowed (only PLATFORM_DESKTOP)
+RLAPI void ToggleFullscreen(void);
+// Toggle window state: borderless windowed (only PLATFORM_DESKTOP)
+RLAPI void ToggleBorderlessWindowed(void);
+// Set window state: maximized, if resizable (only PLATFORM_DESKTOP)
+RLAPI void MaximizeWindow(void);
+// Set window state: minimized, if resizable (only PLATFORM_DESKTOP)
+RLAPI void MinimizeWindow(void);
+// Set window state: not minimized/maximized (only PLATFORM_DESKTOP)
+RLAPI void RestoreWindow(void);
+// Set icon for window (single image, RGBA 32bit, only PLATFORM_DESKTOP)
+RLAPI void SetWindowIcon(Image image);
+// Set icon for window (multiple images, RGBA 32bit, only PLATFORM_DESKTOP)
+RLAPI void SetWindowIcons(Image *images, int count);
+// Set title for window (only PLATFORM_DESKTOP and PLATFORM_WEB)
+RLAPI void SetWindowTitle(const char *title);
+// Set window position on screen (only PLATFORM_DESKTOP)
+RLAPI void SetWindowPosition(int x, int y);
+// Set monitor for the current window
+RLAPI void SetWindowMonitor(int monitor);
+// Set window minimum dimensions (for FLAG_WINDOW_RESIZABLE)
+RLAPI void SetWindowMinSize(int width, int height);
+// Set window maximum dimensions (for FLAG_WINDOW_RESIZABLE)
+RLAPI void SetWindowMaxSize(int width, int height);
+// Set window dimensions
+RLAPI void SetWindowSize(int width, int height);
+// Set window opacity [0.0f..1.0f] (only PLATFORM_DESKTOP)
+RLAPI void SetWindowOpacity(float opacity);
+// Set window focused (only PLATFORM_DESKTOP)
+RLAPI void SetWindowFocused(void);
+// Get native window handle
+RLAPI void *GetWindowHandle(void);
+// Get current screen width
+RLAPI int GetScreenWidth(void);
+// Get current screen height
+RLAPI int GetScreenHeight(void);
+// Get current render width (it considers HiDPI)
+RLAPI int GetRenderWidth(void);
+// Get current render height (it considers HiDPI)
+RLAPI int GetRenderHeight(void);
+// Get number of connected monitors
+RLAPI int GetMonitorCount(void);
+// Get current connected monitor
+RLAPI int GetCurrentMonitor(void);
+// Get specified monitor position
+RLAPI Vector2 GetMonitorPosition(int monitor);
+// Get specified monitor width (current video mode used by monitor)
+RLAPI int GetMonitorWidth(int monitor);
+// Get specified monitor height (current video mode used by monitor)
+RLAPI int GetMonitorHeight(int monitor);
+// Get specified monitor physical width in millimetres
+RLAPI int GetMonitorPhysicalWidth(int monitor);
+// Get specified monitor physical height in millimetres
+RLAPI int GetMonitorPhysicalHeight(int monitor);
+// Get specified monitor refresh rate
+RLAPI int GetMonitorRefreshRate(int monitor);
+// Get window position XY on monitor
+RLAPI Vector2 GetWindowPosition(void);
+// Get window scale DPI factor
+RLAPI Vector2 GetWindowScaleDPI(void);
+// Get the human-readable, UTF-8 encoded name of the specified monitor
+RLAPI const char *GetMonitorName(int monitor);
+// Set clipboard text content
+RLAPI void SetClipboardText(const char *text);
+// Get clipboard text content
+RLAPI const char *GetClipboardText(void);
+// Enable waiting for events on EndDrawing(), no automatic event polling
+RLAPI void EnableEventWaiting(void);
+// Disable waiting for events on EndDrawing(), automatic events polling
+RLAPI void DisableEventWaiting(void);
 
 // Cursor-related functions
-RLAPI void ShowCursor(void);                                      // Shows cursor
-RLAPI void HideCursor(void);                                      // Hides cursor
-RLAPI bool IsCursorHidden(void);                                  // Check if cursor is not visible
-RLAPI void EnableCursor(void);                                    // Enables cursor (unlock cursor)
-RLAPI void DisableCursor(void);                                   // Disables cursor (lock cursor)
-RLAPI bool IsCursorOnScreen(void);                                // Check if cursor is on the screen
+
+// Shows cursor
+RLAPI void ShowCursor(void);
+// Hides cursor
+RLAPI void HideCursor(void);
+// Check if cursor is not visible
+RLAPI bool IsCursorHidden(void);
+// Enables cursor (unlock cursor)
+RLAPI void EnableCursor(void);
+// Disables cursor (lock cursor)
+RLAPI void DisableCursor(void);
+// Check if cursor is on the screen
+RLAPI bool IsCursorOnScreen(void);
 
 // Drawing-related functions
-RLAPI void ClearBackground(Color color);                          // Set background color (framebuffer clear color)
-RLAPI void BeginDrawing(void);                                    // Setup canvas (framebuffer) to start drawing
-RLAPI void EndDrawing(void);                                      // End canvas drawing and swap buffers (double buffering)
-RLAPI void BeginMode2D(Camera2D camera);                          // Begin 2D mode with custom camera (2D)
-RLAPI void EndMode2D(void);                                       // Ends 2D mode with custom camera
-RLAPI void BeginMode3D(Camera3D camera);                          // Begin 3D mode with custom camera (3D)
-RLAPI void EndMode3D(void);                                       // Ends 3D mode and returns to default 2D orthographic mode
-RLAPI void BeginTextureMode(RenderTexture2D target);              // Begin drawing to render texture
-RLAPI void EndTextureMode(void);                                  // Ends drawing to render texture
-RLAPI void BeginShaderMode(Shader shader);                        // Begin custom shader drawing
-RLAPI void EndShaderMode(void);                                   // End custom shader drawing (use default shader)
-RLAPI void BeginBlendMode(int mode);                              // Begin blending mode (alpha, additive, multiplied, subtract, custom)
-RLAPI void EndBlendMode(void);                                    // End blending mode (reset to default: alpha blending)
-RLAPI void BeginScissorMode(int x, int y, int width, int height); // Begin scissor mode (define screen area for following drawing)
-RLAPI void EndScissorMode(void);                                  // End scissor mode
-RLAPI void BeginVrStereoMode(VrStereoConfig config);              // Begin stereo rendering (requires VR simulator)
-RLAPI void EndVrStereoMode(void);                                 // End stereo rendering (requires VR simulator)
+
+// Set background color (framebuffer clear color)
+RLAPI void ClearBackground(Color color);
+// Setup canvas (framebuffer) to start drawing
+RLAPI void BeginDrawing(void);
+// End canvas drawing and swap buffers (double buffering)
+RLAPI void EndDrawing(void);
+// Begin 2D mode with custom camera (2D)
+RLAPI void BeginMode2D(Camera2D camera);
+// Ends 2D mode with custom camera
+RLAPI void EndMode2D(void);
+// Begin 3D mode with custom camera (3D)
+RLAPI void BeginMode3D(Camera3D camera);
+// Ends 3D mode and returns to default 2D orthographic mode
+RLAPI void EndMode3D(void);
+// Begin drawing to render texture
+RLAPI void BeginTextureMode(RenderTexture2D target);
+// Ends drawing to render texture
+RLAPI void EndTextureMode(void);
+// Begin custom shader drawing
+RLAPI void BeginShaderMode(Shader shader);
+// End custom shader drawing (use default shader)
+RLAPI void EndShaderMode(void);
+// Begin blending mode (alpha, additive, multiplied, subtract, custom)
+RLAPI void BeginBlendMode(int mode);
+// End blending mode (reset to default: alpha blending)
+RLAPI void EndBlendMode(void);
+// Begin scissor mode (define screen area for following drawing)
+RLAPI void BeginScissorMode(int x, int y, int width, int height);
+// End scissor mode
+RLAPI void EndScissorMode(void);
+// Begin stereo rendering (requires VR simulator)
+RLAPI void BeginVrStereoMode(VrStereoConfig config);
+// End stereo rendering (requires VR simulator)
+RLAPI void EndVrStereoMode(void);
 
 // VR stereo config functions for VR simulator
-RLAPI VrStereoConfig LoadVrStereoConfig(VrDeviceInfo device);     // Load VR stereo config for VR simulator device parameters
-RLAPI void UnloadVrStereoConfig(VrStereoConfig config);           // Unload VR stereo config
+
+// Load VR stereo config for VR simulator device parameters
+RLAPI VrStereoConfig LoadVrStereoConfig(VrDeviceInfo device);
+// Unload VR stereo config
+RLAPI void UnloadVrStereoConfig(VrStereoConfig config);
 
 // Shader management functions
 // NOTE: Shader functionality is not available on OpenGL 1.1
-RLAPI Shader LoadShader(const char *vsFileName, const char *fsFileName);   // Load shader from files and bind default locations
-RLAPI Shader LoadShaderFromMemory(const char *vsCode, const char *fsCode); // Load shader from code strings and bind default locations
-RLAPI bool IsShaderReady(Shader shader);                                   // Check if a shader is ready
-RLAPI int GetShaderLocation(Shader shader, const char *uniformName);       // Get shader uniform location
-RLAPI int GetShaderLocationAttrib(Shader shader, const char *attribName);  // Get shader attribute location
-RLAPI void SetShaderValue(Shader shader, int locIndex, const void *value, int uniformType);               // Set shader uniform value
-RLAPI void SetShaderValueV(Shader shader, int locIndex, const void *value, int uniformType, int count);   // Set shader uniform value vector
-RLAPI void SetShaderValueMatrix(Shader shader, int locIndex, Matrix mat);         // Set shader uniform value (matrix 4x4)
-RLAPI void SetShaderValueTexture(Shader shader, int locIndex, Texture2D texture); // Set shader uniform value for texture (sampler2d)
-RLAPI void UnloadShader(Shader shader);                                    // Unload shader from GPU memory (VRAM)
+
+// Load shader from files and bind default locations
+RLAPI Shader LoadShader(const char *vsFileName, const char *fsFileName);
+// Load shader from code strings and bind default locations
+RLAPI Shader LoadShaderFromMemory(const char *vsCode, const char *fsCode);
+// Check if a shader is ready
+RLAPI bool IsShaderReady(Shader shader);
+// Get shader uniform location
+RLAPI int GetShaderLocation(Shader shader, const char *uniformName);
+// Get shader attribute location
+RLAPI int GetShaderLocationAttrib(Shader shader, const char *attribName);
+// Set shader uniform value
+RLAPI void SetShaderValue(Shader shader, int locIndex, const void *value, int uniformType);
+// Set shader uniform value vector
+RLAPI void SetShaderValueV(Shader shader, int locIndex, const void *value, int uniformType, int count);
+// Set shader uniform value (matrix 4x4)
+RLAPI void SetShaderValueMatrix(Shader shader, int locIndex, Matrix mat);
+// Set shader uniform value for texture (sampler2d)
+RLAPI void SetShaderValueTexture(Shader shader, int locIndex, Texture2D texture);
+// Unload shader from GPU memory (VRAM)
+RLAPI void UnloadShader(Shader shader);
 
 // Screen-space-related functions
+
 #define GetMouseRay GetScreenToWorldRay     // Compatibility hack for previous raylib versions
-RLAPI Ray GetScreenToWorldRay(Vector2 position, Camera camera);         // Get a ray trace from screen position (i.e mouse)
-RLAPI Ray GetScreenToWorldRayEx(Vector2 position, Camera camera, int width, int height); // Get a ray trace from screen position (i.e mouse) in a viewport
-RLAPI Vector2 GetWorldToScreen(Vector3 position, Camera camera);        // Get the screen space position for a 3d world space position
-RLAPI Vector2 GetWorldToScreenEx(Vector3 position, Camera camera, int width, int height); // Get size position for a 3d world space position
-RLAPI Vector2 GetWorldToScreen2D(Vector2 position, Camera2D camera);    // Get the screen space position for a 2d camera world space position
-RLAPI Vector2 GetScreenToWorld2D(Vector2 position, Camera2D camera);    // Get the world space position for a 2d camera screen space position
-RLAPI Matrix GetCameraMatrix(Camera camera);                            // Get camera transform matrix (view matrix)
-RLAPI Matrix GetCameraMatrix2D(Camera2D camera);                        // Get camera 2d transform matrix
+
+// Get a ray trace from screen position (i.e mouse)
+RLAPI Ray GetScreenToWorldRay(Vector2 position, Camera camera);
+// Get a ray trace from screen position (i.e mouse) in a viewport
+RLAPI Ray GetScreenToWorldRayEx(Vector2 position, Camera camera, int width, int height);
+// Get the screen space position for a 3d world space position
+RLAPI Vector2 GetWorldToScreen(Vector3 position, Camera camera);
+// Get size position for a 3d world space position
+RLAPI Vector2 GetWorldToScreenEx(Vector3 position, Camera camera, int width, int height);
+// Get the screen space position for a 2d camera world space position
+RLAPI Vector2 GetWorldToScreen2D(Vector2 position, Camera2D camera);
+// Get the world space position for a 2d camera screen space position
+RLAPI Vector2 GetScreenToWorld2D(Vector2 position, Camera2D camera);
+// Get camera transform matrix (view matrix)
+RLAPI Matrix GetCameraMatrix(Camera camera);
+// Get camera 2d transform matrix
+RLAPI Matrix GetCameraMatrix2D(Camera2D camera);
 
 // Timing-related functions
-RLAPI void SetTargetFPS(int fps);                                 // Set target FPS (maximum)
-RLAPI float GetFrameTime(void);                                   // Get time in seconds for last frame drawn (delta time)
-RLAPI double GetTime(void);                                       // Get elapsed time in seconds since InitWindow()
-RLAPI int GetFPS(void);                                           // Get current FPS
+
+// Set target FPS (maximum)
+RLAPI void SetTargetFPS(int fps);
+// Get time in seconds for last frame drawn (delta time)
+RLAPI float GetFrameTime(void);
+// Get elapsed time in seconds since InitWindow()
+RLAPI double GetTime(void);
+// Get current FPS
+RLAPI int GetFPS(void);
 
 // Custom frame control functions
 // NOTE: Those functions are intended for advanced users that want full control over the frame processing
 // By default EndDrawing() does this job: draws everything + SwapScreenBuffer() + manage frame timing + PollInputEvents()
 // To avoid that behaviour and control frame processes manually, enable in config.h: SUPPORT_CUSTOM_FRAME_CONTROL
-RLAPI void SwapScreenBuffer(void);                                // Swap back buffer with front buffer (screen drawing)
-RLAPI void PollInputEvents(void);                                 // Register all input events
-RLAPI void WaitTime(double seconds);                              // Wait for some time (halt program execution)
+
+// Swap back buffer with front buffer (screen drawing)
+RLAPI void SwapScreenBuffer(void);
+// Register all input events
+RLAPI void PollInputEvents(void);
+// Wait for some time (halt program execution)
+RLAPI void WaitTime(double seconds);
 
 // Random values generation functions
-RLAPI void SetRandomSeed(unsigned int seed);                      // Set the seed for the random number generator
-RLAPI int GetRandomValue(int min, int max);                       // Get a random value between min and max (both included)
-RLAPI int *LoadRandomSequence(unsigned int count, int min, int max); // Load random values sequence, no values repeated
-RLAPI void UnloadRandomSequence(int *sequence);                   // Unload random values sequence
+
+// Set the seed for the random number generator
+RLAPI void SetRandomSeed(unsigned int seed);
+// Get a random value between min and max (both included)
+RLAPI int GetRandomValue(int min, int max);
+// Load random values sequence, no values repeated
+RLAPI int *LoadRandomSequence(unsigned int count, int min, int max);
+// Unload random values sequence
+RLAPI void UnloadRandomSequence(int *sequence);
 
 // Misc. functions
-RLAPI void TakeScreenshot(const char *fileName);                  // Takes a screenshot of current screen (filename extension defines format)
-RLAPI void SetConfigFlags(unsigned int flags);                    // Setup init configuration flags (view FLAGS)
-RLAPI void OpenURL(const char *url);                              // Open URL with default system browser (if available)
+
+// Takes a screenshot of current screen (filename extension defines format)
+RLAPI void TakeScreenshot(const char *fileName);
+// Setup init configuration flags (view FLAGS)
+RLAPI void SetConfigFlags(unsigned int flags);
+// Open URL with default system browser (if available)
+RLAPI void OpenURL(const char *url);
 
 // NOTE: Following functions implemented in module [utils]
 //------------------------------------------------------------------
-RLAPI void TraceLog(int logLevel, const char *text, ...);         // Show trace log messages (LOG_DEBUG, LOG_INFO, LOG_WARNING, LOG_ERROR...)
-RLAPI void SetTraceLogLevel(int logLevel);                        // Set the current threshold (minimum) log level
-RLAPI void *MemAlloc(unsigned int size);                          // Internal memory allocator
-RLAPI void *MemRealloc(void *ptr, unsigned int size);             // Internal memory reallocator
-RLAPI void MemFree(void *ptr);                                    // Internal memory free
+
+// Show trace log messages (LOG_DEBUG, LOG_INFO, LOG_WARNING, LOG_ERROR...)
+RLAPI void TraceLog(int logLevel, const char *text, ...);
+// Set the current threshold (minimum) log level
+RLAPI void SetTraceLogLevel(int logLevel);
+// Internal memory allocator
+RLAPI void *MemAlloc(unsigned int size);
+// Internal memory reallocator
+RLAPI void *MemRealloc(void *ptr, unsigned int size);
+// Internal memory free
+RLAPI void MemFree(void *ptr);
 
 // Set custom callbacks
-// WARNING: Callbacks setup is intended for advanced users
-RLAPI void SetTraceLogCallback(TraceLogCallback callback);         // Set custom trace log
-RLAPI void SetLoadFileDataCallback(LoadFileDataCallback callback); // Set custom file binary data loader
-RLAPI void SetSaveFileDataCallback(SaveFileDataCallback callback); // Set custom file binary data saver
-RLAPI void SetLoadFileTextCallback(LoadFileTextCallback callback); // Set custom file text data loader
-RLAPI void SetSaveFileTextCallback(SaveFileTextCallback callback); // Set custom file text data saver
+
+// Set custom trace log.
+// WARNING: Callbacks setup is intended for advanced users!
+RLAPI void SetTraceLogCallback(TraceLogCallback callback);
+// Set custom file binary data loader.
+// WARNING: Callbacks setup is intended for advanced users!
+RLAPI void SetLoadFileDataCallback(LoadFileDataCallback callback);
+// Set custom file binary data saver.
+// WARNING: Callbacks setup is intended for advanced users!
+RLAPI void SetSaveFileDataCallback(SaveFileDataCallback callback);
+// Set custom file text data loader.
+// WARNING: Callbacks setup is intended for advanced users!
+RLAPI void SetLoadFileTextCallback(LoadFileTextCallback callback);
+// Set custom file text data saver.
+// WARNING: Callbacks setup is intended for advanced users!
+RLAPI void SetSaveFileTextCallback(SaveFileTextCallback callback);
 
 // Files management functions
-RLAPI unsigned char *LoadFileData(const char *fileName, int *dataSize); // Load file data as byte array (read)
-RLAPI void UnloadFileData(unsigned char *data);                   // Unload file data allocated by LoadFileData()
-RLAPI bool SaveFileData(const char *fileName, void *data, int dataSize); // Save data to file from byte array (write), returns true on success
-RLAPI bool ExportDataAsCode(const unsigned char *data, int dataSize, const char *fileName); // Export data to code (.h), returns true on success
-RLAPI char *LoadFileText(const char *fileName);                   // Load text data from file (read), returns a '\0' terminated string
-RLAPI void UnloadFileText(char *text);                            // Unload file text data allocated by LoadFileText()
-RLAPI bool SaveFileText(const char *fileName, char *text);        // Save text data to file (write), string must be '\0' terminated, returns true on success
+
+// Load file data as byte array (read)
+RLAPI unsigned char *LoadFileData(const char *fileName, int *dataSize);
+// Unload file data allocated by LoadFileData()
+RLAPI void UnloadFileData(unsigned char *data);
+// Save data to file from byte array (write), returns true on success
+RLAPI bool SaveFileData(const char *fileName, void *data, int dataSize);
+// Export data to code (.h), returns true on success
+RLAPI bool ExportDataAsCode(const unsigned char *data, int dataSize, const char *fileName);
+// Load text data from file (read), returns a '\0' terminated string
+RLAPI char *LoadFileText(const char *fileName);
+// Unload file text data allocated by LoadFileText()
+RLAPI void UnloadFileText(char *text);
+// Save text data to file (write), string must be '\0' terminated, returns true on success
+RLAPI bool SaveFileText(const char *fileName, char *text);
 //------------------------------------------------------------------
 
 // File system functions
-RLAPI bool FileExists(const char *fileName);                      // Check if file exists
-RLAPI bool DirectoryExists(const char *dirPath);                  // Check if a directory path exists
-RLAPI bool IsFileExtension(const char *fileName, const char *ext); // Check file extension (including point: .png, .wav)
-RLAPI int GetFileLength(const char *fileName);                    // Get file length in bytes (NOTE: GetFileSize() conflicts with windows.h)
-RLAPI const char *GetFileExtension(const char *fileName);         // Get pointer to extension for a filename string (includes dot: '.png')
-RLAPI const char *GetFileName(const char *filePath);              // Get pointer to filename for a path string
-RLAPI const char *GetFileNameWithoutExt(const char *filePath);    // Get filename string without extension (uses static string)
-RLAPI const char *GetDirectoryPath(const char *filePath);         // Get full path for a given fileName with path (uses static string)
-RLAPI const char *GetPrevDirectoryPath(const char *dirPath);      // Get previous directory path for a given path (uses static string)
-RLAPI const char *GetWorkingDirectory(void);                      // Get current working directory (uses static string)
-RLAPI const char *GetApplicationDirectory(void);                  // Get the directory of the running application (uses static string)
-RLAPI bool ChangeDirectory(const char *dir);                      // Change working directory, return true on success
-RLAPI bool IsPathFile(const char *path);                          // Check if a given path is a file or a directory
-RLAPI bool IsFileNameValid(const char *fileName);                 // Check if fileName is valid for the platform/OS
-RLAPI FilePathList LoadDirectoryFiles(const char *dirPath);       // Load directory filepaths
-RLAPI FilePathList LoadDirectoryFilesEx(const char *basePath, const char *filter, bool scanSubdirs); // Load directory filepaths with extension filtering and recursive directory scan
-RLAPI void UnloadDirectoryFiles(FilePathList files);              // Unload filepaths
-RLAPI bool IsFileDropped(void);                                   // Check if a file has been dropped into window
-RLAPI FilePathList LoadDroppedFiles(void);                        // Load dropped filepaths
-RLAPI void UnloadDroppedFiles(FilePathList files);                // Unload dropped filepaths
-RLAPI long GetFileModTime(const char *fileName);                  // Get file modification time (last write time)
+
+// Check if file exists
+RLAPI bool FileExists(const char *fileName);
+// Check if a directory path exists
+RLAPI bool DirectoryExists(const char *dirPath);
+// Check file extension (including point: .png, .wav)
+RLAPI bool IsFileExtension(const char *fileName, const char *ext);
+// Get file length in bytes (NOTE: GetFileSize() conflicts with windows.h)
+RLAPI int GetFileLength(const char *fileName);
+// Get pointer to extension for a filename string (includes dot: '.png')
+RLAPI const char *GetFileExtension(const char *fileName);
+// Get pointer to filename for a path string
+RLAPI const char *GetFileName(const char *filePath);
+// Get filename string without extension (uses static string)
+RLAPI const char *GetFileNameWithoutExt(const char *filePath);
+// Get full path for a given fileName with path (uses static string)
+RLAPI const char *GetDirectoryPath(const char *filePath);
+// Get previous directory path for a given path (uses static string)
+RLAPI const char *GetPrevDirectoryPath(const char *dirPath);
+// Get current working directory (uses static string)
+RLAPI const char *GetWorkingDirectory(void);
+// Get the directory of the running application (uses static string)
+RLAPI const char *GetApplicationDirectory(void);
+// Change working directory, return true on success
+RLAPI bool ChangeDirectory(const char *dir);
+// Check if a given path is a file or a directory
+RLAPI bool IsPathFile(const char *path);
+// Check if fileName is valid for the platform/OS
+RLAPI bool IsFileNameValid(const char *fileName);
+// Load directory filepaths
+RLAPI FilePathList LoadDirectoryFiles(const char *dirPath);
+// Load directory filepaths with extension filtering and recursive directory scan
+RLAPI FilePathList LoadDirectoryFilesEx(const char *basePath, const char *filter, bool scanSubdirs);
+// Unload filepaths
+RLAPI void UnloadDirectoryFiles(FilePathList files);
+// Check if a file has been dropped into window
+RLAPI bool IsFileDropped(void);
+// Load dropped filepaths
+RLAPI FilePathList LoadDroppedFiles(void);
+// Unload dropped filepaths
+RLAPI void UnloadDroppedFiles(FilePathList files);
+// Get file modification time (last write time)
+RLAPI long GetFileModTime(const char *fileName);
 
 // Compression/Encoding functionality
-RLAPI unsigned char *CompressData(const unsigned char *data, int dataSize, int *compDataSize);        // Compress data (DEFLATE algorithm), memory must be MemFree()
-RLAPI unsigned char *DecompressData(const unsigned char *compData, int compDataSize, int *dataSize);  // Decompress data (DEFLATE algorithm), memory must be MemFree()
-RLAPI char *EncodeDataBase64(const unsigned char *data, int dataSize, int *outputSize);               // Encode data to Base64 string, memory must be MemFree()
-RLAPI unsigned char *DecodeDataBase64(const unsigned char *data, int *outputSize);                    // Decode Base64 string data, memory must be MemFree()
+
+// Compress data (DEFLATE algorithm), memory must be MemFree()
+RLAPI unsigned char *CompressData(const unsigned char *data, int dataSize, int *compDataSize);
+// Decompress data (DEFLATE algorithm), memory must be MemFree()
+RLAPI unsigned char *DecompressData(const unsigned char *compData, int compDataSize, int *dataSize);
+// Encode data to Base64 string, memory must be MemFree()
+RLAPI char *EncodeDataBase64(const unsigned char *data, int dataSize, int *outputSize);
+// Decode Base64 string data, memory must be MemFree()
+RLAPI unsigned char *DecodeDataBase64(const unsigned char *data, int *outputSize);
 
 // Automation events functionality
-RLAPI AutomationEventList LoadAutomationEventList(const char *fileName);                // Load automation events list from file, NULL for empty list, capacity = MAX_AUTOMATION_EVENTS
-RLAPI void UnloadAutomationEventList(AutomationEventList list);                         // Unload automation events list from file
-RLAPI bool ExportAutomationEventList(AutomationEventList list, const char *fileName);   // Export automation events list as text file
-RLAPI void SetAutomationEventList(AutomationEventList *list);                           // Set automation event list to record to
-RLAPI void SetAutomationEventBaseFrame(int frame);                                      // Set automation event internal base frame to start recording
-RLAPI void StartAutomationEventRecording(void);                                         // Start recording automation events (AutomationEventList must be set)
-RLAPI void StopAutomationEventRecording(void);                                          // Stop recording automation events
-RLAPI void PlayAutomationEvent(AutomationEvent event);                                  // Play a recorded automation event
+
+// Load automation events list from file, NULL for empty list, capacity = MAX_AUTOMATION_EVENTS
+RLAPI AutomationEventList LoadAutomationEventList(const char *fileName);
+// Unload automation events list from file
+RLAPI void UnloadAutomationEventList(AutomationEventList list);
+// Export automation events list as text file
+RLAPI bool ExportAutomationEventList(AutomationEventList list, const char *fileName);
+// Set automation event list to record to
+RLAPI void SetAutomationEventList(AutomationEventList *list);
+// Set automation event internal base frame to start recording
+RLAPI void SetAutomationEventBaseFrame(int frame);
+// Start recording automation events (AutomationEventList must be set)
+RLAPI void StartAutomationEventRecording(void);
+// Stop recording automation events
+RLAPI void StopAutomationEventRecording(void);
+// Play a recorded automation event
+RLAPI void PlayAutomationEvent(AutomationEvent event);
 
 //------------------------------------------------------------------------------------
 // Input Handling Functions (Module: core)
 //------------------------------------------------------------------------------------
 
 // Input-related functions: keyboard
-RLAPI bool IsKeyPressed(int key);                             // Check if a key has been pressed once
-RLAPI bool IsKeyPressedRepeat(int key);                       // Check if a key has been pressed again (Only PLATFORM_DESKTOP)
-RLAPI bool IsKeyDown(int key);                                // Check if a key is being pressed
-RLAPI bool IsKeyReleased(int key);                            // Check if a key has been released once
-RLAPI bool IsKeyUp(int key);                                  // Check if a key is NOT being pressed
-RLAPI int GetKeyPressed(void);                                // Get key pressed (keycode), call it multiple times for keys queued, returns 0 when the queue is empty
-RLAPI int GetCharPressed(void);                               // Get char pressed (unicode), call it multiple times for chars queued, returns 0 when the queue is empty
-RLAPI void SetExitKey(int key);                               // Set a custom key to exit program (default is ESC)
+
+// Check if a key has been pressed once
+RLAPI bool IsKeyPressed(int key);
+// Check if a key has been pressed again (Only PLATFORM_DESKTOP)
+RLAPI bool IsKeyPressedRepeat(int key);
+// Check if a key is being pressed
+RLAPI bool IsKeyDown(int key);
+// Check if a key has been released once
+RLAPI bool IsKeyReleased(int key);
+// Check if a key is NOT being pressed
+RLAPI bool IsKeyUp(int key);
+// Get key pressed (keycode), call it multiple times for keys queued, returns 0 when the queue is empty
+RLAPI int GetKeyPressed(void);
+// Get char pressed (unicode), call it multiple times for chars queued, returns 0 when the queue is empty
+RLAPI int GetCharPressed(void);
+// Set a custom key to exit program (default is ESC)
+RLAPI void SetExitKey(int key);
 
 // Input-related functions: gamepads
-RLAPI bool IsGamepadAvailable(int gamepad);                                        // Check if a gamepad is available
-RLAPI const char *GetGamepadName(int gamepad);                                     // Get gamepad internal name id
-RLAPI bool IsGamepadButtonPressed(int gamepad, int button);                        // Check if a gamepad button has been pressed once
-RLAPI bool IsGamepadButtonDown(int gamepad, int button);                           // Check if a gamepad button is being pressed
-RLAPI bool IsGamepadButtonReleased(int gamepad, int button);                       // Check if a gamepad button has been released once
-RLAPI bool IsGamepadButtonUp(int gamepad, int button);                             // Check if a gamepad button is NOT being pressed
-RLAPI int GetGamepadButtonPressed(void);                                           // Get the last gamepad button pressed
-RLAPI int GetGamepadAxisCount(int gamepad);                                        // Get gamepad axis count for a gamepad
-RLAPI float GetGamepadAxisMovement(int gamepad, int axis);                         // Get axis movement value for a gamepad axis
-RLAPI int SetGamepadMappings(const char *mappings);                                // Set internal gamepad mappings (SDL_GameControllerDB)
-RLAPI void SetGamepadVibration(int gamepad, float leftMotor, float rightMotor);    // Set gamepad vibration for both motors
+
+// Check if a gamepad is available
+RLAPI bool IsGamepadAvailable(int gamepad);
+// Get gamepad internal name id
+RLAPI const char *GetGamepadName(int gamepad);
+// Check if a gamepad button has been pressed once
+RLAPI bool IsGamepadButtonPressed(int gamepad, int button);
+// Check if a gamepad button is being pressed
+RLAPI bool IsGamepadButtonDown(int gamepad, int button);
+// Check if a gamepad button has been released once
+RLAPI bool IsGamepadButtonReleased(int gamepad, int button);
+// Check if a gamepad button is NOT being pressed
+RLAPI bool IsGamepadButtonUp(int gamepad, int button);
+// Get the last gamepad button pressed
+RLAPI int GetGamepadButtonPressed(void);
+// Get gamepad axis count for a gamepad
+RLAPI int GetGamepadAxisCount(int gamepad);
+// Get axis movement value for a gamepad axis
+RLAPI float GetGamepadAxisMovement(int gamepad, int axis);
+// Set internal gamepad mappings (SDL_GameControllerDB)
+RLAPI int SetGamepadMappings(const char *mappings);
+// Set gamepad vibration for both motors
+RLAPI void SetGamepadVibration(int gamepad, float leftMotor, float rightMotor);
 
 // Input-related functions: mouse
-RLAPI bool IsMouseButtonPressed(int button);                  // Check if a mouse button has been pressed once
-RLAPI bool IsMouseButtonDown(int button);                     // Check if a mouse button is being pressed
-RLAPI bool IsMouseButtonReleased(int button);                 // Check if a mouse button has been released once
-RLAPI bool IsMouseButtonUp(int button);                       // Check if a mouse button is NOT being pressed
-RLAPI int GetMouseX(void);                                    // Get mouse position X
-RLAPI int GetMouseY(void);                                    // Get mouse position Y
-RLAPI Vector2 GetMousePosition(void);                         // Get mouse position XY
-RLAPI Vector2 GetMouseDelta(void);                            // Get mouse delta between frames
-RLAPI void SetMousePosition(int x, int y);                    // Set mouse position XY
-RLAPI void SetMouseOffset(int offsetX, int offsetY);          // Set mouse offset
-RLAPI void SetMouseScale(float scaleX, float scaleY);         // Set mouse scaling
-RLAPI float GetMouseWheelMove(void);                          // Get mouse wheel movement for X or Y, whichever is larger
-RLAPI Vector2 GetMouseWheelMoveV(void);                       // Get mouse wheel movement for both X and Y
-RLAPI void SetMouseCursor(int cursor);                        // Set mouse cursor
+
+// Check if a mouse button has been pressed once
+RLAPI bool IsMouseButtonPressed(int button);
+// Check if a mouse button is being pressed
+RLAPI bool IsMouseButtonDown(int button);
+// Check if a mouse button has been released once
+RLAPI bool IsMouseButtonReleased(int button);
+// Check if a mouse button is NOT being pressed
+RLAPI bool IsMouseButtonUp(int button);
+// Get mouse position X
+RLAPI int GetMouseX(void);
+// Get mouse position Y
+RLAPI int GetMouseY(void);
+// Get mouse position XY
+RLAPI Vector2 GetMousePosition(void);
+// Get mouse delta between frames
+RLAPI Vector2 GetMouseDelta(void);
+// Set mouse position XY
+RLAPI void SetMousePosition(int x, int y);
+// Set mouse offset
+RLAPI void SetMouseOffset(int offsetX, int offsetY);
+// Set mouse scaling
+RLAPI void SetMouseScale(float scaleX, float scaleY);
+// Get mouse wheel movement for X or Y, whichever is larger
+RLAPI float GetMouseWheelMove(void);
+// Get mouse wheel movement for both X and Y
+RLAPI Vector2 GetMouseWheelMoveV(void);
+// Set mouse cursor
+RLAPI void SetMouseCursor(int cursor);
 
 // Input-related functions: touch
-RLAPI int GetTouchX(void);                                    // Get touch position X for touch point 0 (relative to screen size)
-RLAPI int GetTouchY(void);                                    // Get touch position Y for touch point 0 (relative to screen size)
-RLAPI Vector2 GetTouchPosition(int index);                    // Get touch position XY for a touch point index (relative to screen size)
-RLAPI int GetTouchPointId(int index);                         // Get touch point identifier for given index
-RLAPI int GetTouchPointCount(void);                           // Get number of touch points
+
+// Get touch position X for touch point 0 (relative to screen size)
+RLAPI int GetTouchX(void);
+// Get touch position Y for touch point 0 (relative to screen size)
+RLAPI int GetTouchY(void);
+// Get touch position XY for a touch point index (relative to screen size)
+RLAPI Vector2 GetTouchPosition(int index);
+// Get touch point identifier for given index
+RLAPI int GetTouchPointId(int index);
+// Get number of touch points
+RLAPI int GetTouchPointCount(void);
 
 //------------------------------------------------------------------------------------
 // Gestures and Touch Handling Functions (Module: rgestures)
 //------------------------------------------------------------------------------------
-RLAPI void SetGesturesEnabled(unsigned int flags);      // Enable a set of gestures using flags
-RLAPI bool IsGestureDetected(unsigned int gesture);     // Check if a gesture have been detected
-RLAPI int GetGestureDetected(void);                     // Get latest detected gesture
-RLAPI float GetGestureHoldDuration(void);               // Get gesture hold time in milliseconds
-RLAPI Vector2 GetGestureDragVector(void);               // Get gesture drag vector
-RLAPI float GetGestureDragAngle(void);                  // Get gesture drag angle
-RLAPI Vector2 GetGesturePinchVector(void);              // Get gesture pinch delta
-RLAPI float GetGesturePinchAngle(void);                 // Get gesture pinch angle
+
+// Enable a set of gestures using flags
+RLAPI void SetGesturesEnabled(unsigned int flags);
+// Check if a gesture have been detected
+RLAPI bool IsGestureDetected(unsigned int gesture);
+// Get latest detected gesture
+RLAPI int GetGestureDetected(void);
+// Get gesture hold time in milliseconds
+RLAPI float GetGestureHoldDuration(void);
+// Get gesture drag vector
+RLAPI Vector2 GetGestureDragVector(void);
+// Get gesture drag angle
+RLAPI float GetGestureDragAngle(void);
+// Get gesture pinch delta
+RLAPI Vector2 GetGesturePinchVector(void);
+// Get gesture pinch angle
+RLAPI float GetGesturePinchAngle(void);
 
 //------------------------------------------------------------------------------------
 // Camera System Functions (Module: rcamera)
 //------------------------------------------------------------------------------------
-RLAPI void UpdateCamera(Camera *camera, int mode);      // Update camera position for selected mode
-RLAPI void UpdateCameraPro(Camera *camera, Vector3 movement, Vector3 rotation, float zoom); // Update camera movement/rotation
+
+// Update camera position for selected mode
+RLAPI void UpdateCamera(Camera *camera, int mode);
+// Update camera movement/rotation
+RLAPI void UpdateCameraPro(Camera *camera, Vector3 movement, Vector3 rotation, float zoom);
 
 //------------------------------------------------------------------------------------
 // Basic Shapes Drawing Functions (Module: shapes)
@@ -1223,80 +1458,151 @@ RLAPI void UpdateCameraPro(Camera *camera, Vector3 movement, Vector3 rotation, f
 // Set texture and rectangle to be used on shapes drawing
 // NOTE: It can be useful when using basic shapes and one single font,
 // defining a font char white rectangle would allow drawing everything in a single draw call
-RLAPI void SetShapesTexture(Texture2D texture, Rectangle source);       // Set texture and rectangle to be used on shapes drawing
-RLAPI Texture2D GetShapesTexture(void);                                 // Get texture that is used for shapes drawing
-RLAPI Rectangle GetShapesTextureRectangle(void);                        // Get texture source rectangle that is used for shapes drawing
+
+// Set texture and rectangle to be used on shapes drawing
+RLAPI void SetShapesTexture(Texture2D texture, Rectangle source);
+// Get texture that is used for shapes drawing
+RLAPI Texture2D GetShapesTexture(void);
+// Get texture source rectangle that is used for shapes drawing
+RLAPI Rectangle GetShapesTextureRectangle(void);
 
 // Basic shapes drawing functions
-RLAPI void DrawPixel(int posX, int posY, Color color);                                                   // Draw a pixel
-RLAPI void DrawPixelV(Vector2 position, Color color);                                                    // Draw a pixel (Vector version)
-RLAPI void DrawLine(int startPosX, int startPosY, int endPosX, int endPosY, Color color);                // Draw a line
-RLAPI void DrawLineV(Vector2 startPos, Vector2 endPos, Color color);                                     // Draw a line (using gl lines)
-RLAPI void DrawLineEx(Vector2 startPos, Vector2 endPos, float thick, Color color);                       // Draw a line (using triangles/quads)
-RLAPI void DrawLineStrip(const Vector2 *points, int pointCount, Color color);                            // Draw lines sequence (using gl lines)
-RLAPI void DrawLineBezier(Vector2 startPos, Vector2 endPos, float thick, Color color);                   // Draw line segment cubic-bezier in-out interpolation
-RLAPI void DrawCircle(int centerX, int centerY, float radius, Color color);                              // Draw a color-filled circle
-RLAPI void DrawCircleSector(Vector2 center, float radius, float startAngle, float endAngle, int segments, Color color);      // Draw a piece of a circle
-RLAPI void DrawCircleSectorLines(Vector2 center, float radius, float startAngle, float endAngle, int segments, Color color); // Draw circle sector outline
-RLAPI void DrawCircleGradient(int centerX, int centerY, float radius, Color color1, Color color2);       // Draw a gradient-filled circle
-RLAPI void DrawCircleV(Vector2 center, float radius, Color color);                                       // Draw a color-filled circle (Vector version)
-RLAPI void DrawCircleLines(int centerX, int centerY, float radius, Color color);                         // Draw circle outline
-RLAPI void DrawCircleLinesV(Vector2 center, float radius, Color color);                                  // Draw circle outline (Vector version)
-RLAPI void DrawEllipse(int centerX, int centerY, float radiusH, float radiusV, Color color);             // Draw ellipse
-RLAPI void DrawEllipseLines(int centerX, int centerY, float radiusH, float radiusV, Color color);        // Draw ellipse outline
-RLAPI void DrawRing(Vector2 center, float innerRadius, float outerRadius, float startAngle, float endAngle, int segments, Color color); // Draw ring
-RLAPI void DrawRingLines(Vector2 center, float innerRadius, float outerRadius, float startAngle, float endAngle, int segments, Color color);    // Draw ring outline
-RLAPI void DrawRectangle(int posX, int posY, int width, int height, Color color);                        // Draw a color-filled rectangle
-RLAPI void DrawRectangleV(Vector2 position, Vector2 size, Color color);                                  // Draw a color-filled rectangle (Vector version)
-RLAPI void DrawRectangleRec(Rectangle rec, Color color);                                                 // Draw a color-filled rectangle
-RLAPI void DrawRectanglePro(Rectangle rec, Vector2 origin, float rotation, Color color);                 // Draw a color-filled rectangle with pro parameters
-RLAPI void DrawRectangleGradientV(int posX, int posY, int width, int height, Color color1, Color color2);// Draw a vertical-gradient-filled rectangle
-RLAPI void DrawRectangleGradientH(int posX, int posY, int width, int height, Color color1, Color color2);// Draw a horizontal-gradient-filled rectangle
-RLAPI void DrawRectangleGradientEx(Rectangle rec, Color col1, Color col2, Color col3, Color col4);       // Draw a gradient-filled rectangle with custom vertex colors
-RLAPI void DrawRectangleLines(int posX, int posY, int width, int height, Color color);                   // Draw rectangle outline
-RLAPI void DrawRectangleLinesEx(Rectangle rec, float lineThick, Color color);                            // Draw rectangle outline with extended parameters
-RLAPI void DrawRectangleRounded(Rectangle rec, float roundness, int segments, Color color);              // Draw rectangle with rounded edges
-RLAPI void DrawRectangleRoundedLines(Rectangle rec, float roundness, int segments, Color color);         // Draw rectangle lines with rounded edges
-RLAPI void DrawRectangleRoundedLinesEx(Rectangle rec, float roundness, int segments, float lineThick, Color color); // Draw rectangle with rounded edges outline
-RLAPI void DrawTriangle(Vector2 v1, Vector2 v2, Vector2 v3, Color color);                                // Draw a color-filled triangle (vertex in counter-clockwise order!)
-RLAPI void DrawTriangleLines(Vector2 v1, Vector2 v2, Vector2 v3, Color color);                           // Draw triangle outline (vertex in counter-clockwise order!)
-RLAPI void DrawTriangleFan(const Vector2 *points, int pointCount, Color color);                          // Draw a triangle fan defined by points (first vertex is the center)
-RLAPI void DrawTriangleStrip(const Vector2 *points, int pointCount, Color color);                        // Draw a triangle strip defined by points
-RLAPI void DrawPoly(Vector2 center, int sides, float radius, float rotation, Color color);               // Draw a regular polygon (Vector version)
-RLAPI void DrawPolyLines(Vector2 center, int sides, float radius, float rotation, Color color);          // Draw a polygon outline of n sides
-RLAPI void DrawPolyLinesEx(Vector2 center, int sides, float radius, float rotation, float lineThick, Color color); // Draw a polygon outline of n sides with extended parameters
+
+// Draw a pixel
+RLAPI void DrawPixel(int posX, int posY, Color color);
+// Draw a pixel (Vector version)
+RLAPI void DrawPixelV(Vector2 position, Color color);
+// Draw a line
+RLAPI void DrawLine(int startPosX, int startPosY, int endPosX, int endPosY, Color color);
+// Draw a line (using gl lines)
+RLAPI void DrawLineV(Vector2 startPos, Vector2 endPos, Color color);
+// Draw a line (using triangles/quads)
+RLAPI void DrawLineEx(Vector2 startPos, Vector2 endPos, float thick, Color color);
+// Draw lines sequence (using gl lines)
+RLAPI void DrawLineStrip(const Vector2 *points, int pointCount, Color color);
+// Draw line segment cubic-bezier in-out interpolation
+RLAPI void DrawLineBezier(Vector2 startPos, Vector2 endPos, float thick, Color color);
+// Draw a color-filled circle
+RLAPI void DrawCircle(int centerX, int centerY, float radius, Color color);
+// Draw a piece of a circle
+RLAPI void DrawCircleSector(Vector2 center, float radius, float startAngle, float endAngle, int segments, Color color);
+// Draw circle sector outline
+RLAPI void DrawCircleSectorLines(Vector2 center, float radius, float startAngle, float endAngle, int segments, Color color);
+// Draw a gradient-filled circle
+RLAPI void DrawCircleGradient(int centerX, int centerY, float radius, Color color1, Color color2);
+// Draw a color-filled circle (Vector version)
+RLAPI void DrawCircleV(Vector2 center, float radius, Color color);
+// Draw circle outline
+RLAPI void DrawCircleLines(int centerX, int centerY, float radius, Color color);
+// Draw circle outline (Vector version)
+RLAPI void DrawCircleLinesV(Vector2 center, float radius, Color color);
+// Draw ellipse
+RLAPI void DrawEllipse(int centerX, int centerY, float radiusH, float radiusV, Color color);
+// Draw ellipse outline
+RLAPI void DrawEllipseLines(int centerX, int centerY, float radiusH, float radiusV, Color color);
+// Draw ring
+RLAPI void DrawRing(Vector2 center, float innerRadius, float outerRadius, float startAngle, float endAngle, int segments, Color color);
+// Draw ring outline
+RLAPI void DrawRingLines(Vector2 center, float innerRadius, float outerRadius, float startAngle, float endAngle, int segments, Color color);
+// Draw a color-filled rectangle
+RLAPI void DrawRectangle(int posX, int posY, int width, int height, Color color);
+// Draw a color-filled rectangle (Vector version)
+RLAPI void DrawRectangleV(Vector2 position, Vector2 size, Color color);
+// Draw a color-filled rectangle
+RLAPI void DrawRectangleRec(Rectangle rec, Color color);
+// Draw a color-filled rectangle with pro parameters
+RLAPI void DrawRectanglePro(Rectangle rec, Vector2 origin, float rotation, Color color);
+// Draw a vertical-gradient-filled rectangle
+RLAPI void DrawRectangleGradientV(int posX, int posY, int width, int height, Color color1, Color color2);
+// Draw a horizontal-gradient-filled rectangle
+RLAPI void DrawRectangleGradientH(int posX, int posY, int width, int height, Color color1, Color color2);
+// Draw a gradient-filled rectangle with custom vertex colors
+RLAPI void DrawRectangleGradientEx(Rectangle rec, Color col1, Color col2, Color col3, Color col4);
+// Draw rectangle outline
+RLAPI void DrawRectangleLines(int posX, int posY, int width, int height, Color color);
+// Draw rectangle outline with extended parameters
+RLAPI void DrawRectangleLinesEx(Rectangle rec, float lineThick, Color color);
+// Draw rectangle with rounded edges
+RLAPI void DrawRectangleRounded(Rectangle rec, float roundness, int segments, Color color);
+// Draw rectangle lines with rounded edges
+RLAPI void DrawRectangleRoundedLines(Rectangle rec, float roundness, int segments, Color color);
+// Draw rectangle with rounded edges outline
+RLAPI void DrawRectangleRoundedLinesEx(Rectangle rec, float roundness, int segments, float lineThick, Color color);
+// Draw a color-filled triangle (vertex in counter-clockwise order!)
+RLAPI void DrawTriangle(Vector2 v1, Vector2 v2, Vector2 v3, Color color);
+// Draw triangle outline (vertex in counter-clockwise order!)
+RLAPI void DrawTriangleLines(Vector2 v1, Vector2 v2, Vector2 v3, Color color);
+// Draw a triangle fan defined by points (first vertex is the center)
+RLAPI void DrawTriangleFan(const Vector2 *points, int pointCount, Color color);
+// Draw a triangle strip defined by points
+RLAPI void DrawTriangleStrip(const Vector2 *points, int pointCount, Color color);
+// Draw a regular polygon (Vector version)
+RLAPI void DrawPoly(Vector2 center, int sides, float radius, float rotation, Color color);
+// Draw a polygon outline of n sides
+RLAPI void DrawPolyLines(Vector2 center, int sides, float radius, float rotation, Color color);
+// Draw a polygon outline of n sides with extended parameters
+RLAPI void DrawPolyLinesEx(Vector2 center, int sides, float radius, float rotation, float lineThick, Color color);
 
 // Splines drawing functions
-RLAPI void DrawSplineLinear(const Vector2 *points, int pointCount, float thick, Color color);                  // Draw spline: Linear, minimum 2 points
-RLAPI void DrawSplineBasis(const Vector2 *points, int pointCount, float thick, Color color);                   // Draw spline: B-Spline, minimum 4 points
-RLAPI void DrawSplineCatmullRom(const Vector2 *points, int pointCount, float thick, Color color);              // Draw spline: Catmull-Rom, minimum 4 points
-RLAPI void DrawSplineBezierQuadratic(const Vector2 *points, int pointCount, float thick, Color color);         // Draw spline: Quadratic Bezier, minimum 3 points (1 control point): [p1, c2, p3, c4...]
-RLAPI void DrawSplineBezierCubic(const Vector2 *points, int pointCount, float thick, Color color);             // Draw spline: Cubic Bezier, minimum 4 points (2 control points): [p1, c2, c3, p4, c5, c6...]
-RLAPI void DrawSplineSegmentLinear(Vector2 p1, Vector2 p2, float thick, Color color);                    // Draw spline segment: Linear, 2 points
-RLAPI void DrawSplineSegmentBasis(Vector2 p1, Vector2 p2, Vector2 p3, Vector2 p4, float thick, Color color); // Draw spline segment: B-Spline, 4 points
-RLAPI void DrawSplineSegmentCatmullRom(Vector2 p1, Vector2 p2, Vector2 p3, Vector2 p4, float thick, Color color); // Draw spline segment: Catmull-Rom, 4 points
-RLAPI void DrawSplineSegmentBezierQuadratic(Vector2 p1, Vector2 c2, Vector2 p3, float thick, Color color); // Draw spline segment: Quadratic Bezier, 2 points, 1 control point
-RLAPI void DrawSplineSegmentBezierCubic(Vector2 p1, Vector2 c2, Vector2 c3, Vector2 p4, float thick, Color color); // Draw spline segment: Cubic Bezier, 2 points, 2 control points
+
+// Draw spline: Linear, minimum 2 points
+RLAPI void DrawSplineLinear(const Vector2 *points, int pointCount, float thick, Color color);
+// Draw spline: B-Spline, minimum 4 points
+RLAPI void DrawSplineBasis(const Vector2 *points, int pointCount, float thick, Color color);
+// Draw spline: Catmull-Rom, minimum 4 points
+RLAPI void DrawSplineCatmullRom(const Vector2 *points, int pointCount, float thick, Color color);
+// Draw spline: Quadratic Bezier, minimum 3 points (1 control point): [p1, c2, p3, c4...]
+RLAPI void DrawSplineBezierQuadratic(const Vector2 *points, int pointCount, float thick, Color color);
+// Draw spline: Cubic Bezier, minimum 4 points (2 control points): [p1, c2, c3, p4, c5, c6...]
+RLAPI void DrawSplineBezierCubic(const Vector2 *points, int pointCount, float thick, Color color);
+// Draw spline segment: Linear, 2 points
+RLAPI void DrawSplineSegmentLinear(Vector2 p1, Vector2 p2, float thick, Color color);
+// Draw spline segment: B-Spline, 4 points
+RLAPI void DrawSplineSegmentBasis(Vector2 p1, Vector2 p2, Vector2 p3, Vector2 p4, float thick, Color color);
+// Draw spline segment: Catmull-Rom, 4 points
+RLAPI void DrawSplineSegmentCatmullRom(Vector2 p1, Vector2 p2, Vector2 p3, Vector2 p4, float thick, Color color);
+// Draw spline segment: Quadratic Bezier, 2 points, 1 control point
+RLAPI void DrawSplineSegmentBezierQuadratic(Vector2 p1, Vector2 c2, Vector2 p3, float thick, Color color);
+// Draw spline segment: Cubic Bezier, 2 points, 2 control points
+RLAPI void DrawSplineSegmentBezierCubic(Vector2 p1, Vector2 c2, Vector2 c3, Vector2 p4, float thick, Color color);
 
 // Spline segment point evaluation functions, for a given t [0.0f .. 1.0f]
-RLAPI Vector2 GetSplinePointLinear(Vector2 startPos, Vector2 endPos, float t);                           // Get (evaluate) spline point: Linear
-RLAPI Vector2 GetSplinePointBasis(Vector2 p1, Vector2 p2, Vector2 p3, Vector2 p4, float t);              // Get (evaluate) spline point: B-Spline
-RLAPI Vector2 GetSplinePointCatmullRom(Vector2 p1, Vector2 p2, Vector2 p3, Vector2 p4, float t);         // Get (evaluate) spline point: Catmull-Rom
-RLAPI Vector2 GetSplinePointBezierQuad(Vector2 p1, Vector2 c2, Vector2 p3, float t);                     // Get (evaluate) spline point: Quadratic Bezier
-RLAPI Vector2 GetSplinePointBezierCubic(Vector2 p1, Vector2 c2, Vector2 c3, Vector2 p4, float t);        // Get (evaluate) spline point: Cubic Bezier
+
+// Get (evaluate) spline point: Linear
+RLAPI Vector2 GetSplinePointLinear(Vector2 startPos, Vector2 endPos, float t);
+// Get (evaluate) spline point: B-Spline
+RLAPI Vector2 GetSplinePointBasis(Vector2 p1, Vector2 p2, Vector2 p3, Vector2 p4, float t);
+// Get (evaluate) spline point: Catmull-Rom
+RLAPI Vector2 GetSplinePointCatmullRom(Vector2 p1, Vector2 p2, Vector2 p3, Vector2 p4, float t);
+// Get (evaluate) spline point: Quadratic Bezier
+RLAPI Vector2 GetSplinePointBezierQuad(Vector2 p1, Vector2 c2, Vector2 p3, float t);
+// Get (evaluate) spline point: Cubic Bezier
+RLAPI Vector2 GetSplinePointBezierCubic(Vector2 p1, Vector2 c2, Vector2 c3, Vector2 p4, float t);
 
 // Basic shapes collision detection functions
-RLAPI bool CheckCollisionRecs(Rectangle rec1, Rectangle rec2);                                           // Check collision between two rectangles
-RLAPI bool CheckCollisionCircles(Vector2 center1, float radius1, Vector2 center2, float radius2);        // Check collision between two circles
-RLAPI bool CheckCollisionCircleRec(Vector2 center, float radius, Rectangle rec);                         // Check collision between circle and rectangle
-RLAPI bool CheckCollisionPointRec(Vector2 point, Rectangle rec);                                         // Check if point is inside rectangle
-RLAPI bool CheckCollisionPointCircle(Vector2 point, Vector2 center, float radius);                       // Check if point is inside circle
-RLAPI bool CheckCollisionPointTriangle(Vector2 point, Vector2 p1, Vector2 p2, Vector2 p3);               // Check if point is inside a triangle
-RLAPI bool CheckCollisionPointPoly(Vector2 point, const Vector2 *points, int pointCount);                // Check if point is within a polygon described by array of vertices
-RLAPI bool CheckCollisionLines(Vector2 startPos1, Vector2 endPos1, Vector2 startPos2, Vector2 endPos2, Vector2 *collisionPoint); // Check the collision between two lines defined by two points each, returns collision point by reference
-RLAPI bool CheckCollisionPointLine(Vector2 point, Vector2 p1, Vector2 p2, int threshold);                // Check if point belongs to line created between two points [p1] and [p2] with defined margin in pixels [threshold]
-RLAPI bool CheckCollisionCircleLine(Vector2 center, float radius, Vector2 p1, Vector2 p2);               // Check if circle collides with a line created betweeen two points [p1] and [p2]
-RLAPI Rectangle GetCollisionRec(Rectangle rec1, Rectangle rec2);                                         // Get collision rectangle for two rectangles collision
+
+// Check collision between two rectangles
+RLAPI bool CheckCollisionRecs(Rectangle rec1, Rectangle rec2);
+// Check collision between two circles
+RLAPI bool CheckCollisionCircles(Vector2 center1, float radius1, Vector2 center2, float radius2);
+// Check collision between circle and rectangle
+RLAPI bool CheckCollisionCircleRec(Vector2 center, float radius, Rectangle rec);
+// Check if point is inside rectangle
+RLAPI bool CheckCollisionPointRec(Vector2 point, Rectangle rec);
+// Check if point is inside circle
+RLAPI bool CheckCollisionPointCircle(Vector2 point, Vector2 center, float radius);
+// Check if point is inside a triangle
+RLAPI bool CheckCollisionPointTriangle(Vector2 point, Vector2 p1, Vector2 p2, Vector2 p3);
+// Check if point is within a polygon described by array of vertices
+RLAPI bool CheckCollisionPointPoly(Vector2 point, const Vector2 *points, int pointCount);
+// Check the collision between two lines defined by two points each, returns collision point by reference
+RLAPI bool CheckCollisionLines(Vector2 startPos1, Vector2 endPos1, Vector2 startPos2, Vector2 endPos2, Vector2 *collisionPoint);
+// Check if point belongs to line created between two points [p1] and [p2] with defined margin in pixels [threshold]
+RLAPI bool CheckCollisionPointLine(Vector2 point, Vector2 p1, Vector2 p2, int threshold);
+// Check if circle collides with a line created betweeen two points [p1] and [p2]
+RLAPI bool CheckCollisionCircleLine(Vector2 center, float radius, Vector2 p1, Vector2 p2);
+// Get collision rectangle for two rectangles collision
+RLAPI Rectangle GetCollisionRec(Rectangle rec1, Rectangle rec2);
 
 //------------------------------------------------------------------------------------
 // Texture Loading and Drawing Functions (Module: textures)
@@ -1304,300 +1610,559 @@ RLAPI Rectangle GetCollisionRec(Rectangle rec1, Rectangle rec2);                
 
 // Image loading functions
 // NOTE: These functions do not require GPU access
-RLAPI Image LoadImage(const char *fileName);                                                             // Load image from file into CPU memory (RAM)
-RLAPI Image LoadImageRaw(const char *fileName, int width, int height, int format, int headerSize);       // Load image from RAW file data
-RLAPI Image LoadImageSvg(const char *fileNameOrString, int width, int height);                           // Load image from SVG file data or string with specified size
-RLAPI Image LoadImageAnim(const char *fileName, int *frames);                                            // Load image sequence from file (frames appended to image.data)
-RLAPI Image LoadImageAnimFromMemory(const char *fileType, const unsigned char *fileData, int dataSize, int *frames); // Load image sequence from memory buffer
-RLAPI Image LoadImageFromMemory(const char *fileType, const unsigned char *fileData, int dataSize);      // Load image from memory buffer, fileType refers to extension: i.e. '.png'
-RLAPI Image LoadImageFromTexture(Texture2D texture);                                                     // Load image from GPU texture data
-RLAPI Image LoadImageFromScreen(void);                                                                   // Load image from screen buffer and (screenshot)
-RLAPI bool IsImageReady(Image image);                                                                    // Check if an image is ready
-RLAPI void UnloadImage(Image image);                                                                     // Unload image from CPU memory (RAM)
-RLAPI bool ExportImage(Image image, const char *fileName);                                               // Export image data to file, returns true on success
-RLAPI unsigned char *ExportImageToMemory(Image image, const char *fileType, int *fileSize);              // Export image to memory buffer
-RLAPI bool ExportImageAsCode(Image image, const char *fileName);                                         // Export image as code file defining an array of bytes, returns true on success
+
+// Load image from file into CPU memory (RAM)
+RLAPI Image LoadImage(const char *fileName);
+// Load image from RAW file data
+RLAPI Image LoadImageRaw(const char *fileName, int width, int height, int format, int headerSize);
+// Load image from SVG file data or string with specified size
+RLAPI Image LoadImageSvg(const char *fileNameOrString, int width, int height);
+// Load image sequence from file (frames appended to image.data)
+RLAPI Image LoadImageAnim(const char *fileName, int *frames);
+// Load image sequence from memory buffer
+RLAPI Image LoadImageAnimFromMemory(const char *fileType, const unsigned char *fileData, int dataSize, int *frames);
+// Load image from memory buffer, fileType refers to extension: i.e. '.png'
+RLAPI Image LoadImageFromMemory(const char *fileType, const unsigned char *fileData, int dataSize);
+// Load image from GPU texture data
+RLAPI Image LoadImageFromTexture(Texture2D texture);
+// Load image from screen buffer and (screenshot)
+RLAPI Image LoadImageFromScreen(void);
+// Check if an image is ready
+RLAPI bool IsImageReady(Image image);
+// Unload image from CPU memory (RAM)
+RLAPI void UnloadImage(Image image);
+// Export image data to file, returns true on success
+RLAPI bool ExportImage(Image image, const char *fileName);
+// Export image to memory buffer
+RLAPI unsigned char *ExportImageToMemory(Image image, const char *fileType, int *fileSize);
+// Export image as code file defining an array of bytes, returns true on success
+RLAPI bool ExportImageAsCode(Image image, const char *fileName);
 
 // Image generation functions
-RLAPI Image GenImageColor(int width, int height, Color color);                                           // Generate image: plain color
-RLAPI Image GenImageGradientLinear(int width, int height, int direction, Color start, Color end);        // Generate image: linear gradient, direction in degrees [0..360], 0=Vertical gradient
-RLAPI Image GenImageGradientRadial(int width, int height, float density, Color inner, Color outer);      // Generate image: radial gradient
-RLAPI Image GenImageGradientSquare(int width, int height, float density, Color inner, Color outer);      // Generate image: square gradient
-RLAPI Image GenImageChecked(int width, int height, int checksX, int checksY, Color col1, Color col2);    // Generate image: checked
-RLAPI Image GenImageWhiteNoise(int width, int height, float factor);                                     // Generate image: white noise
-RLAPI Image GenImagePerlinNoise(int width, int height, int offsetX, int offsetY, float scale);           // Generate image: perlin noise
-RLAPI Image GenImageCellular(int width, int height, int tileSize);                                       // Generate image: cellular algorithm, bigger tileSize means bigger cells
-RLAPI Image GenImageText(int width, int height, const char *text);                                       // Generate image: grayscale image from text data
+
+// Generate image: plain color
+RLAPI Image GenImageColor(int width, int height, Color color);
+// Generate image: linear gradient, direction in degrees [0..360], 0=Vertical gradient
+RLAPI Image GenImageGradientLinear(int width, int height, int direction, Color start, Color end);
+// Generate image: radial gradient
+RLAPI Image GenImageGradientRadial(int width, int height, float density, Color inner, Color outer);
+// Generate image: square gradient
+RLAPI Image GenImageGradientSquare(int width, int height, float density, Color inner, Color outer);
+// Generate image: checked
+RLAPI Image GenImageChecked(int width, int height, int checksX, int checksY, Color col1, Color col2);
+// Generate image: white noise
+RLAPI Image GenImageWhiteNoise(int width, int height, float factor);
+// Generate image: perlin noise
+RLAPI Image GenImagePerlinNoise(int width, int height, int offsetX, int offsetY, float scale);
+// Generate image: cellular algorithm, bigger tileSize means bigger cells
+RLAPI Image GenImageCellular(int width, int height, int tileSize);
+// Generate image: grayscale image from text data
+RLAPI Image GenImageText(int width, int height, const char *text);
 
 // Image manipulation functions
-RLAPI Image ImageCopy(Image image);                                                                      // Create an image duplicate (useful for transformations)
-RLAPI Image ImageFromImage(Image image, Rectangle rec);                                                  // Create an image from another image piece
-RLAPI Image ImageFromChannel(Image image, int selectedChannel);                                          // Create an image from a selected channel of another image (GRAYSCALE)
-RLAPI Image ImageText(const char *text, int fontSize, Color color);                                      // Create an image from text (default font)
-RLAPI Image ImageTextEx(Font font, const char *text, float fontSize, float spacing, Color tint);         // Create an image from text (custom sprite font)
-RLAPI void ImageFormat(Image *image, int newFormat);                                                     // Convert image data to desired format
-RLAPI void ImageToPOT(Image *image, Color fill);                                                         // Convert image to POT (power-of-two)
-RLAPI void ImageCrop(Image *image, Rectangle crop);                                                      // Crop an image to a defined rectangle
-RLAPI void ImageAlphaCrop(Image *image, float threshold);                                                // Crop image depending on alpha value
-RLAPI void ImageAlphaClear(Image *image, Color color, float threshold);                                  // Clear alpha channel to desired color
-RLAPI void ImageAlphaMask(Image *image, Image alphaMask);                                                // Apply alpha mask to image
-RLAPI void ImageAlphaPremultiply(Image *image);                                                          // Premultiply alpha channel
-RLAPI void ImageBlurGaussian(Image *image, int blurSize);                                                // Apply Gaussian blur using a box blur approximation
-RLAPI void ImageKernelConvolution(Image *image, const float *kernel, int kernelSize);                    // Apply custom square convolution kernel to image
-RLAPI void ImageResize(Image *image, int newWidth, int newHeight);                                       // Resize image (Bicubic scaling algorithm)
-RLAPI void ImageResizeNN(Image *image, int newWidth,int newHeight);                                      // Resize image (Nearest-Neighbor scaling algorithm)
-RLAPI void ImageResizeCanvas(Image *image, int newWidth, int newHeight, int offsetX, int offsetY, Color fill); // Resize canvas and fill with color
-RLAPI void ImageMipmaps(Image *image);                                                                   // Compute all mipmap levels for a provided image
-RLAPI void ImageDither(Image *image, int rBpp, int gBpp, int bBpp, int aBpp);                            // Dither image data to 16bpp or lower (Floyd-Steinberg dithering)
-RLAPI void ImageFlipVertical(Image *image);                                                              // Flip image vertically
-RLAPI void ImageFlipHorizontal(Image *image);                                                            // Flip image horizontally
-RLAPI void ImageRotate(Image *image, int degrees);                                                       // Rotate image by input angle in degrees (-359 to 359)
-RLAPI void ImageRotateCW(Image *image);                                                                  // Rotate image clockwise 90deg
-RLAPI void ImageRotateCCW(Image *image);                                                                 // Rotate image counter-clockwise 90deg
-RLAPI void ImageColorTint(Image *image, Color color);                                                    // Modify image color: tint
-RLAPI void ImageColorInvert(Image *image);                                                               // Modify image color: invert
-RLAPI void ImageColorGrayscale(Image *image);                                                            // Modify image color: grayscale
-RLAPI void ImageColorContrast(Image *image, float contrast);                                             // Modify image color: contrast (-100 to 100)
-RLAPI void ImageColorBrightness(Image *image, int brightness);                                           // Modify image color: brightness (-255 to 255)
-RLAPI void ImageColorReplace(Image *image, Color color, Color replace);                                  // Modify image color: replace color
-RLAPI Color *LoadImageColors(Image image);                                                               // Load color data from image as a Color array (RGBA - 32bit)
-RLAPI Color *LoadImagePalette(Image image, int maxPaletteSize, int *colorCount);                         // Load colors palette from image as a Color array (RGBA - 32bit)
-RLAPI void UnloadImageColors(Color *colors);                                                             // Unload color data loaded with LoadImageColors()
-RLAPI void UnloadImagePalette(Color *colors);                                                            // Unload colors palette loaded with LoadImagePalette()
-RLAPI Rectangle GetImageAlphaBorder(Image image, float threshold);                                       // Get image alpha border rectangle
-RLAPI Color GetImageColor(Image image, int x, int y);                                                    // Get image pixel color at (x, y) position
+
+// Create an image duplicate (useful for transformations)
+RLAPI Image ImageCopy(Image image);
+// Create an image from another image piece
+RLAPI Image ImageFromImage(Image image, Rectangle rec);
+// Create an image from a selected channel of another image (GRAYSCALE)
+RLAPI Image ImageFromChannel(Image image, int selectedChannel);
+// Create an image from text (default font)
+RLAPI Image ImageText(const char *text, int fontSize, Color color);
+// Create an image from text (custom sprite font)
+RLAPI Image ImageTextEx(Font font, const char *text, float fontSize, float spacing, Color tint);
+// Convert image data to desired format
+RLAPI void ImageFormat(Image *image, int newFormat);
+// Convert image to POT (power-of-two)
+RLAPI void ImageToPOT(Image *image, Color fill);
+// Crop an image to a defined rectangle
+RLAPI void ImageCrop(Image *image, Rectangle crop);
+// Crop image depending on alpha value
+RLAPI void ImageAlphaCrop(Image *image, float threshold);
+// Clear alpha channel to desired color
+RLAPI void ImageAlphaClear(Image *image, Color color, float threshold);
+// Apply alpha mask to image
+RLAPI void ImageAlphaMask(Image *image, Image alphaMask);
+// Premultiply alpha channel
+RLAPI void ImageAlphaPremultiply(Image *image);
+// Apply Gaussian blur using a box blur approximation
+RLAPI void ImageBlurGaussian(Image *image, int blurSize);
+// Apply custom square convolution kernel to image
+RLAPI void ImageKernelConvolution(Image *image, const float *kernel, int kernelSize);
+// Resize image (Bicubic scaling algorithm)
+RLAPI void ImageResize(Image *image, int newWidth, int newHeight);
+// Resize image (Nearest-Neighbor scaling algorithm)
+RLAPI void ImageResizeNN(Image *image, int newWidth,int newHeight);
+// Resize canvas and fill with color
+RLAPI void ImageResizeCanvas(Image *image, int newWidth, int newHeight, int offsetX, int offsetY, Color fill);
+// Compute all mipmap levels for a provided image
+RLAPI void ImageMipmaps(Image *image);
+// Dither image data to 16bpp or lower (Floyd-Steinberg dithering)
+RLAPI void ImageDither(Image *image, int rBpp, int gBpp, int bBpp, int aBpp);
+// Flip image vertically
+RLAPI void ImageFlipVertical(Image *image);
+// Flip image horizontally
+RLAPI void ImageFlipHorizontal(Image *image);
+// Rotate image by input angle in degrees (-359 to 359)
+RLAPI void ImageRotate(Image *image, int degrees);
+// Rotate image clockwise 90deg
+RLAPI void ImageRotateCW(Image *image);
+// Rotate image counter-clockwise 90deg
+RLAPI void ImageRotateCCW(Image *image);
+// Modify image color: tint
+RLAPI void ImageColorTint(Image *image, Color color);
+// Modify image color: invert
+RLAPI void ImageColorInvert(Image *image);
+// Modify image color: grayscale
+RLAPI void ImageColorGrayscale(Image *image);
+// Modify image color: contrast (-100 to 100)
+RLAPI void ImageColorContrast(Image *image, float contrast);
+// Modify image color: brightness (-255 to 255)
+RLAPI void ImageColorBrightness(Image *image, int brightness);
+// Modify image color: replace color
+RLAPI void ImageColorReplace(Image *image, Color color, Color replace);
+// Load color data from image as a Color array (RGBA - 32bit)
+RLAPI Color *LoadImageColors(Image image);
+// Load colors palette from image as a Color array (RGBA - 32bit)
+RLAPI Color *LoadImagePalette(Image image, int maxPaletteSize, int *colorCount);
+// Unload color data loaded with LoadImageColors()
+RLAPI void UnloadImageColors(Color *colors);
+// Unload colors palette loaded with LoadImagePalette()
+RLAPI void UnloadImagePalette(Color *colors);
+// Get image alpha border rectangle
+RLAPI Rectangle GetImageAlphaBorder(Image image, float threshold);
+// Get image pixel color at (x, y) position
+RLAPI Color GetImageColor(Image image, int x, int y);
 
 // Image drawing functions
 // NOTE: Image software-rendering functions (CPU)
-RLAPI void ImageClearBackground(Image *dst, Color color);                                                // Clear image background with given color
-RLAPI void ImageDrawPixel(Image *dst, int posX, int posY, Color color);                                  // Draw pixel within an image
-RLAPI void ImageDrawPixelV(Image *dst, Vector2 position, Color color);                                   // Draw pixel within an image (Vector version)
-RLAPI void ImageDrawLine(Image *dst, int startPosX, int startPosY, int endPosX, int endPosY, Color color); // Draw line within an image
-RLAPI void ImageDrawLineV(Image *dst, Vector2 start, Vector2 end, Color color);                          // Draw line within an image (Vector version)
-RLAPI void ImageDrawLineEx(Image *dst, Vector2 start, Vector2 end, int thick, Color color);              // Draw a line defining thickness within an image
-RLAPI void ImageDrawCircle(Image *dst, int centerX, int centerY, int radius, Color color);               // Draw a filled circle within an image
-RLAPI void ImageDrawCircleV(Image *dst, Vector2 center, int radius, Color color);                        // Draw a filled circle within an image (Vector version)
-RLAPI void ImageDrawCircleLines(Image *dst, int centerX, int centerY, int radius, Color color);          // Draw circle outline within an image
-RLAPI void ImageDrawCircleLinesV(Image *dst, Vector2 center, int radius, Color color);                   // Draw circle outline within an image (Vector version)
-RLAPI void ImageDrawRectangle(Image *dst, int posX, int posY, int width, int height, Color color);       // Draw rectangle within an image
-RLAPI void ImageDrawRectangleV(Image *dst, Vector2 position, Vector2 size, Color color);                 // Draw rectangle within an image (Vector version)
-RLAPI void ImageDrawRectangleRec(Image *dst, Rectangle rec, Color color);                                // Draw rectangle within an image
-RLAPI void ImageDrawRectangleLines(Image *dst, Rectangle rec, int thick, Color color);                   // Draw rectangle lines within an image
-RLAPI void ImageDrawTriangle(Image *dst, Vector2 v1, Vector2 v2, Vector2 v3, Color color);               // Draw triangle within an image
-RLAPI void ImageDrawTriangleEx(Image *dst, Vector2 v1, Vector2 v2, Vector2 v3, Color c1, Color c2, Color c3); // Draw triangle with interpolated colors within an image
-RLAPI void ImageDrawTriangleLines(Image *dst, Vector2 v1, Vector2 v2, Vector2 v3, Color color);          // Draw triangle outline within an image
-RLAPI void ImageDrawTriangleFan(Image *dst, Vector2 *points, int pointCount, Color color);               // Draw a triangle fan defined by points within an image (first vertex is the center)
-RLAPI void ImageDrawTriangleStrip(Image *dst, Vector2 *points, int pointCount, Color color);             // Draw a triangle strip defined by points within an image
-RLAPI void ImageDraw(Image *dst, Image src, Rectangle srcRec, Rectangle dstRec, Color tint);             // Draw a source image within a destination image (tint applied to source)
-RLAPI void ImageDrawText(Image *dst, const char *text, int posX, int posY, int fontSize, Color color);   // Draw text (using default font) within an image (destination)
-RLAPI void ImageDrawTextEx(Image *dst, Font font, const char *text, Vector2 position, float fontSize, float spacing, Color tint); // Draw text (custom sprite font) within an image (destination)
+
+// Clear image background with given color
+RLAPI void ImageClearBackground(Image *dst, Color color);
+// Draw pixel within an image
+RLAPI void ImageDrawPixel(Image *dst, int posX, int posY, Color color);
+// Draw pixel within an image (Vector version)
+RLAPI void ImageDrawPixelV(Image *dst, Vector2 position, Color color);
+// Draw line within an image
+RLAPI void ImageDrawLine(Image *dst, int startPosX, int startPosY, int endPosX, int endPosY, Color color);
+// Draw line within an image (Vector version)
+RLAPI void ImageDrawLineV(Image *dst, Vector2 start, Vector2 end, Color color);
+// Draw a line defining thickness within an image
+RLAPI void ImageDrawLineEx(Image *dst, Vector2 start, Vector2 end, int thick, Color color);
+// Draw a filled circle within an image
+RLAPI void ImageDrawCircle(Image *dst, int centerX, int centerY, int radius, Color color);
+// Draw a filled circle within an image (Vector version)
+RLAPI void ImageDrawCircleV(Image *dst, Vector2 center, int radius, Color color);
+// Draw circle outline within an image
+RLAPI void ImageDrawCircleLines(Image *dst, int centerX, int centerY, int radius, Color color);
+// Draw circle outline within an image (Vector version)
+RLAPI void ImageDrawCircleLinesV(Image *dst, Vector2 center, int radius, Color color);
+// Draw rectangle within an image
+RLAPI void ImageDrawRectangle(Image *dst, int posX, int posY, int width, int height, Color color);
+// Draw rectangle within an image (Vector version)
+RLAPI void ImageDrawRectangleV(Image *dst, Vector2 position, Vector2 size, Color color);
+// Draw rectangle within an image
+RLAPI void ImageDrawRectangleRec(Image *dst, Rectangle rec, Color color);
+// Draw rectangle lines within an image
+RLAPI void ImageDrawRectangleLines(Image *dst, Rectangle rec, int thick, Color color);
+// Draw triangle within an image
+RLAPI void ImageDrawTriangle(Image *dst, Vector2 v1, Vector2 v2, Vector2 v3, Color color);
+// Draw triangle with interpolated colors within an image
+RLAPI void ImageDrawTriangleEx(Image *dst, Vector2 v1, Vector2 v2, Vector2 v3, Color c1, Color c2, Color c3);
+// Draw triangle outline within an image
+RLAPI void ImageDrawTriangleLines(Image *dst, Vector2 v1, Vector2 v2, Vector2 v3, Color color);
+// Draw a triangle fan defined by points within an image (first vertex is the center)
+RLAPI void ImageDrawTriangleFan(Image *dst, Vector2 *points, int pointCount, Color color);
+// Draw a triangle strip defined by points within an image
+RLAPI void ImageDrawTriangleStrip(Image *dst, Vector2 *points, int pointCount, Color color);
+// Draw a source image within a destination image (tint applied to source)
+RLAPI void ImageDraw(Image *dst, Image src, Rectangle srcRec, Rectangle dstRec, Color tint);
+// Draw text (using default font) within an image (destination)
+RLAPI void ImageDrawText(Image *dst, const char *text, int posX, int posY, int fontSize, Color color);
+// Draw text (custom sprite font) within an image (destination)
+RLAPI void ImageDrawTextEx(Image *dst, Font font, const char *text, Vector2 position, float fontSize, float spacing, Color tint);
 
 // Texture loading functions
 // NOTE: These functions require GPU access
-RLAPI Texture2D LoadTexture(const char *fileName);                                                       // Load texture from file into GPU memory (VRAM)
-RLAPI Texture2D LoadTextureFromImage(Image image);                                                       // Load texture from image data
-RLAPI TextureCubemap LoadTextureCubemap(Image image, int layout);                                        // Load cubemap from image, multiple image cubemap layouts supported
-RLAPI RenderTexture2D LoadRenderTexture(int width, int height);                                          // Load texture for rendering (framebuffer)
-RLAPI bool IsTextureReady(Texture2D texture);                                                            // Check if a texture is ready
-RLAPI void UnloadTexture(Texture2D texture);                                                             // Unload texture from GPU memory (VRAM)
-RLAPI bool IsRenderTextureReady(RenderTexture2D target);                                                 // Check if a render texture is ready
-RLAPI void UnloadRenderTexture(RenderTexture2D target);                                                  // Unload render texture from GPU memory (VRAM)
-RLAPI void UpdateTexture(Texture2D texture, const void *pixels);                                         // Update GPU texture with new data
-RLAPI void UpdateTextureRec(Texture2D texture, Rectangle rec, const void *pixels);                       // Update GPU texture rectangle with new data
+
+// Load texture from file into GPU memory (VRAM).
+RLAPI Texture2D LoadTexture(const char *fileName);
+// Load texture from image data.
+RLAPI Texture2D LoadTextureFromImage(Image image);
+// Load cubemap from image, multiple image cubemap layouts supported.
+RLAPI TextureCubemap LoadTextureCubemap(Image image, int layout);
+// Load texture for rendering (framebuffer).
+RLAPI RenderTexture2D LoadRenderTexture(int width, int height);
+// Check if a texture is ready.
+RLAPI bool IsTextureReady(Texture2D texture);
+// Unload texture from GPU memory (VRAM).
+RLAPI void UnloadTexture(Texture2D texture);
+// Check if a render texture is ready.
+RLAPI bool IsRenderTextureReady(RenderTexture2D target);
+// Unload render texture from GPU memory (VRAM).
+RLAPI void UnloadRenderTexture(RenderTexture2D target);
+// Update GPU texture with new data.
+RLAPI void UpdateTexture(Texture2D texture, const void *pixels);
+// Update GPU texture rectangle with new data.
+RLAPI void UpdateTextureRec(Texture2D texture, Rectangle rec, const void *pixels);
 
 // Texture configuration functions
-RLAPI void GenTextureMipmaps(Texture2D *texture);                                                        // Generate GPU mipmaps for a texture
-RLAPI void SetTextureFilter(Texture2D texture, int filter);                                              // Set texture scaling filter mode
-RLAPI void SetTextureWrap(Texture2D texture, int wrap);                                                  // Set texture wrapping mode
+
+// Generate GPU mipmaps for a texture
+RLAPI void GenTextureMipmaps(Texture2D *texture);
+// Set texture scaling filter mode
+RLAPI void SetTextureFilter(Texture2D texture, int filter);
+// Set texture wrapping mode
+RLAPI void SetTextureWrap(Texture2D texture, int wrap);
 
 // Texture drawing functions
-RLAPI void DrawTexture(Texture2D texture, int posX, int posY, Color tint);                               // Draw a Texture2D
-RLAPI void DrawTextureV(Texture2D texture, Vector2 position, Color tint);                                // Draw a Texture2D with position defined as Vector2
-RLAPI void DrawTextureEx(Texture2D texture, Vector2 position, float rotation, float scale, Color tint);  // Draw a Texture2D with extended parameters
-RLAPI void DrawTextureRec(Texture2D texture, Rectangle source, Vector2 position, Color tint);            // Draw a part of a texture defined by a rectangle
-RLAPI void DrawTexturePro(Texture2D texture, Rectangle source, Rectangle dest, Vector2 origin, float rotation, Color tint); // Draw a part of a texture defined by a rectangle with 'pro' parameters
-RLAPI void DrawTextureNPatch(Texture2D texture, NPatchInfo nPatchInfo, Rectangle dest, Vector2 origin, float rotation, Color tint); // Draws a texture (or part of it) that stretches or shrinks nicely
+
+// Draw a Texture2D
+RLAPI void DrawTexture(Texture2D texture, int posX, int posY, Color tint);
+// Draw a Texture2D with position defined as Vector2
+RLAPI void DrawTextureV(Texture2D texture, Vector2 position, Color tint);
+// Draw a Texture2D with extended parameters
+RLAPI void DrawTextureEx(Texture2D texture, Vector2 position, float rotation, float scale, Color tint);
+// Draw a part of a texture defined by a rectangle
+RLAPI void DrawTextureRec(Texture2D texture, Rectangle source, Vector2 position, Color tint);
+// Draw a part of a texture defined by a rectangle with 'pro' parameters
+RLAPI void DrawTexturePro(Texture2D texture, Rectangle source, Rectangle dest, Vector2 origin, float rotation, Color tint);
+// Draws a texture (or part of it) that stretches or shrinks nicely
+RLAPI void DrawTextureNPatch(Texture2D texture, NPatchInfo nPatchInfo, Rectangle dest, Vector2 origin, float rotation, Color tint);
 
 // Color/pixel related functions
-RLAPI bool ColorIsEqual(Color col1, Color col2);                            // Check if two colors are equal
-RLAPI Color Fade(Color color, float alpha);                                 // Get color with alpha applied, alpha goes from 0.0f to 1.0f
-RLAPI int ColorToInt(Color color);                                          // Get hexadecimal value for a Color (0xRRGGBBAA)
-RLAPI Vector4 ColorNormalize(Color color);                                  // Get Color normalized as float [0..1]
-RLAPI Color ColorFromNormalized(Vector4 normalized);                        // Get Color from normalized values [0..1]
-RLAPI Vector3 ColorToHSV(Color color);                                      // Get HSV values for a Color, hue [0..360], saturation/value [0..1]
-RLAPI Color ColorFromHSV(float hue, float saturation, float value);         // Get a Color from HSV values, hue [0..360], saturation/value [0..1]
-RLAPI Color ColorTint(Color color, Color tint);                             // Get color multiplied with another color
-RLAPI Color ColorBrightness(Color color, float factor);                     // Get color with brightness correction, brightness factor goes from -1.0f to 1.0f
-RLAPI Color ColorContrast(Color color, float contrast);                     // Get color with contrast correction, contrast values between -1.0f and 1.0f
-RLAPI Color ColorAlpha(Color color, float alpha);                           // Get color with alpha applied, alpha goes from 0.0f to 1.0f
-RLAPI Color ColorAlphaBlend(Color dst, Color src, Color tint);              // Get src alpha-blended into dst color with tint
-RLAPI Color GetColor(unsigned int hexValue);                                // Get Color structure from hexadecimal value
-RLAPI Color GetPixelColor(void *srcPtr, int format);                        // Get Color from a source pixel pointer of certain format
-RLAPI void SetPixelColor(void *dstPtr, Color color, int format);            // Set color formatted into destination pixel pointer
-RLAPI int GetPixelDataSize(int width, int height, int format);              // Get pixel data size in bytes for certain format
+
+// Check if two colors are equal
+RLAPI bool ColorIsEqual(Color col1, Color col2);
+// Get color with alpha applied, alpha goes from 0.0f to 1.0f
+RLAPI Color Fade(Color color, float alpha);
+// Get hexadecimal value for a Color (0xRRGGBBAA)
+RLAPI int ColorToInt(Color color);
+// Get Color normalized as float [0..1]
+RLAPI Vector4 ColorNormalize(Color color);
+// Get Color from normalized values [0..1]
+RLAPI Color ColorFromNormalized(Vector4 normalized);
+// Get HSV values for a Color, hue [0..360], saturation/value [0..1]
+RLAPI Vector3 ColorToHSV(Color color);
+// Get a Color from HSV values, hue [0..360], saturation/value [0..1]
+RLAPI Color ColorFromHSV(float hue, float saturation, float value);
+// Get color multiplied with another color
+RLAPI Color ColorTint(Color color, Color tint);
+// Get color with brightness correction, brightness factor goes from -1.0f to 1.0f
+RLAPI Color ColorBrightness(Color color, float factor);
+// Get color with contrast correction, contrast values between -1.0f and 1.0f
+RLAPI Color ColorContrast(Color color, float contrast);
+// Get color with alpha applied, alpha goes from 0.0f to 1.0f
+RLAPI Color ColorAlpha(Color color, float alpha);
+// Get src alpha-blended into dst color with tint
+RLAPI Color ColorAlphaBlend(Color dst, Color src, Color tint);
+// Get Color structure from hexadecimal value
+RLAPI Color GetColor(unsigned int hexValue);
+// Get Color from a source pixel pointer of certain format
+RLAPI Color GetPixelColor(void *srcPtr, int format);
+// Set color formatted into destination pixel pointer
+RLAPI void SetPixelColor(void *dstPtr, Color color, int format);
+// Get pixel data size in bytes for certain format
+RLAPI int GetPixelDataSize(int width, int height, int format);
 
 //------------------------------------------------------------------------------------
 // Font Loading and Text Drawing Functions (Module: text)
 //------------------------------------------------------------------------------------
 
 // Font loading/unloading functions
-RLAPI Font GetFontDefault(void);                                                            // Get the default Font
-RLAPI Font LoadFont(const char *fileName);                                                  // Load font from file into GPU memory (VRAM)
-RLAPI Font LoadFontEx(const char *fileName, int fontSize, int *codepoints, int codepointCount); // Load font from file with extended parameters, use NULL for codepoints and 0 for codepointCount to load the default character set
-RLAPI Font LoadFontFromImage(Image image, Color key, int firstChar);                        // Load font from Image (XNA style)
-RLAPI Font LoadFontFromMemory(const char *fileType, const unsigned char *fileData, int dataSize, int fontSize, int *codepoints, int codepointCount); // Load font from memory buffer, fileType refers to extension: i.e. '.ttf'
-RLAPI bool IsFontReady(Font font);                                                          // Check if a font is ready
-RLAPI GlyphInfo *LoadFontData(const unsigned char *fileData, int dataSize, int fontSize, int *codepoints, int codepointCount, int type); // Load font data for further use
-RLAPI Image GenImageFontAtlas(const GlyphInfo *glyphs, Rectangle **glyphRecs, int glyphCount, int fontSize, int padding, int packMethod); // Generate image font atlas using chars info
-RLAPI void UnloadFontData(GlyphInfo *glyphs, int glyphCount);                               // Unload font chars info data (RAM)
-RLAPI void UnloadFont(Font font);                                                           // Unload font from GPU memory (VRAM)
-RLAPI bool ExportFontAsCode(Font font, const char *fileName);                               // Export font as code file, returns true on success
+
+// Get the default Font
+RLAPI Font GetFontDefault(void);
+// Load font from file into GPU memory (VRAM)
+RLAPI Font LoadFont(const char *fileName);
+// Load font from file with extended parameters, use NULL for codepoints and 0 for codepointCount to load the default character set
+RLAPI Font LoadFontEx(const char *fileName, int fontSize, int *codepoints, int codepointCount);
+// Load font from Image (XNA style)
+RLAPI Font LoadFontFromImage(Image image, Color key, int firstChar);
+// Load font from memory buffer, fileType refers to extension: i.e. '.ttf'
+RLAPI Font LoadFontFromMemory(const char *fileType, const unsigned char *fileData, int dataSize, int fontSize, int *codepoints, int codepointCount);
+// Check if a font is ready
+RLAPI bool IsFontReady(Font font);
+// Load font data for further use
+RLAPI GlyphInfo *LoadFontData(const unsigned char *fileData, int dataSize, int fontSize, int *codepoints, int codepointCount, int type);
+// Generate image font atlas using chars info
+RLAPI Image GenImageFontAtlas(const GlyphInfo *glyphs, Rectangle **glyphRecs, int glyphCount, int fontSize, int padding, int packMethod);
+// Unload font chars info data (RAM)
+RLAPI void UnloadFontData(GlyphInfo *glyphs, int glyphCount);
+// Unload font from GPU memory (VRAM)
+RLAPI void UnloadFont(Font font);
+// Export font as code file, returns true on success
+RLAPI bool ExportFontAsCode(Font font, const char *fileName);
 
 // Text drawing functions
-RLAPI void DrawFPS(int posX, int posY);                                                     // Draw current FPS
-RLAPI void DrawText(const char *text, int posX, int posY, int fontSize, Color color);       // Draw text (using default font)
-RLAPI void DrawTextEx(Font font, const char *text, Vector2 position, float fontSize, float spacing, Color tint); // Draw text using font and additional parameters
-RLAPI void DrawTextPro(Font font, const char *text, Vector2 position, Vector2 origin, float rotation, float fontSize, float spacing, Color tint); // Draw text using Font and pro parameters (rotation)
-RLAPI void DrawTextCodepoint(Font font, int codepoint, Vector2 position, float fontSize, Color tint); // Draw one character (codepoint)
-RLAPI void DrawTextCodepoints(Font font, const int *codepoints, int codepointCount, Vector2 position, float fontSize, float spacing, Color tint); // Draw multiple character (codepoint)
+
+// Draw current FPS
+RLAPI void DrawFPS(int posX, int posY);
+// Draw text (using default font)
+RLAPI void DrawText(const char *text, int posX, int posY, int fontSize, Color color);
+// Draw text using font and additional parameters
+RLAPI void DrawTextEx(Font font, const char *text, Vector2 position, float fontSize, float spacing, Color tint);
+// Draw text using Font and pro parameters (rotation)
+RLAPI void DrawTextPro(Font font, const char *text, Vector2 position, Vector2 origin, float rotation, float fontSize, float spacing, Color tint);
+// Draw one character (codepoint)
+RLAPI void DrawTextCodepoint(Font font, int codepoint, Vector2 position, float fontSize, Color tint);
+// Draw multiple character (codepoint)
+RLAPI void DrawTextCodepoints(Font font, const int *codepoints, int codepointCount, Vector2 position, float fontSize, float spacing, Color tint);
 
 // Text font info functions
-RLAPI void SetTextLineSpacing(int spacing);                                                 // Set vertical line spacing when drawing with line-breaks
-RLAPI int MeasureText(const char *text, int fontSize);                                      // Measure string width for default font
-RLAPI Vector2 MeasureTextEx(Font font, const char *text, float fontSize, float spacing);    // Measure string size for Font
-RLAPI int GetGlyphIndex(Font font, int codepoint);                                          // Get glyph index position in font for a codepoint (unicode character), fallback to '?' if not found
-RLAPI GlyphInfo GetGlyphInfo(Font font, int codepoint);                                     // Get glyph font info data for a codepoint (unicode character), fallback to '?' if not found
-RLAPI Rectangle GetGlyphAtlasRec(Font font, int codepoint);                                 // Get glyph rectangle in font atlas for a codepoint (unicode character), fallback to '?' if not found
+
+// Set vertical line spacing when drawing with line-breaks
+RLAPI void SetTextLineSpacing(int spacing);
+// Measure string width for default font
+RLAPI int MeasureText(const char *text, int fontSize);
+// Measure string size for Font
+RLAPI Vector2 MeasureTextEx(Font font, const char *text, float fontSize, float spacing);
+// Get glyph index position in font for a codepoint (unicode character), fallback to '?' if not found
+RLAPI int GetGlyphIndex(Font font, int codepoint);
+// Get glyph font info data for a codepoint (unicode character), fallback to '?' if not found
+RLAPI GlyphInfo GetGlyphInfo(Font font, int codepoint);
+// Get glyph rectangle in font atlas for a codepoint (unicode character), fallback to '?' if not found
+RLAPI Rectangle GetGlyphAtlasRec(Font font, int codepoint);
 
 // Text codepoints management functions (unicode characters)
-RLAPI char *LoadUTF8(const int *codepoints, int length);                // Load UTF-8 text encoded from codepoints array
-RLAPI void UnloadUTF8(char *text);                                      // Unload UTF-8 text encoded from codepoints array
-RLAPI int *LoadCodepoints(const char *text, int *count);                // Load all codepoints from a UTF-8 text string, codepoints count returned by parameter
-RLAPI void UnloadCodepoints(int *codepoints);                           // Unload codepoints data from memory
-RLAPI int GetCodepointCount(const char *text);                          // Get total number of codepoints in a UTF-8 encoded string
-RLAPI int GetCodepoint(const char *text, int *codepointSize);           // Get next codepoint in a UTF-8 encoded string, 0x3f('?') is returned on failure
-RLAPI int GetCodepointNext(const char *text, int *codepointSize);       // Get next codepoint in a UTF-8 encoded string, 0x3f('?') is returned on failure
-RLAPI int GetCodepointPrevious(const char *text, int *codepointSize);   // Get previous codepoint in a UTF-8 encoded string, 0x3f('?') is returned on failure
-RLAPI const char *CodepointToUTF8(int codepoint, int *utf8Size);        // Encode one codepoint into UTF-8 byte array (array length returned as parameter)
+
+// Load UTF-8 text encoded from codepoints array
+RLAPI char *LoadUTF8(const int *codepoints, int length);
+// Unload UTF-8 text encoded from codepoints array
+RLAPI void UnloadUTF8(char *text);
+// Load all codepoints from a UTF-8 text string, codepoints count returned by parameter
+RLAPI int *LoadCodepoints(const char *text, int *count);
+// Unload codepoints data from memory
+RLAPI void UnloadCodepoints(int *codepoints);
+// Get total number of codepoints in a UTF-8 encoded string
+RLAPI int GetCodepointCount(const char *text);
+// Get next codepoint in a UTF-8 encoded string, 0x3f('?') is returned on failure
+RLAPI int GetCodepoint(const char *text, int *codepointSize);
+// Get next codepoint in a UTF-8 encoded string, 0x3f('?') is returned on failure
+RLAPI int GetCodepointNext(const char *text, int *codepointSize);
+// Get previous codepoint in a UTF-8 encoded string, 0x3f('?') is returned on failure
+RLAPI int GetCodepointPrevious(const char *text, int *codepointSize);
+// Encode one codepoint into UTF-8 byte array (array length returned as parameter)
+RLAPI const char *CodepointToUTF8(int codepoint, int *utf8Size);
 
 // Text strings management functions (no UTF-8 strings, only byte chars)
 // NOTE: Some strings allocate memory internally for returned strings, just be careful!
-RLAPI int TextCopy(char *dst, const char *src);                                             // Copy one string to another, returns bytes copied
-RLAPI bool TextIsEqual(const char *text1, const char *text2);                               // Check if two text string are equal
-RLAPI unsigned int TextLength(const char *text);                                            // Get text length, checks for '\0' ending
-RLAPI const char *TextFormat(const char *text, ...);                                        // Text formatting with variables (sprintf() style)
-RLAPI const char *TextSubtext(const char *text, int position, int length);                  // Get a piece of a text string
-RLAPI char *TextReplace(const char *text, const char *replace, const char *by);             // Replace text string (WARNING: memory must be freed!)
-RLAPI char *TextInsert(const char *text, const char *insert, int position);                 // Insert text in a position (WARNING: memory must be freed!)
-RLAPI const char *TextJoin(const char **textList, int count, const char *delimiter);        // Join text strings with delimiter
-RLAPI const char **TextSplit(const char *text, char delimiter, int *count);                 // Split text into multiple strings
-RLAPI void TextAppend(char *text, const char *append, int *position);                       // Append text at specific position and move cursor!
-RLAPI int TextFindIndex(const char *text, const char *find);                                // Find first text occurrence within a string
-RLAPI const char *TextToUpper(const char *text);                      // Get upper case version of provided string
-RLAPI const char *TextToLower(const char *text);                      // Get lower case version of provided string
-RLAPI const char *TextToPascal(const char *text);                     // Get Pascal case notation version of provided string
-RLAPI const char *TextToSnake(const char *text);                      // Get Snake case notation version of provided string
-RLAPI const char *TextToCamel(const char *text);                      // Get Camel case notation version of provided string
 
-RLAPI int TextToInteger(const char *text);                            // Get integer value from text (negative values not supported)
-RLAPI float TextToFloat(const char *text);                            // Get float value from text (negative values not supported)
+// Copy one string to another, returns bytes copied
+RLAPI int TextCopy(char *dst, const char *src);
+// Check if two text string are equal
+RLAPI bool TextIsEqual(const char *text1, const char *text2);
+// Get text length, checks for '\0' ending
+RLAPI unsigned int TextLength(const char *text);
+// Text formatting with variables (sprintf() style)
+RLAPI const char *TextFormat(const char *text, ...);
+// Get a piece of a text string
+RLAPI const char *TextSubtext(const char *text, int position, int length);
+// Replace text string (WARNING: memory must be freed!)
+RLAPI char *TextReplace(const char *text, const char *replace, const char *by);
+// Insert text in a position (WARNING: memory must be freed!)
+RLAPI char *TextInsert(const char *text, const char *insert, int position);
+// Join text strings with delimiter
+RLAPI const char *TextJoin(const char **textList, int count, const char *delimiter);
+// Split text into multiple strings
+RLAPI const char **TextSplit(const char *text, char delimiter, int *count);
+// Append text at specific position and move cursor!
+RLAPI void TextAppend(char *text, const char *append, int *position);
+// Find first text occurrence within a string
+RLAPI int TextFindIndex(const char *text, const char *find);
+// Get upper case version of provided string
+RLAPI const char *TextToUpper(const char *text);
+// Get lower case version of provided string
+RLAPI const char *TextToLower(const char *text);
+// Get Pascal case notation version of provided string
+RLAPI const char *TextToPascal(const char *text);
+// Get Snake case notation version of provided string
+RLAPI const char *TextToSnake(const char *text);
+// Get Camel case notation version of provided string
+RLAPI const char *TextToCamel(const char *text);
+
+// Get integer value from text (negative values not supported)
+RLAPI int TextToInteger(const char *text);
+// Get float value from text (negative values not supported)
+RLAPI float TextToFloat(const char *text);
 
 //------------------------------------------------------------------------------------
 // Basic 3d Shapes Drawing Functions (Module: models)
 //------------------------------------------------------------------------------------
 
 // Basic geometric 3D shapes drawing functions
-RLAPI void DrawLine3D(Vector3 startPos, Vector3 endPos, Color color);                                    // Draw a line in 3D world space
-RLAPI void DrawPoint3D(Vector3 position, Color color);                                                   // Draw a point in 3D space, actually a small line
-RLAPI void DrawCircle3D(Vector3 center, float radius, Vector3 rotationAxis, float rotationAngle, Color color); // Draw a circle in 3D world space
-RLAPI void DrawTriangle3D(Vector3 v1, Vector3 v2, Vector3 v3, Color color);                              // Draw a color-filled triangle (vertex in counter-clockwise order!)
-RLAPI void DrawTriangleStrip3D(const Vector3 *points, int pointCount, Color color);                      // Draw a triangle strip defined by points
-RLAPI void DrawCube(Vector3 position, float width, float height, float length, Color color);             // Draw cube
-RLAPI void DrawCubeV(Vector3 position, Vector3 size, Color color);                                       // Draw cube (Vector version)
-RLAPI void DrawCubeWires(Vector3 position, float width, float height, float length, Color color);        // Draw cube wires
-RLAPI void DrawCubeWiresV(Vector3 position, Vector3 size, Color color);                                  // Draw cube wires (Vector version)
-RLAPI void DrawSphere(Vector3 centerPos, float radius, Color color);                                     // Draw sphere
-RLAPI void DrawSphereEx(Vector3 centerPos, float radius, int rings, int slices, Color color);            // Draw sphere with extended parameters
-RLAPI void DrawSphereWires(Vector3 centerPos, float radius, int rings, int slices, Color color);         // Draw sphere wires
-RLAPI void DrawCylinder(Vector3 position, float radiusTop, float radiusBottom, float height, int slices, Color color); // Draw a cylinder/cone
-RLAPI void DrawCylinderEx(Vector3 startPos, Vector3 endPos, float startRadius, float endRadius, int sides, Color color); // Draw a cylinder with base at startPos and top at endPos
-RLAPI void DrawCylinderWires(Vector3 position, float radiusTop, float radiusBottom, float height, int slices, Color color); // Draw a cylinder/cone wires
-RLAPI void DrawCylinderWiresEx(Vector3 startPos, Vector3 endPos, float startRadius, float endRadius, int sides, Color color); // Draw a cylinder wires with base at startPos and top at endPos
-RLAPI void DrawCapsule(Vector3 startPos, Vector3 endPos, float radius, int slices, int rings, Color color); // Draw a capsule with the center of its sphere caps at startPos and endPos
-RLAPI void DrawCapsuleWires(Vector3 startPos, Vector3 endPos, float radius, int slices, int rings, Color color); // Draw capsule wireframe with the center of its sphere caps at startPos and endPos
-RLAPI void DrawPlane(Vector3 centerPos, Vector2 size, Color color);                                      // Draw a plane XZ
-RLAPI void DrawRay(Ray ray, Color color);                                                                // Draw a ray line
-RLAPI void DrawGrid(int slices, float spacing);                                                          // Draw a grid (centered at (0, 0, 0))
+
+// Draw a line in 3D world space
+RLAPI void DrawLine3D(Vector3 startPos, Vector3 endPos, Color color);
+// Draw a point in 3D space, actually a small line
+RLAPI void DrawPoint3D(Vector3 position, Color color);
+// Draw a circle in 3D world space
+RLAPI void DrawCircle3D(Vector3 center, float radius, Vector3 rotationAxis, float rotationAngle, Color color);
+// Draw a color-filled triangle (vertex in counter-clockwise order!)
+RLAPI void DrawTriangle3D(Vector3 v1, Vector3 v2, Vector3 v3, Color color);
+// Draw a triangle strip defined by points
+RLAPI void DrawTriangleStrip3D(const Vector3 *points, int pointCount, Color color);
+// Draw cube
+RLAPI void DrawCube(Vector3 position, float width, float height, float length, Color color);
+// Draw cube (Vector version)
+RLAPI void DrawCubeV(Vector3 position, Vector3 size, Color color);
+// Draw cube wires
+RLAPI void DrawCubeWires(Vector3 position, float width, float height, float length, Color color);
+// Draw cube wires (Vector version)
+RLAPI void DrawCubeWiresV(Vector3 position, Vector3 size, Color color);
+// Draw sphere
+RLAPI void DrawSphere(Vector3 centerPos, float radius, Color color);
+// Draw sphere with extended parameters
+RLAPI void DrawSphereEx(Vector3 centerPos, float radius, int rings, int slices, Color color);
+// Draw sphere wires
+RLAPI void DrawSphereWires(Vector3 centerPos, float radius, int rings, int slices, Color color);
+// Draw a cylinder/cone
+RLAPI void DrawCylinder(Vector3 position, float radiusTop, float radiusBottom, float height, int slices, Color color);
+// Draw a cylinder with base at startPos and top at endPos
+RLAPI void DrawCylinderEx(Vector3 startPos, Vector3 endPos, float startRadius, float endRadius, int sides, Color color);
+// Draw a cylinder/cone wires
+RLAPI void DrawCylinderWires(Vector3 position, float radiusTop, float radiusBottom, float height, int slices, Color color);
+// Draw a cylinder wires with base at startPos and top at endPos
+RLAPI void DrawCylinderWiresEx(Vector3 startPos, Vector3 endPos, float startRadius, float endRadius, int sides, Color color);
+// Draw a capsule with the center of its sphere caps at startPos and endPos
+RLAPI void DrawCapsule(Vector3 startPos, Vector3 endPos, float radius, int slices, int rings, Color color);
+// Draw capsule wireframe with the center of its sphere caps at startPos and endPos
+RLAPI void DrawCapsuleWires(Vector3 startPos, Vector3 endPos, float radius, int slices, int rings, Color color);
+// Draw a plane XZ
+RLAPI void DrawPlane(Vector3 centerPos, Vector2 size, Color color);
+// Draw a ray line
+RLAPI void DrawRay(Ray ray, Color color);
+// Draw a grid (centered at (0, 0, 0))
+RLAPI void DrawGrid(int slices, float spacing);
 
 //------------------------------------------------------------------------------------
 // Model 3d Loading and Drawing Functions (Module: models)
 //------------------------------------------------------------------------------------
 
 // Model management functions
-RLAPI Model LoadModel(const char *fileName);                                                // Load model from files (meshes and materials)
-RLAPI Model LoadModelFromMesh(Mesh mesh);                                                   // Load model from generated mesh (default material)
-RLAPI bool IsModelReady(Model model);                                                       // Check if a model is ready
-RLAPI void UnloadModel(Model model);                                                        // Unload model (including meshes) from memory (RAM and/or VRAM)
-RLAPI BoundingBox GetModelBoundingBox(Model model);                                         // Compute model bounding box limits (considers all meshes)
+
+// Load model from files (meshes and materials)
+RLAPI Model LoadModel(const char *fileName);
+// Load model from generated mesh (default material)
+RLAPI Model LoadModelFromMesh(Mesh mesh);
+// Check if a model is ready
+RLAPI bool IsModelReady(Model model);
+// Unload model (including meshes) from memory (RAM and/or VRAM)
+RLAPI void UnloadModel(Model model);
+// Compute model bounding box limits (considers all meshes)
+RLAPI BoundingBox GetModelBoundingBox(Model model);
 
 // Model drawing functions
-RLAPI void DrawModel(Model model, Vector3 position, float scale, Color tint);               // Draw a model (with texture if set)
-RLAPI void DrawModelEx(Model model, Vector3 position, Vector3 rotationAxis, float rotationAngle, Vector3 scale, Color tint); // Draw a model with extended parameters
-RLAPI void DrawModelWires(Model model, Vector3 position, float scale, Color tint);          // Draw a model wires (with texture if set)
-RLAPI void DrawModelWiresEx(Model model, Vector3 position, Vector3 rotationAxis, float rotationAngle, Vector3 scale, Color tint); // Draw a model wires (with texture if set) with extended parameters
-RLAPI void DrawBoundingBox(BoundingBox box, Color color);                                   // Draw bounding box (wires)
-RLAPI void DrawBillboard(Camera camera, Texture2D texture, Vector3 position, float scale, Color tint);   // Draw a billboard texture
-RLAPI void DrawBillboardRec(Camera camera, Texture2D texture, Rectangle source, Vector3 position, Vector2 size, Color tint); // Draw a billboard texture defined by source
-RLAPI void DrawBillboardPro(Camera camera, Texture2D texture, Rectangle source, Vector3 position, Vector3 up, Vector2 size, Vector2 origin, float rotation, Color tint); // Draw a billboard texture defined by source and rotation
+
+// Draw a model (with texture if set)
+RLAPI void DrawModel(Model model, Vector3 position, float scale, Color tint);
+// Draw a model with extended parameters
+RLAPI void DrawModelEx(Model model, Vector3 position, Vector3 rotationAxis, float rotationAngle, Vector3 scale, Color tint);
+// Draw a model wires (with texture if set)
+RLAPI void DrawModelWires(Model model, Vector3 position, float scale, Color tint);
+// Draw a model wires (with texture if set) with extended parameters
+RLAPI void DrawModelWiresEx(Model model, Vector3 position, Vector3 rotationAxis, float rotationAngle, Vector3 scale, Color tint);
+// Draw bounding box (wires)
+RLAPI void DrawBoundingBox(BoundingBox box, Color color);
+// Draw a billboard texture 
+RLAPI void DrawBillboardRec(Camera camera, Texture2D texture, Rectangle source, Vector3 position, Vector2 size, Color tint); 
+// Draw a billboard texture defined by source
+RLAPI void DrawBillboard(Camera camera, Texture2D texture, Vector3 position, float scale, Color tint);
+// Draw a billboard texture defined by source and rotation
+RLAPI void DrawBillboardPro(Camera camera, Texture2D texture, Rectangle source, Vector3 position, Vector3 up, Vector2 size, Vector2 origin, float rotation, Color tint);
 
 // Mesh management functions
-RLAPI void UploadMesh(Mesh *mesh, bool dynamic);                                            // Upload mesh vertex data in GPU and provide VAO/VBO ids
-RLAPI void UpdateMeshBuffer(Mesh mesh, int index, const void *data, int dataSize, int offset); // Update mesh vertex data in GPU for a specific buffer index
-RLAPI void UnloadMesh(Mesh mesh);                                                           // Unload mesh data from CPU and GPU
-RLAPI void DrawMesh(Mesh mesh, Material material, Matrix transform);                        // Draw a 3d mesh with material and transform
-RLAPI void DrawMeshInstanced(Mesh mesh, Material material, const Matrix *transforms, int instances); // Draw multiple mesh instances with material and different transforms
-RLAPI BoundingBox GetMeshBoundingBox(Mesh mesh);                                            // Compute mesh bounding box limits
-RLAPI void GenMeshTangents(Mesh *mesh);                                                     // Compute mesh tangents
-RLAPI bool ExportMesh(Mesh mesh, const char *fileName);                                     // Export mesh data to file, returns true on success
-RLAPI bool ExportMeshAsCode(Mesh mesh, const char *fileName);                               // Export mesh as code file (.h) defining multiple arrays of vertex attributes
+
+// Upload mesh vertex data in GPU and provide VAO/VBO ids
+RLAPI void UploadMesh(Mesh *mesh, bool dynamic);
+// Update mesh vertex data in GPU for a specific buffer index
+RLAPI void UpdateMeshBuffer(Mesh mesh, int index, const void *data, int dataSize, int offset);
+// Unload mesh data from CPU and GPU
+RLAPI void UnloadMesh(Mesh mesh);
+// Draw a 3d mesh with material and transform
+RLAPI void DrawMesh(Mesh mesh, Material material, Matrix transform);
+// Draw multiple mesh instances with material and different transforms
+RLAPI void DrawMeshInstanced(Mesh mesh, Material material, const Matrix *transforms, int instances);
+// Compute mesh bounding box limits
+RLAPI BoundingBox GetMeshBoundingBox(Mesh mesh);
+// Compute mesh tangents
+RLAPI void GenMeshTangents(Mesh *mesh);
+// Export mesh data to file, returns true on success
+RLAPI bool ExportMesh(Mesh mesh, const char *fileName);
+// Export mesh as code file (.h) defining multiple arrays of vertex attributes
+RLAPI bool ExportMeshAsCode(Mesh mesh, const char *fileName);
 
 // Mesh generation functions
-RLAPI Mesh GenMeshPoly(int sides, float radius);                                            // Generate polygonal mesh
-RLAPI Mesh GenMeshPlane(float width, float length, int resX, int resZ);                     // Generate plane mesh (with subdivisions)
-RLAPI Mesh GenMeshCube(float width, float height, float length);                            // Generate cuboid mesh
-RLAPI Mesh GenMeshSphere(float radius, int rings, int slices);                              // Generate sphere mesh (standard sphere)
-RLAPI Mesh GenMeshHemiSphere(float radius, int rings, int slices);                          // Generate half-sphere mesh (no bottom cap)
-RLAPI Mesh GenMeshCylinder(float radius, float height, int slices);                         // Generate cylinder mesh
-RLAPI Mesh GenMeshCone(float radius, float height, int slices);                             // Generate cone/pyramid mesh
-RLAPI Mesh GenMeshTorus(float radius, float size, int radSeg, int sides);                   // Generate torus mesh
-RLAPI Mesh GenMeshKnot(float radius, float size, int radSeg, int sides);                    // Generate trefoil knot mesh
-RLAPI Mesh GenMeshHeightmap(Image heightmap, Vector3 size);                                 // Generate heightmap mesh from image data
-RLAPI Mesh GenMeshCubicmap(Image cubicmap, Vector3 cubeSize);                               // Generate cubes-based map mesh from image data
+
+// Generate polygonal mesh
+RLAPI Mesh GenMeshPoly(int sides, float radius);
+// Generate plane mesh (with subdivisions)
+RLAPI Mesh GenMeshPlane(float width, float length, int resX, int resZ);
+// Generate cuboid mesh
+RLAPI Mesh GenMeshCube(float width, float height, float length);
+// Generate sphere mesh (standard sphere)
+RLAPI Mesh GenMeshSphere(float radius, int rings, int slices);
+// Generate half-sphere mesh (no bottom cap)
+RLAPI Mesh GenMeshHemiSphere(float radius, int rings, int slices);
+// Generate cylinder mesh
+RLAPI Mesh GenMeshCylinder(float radius, float height, int slices);
+// Generate cone/pyramid mesh
+RLAPI Mesh GenMeshCone(float radius, float height, int slices);
+// Generate torus mesh
+RLAPI Mesh GenMeshTorus(float radius, float size, int radSeg, int sides);
+// Generate trefoil knot mesh
+RLAPI Mesh GenMeshKnot(float radius, float size, int radSeg, int sides);
+// Generate heightmap mesh from image data
+RLAPI Mesh GenMeshHeightmap(Image heightmap, Vector3 size);
+// Generate cubes-based map mesh from image data
+RLAPI Mesh GenMeshCubicmap(Image cubicmap, Vector3 cubeSize);
 
 // Material loading/unloading functions
-RLAPI Material *LoadMaterials(const char *fileName, int *materialCount);                    // Load materials from model file
-RLAPI Material LoadMaterialDefault(void);                                                   // Load default material (Supports: DIFFUSE, SPECULAR, NORMAL maps)
-RLAPI bool IsMaterialReady(Material material);                                              // Check if a material is ready
-RLAPI void UnloadMaterial(Material material);                                               // Unload material from GPU memory (VRAM)
-RLAPI void SetMaterialTexture(Material *material, int mapType, Texture2D texture);          // Set texture for a material map type (MATERIAL_MAP_DIFFUSE, MATERIAL_MAP_SPECULAR...)
-RLAPI void SetModelMeshMaterial(Model *model, int meshId, int materialId);                  // Set material for a mesh
+
+// Load materials from model file
+RLAPI Material *LoadMaterials(const char *fileName, int *materialCount);
+// Load default material (Supports: DIFFUSE, SPECULAR, NORMAL maps)
+RLAPI Material LoadMaterialDefault(void);
+// Check if a material is ready
+RLAPI bool IsMaterialReady(Material material);
+// Unload material from GPU memory (VRAM)
+RLAPI void UnloadMaterial(Material material);
+// Set texture for a material map type (MATERIAL_MAP_DIFFUSE, MATERIAL_MAP_SPECULAR...)
+RLAPI void SetMaterialTexture(Material *material, int mapType, Texture2D texture);
+// Set material for a mesh
+RLAPI void SetModelMeshMaterial(Model *model, int meshId, int materialId);
 
 // Model animations loading/unloading functions
-RLAPI ModelAnimation *LoadModelAnimations(const char *fileName, int *animCount);            // Load model animations from file
-RLAPI void UpdateModelAnimation(Model model, ModelAnimation anim, int frame);               // Update model animation pose
-RLAPI void UnloadModelAnimation(ModelAnimation anim);                                       // Unload animation data
-RLAPI void UnloadModelAnimations(ModelAnimation *animations, int animCount);                // Unload animation array data
-RLAPI bool IsModelAnimationValid(Model model, ModelAnimation anim);                         // Check model animation skeleton match
+
+// Load model animations from file
+RLAPI ModelAnimation *LoadModelAnimations(const char *fileName, int *animCount);
+// Update model animation pose
+RLAPI void UpdateModelAnimation(Model model, ModelAnimation anim, int frame);
+// Unload animation data
+RLAPI void UnloadModelAnimation(ModelAnimation anim);
+// Unload animation array data
+RLAPI void UnloadModelAnimations(ModelAnimation *animations, int animCount);
+// Check model animation skeleton match
+RLAPI bool IsModelAnimationValid(Model model, ModelAnimation anim);
 
 // Collision detection functions
-RLAPI bool CheckCollisionSpheres(Vector3 center1, float radius1, Vector3 center2, float radius2);   // Check collision between two spheres
-RLAPI bool CheckCollisionBoxes(BoundingBox box1, BoundingBox box2);                                 // Check collision between two bounding boxes
-RLAPI bool CheckCollisionBoxSphere(BoundingBox box, Vector3 center, float radius);                  // Check collision between box and sphere
-RLAPI RayCollision GetRayCollisionSphere(Ray ray, Vector3 center, float radius);                    // Get collision info between ray and sphere
-RLAPI RayCollision GetRayCollisionBox(Ray ray, BoundingBox box);                                    // Get collision info between ray and box
-RLAPI RayCollision GetRayCollisionMesh(Ray ray, Mesh mesh, Matrix transform);                       // Get collision info between ray and mesh
-RLAPI RayCollision GetRayCollisionTriangle(Ray ray, Vector3 p1, Vector3 p2, Vector3 p3);            // Get collision info between ray and triangle
-RLAPI RayCollision GetRayCollisionQuad(Ray ray, Vector3 p1, Vector3 p2, Vector3 p3, Vector3 p4);    // Get collision info between ray and quad
+
+// Check collision between two spheres
+RLAPI bool CheckCollisionSpheres(Vector3 center1, float radius1, Vector3 center2, float radius2);
+// Check collision between two bounding boxes
+RLAPI bool CheckCollisionBoxes(BoundingBox box1, BoundingBox box2);
+// Check collision between box and sphere
+RLAPI bool CheckCollisionBoxSphere(BoundingBox box, Vector3 center, float radius);
+// Get collision info between ray and sphere
+RLAPI RayCollision GetRayCollisionSphere(Ray ray, Vector3 center, float radius);
+// Get collision info between ray and box
+RLAPI RayCollision GetRayCollisionBox(Ray ray, BoundingBox box);
+// Get collision info between ray and mesh
+RLAPI RayCollision GetRayCollisionMesh(Ray ray, Mesh mesh, Matrix transform);
+// Get collision info between ray and triangle
+RLAPI RayCollision GetRayCollisionTriangle(Ray ray, Vector3 p1, Vector3 p2, Vector3 p3);
+// Get collision info between ray and quad
+RLAPI RayCollision GetRayCollisionQuad(Ray ray, Vector3 p1, Vector3 p2, Vector3 p3, Vector3 p4);
 
 //------------------------------------------------------------------------------------
 // Audio Loading and Playing Functions (Module: audio)
@@ -1605,82 +2170,152 @@ RLAPI RayCollision GetRayCollisionQuad(Ray ray, Vector3 p1, Vector3 p2, Vector3 
 typedef void (*AudioCallback)(void *bufferData, unsigned int frames);
 
 // Audio device management functions
-RLAPI void InitAudioDevice(void);                                     // Initialize audio device and context
-RLAPI void CloseAudioDevice(void);                                    // Close the audio device and context
-RLAPI bool IsAudioDeviceReady(void);                                  // Check if audio device has been initialized successfully
-RLAPI void SetMasterVolume(float volume);                             // Set master volume (listener)
-RLAPI float GetMasterVolume(void);                                    // Get master volume (listener)
+
+// Initialize audio device and context
+RLAPI void InitAudioDevice(void);
+// Close the audio device and context
+RLAPI void CloseAudioDevice(void);
+// Check if audio device has been initialized successfully
+RLAPI bool IsAudioDeviceReady(void);
+// Set master volume (listener)
+RLAPI void SetMasterVolume(float volume);
+// Get master volume (listener)
+RLAPI float GetMasterVolume(void);
 
 // Wave/Sound loading/unloading functions
-RLAPI Wave LoadWave(const char *fileName);                            // Load wave data from file
-RLAPI Wave LoadWaveFromMemory(const char *fileType, const unsigned char *fileData, int dataSize); // Load wave from memory buffer, fileType refers to extension: i.e. '.wav'
-RLAPI bool IsWaveReady(Wave wave);                                    // Checks if wave data is ready
-RLAPI Sound LoadSound(const char *fileName);                          // Load sound from file
-RLAPI Sound LoadSoundFromWave(Wave wave);                             // Load sound from wave data
-RLAPI Sound LoadSoundAlias(Sound source);                             // Create a new sound that shares the same sample data as the source sound, does not own the sound data
-RLAPI bool IsSoundReady(Sound sound);                                 // Checks if a sound is ready
-RLAPI void UpdateSound(Sound sound, const void *data, int sampleCount); // Update sound buffer with new data
-RLAPI void UnloadWave(Wave wave);                                     // Unload wave data
-RLAPI void UnloadSound(Sound sound);                                  // Unload sound
-RLAPI void UnloadSoundAlias(Sound alias);                             // Unload a sound alias (does not deallocate sample data)
-RLAPI bool ExportWave(Wave wave, const char *fileName);               // Export wave data to file, returns true on success
-RLAPI bool ExportWaveAsCode(Wave wave, const char *fileName);         // Export wave sample data to code (.h), returns true on success
+
+// Load wave data from file
+RLAPI Wave LoadWave(const char *fileName);
+// Load wave from memory buffer, fileType refers to extension: i.e. '.wav'
+RLAPI Wave LoadWaveFromMemory(const char *fileType, const unsigned char *fileData, int dataSize);
+// Checks if wave data is ready
+RLAPI bool IsWaveReady(Wave wave);
+// Load sound from file
+RLAPI Sound LoadSound(const char *fileName);
+// Load sound from wave data
+RLAPI Sound LoadSoundFromWave(Wave wave);
+// Create a new sound that shares the same sample data as the source sound, does not own the sound data
+RLAPI Sound LoadSoundAlias(Sound source);
+// Checks if a sound is ready
+RLAPI bool IsSoundReady(Sound sound);
+// Update sound buffer with new data
+RLAPI void UpdateSound(Sound sound, const void *data, int sampleCount);
+// Unload wave data
+RLAPI void UnloadWave(Wave wave);
+// Unload sound
+RLAPI void UnloadSound(Sound sound);
+// Unload a sound alias (does not deallocate sample data)
+RLAPI void UnloadSoundAlias(Sound alias);
+// Export wave data to file, returns true on success
+RLAPI bool ExportWave(Wave wave, const char *fileName);
+// Export wave sample data to code (.h), returns true on success
+RLAPI bool ExportWaveAsCode(Wave wave, const char *fileName);
 
 // Wave/Sound management functions
-RLAPI void PlaySound(Sound sound);                                    // Play a sound
-RLAPI void StopSound(Sound sound);                                    // Stop playing a sound
-RLAPI void PauseSound(Sound sound);                                   // Pause a sound
-RLAPI void ResumeSound(Sound sound);                                  // Resume a paused sound
-RLAPI bool IsSoundPlaying(Sound sound);                               // Check if a sound is currently playing
-RLAPI void SetSoundVolume(Sound sound, float volume);                 // Set volume for a sound (1.0 is max level)
-RLAPI void SetSoundPitch(Sound sound, float pitch);                   // Set pitch for a sound (1.0 is base level)
-RLAPI void SetSoundPan(Sound sound, float pan);                       // Set pan for a sound (0.5 is center)
-RLAPI Wave WaveCopy(Wave wave);                                       // Copy a wave to a new wave
-RLAPI void WaveCrop(Wave *wave, int initFrame, int finalFrame);       // Crop a wave to defined frames range
-RLAPI void WaveFormat(Wave *wave, int sampleRate, int sampleSize, int channels); // Convert wave data to desired format
-RLAPI float *LoadWaveSamples(Wave wave);                              // Load samples data from wave as a 32bit float data array
-RLAPI void UnloadWaveSamples(float *samples);                         // Unload samples data loaded with LoadWaveSamples()
+
+// Play a sound
+RLAPI void PlaySound(Sound sound);
+// Stop playing a sound
+RLAPI void StopSound(Sound sound);
+// Pause a sound
+RLAPI void PauseSound(Sound sound);
+// Resume a paused sound
+RLAPI void ResumeSound(Sound sound);
+// Check if a sound is currently playing
+RLAPI bool IsSoundPlaying(Sound sound);
+// Set volume for a sound (1.0 is max level)
+RLAPI void SetSoundVolume(Sound sound, float volume);
+// Set pitch for a sound (1.0 is base level)
+RLAPI void SetSoundPitch(Sound sound, float pitch);
+// Set pan for a sound (0.5 is center)
+RLAPI void SetSoundPan(Sound sound, float pan);
+// Copy a wave to a new wave
+RLAPI Wave WaveCopy(Wave wave);
+// Crop a wave to defined frames range
+RLAPI void WaveCrop(Wave *wave, int initFrame, int finalFrame);
+// Convert wave data to desired format
+RLAPI void WaveFormat(Wave *wave, int sampleRate, int sampleSize, int channels);
+// Load samples data from wave as a 32bit float data array
+RLAPI float *LoadWaveSamples(Wave wave);
+// Unload samples data loaded with LoadWaveSamples()
+RLAPI void UnloadWaveSamples(float *samples);
 
 // Music management functions
-RLAPI Music LoadMusicStream(const char *fileName);                    // Load music stream from file
-RLAPI Music LoadMusicStreamFromMemory(const char *fileType, const unsigned char *data, int dataSize); // Load music stream from data
-RLAPI bool IsMusicReady(Music music);                                 // Checks if a music stream is ready
-RLAPI void UnloadMusicStream(Music music);                            // Unload music stream
-RLAPI void PlayMusicStream(Music music);                              // Start music playing
-RLAPI bool IsMusicStreamPlaying(Music music);                         // Check if music is playing
-RLAPI void UpdateMusicStream(Music music);                            // Updates buffers for music streaming
-RLAPI void StopMusicStream(Music music);                              // Stop music playing
-RLAPI void PauseMusicStream(Music music);                             // Pause music playing
-RLAPI void ResumeMusicStream(Music music);                            // Resume playing paused music
-RLAPI void SeekMusicStream(Music music, float position);              // Seek music to a position (in seconds)
-RLAPI void SetMusicVolume(Music music, float volume);                 // Set volume for music (1.0 is max level)
-RLAPI void SetMusicPitch(Music music, float pitch);                   // Set pitch for a music (1.0 is base level)
-RLAPI void SetMusicPan(Music music, float pan);                       // Set pan for a music (0.5 is center)
-RLAPI float GetMusicTimeLength(Music music);                          // Get music time length (in seconds)
-RLAPI float GetMusicTimePlayed(Music music);                          // Get current music time played (in seconds)
+
+// Load music stream from file
+RLAPI Music LoadMusicStream(const char *fileName);
+// Load music stream from data
+RLAPI Music LoadMusicStreamFromMemory(const char *fileType, const unsigned char *data, int dataSize);
+// Checks if a music stream is ready
+RLAPI bool IsMusicReady(Music music);
+// Unload music stream
+RLAPI void UnloadMusicStream(Music music);
+// Start music playing
+RLAPI void PlayMusicStream(Music music);
+// Check if music is playing
+RLAPI bool IsMusicStreamPlaying(Music music);
+// Updates buffers for music streaming
+RLAPI void UpdateMusicStream(Music music);
+// Stop music playing
+RLAPI void StopMusicStream(Music music);
+// Pause music playing
+RLAPI void PauseMusicStream(Music music);
+// Resume playing paused music
+RLAPI void ResumeMusicStream(Music music);
+// Seek music to a position (in seconds)
+RLAPI void SeekMusicStream(Music music, float position);
+// Set volume for music (1.0 is max level)
+RLAPI void SetMusicVolume(Music music, float volume);
+// Set pitch for a music (1.0 is base level)
+RLAPI void SetMusicPitch(Music music, float pitch);
+// Set pan for a music (0.5 is center)
+RLAPI void SetMusicPan(Music music, float pan);
+// Get music time length (in seconds)
+RLAPI float GetMusicTimeLength(Music music);
+// Get current music time played (in seconds)
+RLAPI float GetMusicTimePlayed(Music music);
 
 // AudioStream management functions
-RLAPI AudioStream LoadAudioStream(unsigned int sampleRate, unsigned int sampleSize, unsigned int channels); // Load audio stream (to stream raw audio pcm data)
-RLAPI bool IsAudioStreamReady(AudioStream stream);                    // Checks if an audio stream is ready
-RLAPI void UnloadAudioStream(AudioStream stream);                     // Unload audio stream and free memory
-RLAPI void UpdateAudioStream(AudioStream stream, const void *data, int frameCount); // Update audio stream buffers with data
-RLAPI bool IsAudioStreamProcessed(AudioStream stream);                // Check if any audio stream buffers requires refill
-RLAPI void PlayAudioStream(AudioStream stream);                       // Play audio stream
-RLAPI void PauseAudioStream(AudioStream stream);                      // Pause audio stream
-RLAPI void ResumeAudioStream(AudioStream stream);                     // Resume audio stream
-RLAPI bool IsAudioStreamPlaying(AudioStream stream);                  // Check if audio stream is playing
-RLAPI void StopAudioStream(AudioStream stream);                       // Stop audio stream
-RLAPI void SetAudioStreamVolume(AudioStream stream, float volume);    // Set volume for audio stream (1.0 is max level)
-RLAPI void SetAudioStreamPitch(AudioStream stream, float pitch);      // Set pitch for audio stream (1.0 is base level)
-RLAPI void SetAudioStreamPan(AudioStream stream, float pan);          // Set pan for audio stream (0.5 is centered)
-RLAPI void SetAudioStreamBufferSizeDefault(int size);                 // Default size for new audio streams
-RLAPI void SetAudioStreamCallback(AudioStream stream, AudioCallback callback); // Audio thread callback to request new data
 
-RLAPI void AttachAudioStreamProcessor(AudioStream stream, AudioCallback processor); // Attach audio stream processor to stream, receives the samples as 'float'
-RLAPI void DetachAudioStreamProcessor(AudioStream stream, AudioCallback processor); // Detach audio stream processor from stream
+// Load audio stream (to stream raw audio pcm data)
+RLAPI AudioStream LoadAudioStream(unsigned int sampleRate, unsigned int sampleSize, unsigned int channels);
+// Checks if an audio stream is ready
+RLAPI bool IsAudioStreamReady(AudioStream stream);
+// Unload audio stream and free memory
+RLAPI void UnloadAudioStream(AudioStream stream);
+// Update audio stream buffers with data
+RLAPI void UpdateAudioStream(AudioStream stream, const void *data, int frameCount);
+// Check if any audio stream buffers requires refill
+RLAPI bool IsAudioStreamProcessed(AudioStream stream);
+// Play audio stream
+RLAPI void PlayAudioStream(AudioStream stream);
+// Pause audio stream
+RLAPI void PauseAudioStream(AudioStream stream);
+// Resume audio stream
+RLAPI void ResumeAudioStream(AudioStream stream);
+// Check if audio stream is playing
+RLAPI bool IsAudioStreamPlaying(AudioStream stream);
+// Stop audio stream
+RLAPI void StopAudioStream(AudioStream stream);
+// Set volume for audio stream (1.0 is max level)
+RLAPI void SetAudioStreamVolume(AudioStream stream, float volume);
+// Set pitch for audio stream (1.0 is base level)
+RLAPI void SetAudioStreamPitch(AudioStream stream, float pitch);
+// Set pan for audio stream (0.5 is centered)
+RLAPI void SetAudioStreamPan(AudioStream stream, float pan);
+// Default size for new audio streams
+RLAPI void SetAudioStreamBufferSizeDefault(int size);
+// Audio thread callback to request new data
+RLAPI void SetAudioStreamCallback(AudioStream stream, AudioCallback callback);
+// Attach audio stream processor to stream, receives the samples as 'float'
+RLAPI void AttachAudioStreamProcessor(AudioStream stream, AudioCallback processor);
+// Detach audio stream processor from stream
+RLAPI void DetachAudioStreamProcessor(AudioStream stream, AudioCallback processor);
 
-RLAPI void AttachAudioMixedProcessor(AudioCallback processor); // Attach audio stream processor to the entire audio pipeline, receives the samples as 'float'
-RLAPI void DetachAudioMixedProcessor(AudioCallback processor); // Detach audio stream processor from the entire audio pipeline
+// Attach audio stream processor to the entire audio pipeline, receives the samples as 'float'
+RLAPI void AttachAudioMixedProcessor(AudioCallback processor);
+// Detach audio stream processor from the entire audio pipeline
+RLAPI void DetachAudioMixedProcessor(AudioCallback processor);
 
 #if defined(__cplusplus)
 }


### PR DESCRIPTION
### Tooltips fail to display correct information in VSCode and Nvim
- I moved the documentation comments in raylib.h to directly above a given function definition. 
- Doing so allows modern IDEs to display the correct information in tooltips.


### An example of incorrect information in Nvim and VSCode
- The ClearBackground function incorrectly displays the text "Drawing related functions".
- Should say: "Set background color (framebuffer clear color)"
<img width="542" alt="incorrect-tooltip-Nvim" src="https://github.com/user-attachments/assets/d746b3ae-a38b-454f-b32e-e974dfb32bfd">
<img width="666" alt="incorrect-tooltip-VSCode" src="https://github.com/user-attachments/assets/1eddb20f-285b-460a-aad5-a5dee22db068">

### Using my updates to raylib.h
- The tooltips now display helpful information.
<img width="1108" alt="correct-tooltip-Nvim" src="https://github.com/user-attachments/assets/af409465-5873-4d75-aa61-c671674386f0">
<img width="857" alt="correct-tooltip-VSCode" src="https://github.com/user-attachments/assets/71714b65-3e32-4955-b120-2a65eed51fbe">

