### PR TITLE
Update audio mixed processor

### DIFF
--- a/examples/audio/audio_mixed_processor.c
+++ b/examples/audio/audio_mixed_processor.c
@@ -97,7 +97,7 @@ int main(void)
             DrawRectangle(199, 199, 402, 34, LIGHTGRAY);
             for (int i = 0; i < 400; i++)
             {
-                DrawLine(201 + i, 232 - (int)averageVolume[i] * 32, 201 + i, 232, MAROON);
+                DrawLine(201 + i, 232 - (float)averageVolume[i] * 32, 201 + i, 232, MAROON);
             }
             DrawRectangleLines(199, 199, 402, 34, GRAY);
 

--- a/examples/audio/audio_mixed_processor.c
+++ b/examples/audio/audio_mixed_processor.c
@@ -97,7 +97,7 @@ int main(void)
             DrawRectangle(199, 199, 402, 34, LIGHTGRAY);
             for (int i = 0; i < 400; i++)
             {
-                DrawLine(201 + i, 232 - (float)averageVolume[i] * 32, 201 + i, 232, MAROON);
+                DrawLine(201 + i, 232 - (averageVolume[i] * 32), 201 + i, 232, MAROON);
             }
             DrawRectangleLines(199, 199, 402, 34, GRAY);
 


### PR DESCRIPTION
This fixes the display issue. The average volume is a float such as 0.03, so the cast to int was making it always 0 and having no height