### PR TITLE
[Examples] Fix `core_input_gamepad` example for Xbox gamepads

### DIFF
--- a/examples/core/core_input_gamepad.c
+++ b/examples/core/core_input_gamepad.c
@@ -67,7 +67,7 @@ int main(void)
             {
                 DrawText(TextFormat("GP%d: %s", gamepad, GetGamepadName(gamepad)), 10, 10, 10, BLACK);
 
-                if (TextFindIndex(TextToLower(GetGamepadName(gamepad)), XBOX_ALIAS_1) || TextFindIndex(TextToLower(GetGamepadName(gamepad)), XBOX_ALIAS_2))
+                if (TextFindIndex(TextToLower(GetGamepadName(gamepad)), XBOX_ALIAS_1) > -1 || TextFindIndex(TextToLower(GetGamepadName(gamepad)), XBOX_ALIAS_2) > -1)
                 {
                     DrawTexture(texXboxPad, 0, 0, DARKGRAY);
 

--- a/examples/core/core_input_gamepad.c
+++ b/examples/core/core_input_gamepad.c
@@ -20,9 +20,9 @@
 #include "raylib.h"
 
 // NOTE: Gamepad name ID depends on drivers and OS
-#define XBOX360_LEGACY_NAME_ID  "Xbox Controller"
-#define XBOX360_NAME_ID     "Xbox 360 Controller"
-#define PS3_NAME_ID         "Sony PLAYSTATION(R)3 Controller"
+#define XBOX_ALIAS_1 "xbox"
+#define XBOX_ALIAS_2 "x-box"
+#define PS3_NAME_ID  "Sony PLAYSTATION(R)3 Controller"
 
 //------------------------------------------------------------------------------------
 // Program main entry point
@@ -67,7 +67,7 @@ int main(void)
             {
                 DrawText(TextFormat("GP%d: %s", gamepad, GetGamepadName(gamepad)), 10, 10, 10, BLACK);
 
-                if (TextIsEqual(GetGamepadName(gamepad), XBOX360_LEGACY_NAME_ID) || TextIsEqual(GetGamepadName(gamepad), XBOX360_NAME_ID))
+                if (TextFindIndex(TextToLower(GetGamepadName(gamepad)), XBOX_ALIAS_1) || TextFindIndex(TextToLower(GetGamepadName(gamepad)), XBOX_ALIAS_2))
                 {
                     DrawTexture(texXboxPad, 0, 0, DARKGRAY);
 


### PR DESCRIPTION
Hello,

This pull request fixes the `core_input_gamepad` example for Xbox gamepads.

The problem was that the `XBOX360_LEGACY_NAME_ID` and `XBOX360_NAME_ID` defines were too specific and there's just way too many possible Xbox compatible gamepad strings for an exact match ([ref](https://github.com/mdqinc/SDL_GameControllerDB/blob/master/gamecontrollerdb.txt)). This issue can be solved with more generic alias defines and the use of `TextFindIndex`.

Note: there's no need to update the example screenshot as the current one ([ref](https://github.com/raysan5/raylib/blob/master/examples/core/core_input_gamepad.png)) is still accurate.

Best regards.