### PR TITLE
[Projects]CMakeLists.txt for raylib version issue

### DIFF
--- a/projects/CMake/CMakeLists.txt
+++ b/projects/CMake/CMakeLists.txt
@@ -5,7 +5,7 @@ project(example)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 # Dependencies
-set(RAYLIB_VERSION 5.5)
+set(RAYLIB_VERSION 5.0)
 find_package(raylib ${RAYLIB_VERSION} QUIET) # QUIET or REQUIRED
 if (NOT raylib_FOUND) # If there's none, fetch and build raylib
   include(FetchContent)


### PR DESCRIPTION
i dont know but i do think that raylib 5.5 is not out yet and putting it instead of 5.0 break the cmake project but when using raylib target version 5.0 it works