### PR TITLE
[Examples] Update core_3d_camera_first_personCamera

### DIFF
--- a/examples/core/core_3d_camera_first_person.c
+++ b/examples/core/core_3d_camera_first_person.c
@@ -65,6 +65,7 @@ int main(void)
         {
             cameraMode = CAMERA_FREE;
             camera.up = (Vector3){ 0.0f, 1.0f, 0.0f }; // Reset roll
+            camera.fovy = 60.0f;
         }
 
         if (IsKeyPressed(KEY_TWO))

--- a/examples/core/core_3d_camera_first_person.c
+++ b/examples/core/core_3d_camera_first_person.c
@@ -117,22 +117,22 @@ int main(void)
             }
         }
 
-        //Camera zooming
-        float wheelMove = GetMouseWheelMove();
-        bool zoomIn = IsKeyDown(KEY_KP_ADD);
-        bool zoomOut = IsKeyDown(KEY_KP_SUBTRACT);
+        ////Camera zooming
+        //float wheelMove = GetMouseWheelMove();
+        //bool zoomIn = IsKeyDown(KEY_KP_ADD);
+        //bool zoomOut = IsKeyDown(KEY_KP_SUBTRACT);
 
-        if (cameraMode == CAMERA_FIRST_PERSON && (wheelMove != 0 || zoomIn || zoomOut))
-        {
-            if ((wheelMove > 0 || zoomIn) && camera.fovy >= 20.0f)
-            {
-                camera.fovy -= 5.0f;
-            }
-            else if ((wheelMove < 0 || zoomOut) && camera.fovy <= 90.0f)
-            {
-                camera.fovy += 5.0f;
-            }
-        }
+        //if (cameraMode == CAMERA_FIRST_PERSON && (wheelMove != 0 || zoomIn || zoomOut))
+        //{
+        //    if ((wheelMove > 0 || zoomIn) && camera.fovy >= 20.0f)
+        //    {
+        //        camera.fovy -= 5.0f;
+        //    }
+        //    else if ((wheelMove < 0 || zoomOut) && camera.fovy <= 90.0f)
+        //    {
+        //        camera.fovy += 5.0f;
+        //    }
+        //}
         
         // Update camera computes movement internally depending on the camera mode
         // Some default standard keyboard/mouse inputs are hardcoded to simplify use
@@ -190,16 +190,15 @@ int main(void)
             EndMode3D();
 
             // Draw info boxes
-            DrawRectangle(5, 5, 330, 120, Fade(SKYBLUE, 0.5f));
-            DrawRectangleLines(5, 5, 330, 120, BLUE);
+            DrawRectangle(5, 5, 330, 100, Fade(SKYBLUE, 0.5f));
+            DrawRectangleLines(5, 5, 330, 100, BLUE);
 
             DrawText("Camera controls:", 15, 15, 10, BLACK);
-            DrawText("- Move keys: W, A, S, D, Space, Left-Ctrl", 15, 30, 10, BLACK);
-            DrawText("  (Space and Left-Ctrl in Free Camera mode only)", 15, 45, 10, DARKGRAY);
-            DrawText("- Look around: arrow keys or mouse", 15, 60, 10, BLACK);
-            DrawText("- Camera mode keys: 1, 2, 3, 4", 15, 75, 10, BLACK);
-            DrawText("- Zoom keys: num-plus, num-minus or mouse scroll", 15, 90, 10, BLACK);
-            DrawText("- Camera projection key: P", 15, 105, 10, BLACK);
+            DrawText(TextFormat("- Move keys: %s", (cameraMode == CAMERA_FREE) ? "W, A, S, D, Space, Left-Ctrl" : "W, A, S, D"), 15, 30, 10, BLACK);
+            DrawText("- Look around: arrow keys or mouse", 15, 45, 10, BLACK);
+            DrawText("- Camera mode keys: 1, 2, 3, 4", 15, 60, 10, BLACK);
+            DrawText(TextFormat("- Zoom keys: %s", (cameraMode == CAMERA_FIRST_PERSON) ? "-" : "num-plus, num-minus or mouse scroll"), 15, 75, 10, BLACK);
+            DrawText("- Camera projection key: P", 15, 90, 10, BLACK);
 
             DrawRectangle(600, 5, 195, 100, Fade(SKYBLUE, 0.5f));
             DrawRectangleLines(600, 5, 195, 100, BLUE);

--- a/examples/core/core_3d_camera_first_person.c
+++ b/examples/core/core_3d_camera_first_person.c
@@ -14,6 +14,8 @@
 #include "raylib.h"
 #include "rcamera.h"
 
