### PR TITLE
Replace deprecated Android function ALooper_pollAll

### DIFF
--- a/src/platforms/rcore_android.c
+++ b/src/platforms/rcore_android.c
@@ -281,14 +281,15 @@ void android_main(struct android_app *app)
     // Request to end the native activity
     ANativeActivity_finish(app->activity);
 
-    // Android ALooper_pollAll() variables
+    // Android ALooper_pollOnce() variables
     int pollResult = 0;
     int pollEvents = 0;
 
     // Waiting for application events before complete finishing
     while (!app->destroyRequested)
     {
-        while ((pollResult = ALooper_pollAll(0, NULL, &pollEvents, (void **)&platform.source)) >= 0)
+        // Poll all events until we reach return value TIMEOUT, meaning no events left to process
+        while ((pollResult = ALooper_pollOnce(0, NULL, &pollEvents, (void **)&platform.source)) > ALOOPER_POLL_TIMEOUT)
         {
             if (platform.source != NULL) platform.source->process(app, platform.source);
         }
@@ -682,13 +683,13 @@ void PollInputEvents(void)
         CORE.Input.Keyboard.keyRepeatInFrame[i] = 0;
     }
 
-    // Android ALooper_pollAll() variables
+    // Android ALooper_pollOnce() variables
     int pollResult = 0;
     int pollEvents = 0;
 
-    // Poll Events (registered events)
+    // Poll Events (registered events) until we reach TIMEOUT which indicates there are no events left to poll
     // NOTE: Activity is paused if not enabled (platform.appEnabled)
-    while ((pollResult = ALooper_pollAll(platform.appEnabled? 0 : -1, NULL, &pollEvents, (void**)&platform.source)) >= 0)
+    while ((pollResult = ALooper_pollOnce(platform.appEnabled? 0 : -1, NULL, &pollEvents, (void**)&platform.source)) > ALOOPER_POLL_TIMEOUT)
     {
         // Process this event
         if (platform.source != NULL) platform.source->process(platform.app, platform.source);
@@ -767,15 +768,15 @@ int InitPlatform(void)
 
     TRACELOG(LOG_INFO, "PLATFORM: ANDROID: Initialized successfully");
 
-    // Android ALooper_pollAll() variables
+    // Android ALooper_pollOnce() variables
     int pollResult = 0;
     int pollEvents = 0;
 
     // Wait for window to be initialized (display and context)
     while (!CORE.Window.ready)
     {
-        // Process events loop
-        while ((pollResult = ALooper_pollAll(0, NULL, &pollEvents, (void**)&platform.source)) >= 0)
+        // Process events until we reach TIMEOUT, which indicates no more events queued.
+        while ((pollResult = ALooper_pollOnce(0, NULL, &pollEvents, (void**)&platform.source)) > ALOOPER_POLL_TIMEOUT)
         {
             // Process this event
             if (platform.source != NULL) platform.source->process(platform.app, platform.source);


### PR DESCRIPTION
This MR should close #4166

This is my best effort replacement of the ALooperPollAll function that was deleted in ndk-r27.

To be clear, I have exactly zero experience with this API and the NDK,
and barely any experience with android in general.
But I'll explain my reasoning for these changes:

The [documentation](https://developer.android.com/ndk/reference/group/looper#alooper_pollall) for ALooperPollAll claims:

> Like ALooper_pollOnce(), but performs all pending callbacks until all data has been consumed or a file descriptor is available with no callback.

And then the [documentation](https://developer.android.com/ndk/reference/group/looper#alooper_pollonce) for ALooper_pollOnce claims:
> Returns ALOOPER_POLL_TIMEOUT if there was no data before the given timeout expired.

So it seems reasonable to me to just call ALooper_pollOnce until we get `TIMEOUT`, which means no events left to process.

I have tested these changes by compiling and running the Gestures example,
`raylib/examples/core/core_input_gestures.c`. This seemed to work well on my phone.

Noting my lack of experience in this area, I really welcome feedback on how to improve and/or verify these changes. 