### PR TITLE
[Examples] change texture2d to texture

### DIFF
--- a/examples/core/core_input_gamepad.c
+++ b/examples/core/core_input_gamepad.c
@@ -38,8 +38,8 @@ int main(void)
 
     InitWindow(screenWidth, screenHeight, "raylib [core] example - gamepad input");
 
-    Texture2D texPs3Pad = LoadTexture("resources/ps3.png");
-    Texture2D texXboxPad = LoadTexture("resources/xbox.png");
+    Texture texPs3Pad = LoadTexture("resources/ps3.png");
+    Texture texXboxPad = LoadTexture("resources/xbox.png");
 
     SetTargetFPS(60);               // Set our game to run at 60 frames-per-second
     //--------------------------------------------------------------------------------------

--- a/examples/models/models_animation.c
+++ b/examples/models/models_animation.c
@@ -42,7 +42,7 @@ int main(void)
     camera.projection = CAMERA_PERSPECTIVE;             // Camera mode type
 
     Model model = LoadModel("resources/models/iqm/guy.iqm");                    // Load the animated model mesh and basic data
-    Texture2D texture = LoadTexture("resources/models/iqm/guytex.png");         // Load model texture and set material
+    Texture texture = LoadTexture("resources/models/iqm/guytex.png");         // Load model texture and set material
     SetMaterialTexture(&model.materials[0], MATERIAL_MAP_DIFFUSE, texture);     // Set model material map texture
 
     Vector3 position = { 0.0f, 0.0f, 0.0f };            // Set model position

--- a/examples/models/models_billboard.c
+++ b/examples/models/models_billboard.c
@@ -34,7 +34,7 @@ int main(void)
     camera.fovy = 45.0f;                                // Camera field-of-view Y
     camera.projection = CAMERA_PERSPECTIVE;             // Camera projection type
 
-    Texture2D bill = LoadTexture("resources/billboard.png");    // Our billboard texture
+    Texture bill = LoadTexture("resources/billboard.png");    // Our billboard texture
     Vector3 billPositionStatic = { 0.0f, 2.0f, 0.0f };          // Position of static billboard
     Vector3 billPositionRotating = { 1.0f, 2.0f, 1.0f };        // Position of rotating billboard
 

--- a/examples/models/models_cubicmap.c
+++ b/examples/models/models_cubicmap.c
@@ -34,13 +34,13 @@ int main(void)
     camera.projection = CAMERA_PERSPECTIVE;                 // Camera projection type
 
     Image image = LoadImage("resources/cubicmap.png");      // Load cubicmap image (RAM)
-    Texture2D cubicmap = LoadTextureFromImage(image);       // Convert image to texture to display (VRAM)
+    Texture cubicmap = LoadTextureFromImage(image);       // Convert image to texture to display (VRAM)
 
     Mesh mesh = GenMeshCubicmap(image, (Vector3){ 1.0f, 1.0f, 1.0f });
     Model model = LoadModelFromMesh(mesh);
 
     // NOTE: By default each cube is mapped to one part of texture atlas
-    Texture2D texture = LoadTexture("resources/cubicmap_atlas.png");    // Load map texture
+    Texture texture = LoadTexture("resources/cubicmap_atlas.png");    // Load map texture
     model.materials[0].maps[MATERIAL_MAP_DIFFUSE].texture = texture;    // Set map diffuse texture
 
     Vector3 mapPosition = { -16.0f, 0.0f, -8.0f };          // Set model position

--- a/examples/models/models_draw_cube_texture.c
+++ b/examples/models/models_draw_cube_texture.c
@@ -18,8 +18,8 @@
 //------------------------------------------------------------------------------------
 // Custom Functions Declaration
 //------------------------------------------------------------------------------------
-void DrawCubeTexture(Texture2D texture, Vector3 position, float width, float height, float length, Color color); // Draw cube textured
-void DrawCubeTextureRec(Texture2D texture, Rectangle source, Vector3 position, float width, float height, float length, Color color); // Draw cube with a region of a texture
+void DrawCubeTexture(Texture texture, Vector3 position, float width, float height, float length, Color color); // Draw cube textured
+void DrawCubeTextureRec(Texture texture, Rectangle source, Vector3 position, float width, float height, float length, Color color); // Draw cube with a region of a texture
 
 //------------------------------------------------------------------------------------
 // Program main entry point
@@ -42,7 +42,7 @@ int main(void)
     camera.projection = CAMERA_PERSPECTIVE;
     
     // Load texture to be applied to the cubes sides
-    Texture2D texture = LoadTexture("resources/cubicmap_atlas.png");
+    Texture texture = LoadTexture("resources/cubicmap_atlas.png");
 
     SetTargetFPS(60);               // Set our game to run at 60 frames-per-second
     //--------------------------------------------------------------------------------------
@@ -95,7 +95,7 @@ int main(void)
 //------------------------------------------------------------------------------------
 // Draw cube textured
 // NOTE: Cube position is the center position