+#include <stdio.h>
+
 #define MAX_COLUMNS 20
 
 //------------------------------------------------------------------------------------
@@ -113,6 +115,25 @@ int main(void)
             }
         }
 
+        //Camera zooming
+        float wheelMove = GetMouseWheelMove();
+        bool zoomIn = IsKeyDown(KEY_KP_ADD);
+        bool zoomOut = IsKeyDown(KEY_KP_SUBTRACT);
+
+        if (cameraMode != CAMERA_THIRD_PERSON && (wheelMove != 0 || zoomIn || zoomOut))
+        {
+            if ((wheelMove > 0 || zoomIn) && camera.fovy >= 20.0f)
+            {
+                camera.fovy -= 5.0f;
+            }
+            else if ((wheelMove < 0 || zoomOut) && camera.fovy <= 90.0f)
+            {
+                camera.fovy += 5.0f;
+            }
+        }
+        
+        printf("fov: %.2f\n", camera.fovy);
+        printf("bool: %d\n", (cameraMode != CAMERA_THIRD_PERSON && (wheelMove != 0 || zoomIn || zoomOut)));
         // Update camera computes movement internally depending on the camera mode
         // Some default standard keyboard/mouse inputs are hardcoded to simplify use
         // For advance camera controls, it's reecommended to compute camera movement manually
@@ -169,29 +190,31 @@ int main(void)
             EndMode3D();
 
             // Draw info boxes
-            DrawRectangle(5, 5, 330, 100, Fade(SKYBLUE, 0.5f));
-            DrawRectangleLines(5, 5, 330, 100, BLUE);
+            DrawRectangle(5, 5, 330, 120, Fade(SKYBLUE, 0.5f));
+            DrawRectangleLines(5, 5, 330, 120, BLUE);
 
             DrawText("Camera controls:", 15, 15, 10, BLACK);
             DrawText("- Move keys: W, A, S, D, Space, Left-Ctrl", 15, 30, 10, BLACK);
-            DrawText("- Look around: arrow keys or mouse", 15, 45, 10, BLACK);
-            DrawText("- Camera mode keys: 1, 2, 3, 4", 15, 60, 10, BLACK);
-            DrawText("- Zoom keys: num-plus, num-minus or mouse scroll", 15, 75, 10, BLACK);
-            DrawText("- Camera projection key: P", 15, 90, 10, BLACK);
+            DrawText("  (Space and Left-Ctrl in Free Camera mode only)", 15, 45, 10, DARKGRAY);
+            DrawText("- Look around: arrow keys or mouse", 15, 60, 10, BLACK);
+            DrawText("- Camera mode keys: 1, 2, 3, 4", 15, 75, 10, BLACK);
+            DrawText("- Zoom keys: num-plus, num-minus or mouse scroll", 15, 90, 10, BLACK);
+            DrawText("- Camera projection key: P", 15, 105, 10, BLACK);
 
-            DrawRectangle(600, 5, 195, 100, Fade(SKYBLUE, 0.5f));
-            DrawRectangleLines(600, 5, 195, 100, BLUE);
+            DrawRectangle(600, 5, 195, 120, Fade(SKYBLUE, 0.5f));
+            DrawRectangleLines(600, 5, 195, 120, BLUE);
 
             DrawText("Camera status:", 610, 15, 10, BLACK);
             DrawText(TextFormat("- Mode: %s", (cameraMode == CAMERA_FREE) ? "FREE" :
-                                              (cameraMode == CAMERA_FIRST_PERSON) ? "FIRST_PERSON" :
-                                              (cameraMode == CAMERA_THIRD_PERSON) ? "THIRD_PERSON" :
-                                              (cameraMode == CAMERA_ORBITAL) ? "ORBITAL" : "CUSTOM"), 610, 30, 10, BLACK);
+                (cameraMode == CAMERA_FIRST_PERSON) ? "FIRST_PERSON" :
+                (cameraMode == CAMERA_THIRD_PERSON) ? "THIRD_PERSON" :
+                (cameraMode == CAMERA_ORBITAL) ? "ORBITAL" : "CUSTOM"), 610, 30, 10, BLACK);
             DrawText(TextFormat("- Projection: %s", (camera.projection == CAMERA_PERSPECTIVE) ? "PERSPECTIVE" :
-                                                    (camera.projection == CAMERA_ORTHOGRAPHIC) ? "ORTHOGRAPHIC" : "CUSTOM"), 610, 45, 10, BLACK);
+                (camera.projection == CAMERA_ORTHOGRAPHIC) ? "ORTHOGRAPHIC" : "CUSTOM"), 610, 45, 10, BLACK);
             DrawText(TextFormat("- Position: (%06.3f, %06.3f, %06.3f)", camera.position.x, camera.position.y, camera.position.z), 610, 60, 10, BLACK);
             DrawText(TextFormat("- Target: (%06.3f, %06.3f, %06.3f)", camera.target.x, camera.target.y, camera.target.z), 610, 75, 10, BLACK);
             DrawText(TextFormat("- Up: (%06.3f, %06.3f, %06.3f)", camera.up.x, camera.up.y, camera.up.z), 610, 90, 10, BLACK);
