### PR TITLE
[Examples] change rendertexture2d to rendertexture

### DIFF
--- a/examples/core/core_smooth_pixelperfect.c
+++ b/examples/core/core_smooth_pixelperfect.c
@@ -41,7 +41,7 @@ int main(void)
     Camera2D screenSpaceCamera = { 0 }; // Smoothing camera
     screenSpaceCamera.zoom = 1.0f;
 
-    RenderTexture2D target = LoadRenderTexture(virtualScreenWidth, virtualScreenHeight); // This is where we'll draw all our objects.
+    RenderTexture target = LoadRenderTexture(virtualScreenWidth, virtualScreenHeight); // This is where we'll draw all our objects.
 
     Rectangle rec01 = { 70.0f, 35.0f, 20.0f, 20.0f };
     Rectangle rec02 = { 90.0f, 55.0f, 30.0f, 10.0f };

--- a/examples/core/core_vr_simulator.c
+++ b/examples/core/core_vr_simulator.c
@@ -82,7 +82,7 @@ int main(void)
 
     // Initialize framebuffer for stereo rendering
     // NOTE: Screen size should match HMD aspect ratio
-    RenderTexture2D target = LoadRenderTexture(device.hResolution, device.vResolution);
+    RenderTexture target = LoadRenderTexture(device.hResolution, device.vResolution);
 
     // The target's height is flipped (in the source Rectangle), due to OpenGL reasons
     Rectangle sourceRec = { 0.0f, 0.0f, (float)target.texture.width, -(float)target.texture.height };

--- a/examples/core/core_window_letterbox.c
+++ b/examples/core/core_window_letterbox.c
@@ -37,7 +37,7 @@ int main(void)
     int gameScreenHeight = 480;
 
     // Render texture initialization, used to hold the rendering result so we can easily resize it
-    RenderTexture2D target = LoadRenderTexture(gameScreenWidth, gameScreenHeight);
+    RenderTexture target = LoadRenderTexture(gameScreenWidth, gameScreenHeight);
     SetTextureFilter(target.texture, TEXTURE_FILTER_BILINEAR);  // Texture scale filter to use
 
     Color colors[10] = { 0 };

--- a/examples/shaders/shaders_custom_uniform.c
+++ b/examples/shaders/shaders_custom_uniform.c
@@ -64,8 +64,8 @@ int main(void)
 
     float swirlCenter[2] = { (float)screenWidth/2, (float)screenHeight/2 };
 
-    // Create a RenderTexture2D to be used for render to texture
-    RenderTexture2D target = LoadRenderTexture(screenWidth, screenHeight);
+    // Create a RenderTexture to be used for render to texture
+    RenderTexture target = LoadRenderTexture(screenWidth, screenHeight);
 
     SetTargetFPS(60);                   // Set our game to run at 60 frames-per-second
     //--------------------------------------------------------------------------------------

--- a/examples/shaders/shaders_eratosthenes.c
+++ b/examples/shaders/shaders_eratosthenes.c
@@ -45,7 +45,7 @@ int main(void)
 
     InitWindow(screenWidth, screenHeight, "raylib [shaders] example - Sieve of Eratosthenes");
 
-    RenderTexture2D target = LoadRenderTexture(screenWidth, screenHeight);
+    RenderTexture target = LoadRenderTexture(screenWidth, screenHeight);
 
     // Load Eratosthenes shader
     // NOTE: Defining 0 (NULL) for vertex shader forces usage of internal default vertex shader

--- a/examples/shaders/shaders_hybrid_render.c
+++ b/examples/shaders/shaders_hybrid_render.c
@@ -28,9 +28,9 @@
 // Declare custom functions required for the example
 //------------------------------------------------------------------------------------
 // Load custom render texture, create a writable depth texture buffer
-static RenderTexture2D LoadRenderTextureDepthTex(int width, int height);
+static RenderTexture LoadRenderTextureDepthTex(int width, int height);
 // Unload render texture from GPU memory (VRAM)
-static void UnloadRenderTextureDepthTex(RenderTexture2D target);
+static void UnloadRenderTextureDepthTex(RenderTexture target);
 
 //------------------------------------------------------------------------------------
 // Declare custom Structs
@@ -72,7 +72,7 @@ int main(void)
     SetShaderValue(shdrRaymarch, marchLocs.screenCenter , &screenCenter , SHADER_UNIFORM_VEC2);
 
     // Use Customized function to create writable depth texture buffer