-void DrawCubeTexture(Texture2D texture, Vector3 position, float width, float height, float length, Color color)
+void DrawCubeTexture(Texture texture, Vector3 position, float width, float height, float length, Color color)
 {
     float x = position.x;
     float y = position.y;
@@ -157,7 +157,7 @@ void DrawCubeTexture(Texture2D texture, Vector3 position, float width, float hei
 }
 
 // Draw cube with texture piece applied to all faces
-void DrawCubeTextureRec(Texture2D texture, Rectangle source, Vector3 position, float width, float height, float length, Color color)
+void DrawCubeTextureRec(Texture texture, Rectangle source, Vector3 position, float width, float height, float length, Color color)
 {
     float x = position.x;
     float y = position.y;

--- a/examples/models/models_first_person_maze.c
+++ b/examples/models/models_first_person_maze.c
@@ -36,12 +36,12 @@ int main(void)
     camera.projection = CAMERA_PERSPECTIVE;             // Camera projection type
 
     Image imMap = LoadImage("resources/cubicmap.png");      // Load cubicmap image (RAM)
-    Texture2D cubicmap = LoadTextureFromImage(imMap);       // Convert image to texture to display (VRAM)
+    Texture cubicmap = LoadTextureFromImage(imMap);       // Convert image to texture to display (VRAM)
     Mesh mesh = GenMeshCubicmap(imMap, (Vector3){ 1.0f, 1.0f, 1.0f });
     Model model = LoadModelFromMesh(mesh);
 
     // NOTE: By default each cube is mapped to one part of texture atlas
-    Texture2D texture = LoadTexture("resources/cubicmap_atlas.png");    // Load map texture
+    Texture texture = LoadTexture("resources/cubicmap_atlas.png");    // Load map texture
     model.materials[0].maps[MATERIAL_MAP_DIFFUSE].texture = texture;    // Set map diffuse texture
 
     // Get map image data to be used for collision detection

--- a/examples/models/models_heightmap.c
+++ b/examples/models/models_heightmap.c
@@ -34,7 +34,7 @@ int main(void)
     camera.projection = CAMERA_PERSPECTIVE;                 // Camera projection type
 
     Image image = LoadImage("resources/heightmap.png");     // Load heightmap image (RAM)
-    Texture2D texture = LoadTextureFromImage(image);        // Convert image to texture (VRAM)
+    Texture texture = LoadTextureFromImage(image);        // Convert image to texture (VRAM)
 
     Mesh mesh = GenMeshHeightmap(image, (Vector3){ 16, 8, 16 }); // Generate heightmap mesh (RAM and VRAM)
     Model model = LoadModelFromMesh(mesh);                  // Load model from generated mesh

--- a/examples/models/models_loading.c
+++ b/examples/models/models_loading.c
@@ -47,7 +47,7 @@ int main(void)
     camera.projection = CAMERA_PERSPECTIVE;                   // Camera mode type
 
     Model model = LoadModel("resources/models/obj/castle.obj");                 // Load model
-    Texture2D texture = LoadTexture("resources/models/obj/castle_diffuse.png"); // Load model texture
+    Texture texture = LoadTexture("resources/models/obj/castle_diffuse.png"); // Load model texture
     model.materials[0].maps[MATERIAL_MAP_DIFFUSE].texture = texture;            // Set map diffuse texture
 
     Vector3 position = { 0.0f, 0.0f, 0.0f };                    // Set model position

--- a/examples/models/models_mesh_generation.c
+++ b/examples/models/models_mesh_generation.c
@@ -31,7 +31,7 @@ int main(void)
 
     // We generate a checked image for texturing
     Image checked = GenImageChecked(2, 2, 1, 1, RED, GREEN);
-    Texture2D texture = LoadTextureFromImage(checked);
+    Texture texture = LoadTextureFromImage(checked);
     UnloadImage(checked);
 
     Model models[NUM_MODELS] = { 0 };

--- a/examples/models/models_mesh_picking.c
+++ b/examples/models/models_mesh_picking.c
@@ -41,7 +41,7 @@ int main(void)
     Ray ray = { 0 };        // Picking ray
 
     Model tower = LoadModel("resources/models/obj/turret.obj");                 // Load OBJ model
-    Texture2D texture = LoadTexture("resources/models/obj/turret_diffuse.png"); // Load model texture
+    Texture texture = LoadTexture("resources/models/obj/turret_diffuse.png"); // Load model texture
     tower.materials[0].maps[MATERIAL_MAP_DIFFUSE].texture = texture;            // Set model diffuse texture
 
     Vector3 towerPos = { 0.0f, 0.0f, 0.0f };                        // Set model position

--- a/examples/models/models_skybox.c
+++ b/examples/models/models_skybox.c
@@ -23,7 +23,7 @@
 #endif
 
 // Generate cubemap (6 faces) from equirectangular (panorama) texture
-static TextureCubemap GenTextureCubemap(Shader shader, Texture2D panorama, int size, int format);
+static TextureCubemap GenTextureCubemap(Shader shader, Texture panorama, int size, int format);
 
 //------------------------------------------------------------------------------------
 // Program main entry point
@@ -74,7 +74,7 @@ int main(void)
         TextCopy(skyboxFileName, "resources/dresden_square_2k.hdr");
 
         // Load HDR panorama (sphere) texture
-        Texture2D panorama = LoadTexture(skyboxFileName);
+        Texture panorama = LoadTexture(skyboxFileName);
 
         // Generate cubemap (texture with 6 quads-cube-mapping) from panorama HDR texture
         // NOTE 1: New texture is generated rendering to texture, shader calculates the sphere->cube coordinates mapping
@@ -118,7 +118,7 @@ int main(void)
                     if (useHDR)
                     {
                         // Load HDR panorama (sphere) texture
-                        Texture2D panorama = LoadTexture(droppedFiles.paths[0]);
+                        Texture panorama = LoadTexture(droppedFiles.paths[0]);
 
                         // Generate cubemap from panorama texture
                         skybox.materials[0].maps[MATERIAL_MAP_CUBEMAP].texture = GenTextureCubemap(shdrCubemap, panorama, 1024, PIXELFORMAT_UNCOMPRESSED_R8G8B8A8);
@@ -182,7 +182,7 @@ int main(void)
 }
 
 // Generate cubemap texture from HDR texture
-static TextureCubemap GenTextureCubemap(Shader shader, Texture2D panorama, int size, int format)
+static TextureCubemap GenTextureCubemap(Shader shader, Texture panorama, int size, int format)
 {
     TextureCubemap cubemap = { 0 };
 

--- a/examples/models/models_yaw_pitch_roll.c
+++ b/examples/models/models_yaw_pitch_roll.c
@@ -38,7 +38,7 @@ int main(void)
     camera.projection = CAMERA_PERSPECTIVE;             // Camera type
 
     Model model = LoadModel("resources/models/obj/plane.obj");                  // Load model
-    Texture2D texture = LoadTexture("resources/models/obj/plane_diffuse.png");  // Load model texture
+    Texture texture = LoadTexture("resources/models/obj/plane_diffuse.png");  // Load model texture
     model.materials[0].maps[MATERIAL_MAP_DIFFUSE].texture = texture;            // Set map diffuse texture
 
     float pitch = 0.0f;

--- a/examples/others/embedded_files_loading.c
+++ b/examples/others/embedded_files_loading.c
@@ -61,7 +61,7 @@ int main(void)
     };
 
     // Image converted to Texture (VRAM) to be drawn
-    Texture2D texture = LoadTextureFromImage(image);
+    Texture texture = LoadTextureFromImage(image);
 
     // With an Image loaded from file, after Texture is loaded, we can unload Image
     // but in our case, Image is embedded in executable, in program .data segment

--- a/examples/shaders/shaders_custom_uniform.c
+++ b/examples/shaders/shaders_custom_uniform.c
@@ -49,7 +49,7 @@ int main(void)
     camera.projection = CAMERA_PERSPECTIVE;             // Camera projection type
 
     Model model = LoadModel("resources/models/barracks.obj");                   // Load OBJ model
-    Texture2D texture = LoadTexture("resources/models/barracks_diffuse.png");   // Load model texture (diffuse map)
+    Texture texture = LoadTexture("resources/models/barracks_diffuse.png");   // Load model texture (diffuse map)
     model.materials[0].maps[MATERIAL_MAP_DIFFUSE].texture = texture;                     // Set model diffuse texture
 
     Vector3 position = { 0.0f, 0.0f, 0.0f };                                    // Set model position

--- a/examples/shaders/shaders_deferred_render.c
+++ b/examples/shaders/shaders_deferred_render.c
@@ -277,7 +277,7 @@ int main(void)
                 } break;
                 case DEFERRED_POSITION:
                 {
-                    DrawTextureRec((Texture2D){
+                    DrawTextureRec((Texture){
                         .id = gBuffer.positionTexture,
                         .width = screenWidth,
                         .height = screenHeight,
@@ -287,7 +287,7 @@ int main(void)
                 } break;
                 case DEFERRED_NORMAL:
                 {
-                    DrawTextureRec((Texture2D){
+                    DrawTextureRec((Texture){
                         .id = gBuffer.normalTexture,
                         .width = screenWidth,
                         .height = screenHeight,
@@ -297,7 +297,7 @@ int main(void)
                 } break;
                 case DEFERRED_ALBEDO:
                 {
-                    DrawTextureRec((Texture2D){
+                    DrawTextureRec((Texture){
                         .id = gBuffer.albedoSpecTexture,
                         .width = screenWidth,
                         .height = screenHeight,

--- a/examples/shaders/shaders_model_shader.c
+++ b/examples/shaders/shaders_model_shader.c
@@ -49,7 +49,7 @@ int main(void)
     camera.projection = CAMERA_PERSPECTIVE;             // Camera projection type
 
     Model model = LoadModel("resources/models/watermill.obj");                   // Load OBJ model
-    Texture2D texture = LoadTexture("resources/models/watermill_diffuse.png");   // Load model texture
+    Texture texture = LoadTexture("resources/models/watermill_diffuse.png");   // Load model texture
 
     // Load shader for model
     // NOTE: Defining 0 (NULL) for vertex shader forces usage of internal default vertex shader

--- a/examples/shaders/shaders_postprocessing.c
+++ b/examples/shaders/shaders_postprocessing.c
@@ -83,7 +83,7 @@ int main(void)
     camera.projection = CAMERA_PERSPECTIVE;             // Camera projection type
 
     Model model = LoadModel("resources/models/church.obj");                 // Load OBJ model
-    Texture2D texture = LoadTexture("resources/models/church_diffuse.png"); // Load model texture (diffuse map)
+    Texture texture = LoadTexture("resources/models/church_diffuse.png"); // Load model texture (diffuse map)
     model.materials[0].maps[MATERIAL_MAP_DIFFUSE].texture = texture;        // Set model diffuse texture
 
     Vector3 position = { 0.0f, 0.0f, 0.0f };            // Set model position

--- a/examples/shaders/shaders_shapes_textures.c
+++ b/examples/shaders/shaders_shapes_textures.c
@@ -38,7 +38,7 @@ int main(void)
 
     InitWindow(screenWidth, screenHeight, "raylib [shaders] example - shapes and texture shaders");
 
-    Texture2D fudesumi = LoadTexture("resources/fudesumi.png");
+    Texture fudesumi = LoadTexture("resources/fudesumi.png");
 
     // Load shader to be used on some parts drawing
     // NOTE 1: Using GLSL 330 shader version, on OpenGL ES 2.0 use GLSL 100 shader version

--- a/examples/shaders/shaders_texture_drawing.c
+++ b/examples/shaders/shaders_texture_drawing.c
@@ -36,7 +36,7 @@ int main(void)
     InitWindow(screenWidth, screenHeight, "raylib [shaders] example - texture drawing");
 
     Image imBlank = GenImageColor(1024, 1024, BLANK);
-    Texture2D texture = LoadTextureFromImage(imBlank);  // Load blank texture to fill on shader
+    Texture texture = LoadTextureFromImage(imBlank);  // Load blank texture to fill on shader
     UnloadImage(imBlank);
 
     // NOTE: Using GLSL 330 shader version, on OpenGL ES 2.0 use GLSL 100 shader version

--- a/examples/shaders/shaders_texture_outline.c
+++ b/examples/shaders/shaders_texture_outline.c
@@ -36,7 +36,7 @@ int main(void)
 
     InitWindow(screenWidth, screenHeight, "raylib [shaders] example - Apply an outline to a texture");
 
-    Texture2D texture = LoadTexture("resources/fudesumi.png");
+    Texture texture = LoadTexture("resources/fudesumi.png");
 
     Shader shdrOutline = LoadShader(0, TextFormat("resources/shaders/glsl%i/outline.fs", GLSL_VERSION));
 

--- a/examples/shaders/shaders_texture_tiling.c
+++ b/examples/shaders/shaders_texture_tiling.c
@@ -46,7 +46,7 @@ int main(void)
     Model model = LoadModelFromMesh(cube);
     
     // Load a texture and assign to cube model
-    Texture2D texture = LoadTexture("resources/cubicmap_atlas.png");
+    Texture texture = LoadTexture("resources/cubicmap_atlas.png");
     model.materials[0].maps[MATERIAL_MAP_DIFFUSE].texture = texture;
 
     // Set the texture tiling using a shader

--- a/examples/shaders/shaders_texture_waves.c
+++ b/examples/shaders/shaders_texture_waves.c
@@ -41,7 +41,7 @@ int main(void)
     InitWindow(screenWidth, screenHeight, "raylib [shaders] example - texture waves");
 
     // Load texture texture to apply shaders
-    Texture2D texture = LoadTexture("resources/space.png");
+    Texture texture = LoadTexture("resources/space.png");
 
     // Load shader and setup location points and values
     Shader shader = LoadShader(0, TextFormat("resources/shaders/glsl%i/wave.fs", GLSL_VERSION));

--- a/examples/shapes/shapes_top_down_lights.c
+++ b/examples/shapes/shapes_top_down_lights.c
@@ -227,7 +227,7 @@ int main(void)
 
     // Create a checkerboard ground texture
     Image img = GenImageChecked(64, 64, 32, 32, DARKBROWN, DARKGRAY);
-    Texture2D backgroundTexture = LoadTextureFromImage(img);
+    Texture backgroundTexture = LoadTextureFromImage(img);
     UnloadImage(img);
 
     // Create a global light mask to hold all the blended lights

--- a/examples/textures/textures_background_scrolling.c
+++ b/examples/textures/textures_background_scrolling.c
@@ -27,9 +27,9 @@ int main(void)
 
     // NOTE: Be careful, background width must be equal or bigger than screen width
     // if not, texture should be draw more than two times for scrolling effect
-    Texture2D background = LoadTexture("resources/cyberpunk_street_background.png");
-    Texture2D midground = LoadTexture("resources/cyberpunk_street_midground.png");
-    Texture2D foreground = LoadTexture("resources/cyberpunk_street_foreground.png");
+    Texture background = LoadTexture("resources/cyberpunk_street_background.png");
+    Texture midground = LoadTexture("resources/cyberpunk_street_midground.png");
+    Texture foreground = LoadTexture("resources/cyberpunk_street_foreground.png");
 
     float scrollingBack = 0.0f;
     float scrollingMid = 0.0f;

--- a/examples/textures/textures_blend_modes.c
+++ b/examples/textures/textures_blend_modes.c
@@ -31,10 +31,10 @@ int main(void)
 
     // NOTE: Textures MUST be loaded after Window initialization (OpenGL context is required)
     Image bgImage = LoadImage("resources/cyberpunk_street_background.png");     // Loaded in CPU memory (RAM)
-    Texture2D bgTexture = LoadTextureFromImage(bgImage);          // Image converted to texture, GPU memory (VRAM)
+    Texture bgTexture = LoadTextureFromImage(bgImage);          // Image converted to texture, GPU memory (VRAM)
 
     Image fgImage = LoadImage("resources/cyberpunk_street_foreground.png");     // Loaded in CPU memory (RAM)
-    Texture2D fgTexture = LoadTextureFromImage(fgImage);          // Image converted to texture, GPU memory (VRAM)
+    Texture fgTexture = LoadTextureFromImage(fgImage);          // Image converted to texture, GPU memory (VRAM)
 
     // Once image has been converted to texture and uploaded to VRAM, it can be unloaded from RAM
     UnloadImage(bgImage);

--- a/examples/textures/textures_bunnymark.c
+++ b/examples/textures/textures_bunnymark.c
@@ -40,7 +40,7 @@ int main(void)
     InitWindow(screenWidth, screenHeight, "raylib [textures] example - bunnymark");
 
     // Load bunny texture
-    Texture2D texBunny = LoadTexture("resources/wabbit_alpha.png");
+    Texture texBunny = LoadTexture("resources/wabbit_alpha.png");
 
     Bunny *bunnies = (Bunny *)malloc(MAX_BUNNIES*sizeof(Bunny));    // Bunnies array
 

--- a/examples/textures/textures_draw_tiled.c
+++ b/examples/textures/textures_draw_tiled.c
@@ -21,7 +21,7 @@
 #define COLOR_SIZE       16       // Size of the color select buttons
 
 // Draw part of a texture (defined by a rectangle) with rotation and scale tiled into dest.
-void DrawTextureTiled(Texture2D texture, Rectangle source, Rectangle dest, Vector2 origin, float rotation, float scale, Color tint);
+void DrawTextureTiled(Texture texture, Rectangle source, Rectangle dest, Vector2 origin, float rotation, float scale, Color tint);
 
 //------------------------------------------------------------------------------------
 // Program main entry point
@@ -172,7 +172,7 @@ int main(void)
 }
 
 // Draw part of a texture (defined by a rectangle) with rotation and scale tiled into dest.
-void DrawTextureTiled(Texture2D texture, Rectangle source, Rectangle dest, Vector2 origin, float rotation, float scale, Color tint)
+void DrawTextureTiled(Texture texture, Rectangle source, Rectangle dest, Vector2 origin, float rotation, float scale, Color tint)
 {
     if ((texture.id <= 0) || (scale <= 0.0f)) return;  // Wanna see a infinite loop?!...just delete this line!
     if ((source.width == 0) || (source.height == 0)) return;

--- a/examples/textures/textures_gif_player.c
+++ b/examples/textures/textures_gif_player.c
@@ -39,7 +39,7 @@ int main(void)
     // NOTE: We will update this texture when required with next frame data
     // WARNING: It's not recommended to use this technique for sprites animation,
     // use spritesheets instead, like illustrated in textures_sprite_anim example
-    Texture2D texScarfyAnim = LoadTextureFromImage(imScarfyAnim);
+    Texture texScarfyAnim = LoadTextureFromImage(imScarfyAnim);
 
     unsigned int nextFrameDataOffset = 0;  // Current byte offset to next frame in image.data
 

--- a/examples/textures/textures_image_channel.c
+++ b/examples/textures/textures_image_channel.c
@@ -46,12 +46,12 @@ int main(void)
 
     Image backgroundImage = GenImageChecked(screenWidth, screenHeight, screenWidth/20, screenHeight/20, ORANGE, YELLOW);
 
-    Texture2D fudesumiTexture = LoadTextureFromImage(fudesumiImage);
-    Texture2D textureAlpha = LoadTextureFromImage(imageAlpha);
-    Texture2D textureRed = LoadTextureFromImage(imageRed);
-    Texture2D textureGreen = LoadTextureFromImage(imageGreen);
-    Texture2D textureBlue = LoadTextureFromImage(imageBlue);
-    Texture2D backgroundTexture = LoadTextureFromImage(backgroundImage);
+    Texture fudesumiTexture = LoadTextureFromImage(fudesumiImage);
+    Texture textureAlpha = LoadTextureFromImage(imageAlpha);
+    Texture textureRed = LoadTextureFromImage(imageRed);
+    Texture textureGreen = LoadTextureFromImage(imageGreen);
+    Texture textureBlue = LoadTextureFromImage(imageBlue);
+    Texture backgroundTexture = LoadTextureFromImage(backgroundImage);
 
     UnloadImage(fudesumiImage);
     UnloadImage(imageAlpha);

--- a/examples/textures/textures_image_drawing.c
+++ b/examples/textures/textures_image_drawing.c
@@ -55,7 +55,7 @@ int main(void)
 
     UnloadFont(font);       // Unload custom font (already drawn used on image)
 
-    Texture2D texture = LoadTextureFromImage(parrots);      // Image converted to texture, uploaded to GPU memory (VRAM)
+    Texture texture = LoadTextureFromImage(parrots);      // Image converted to texture, uploaded to GPU memory (VRAM)
     UnloadImage(parrots);   // Once image has been converted to texture and uploaded to VRAM, it can be unloaded from RAM
 
     SetTargetFPS(60);

--- a/examples/textures/textures_image_generation.c
+++ b/examples/textures/textures_image_generation.c
@@ -37,7 +37,7 @@ int main(void)
     Image perlinNoise = GenImagePerlinNoise(screenWidth, screenHeight, 50, 50, 4.0f);
     Image cellular = GenImageCellular(screenWidth, screenHeight, 32);
 
-    Texture2D textures[NUM_TEXTURES] = { 0 };
+    Texture textures[NUM_TEXTURES] = { 0 };
 
     textures[0] = LoadTextureFromImage(verticalGradient);
     textures[1] = LoadTextureFromImage(horizontalGradient);

--- a/examples/textures/textures_image_kernel.c
+++ b/examples/textures/textures_image_kernel.c
@@ -78,10 +78,10 @@ int main(void)
     ImageCrop(&catSharpend, (Rectangle){ 0, 0, (float)200, (float)450 });
     
     // Images converted to texture, GPU memory (VRAM)
-    Texture2D texture = LoadTextureFromImage(image);
-    Texture2D catSharpendTexture = LoadTextureFromImage(catSharpend);
-    Texture2D catSobelTexture = LoadTextureFromImage(catSobel);
-    Texture2D catGaussianTexture = LoadTextureFromImage(catGaussian);
+    Texture texture = LoadTextureFromImage(image);
+    Texture catSharpendTexture = LoadTextureFromImage(catSharpend);
+    Texture catSobelTexture = LoadTextureFromImage(catSobel);
+    Texture catGaussianTexture = LoadTextureFromImage(catGaussian);
     
     // Once images have been converted to texture and uploaded to VRAM, 
     // they can be unloaded from RAM

--- a/examples/textures/textures_image_loading.c
+++ b/examples/textures/textures_image_loading.c
@@ -30,7 +30,7 @@ int main(void)
     // NOTE: Textures MUST be loaded after Window initialization (OpenGL context is required)
 
     Image image = LoadImage("resources/raylib_logo.png");     // Loaded in CPU memory (RAM)
-    Texture2D texture = LoadTextureFromImage(image);          // Image converted to texture, GPU memory (VRAM)
+    Texture texture = LoadTextureFromImage(image);          // Image converted to texture, GPU memory (VRAM)
     UnloadImage(image);   // Once image has been converted to texture and uploaded to VRAM, it can be unloaded from RAM
 
     SetTargetFPS(60);     // Set our game to run at 60 frames-per-second

--- a/examples/textures/textures_image_processing.c
+++ b/examples/textures/textures_image_processing.c
@@ -59,7 +59,7 @@ int main(void)
 
     Image imOrigin = LoadImage("resources/parrots.png");   // Loaded in CPU memory (RAM)
     ImageFormat(&imOrigin, PIXELFORMAT_UNCOMPRESSED_R8G8B8A8);         // Format image to RGBA 32bit (required for texture update) <-- ISSUE
-    Texture2D texture = LoadTextureFromImage(imOrigin);    // Image converted to texture, GPU memory (VRAM)
+    Texture texture = LoadTextureFromImage(imOrigin);    // Image converted to texture, GPU memory (VRAM)
 
     Image imCopy = ImageCopy(imOrigin);
 

--- a/examples/textures/textures_image_rotate.c
+++ b/examples/textures/textures_image_rotate.c
@@ -36,7 +36,7 @@ int main(void)
     ImageRotate(&image90, 90);
     ImageRotate(&imageNeg90, -90);
 
-    Texture2D textures[NUM_TEXTURES] = { 0 };
+    Texture textures[NUM_TEXTURES] = { 0 };
 
     textures[0] = LoadTextureFromImage(image45);
     textures[1] = LoadTextureFromImage(image90);

--- a/examples/textures/textures_image_text.c
+++ b/examples/textures/textures_image_text.c
@@ -33,7 +33,7 @@ int main(void)
     // Draw over image using custom font
     ImageDrawTextEx(&parrots, font, "[Parrots font drawing]", (Vector2){ 20.0f, 20.0f }, (float)font.baseSize, 0.0f, RED);
 
-    Texture2D texture = LoadTextureFromImage(parrots);  // Image converted to texture, uploaded to GPU memory (VRAM)
+    Texture texture = LoadTextureFromImage(parrots);  // Image converted to texture, uploaded to GPU memory (VRAM)
     UnloadImage(parrots);   // Once image has been converted to texture and uploaded to VRAM, it can be unloaded from RAM
 
     Vector2 position = { (float)(screenWidth/2 - texture.width/2), (float)(screenHeight/2 - texture.height/2 - 20) };

--- a/examples/textures/textures_logo_raylib.c
+++ b/examples/textures/textures_logo_raylib.c
@@ -26,7 +26,7 @@ int main(void)
     InitWindow(screenWidth, screenHeight, "raylib [textures] example - texture loading and drawing");
 
     // NOTE: Textures MUST be loaded after Window initialization (OpenGL context is required)
-    Texture2D texture = LoadTexture("resources/raylib_logo.png");        // Texture loading
+    Texture texture = LoadTexture("resources/raylib_logo.png");        // Texture loading
     //---------------------------------------------------------------------------------------
 
     // Main game loop

--- a/examples/textures/textures_npatch_drawing.c
+++ b/examples/textures/textures_npatch_drawing.c
@@ -30,7 +30,7 @@ int main(void)
     InitWindow(screenWidth, screenHeight, "raylib [textures] example - N-patch drawing");
 
     // NOTE: Textures MUST be loaded after Window initialization (OpenGL context is required)
-    Texture2D nPatchTexture = LoadTexture("resources/ninepatch_button.png");
+    Texture nPatchTexture = LoadTexture("resources/ninepatch_button.png");
 
     Vector2 mousePosition = { 0 };
     Vector2 origin = { 0.0f, 0.0f };

--- a/examples/textures/textures_particles_blending.c
+++ b/examples/textures/textures_particles_blending.c
@@ -53,7 +53,7 @@ int main(void)
 
     float gravity = 3.0f;
 
-    Texture2D smoke = LoadTexture("resources/spark_flame.png");
+    Texture smoke = LoadTexture("resources/spark_flame.png");
 
     int blending = BLEND_ALPHA;
 

--- a/examples/textures/textures_polygon.c
+++ b/examples/textures/textures_polygon.c
@@ -21,7 +21,7 @@
 #define MAX_POINTS  11      // 10 points and back to the start
 
 // Draw textured polygon, defined by vertex and texture coordinates
-void DrawTexturePoly(Texture2D texture, Vector2 center, Vector2 *points, Vector2 *texcoords, int pointCount, Color tint);
+void DrawTexturePoly(Texture texture, Vector2 center, Vector2 *points, Vector2 *texcoords, int pointCount, Color tint);
 
 //------------------------------------------------------------------------------------
 // Program main entry point
@@ -111,7 +111,7 @@ int main(void)
 // Draw textured polygon, defined by vertex and texture coordinates
 // NOTE: Polygon center must have straight line path to all points
 // without crossing perimeter, points must be in anticlockwise order
-void DrawTexturePoly(Texture2D texture, Vector2 center, Vector2 *points, Vector2 *texcoords, int pointCount, Color tint)
+void DrawTexturePoly(Texture texture, Vector2 center, Vector2 *points, Vector2 *texcoords, int pointCount, Color tint)
 {
     rlSetTexture(texture.id);
 

--- a/examples/textures/textures_raw_data.c
+++ b/examples/textures/textures_raw_data.c
@@ -33,7 +33,7 @@ int main(void)
 
     // Load RAW image data (512x512, 32bit RGBA, no file header)
     Image fudesumiRaw = LoadImageRaw("resources/fudesumi.raw", 384, 512, PIXELFORMAT_UNCOMPRESSED_R8G8B8A8, 0);
-    Texture2D fudesumi = LoadTextureFromImage(fudesumiRaw);  // Upload CPU (RAM) image to GPU (VRAM)
+    Texture fudesumi = LoadTextureFromImage(fudesumiRaw);  // Upload CPU (RAM) image to GPU (VRAM)
     UnloadImage(fudesumiRaw);                                // Unload CPU (RAM) image data
 
     // Generate a checked texture by code
@@ -61,7 +61,7 @@ int main(void)
         .mipmaps = 1
     };
 
-    Texture2D checked = LoadTextureFromImage(checkedIm);
+    Texture checked = LoadTextureFromImage(checkedIm);
     UnloadImage(checkedIm);         // Unload CPU (RAM) image data (pixels)
     //---------------------------------------------------------------------------------------
 

--- a/examples/textures/textures_sprite_anim.c
+++ b/examples/textures/textures_sprite_anim.c
@@ -29,7 +29,7 @@ int main(void)
     InitWindow(screenWidth, screenHeight, "raylib [texture] example - sprite anim");
 
     // NOTE: Textures MUST be loaded after Window initialization (OpenGL context is required)
-    Texture2D scarfy = LoadTexture("resources/scarfy.png");        // Texture loading
+    Texture scarfy = LoadTexture("resources/scarfy.png");        // Texture loading
 
     Vector2 position = { 350.0f, 280.0f };
     Rectangle frameRec = { 0.0f, 0.0f, (float)scarfy.width/6, (float)scarfy.height };

--- a/examples/textures/textures_sprite_button.c
+++ b/examples/textures/textures_sprite_button.c
@@ -30,7 +30,7 @@ int main(void)
     InitAudioDevice();      // Initialize audio device
 
     Sound fxButton = LoadSound("resources/buttonfx.wav");   // Load button sound
-    Texture2D button = LoadTexture("resources/button.png"); // Load button texture
+    Texture button = LoadTexture("resources/button.png"); // Load button texture
 
     // Define frame rectangle for drawing
     float frameHeight = (float)button.height/NUM_FRAMES;

--- a/examples/textures/textures_sprite_explosion.c
+++ b/examples/textures/textures_sprite_explosion.c
@@ -34,7 +34,7 @@ int main(void)
     Sound fxBoom = LoadSound("resources/boom.wav");
 
     // Load explosion texture
-    Texture2D explosion = LoadTexture("resources/explosion.png");
+    Texture explosion = LoadTexture("resources/explosion.png");
 
     // Init variables for animation
     float frameWidth = (float)(explosion.width/NUM_FRAMES_PER_LINE);   // Sprite one frame rectangle width

--- a/examples/textures/textures_srcrec_dstrec.c
+++ b/examples/textures/textures_srcrec_dstrec.c
@@ -27,7 +27,7 @@ int main(void)
 
     // NOTE: Textures MUST be loaded after Window initialization (OpenGL context is required)
 
-    Texture2D scarfy = LoadTexture("resources/scarfy.png");        // Texture loading
+    Texture scarfy = LoadTexture("resources/scarfy.png");        // Texture loading
 
     int frameWidth = scarfy.width/6;
     int frameHeight = scarfy.height;

--- a/examples/textures/textures_svg_loading.c
+++ b/examples/textures/textures_svg_loading.c
@@ -30,7 +30,7 @@ int main(void)
     // NOTE: Textures MUST be loaded after Window initialization (OpenGL context is required)
 
     Image image = LoadImageSvg("resources/test.svg", 400, 350);     // Loaded in CPU memory (RAM)
-    Texture2D texture = LoadTextureFromImage(image);          // Image converted to texture, GPU memory (VRAM)
+    Texture texture = LoadTextureFromImage(image);          // Image converted to texture, GPU memory (VRAM)
     UnloadImage(image);   // Once image has been converted to texture and uploaded to VRAM, it can be unloaded from RAM
 
     SetTargetFPS(60);     // Set our game to run at 60 frames-per-second

--- a/examples/textures/textures_to_image.c
+++ b/examples/textures/textures_to_image.c
@@ -30,7 +30,7 @@ int main(void)
     // NOTE: Textures MUST be loaded after Window initialization (OpenGL context is required)
 
     Image image = LoadImage("resources/raylib_logo.png");  // Load image data into CPU memory (RAM)
-    Texture2D texture = LoadTextureFromImage(image);       // Image converted to texture, GPU memory (RAM -> VRAM)
+    Texture texture = LoadTextureFromImage(image);       // Image converted to texture, GPU memory (RAM -> VRAM)
     UnloadImage(image);                                    // Unload image data from CPU memory (RAM)
 
     image = LoadImageFromTexture(texture);                 // Load image from GPU texture (VRAM -> RAM)


### PR DESCRIPTION
[Texture2D is just an alias for Texture](https://github.com/raysan5/raylib/blob/97c02b2425225982da6f3569d50fb490fab53c10/src/raylib.h#L275) and i think it looks cleaner with just "Texture". It also makes it clear that there is NOT a Texture3D, etc

This pattern is also used in existing examples such as https://github.com/raysan5/raylib/blob/97c02b2425225982da6f3569d50fb490fab53c10/examples/shaders/shaders_simple_mask.c#L67