+            DrawText(TextFormat("- FOV: %06.3f", camera.fovy), 610, 105, 10, BLACK);
 
         EndDrawing();
         //----------------------------------------------------------------------------------

--- a/examples/core/core_3d_camera_first_person.c
+++ b/examples/core/core_3d_camera_first_person.c
@@ -207,11 +207,11 @@ int main(void)
 
             DrawText("Camera status:", 610, 15, 10, BLACK);
             DrawText(TextFormat("- Mode: %s", (cameraMode == CAMERA_FREE) ? "FREE" :
-                (cameraMode == CAMERA_FIRST_PERSON) ? "FIRST_PERSON" :
-                (cameraMode == CAMERA_THIRD_PERSON) ? "THIRD_PERSON" :
-                (cameraMode == CAMERA_ORBITAL) ? "ORBITAL" : "CUSTOM"), 610, 30, 10, BLACK);
+                                              (cameraMode == CAMERA_FIRST_PERSON) ? "FIRST_PERSON" :
+                                              (cameraMode == CAMERA_THIRD_PERSON) ? "THIRD_PERSON" :
+                                              (cameraMode == CAMERA_ORBITAL) ? "ORBITAL" : "CUSTOM"), 610, 30, 10, BLACK);
             DrawText(TextFormat("- Projection: %s", (camera.projection == CAMERA_PERSPECTIVE) ? "PERSPECTIVE" :
-                (camera.projection == CAMERA_ORTHOGRAPHIC) ? "ORTHOGRAPHIC" : "CUSTOM"), 610, 45, 10, BLACK);
+                                                    (camera.projection == CAMERA_ORTHOGRAPHIC) ? "ORTHOGRAPHIC" : "CUSTOM"), 610, 45, 10, BLACK);
             DrawText(TextFormat("- Position: (%06.3f, %06.3f, %06.3f)", camera.position.x, camera.position.y, camera.position.z), 610, 60, 10, BLACK);
             DrawText(TextFormat("- Target: (%06.3f, %06.3f, %06.3f)", camera.target.x, camera.target.y, camera.target.z), 610, 75, 10, BLACK);
             DrawText(TextFormat("- Up: (%06.3f, %06.3f, %06.3f)", camera.up.x, camera.up.y, camera.up.z), 610, 90, 10, BLACK);

--- a/examples/core/core_3d_camera_first_person.c
+++ b/examples/core/core_3d_camera_first_person.c
@@ -14,8 +14,6 @@
 #include "raylib.h"
 #include "rcamera.h"
 
-#include <stdio.h>
-
 #define MAX_COLUMNS 20
 
 //------------------------------------------------------------------------------------

--- a/examples/core/core_3d_camera_first_person.c
+++ b/examples/core/core_3d_camera_first_person.c
@@ -73,18 +73,21 @@ int main(void)
         {
             cameraMode = CAMERA_FIRST_PERSON;
             camera.up = (Vector3){ 0.0f, 1.0f, 0.0f }; // Reset roll
+            camera.fovy = 60.0f;
         }
 
         if (IsKeyPressed(KEY_THREE))
         {
             cameraMode = CAMERA_THIRD_PERSON;
             camera.up = (Vector3){ 0.0f, 1.0f, 0.0f }; // Reset roll
+            camera.fovy = 60.0f;
         }
 
         if (IsKeyPressed(KEY_FOUR))
         {
             cameraMode = CAMERA_ORBITAL;
             camera.up = (Vector3){ 0.0f, 1.0f, 0.0f }; // Reset roll
+            camera.fovy = 60.0f;
         }
 
         // Switch camera projection
@@ -120,7 +123,7 @@ int main(void)
         bool zoomIn = IsKeyDown(KEY_KP_ADD);
         bool zoomOut = IsKeyDown(KEY_KP_SUBTRACT);
 
