### PR TITLE
[build.zig] X11-only systems fail builds by default

### DIFF
--- a/src/build.zig
+++ b/src/build.zig
@@ -155,6 +155,13 @@ fn compileRaylib(b: *std.Build, target: std.Build.ResolvedTarget, optimize: std.
                 }
 
                 if (options.linux_display_backend == .Wayland or options.linux_display_backend == .Both) {
+                    _ = b.findProgram(&.{"wayland-scanner"}, &.{}) catch {
+                        std.log.err(
+                            \\ Wayland may not be installed on the system.
+                            \\ You can switch to X11 in your `build.zig` by changing `Options.linux_display_backend`
+                        , .{});
+                        @panic("No Wayland");
+                    };
                     raylib.defineCMacro("_GLFW_WAYLAND", null);
                     raylib.linkSystemLibrary("wayland-client");
                     raylib.linkSystemLibrary("wayland-cursor");


### PR DESCRIPTION
- this PR references the https://github.com/raysan5/raylib/pull/4150#issuecomment-2271084090

I added a check to find the program `wayland-scanner`, if it's not found the following error log is printed and the build fails:
```
 Wayland may not be installed on the system.
 You can switch to X11 in your `build.zig` by changing `Options.linux_display_backend`
```

- **NOTE:** in zig 0.14.0 it will be possible to add a failure message directly to a failed step (https://github.com/ziglang/zig/pull/20312). It is not needed, but I reference it here for the future.