### PR TITLE
[raudio] Support 24-bit FLACs in `LoadMusicStreamFromMemory`

### DIFF
--- a/src/raudio.c
+++ b/src/raudio.c
@@ -1626,7 +1626,9 @@ Music LoadMusicStreamFromMemory(const char *fileType, const unsigned char *data,
         {
             music.ctxType = MUSIC_AUDIO_FLAC;
             music.ctxData = ctxFlac;
-            music.stream = LoadAudioStream(ctxFlac->sampleRate, ctxFlac->bitsPerSample, ctxFlac->channels);
+            int sampleSize = ctxFlac->bitsPerSample;
+            if (ctxFlac->bitsPerSample == 24) sampleSize = 16;   // Forcing conversion to s16 on UpdateMusicStream()
+            music.stream = LoadAudioStream(ctxFlac->sampleRate, sampleSize, ctxFlac->channels);
             music.frameCount = (unsigned int)ctxFlac->totalPCMFrameCount;
             music.looping = true;   // Looping enabled by default
             musicLoaded = true;


### PR DESCRIPTION
When loading FLAC files using `LoadMusicStreamFromMemory`, 24-bit files play either silence (Windows) or extreme noise (Linux, macOS), while 16-bit files work all fine.

While debugging this I stumbled on #4058, which recently fixed the same problem in `LoadMusicStream` by forcing conversion to 16-bit.

Here simply copying the same fix to `LoadMusicStreamFromMemory`, which fixes all the issues with 24-bit files for me.