-        if (cameraMode != CAMERA_THIRD_PERSON && (wheelMove != 0 || zoomIn || zoomOut))
+        if (cameraMode == CAMERA_FIRST_PERSON && (wheelMove != 0 || zoomIn || zoomOut))
         {
             if ((wheelMove > 0 || zoomIn) && camera.fovy >= 20.0f)
             {
@@ -132,8 +135,6 @@ int main(void)
             }
         }
         
-        printf("fov: %.2f\n", camera.fovy);
-        printf("bool: %d\n", (cameraMode != CAMERA_THIRD_PERSON && (wheelMove != 0 || zoomIn || zoomOut)));
         // Update camera computes movement internally depending on the camera mode
         // Some default standard keyboard/mouse inputs are hardcoded to simplify use
         // For advance camera controls, it's reecommended to compute camera movement manually
@@ -201,8 +202,8 @@ int main(void)
             DrawText("- Zoom keys: num-plus, num-minus or mouse scroll", 15, 90, 10, BLACK);
             DrawText("- Camera projection key: P", 15, 105, 10, BLACK);
 
-            DrawRectangle(600, 5, 195, 120, Fade(SKYBLUE, 0.5f));
-            DrawRectangleLines(600, 5, 195, 120, BLUE);
+            DrawRectangle(600, 5, 195, 100, Fade(SKYBLUE, 0.5f));
+            DrawRectangleLines(600, 5, 195, 100, BLUE);
 
             DrawText("Camera status:", 610, 15, 10, BLACK);
             DrawText(TextFormat("- Mode: %s", (cameraMode == CAMERA_FREE) ? "FREE" :
@@ -214,7 +215,6 @@ int main(void)
             DrawText(TextFormat("- Position: (%06.3f, %06.3f, %06.3f)", camera.position.x, camera.position.y, camera.position.z), 610, 60, 10, BLACK);
             DrawText(TextFormat("- Target: (%06.3f, %06.3f, %06.3f)", camera.target.x, camera.target.y, camera.target.z), 610, 75, 10, BLACK);
             DrawText(TextFormat("- Up: (%06.3f, %06.3f, %06.3f)", camera.up.x, camera.up.y, camera.up.z), 610, 90, 10, BLACK);
-            DrawText(TextFormat("- FOV: %06.3f", camera.fovy), 610, 105, 10, BLACK);
 
         EndDrawing();
         //----------------------------------------------------------------------------------

--- a/examples/core/core_3d_camera_first_person.c
+++ b/examples/core/core_3d_camera_first_person.c
@@ -65,28 +65,28 @@ int main(void)
         {
             cameraMode = CAMERA_FREE;
             camera.up = (Vector3){ 0.0f, 1.0f, 0.0f }; // Reset roll
-            camera.fovy = 60.0f;
+            //camera.fovy = 60.0f;
         }
 
         if (IsKeyPressed(KEY_TWO))
         {
             cameraMode = CAMERA_FIRST_PERSON;
             camera.up = (Vector3){ 0.0f, 1.0f, 0.0f }; // Reset roll
-            camera.fovy = 60.0f;
+            //camera.fovy = 60.0f;
         }
 
         if (IsKeyPressed(KEY_THREE))
         {
             cameraMode = CAMERA_THIRD_PERSON;
             camera.up = (Vector3){ 0.0f, 1.0f, 0.0f }; // Reset roll
-            camera.fovy = 60.0f;
+            //camera.fovy = 60.0f;
         }
 
         if (IsKeyPressed(KEY_FOUR))
         {
             cameraMode = CAMERA_ORBITAL;
             camera.up = (Vector3){ 0.0f, 1.0f, 0.0f }; // Reset roll
-            camera.fovy = 60.0f;
+            //camera.fovy = 60.0f;
         }
 
         // Switch camera projection


### PR DESCRIPTION
Regarding issue https://github.com/raysan5/raylib/issues/4208 for core_3d_camera_first_person.

It doesn't mention that SPACE and LCTRL only work in CAMERA_FREE mode. So I added some text to clarify. Im not sure if adding functionallity to SPACE AND LCTRL was the intention for CAMERA_FIRST_PERSON, CAMERA_THIRD_PERSON, and CAMERA_ORBITAL? Because that would make CAMERA_FREE and CAMERA_FIRST_PERSON function identical if im not mistaken?

Also it never mentions that the zoom functionality is not availible in CAMERA_FIRST_PERSON, so I propose the change that zooming in CAMERA_FIRST_PERSON changes your fovy which mimics how zoom works first-person gameplay. It just resets back to the default value of 60.0f once you change cameraMode. That will make CAMERA_FIRST_PERSON differ a little more from CAMERA_FREE.