### PR TITLE
Fix warnings

### DIFF
--- a/src/rtextures.c
+++ b/src/rtextures.c
@@ -371,7 +371,7 @@ Image LoadImageSvg(const char *fileNameOrString, int width, int height)
 
         if (isSvgStringValid)
         {
-            struct NSVGimage *svgImage = nsvgParse(fileData, "px", 96.0f);
+            struct NSVGimage *svgImage = nsvgParse((char *)fileData, "px", 96.0f);
 
             unsigned char *img = RL_MALLOC(width*height*4);
 
@@ -404,7 +404,7 @@ Image LoadImageSvg(const char *fileNameOrString, int width, int height)
             nsvgDeleteRasterizer(rast);
         }
 
-        if (isSvgStringValid && (fileData != fileNameOrString)) UnloadFileData(fileData);
+        if (isSvgStringValid && (fileData != (unsigned char *)fileNameOrString)) UnloadFileData(fileData);
     }
 #else
     TRACELOG(LOG_WARNING, "SVG image support not enabled, image can not be loaded");
@@ -611,7 +611,7 @@ Image LoadImageFromMemory(const char *fileType, const unsigned char *fileData, i
             (fileData[2] == 'v') &&
             (fileData[3] == 'g'))
         {
-            struct NSVGimage *svgImage = nsvgParse(fileData, "px", 96.0f);
+            struct NSVGimage *svgImage = nsvgParse((char *)fileData, "px", 96.0f);
             unsigned char *img = RL_MALLOC(svgImage->width*svgImage->height*4);
 
             // Rasterize


### PR DESCRIPTION
Fix following gcc warnings when SVG enabled:

```
rtextures.c: In function 'LoadImageSvg':
rtextures.c:374:52: warning: pointer targets in passing argument 1 of 'nsvgParse' differ in signedness [-Wpointer-sign]
  374 |             struct NSVGimage *svgImage = nsvgParse(fileData, "px", 96.0f);
      |                                                    ^~~~~~~~
      |                                                    |
      |                                                    unsigned char *
In file included from rtextures.c:230:
external/nanosvg.h:2952:28: note: expected 'char *' but argument is of type 'unsigned char *'
 2952 | NSVGimage* nsvgParse(char* input, const char* units, float dpi)
      |                      ~~~~~~^~~~~
rtextures.c:407:43: warning: comparison of distinct pointer types lacks a cast [-Wcompare-distinct-pointer-types]
  407 |         if (isSvgStringValid && (fileData != fileNameOrString)) UnloadFileData(fileData);
      |                                           ^~
rtextures.c: In function 'LoadImageFromMemory':
rtextures.c:614:52: warning: passing argument 1 of 'nsvgParse' discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
  614 |             struct NSVGimage *svgImage = nsvgParse(fileData, "px", 96.0f);
      |                                                    ^~~~~~~~
external/nanosvg.h:2952:28: note: expected 'char *' but argument is of type 'const unsigned char *'
 2952 | NSVGimage* nsvgParse(char* input, const char* units, float dpi)
      |                      ~~~~~~^~~~~
```