### PR TITLE
[rtext] add ExportFontAsCodeEx()

### DIFF
--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1452,6 +1452,7 @@ RLAPI Image GenImageFontAtlas(const GlyphInfo *glyphs, Rectangle **glyphRecs, in
 RLAPI void UnloadFontData(GlyphInfo *glyphs, int glyphCount);                               // Unload font chars info data (RAM)
 RLAPI void UnloadFont(Font font);                                                           // Unload font from GPU memory (VRAM)
 RLAPI bool ExportFontAsCode(Font font, const char *fileName);                               // Export font as code file, returns true on success
+RLAPI bool ExportFontAsCodeEx(const char *fontFileName, const char *outputFileName, int fontSize, int *codepoints, int codepointCount); // Export font as code file with extra parameters; returns true on success
 
 // Text drawing functions
 RLAPI void DrawFPS(int posX, int posY);                                                     // Draw current FPS


### PR DESCRIPTION
Hi All,

This PR introduces a function to export font as code without ever opening a window. This allows me to include the required font file with my project's source code and export it as an automatically generated header from a build script on a system without a GPU present.

Any comments/review is appreciated!

Commit message follows:

ExportFontAsCode() loads image data from a font that is already uploaded to the GPU; this means that it requires a full graphics context/window. ExportFontAsCodeEx() loads the relevant font data into an atlas itself without ever creating a texture. This makes it possible to export font data as part of a build step when compiling a project when there is no GPU present (e.g. github CI).

One minor change is that ExportFontAsCode() no longer converts the name to PascalCase. Its up to the user to pass the name in in that format if they want it.