### PR TITLE
[Examples] Fix `core_input_gamepad_info` example so all buttons are displayed

### DIFF
--- a/examples/core/core_input_gamepad_info.c
+++ b/examples/core/core_input_gamepad_info.c
@@ -47,25 +47,25 @@ int main(void)
 
             ClearBackground(RAYWHITE);
 
-            for (int i = 0, y = 10; i < 4; i++)     // MAX_GAMEPADS = 4
+            for (int i = 0, y = 5; i < 4; i++)     // MAX_GAMEPADS = 4
             {
                 if (IsGamepadAvailable(i))
                 {
-                    DrawText(TextFormat("Gamepad name: %s", GetGamepadName(i)), 10, y, 20, BLACK);
-                    y += 30;
-                    DrawText(TextFormat("\tAxis count:   %d", GetGamepadAxisCount(i)), 10, y, 20, BLACK);
-                    y += 30;
+                    DrawText(TextFormat("Gamepad name: %s", GetGamepadName(i)), 10, y, 10, BLACK);
+                    y += 11;
+                    DrawText(TextFormat("\tAxis count:   %d", GetGamepadAxisCount(i)), 10, y, 10, BLACK);
+                    y += 11;
 
                     for (int axis = 0; axis < GetGamepadAxisCount(i); axis++)
                     {
-                        DrawText(TextFormat("\tAxis %d = %f", axis, GetGamepadAxisMovement(i, axis)), 10, y, 20, BLACK);
-                        y += 30;
+                        DrawText(TextFormat("\tAxis %d = %f", axis, GetGamepadAxisMovement(i, axis)), 10, y, 10, BLACK);
+                        y += 11;
                     }
 
                     for (int button = 0; button < 32; button++)
                     {
-                        DrawText(TextFormat("\tButton %d = %d", button, IsGamepadButtonDown(i, button)), 10, y, 20, BLACK);
-                        y += 30;
+                        DrawText(TextFormat("\tButton %d = %d", button, IsGamepadButtonDown(i, button)), 10, y, 10, BLACK);
+                        y += 11;
                     }
                 }
             }


### PR DESCRIPTION
Hello,

This pull request fixes the `core_input_gamepad_info` example so now all possible (32) buttons are displayed within the window area.

Best regards.