### PR TITLE
[build] CMake: Fix warnings in projects/CMake/CMakeLists.txt

### DIFF
--- a/projects/CMake/CMakeLists.txt
+++ b/projects/CMake/CMakeLists.txt
@@ -17,9 +17,8 @@ if (NOT raylib_FOUND) # If there's none, fetch and build raylib
   FetchContent_GetProperties(raylib)
   if (NOT raylib_POPULATED) # Have we downloaded raylib yet?
     set(FETCHCONTENT_QUIET NO)
-    FetchContent_Populate(raylib)
+    FetchContent_MakeAvailable(raylib)
     set(BUILD_EXAMPLES OFF CACHE BOOL "" FORCE) # don't build the supplied examples
-    add_subdirectory(${raylib_SOURCE_DIR} ${raylib_BINARY_DIR})
   endif()
 endif()
 


### PR DESCRIPTION
Currently, when building, the cmake example in projects/CMake gives this warning, with CMake 3.30.2

CMake Warning (dev) at /usr/share/cmake/Modules/FetchContent.cmake:1953 (message):
  Calling FetchContent_Populate(raylib) is deprecated, call
  FetchContent_MakeAvailable(raylib) instead.  Policy CMP0169 can be set to
  OLD to allow FetchContent_Populate(raylib) to be called directly for now,
  but the ability to call it with declared details will be removed completely
  in a future version.
Call Stack (most recent call first):
  CMakeLists.txt:20 (FetchContent_Populate)
This warning is for project developers.  Use -Wno-dev to suppress it.

Changing FetchContent_Populate to FetchContent_MakeAvailable didn't cause any issues I could observe when building. I'm not sure why it wasn't like that to begin with.