-    RenderTexture2D target = LoadRenderTextureDepthTex(screenWidth, screenHeight);
+    RenderTexture target = LoadRenderTextureDepthTex(screenWidth, screenHeight);
 
     // Define the camera to look into our 3d world
     Camera camera = {
@@ -154,9 +154,9 @@ int main(void)
 // Define custom functions required for the example
 //------------------------------------------------------------------------------------
 // Load custom render texture, create a writable depth texture buffer
-RenderTexture2D LoadRenderTextureDepthTex(int width, int height)
+RenderTexture LoadRenderTextureDepthTex(int width, int height)
 {
-    RenderTexture2D target = { 0 };
+    RenderTexture target = { 0 };
 
     target.id = rlLoadFramebuffer(); // Load an empty framebuffer
 
@@ -193,7 +193,7 @@ RenderTexture2D LoadRenderTextureDepthTex(int width, int height)
 }
 
 // Unload render texture from GPU memory (VRAM)
-void UnloadRenderTextureDepthTex(RenderTexture2D target)
+void UnloadRenderTextureDepthTex(RenderTexture target)
 {
     if (target.id > 0)
     {

--- a/examples/shaders/shaders_julia_set.c
+++ b/examples/shaders/shaders_julia_set.c
@@ -57,8 +57,8 @@ int main(void)
     // NOTE: Defining 0 (NULL) for vertex shader forces usage of internal default vertex shader
     Shader shader = LoadShader(0, TextFormat("resources/shaders/glsl%i/julia_set.fs", GLSL_VERSION));
 
-    // Create a RenderTexture2D to be used for render to texture
-    RenderTexture2D target = LoadRenderTexture(GetScreenWidth(), GetScreenHeight());
+    // Create a RenderTexture to be used for render to texture
+    RenderTexture target = LoadRenderTexture(GetScreenWidth(), GetScreenHeight());
 
     // c constant to use in z^2 + c
     float c[2] = { pointsOfInterest[0][0], pointsOfInterest[0][1] };
@@ -173,7 +173,7 @@ int main(void)
             // NOTE: We do not invert texture on Y, already considered inside shader
             BeginShaderMode(shader);
                 // WARNING: If FLAG_WINDOW_HIGHDPI is enabled, HighDPI monitor scaling should be considered
-                // when rendering the RenderTexture2D to fit in the HighDPI scaled Window
+                // when rendering the RenderTexture to fit in the HighDPI scaled Window
                 DrawTextureEx(target.texture, (Vector2){ 0.0f, 0.0f }, 0.0f, 1.0f, WHITE);
             EndShaderMode();
 

--- a/examples/shaders/shaders_postprocessing.c
+++ b/examples/shaders/shaders_postprocessing.c
@@ -109,8 +109,8 @@ int main(void)
 
     int currentShader = FX_GRAYSCALE;
 
-    // Create a RenderTexture2D to be used for render to texture
-    RenderTexture2D target = LoadRenderTexture(screenWidth, screenHeight);
+    // Create a RenderTexture to be used for render to texture
+    RenderTexture target = LoadRenderTexture(screenWidth, screenHeight);
 
     SetTargetFPS(60);                   // Set our game to run at 60 frames-per-second
     //--------------------------------------------------------------------------------------

--- a/examples/shaders/shaders_shadowmap.c
+++ b/examples/shaders/shaders_shadowmap.c
@@ -23,8 +23,8 @@
 
 #define SHADOWMAP_RESOLUTION 1024
 
-RenderTexture2D LoadShadowmapRenderTexture(int width, int height);
-void UnloadShadowmapRenderTexture(RenderTexture2D target);
+RenderTexture LoadShadowmapRenderTexture(int width, int height);
+void UnloadShadowmapRenderTexture(RenderTexture target);
 void DrawScene(Model cube, Model robot);
 
 //------------------------------------------------------------------------------------
@@ -78,7 +78,7 @@ int main(void)
     int animCount = 0;
     ModelAnimation* robotAnimations = LoadModelAnimations("resources/models/robot.glb", &animCount);
 
-    RenderTexture2D shadowMap = LoadShadowmapRenderTexture(SHADOWMAP_RESOLUTION, SHADOWMAP_RESOLUTION);
+    RenderTexture shadowMap = LoadShadowmapRenderTexture(SHADOWMAP_RESOLUTION, SHADOWMAP_RESOLUTION);
     // For the shadowmapping algorithm, we will be rendering everything from the light's point of view
     Camera3D lightCam = (Camera3D){ 0 };
     lightCam.position = Vector3Scale(lightDir, -15.0f);
@@ -199,9 +199,9 @@ int main(void)
     return 0;
 }
 
-RenderTexture2D LoadShadowmapRenderTexture(int width, int height)
+RenderTexture LoadShadowmapRenderTexture(int width, int height)
 {
-    RenderTexture2D target = { 0 };
+    RenderTexture target = { 0 };
 
     target.id = rlLoadFramebuffer(); // Load an empty framebuffer
     target.texture.width = width;
@@ -233,7 +233,7 @@ RenderTexture2D LoadShadowmapRenderTexture(int width, int height)
 }
 
 // Unload shadowmap render texture from GPU memory (VRAM)
-void UnloadShadowmapRenderTexture(RenderTexture2D target)
+void UnloadShadowmapRenderTexture(RenderTexture target)
 {
     if (target.id > 0)
     {

--- a/examples/shaders/shaders_write_depth.c
+++ b/examples/shaders/shaders_write_depth.c
@@ -27,10 +27,10 @@
 // Declare custom functions required for the example
 //------------------------------------------------------------------------------------
 // Load custom render texture, create a writable depth texture buffer
-static RenderTexture2D LoadRenderTextureDepthTex(int width, int height);
+static RenderTexture LoadRenderTextureDepthTex(int width, int height);
 
 // Unload render texture from GPU memory (VRAM)
-static void UnloadRenderTextureDepthTex(RenderTexture2D target);
+static void UnloadRenderTextureDepthTex(RenderTexture target);
 
 //------------------------------------------------------------------------------------
 // Program main entry point
@@ -48,7 +48,7 @@ int main(void)
     Shader shader = LoadShader(0, TextFormat("resources/shaders/glsl%i/write_depth.fs", GLSL_VERSION));
 
     // Use Customized function to create writable depth texture buffer
-    RenderTexture2D target = LoadRenderTextureDepthTex(screenWidth, screenHeight);
+    RenderTexture target = LoadRenderTextureDepthTex(screenWidth, screenHeight);
 
     // Define the camera to look into our 3d world
     Camera camera = {
@@ -113,9 +113,9 @@ int main(void)
 // Define custom functions required for the example
 //------------------------------------------------------------------------------------
 // Load custom render texture, create a writable depth texture buffer
-RenderTexture2D LoadRenderTextureDepthTex(int width, int height)
+RenderTexture LoadRenderTextureDepthTex(int width, int height)
 {
-    RenderTexture2D target = { 0 };
+    RenderTexture target = { 0 };
 
     target.id = rlLoadFramebuffer(); // Load an empty framebuffer
 
@@ -152,7 +152,7 @@ RenderTexture2D LoadRenderTextureDepthTex(int width, int height)
 }
 
 // Unload render texture from GPU memory (VRAM)
-void UnloadRenderTextureDepthTex(RenderTexture2D target)
+void UnloadRenderTextureDepthTex(RenderTexture target)
 {
     if (target.id > 0)
     {

--- a/examples/textures/textures_fog_of_war.c
+++ b/examples/textures/textures_fog_of_war.c
@@ -61,7 +61,7 @@ int main(void)
     // Render texture to render fog of war
     // NOTE: To get an automatic smooth-fog effect we use a render texture to render fog
     // at a smaller size (one pixel per tile) and scale it on drawing with bilinear filtering
-    RenderTexture2D fogOfWar = LoadRenderTexture(map.tilesX, map.tilesY);
+    RenderTexture fogOfWar = LoadRenderTexture(map.tilesX, map.tilesY);
     SetTextureFilter(fogOfWar.texture, TEXTURE_FILTER_BILINEAR);
 
     SetTargetFPS(60);               // Set our game to run at 60 frames-per-second

--- a/examples/textures/textures_mouse_painting.c
+++ b/examples/textures/textures_mouse_painting.c
@@ -57,8 +57,8 @@ int main(void)
     bool showSaveMessage = false;
     int saveMessageCounter = 0;
 
-    // Create a RenderTexture2D to use as a canvas
-    RenderTexture2D target = LoadRenderTexture(screenWidth, screenHeight);
+    // Create a RenderTexture to use as a canvas
+    RenderTexture target = LoadRenderTexture(screenWidth, screenHeight);
 
     // Clear render texture before entering the game loop
     BeginTextureMode(target);


### PR DESCRIPTION
[RenderTexture2D is just an alias for RenderTexture](https://github.com/raysan5/raylib/blob/97c02b2425225982da6f3569d50fb490fab53c10/src/raylib.h#L288) and i think it looks cleaner with just "RenderTexture". It also makes it clear that there is NOT a RenderTexture3D, etc