### PR TITLE
(rcore_desktop_rgfw.c) fix errors when compiling with mingw

### DIFF
--- a/src/external/RGFW.h
+++ b/src/external/RGFW.h
@@ -4999,7 +4999,9 @@ static const struct wl_callback_listener wl_surface_frame_listener = {
 	#define WIN32_LEAN_AND_MEAN
 	#define OEMRESOURCE
 	#include <windows.h>
-	
+
+	__declspec(dllimport) int __stdcall WideCharToMultiByte( UINT CodePage, DWORD dwFlags, const WCHAR* lpWideCharStr, int cchWideChar,  LPSTR lpMultiByteStr, int cbMultiByte, LPCCH lpDefaultChar, LPBOOL lpUsedDefaultChar);
+
 	#include <processthreadsapi.h>
 	#include <wchar.h>
 	#include <locale.h>

--- a/src/platforms/rcore_desktop_rgfw.c
+++ b/src/platforms/rcore_desktop_rgfw.c
@@ -76,9 +76,7 @@ void CloseWindow(void);
     #define Size NSSIZE
 #endif
 
-#if defined(_MSC_VER)
 __declspec(dllimport) int __stdcall MultiByteToWideChar(unsigned int CodePage, unsigned long dwFlags, const char *lpMultiByteStr, int cbMultiByte, wchar_t *lpWideCharStr, int cchWideChar);
-#endif
 
 #include "../external/RGFW.h"
 
@@ -538,10 +536,8 @@ void *GetWindowHandle(void)
 {
 #ifdef RGFW_WEBASM
     return (void*)platform.window->src.ctx;
-#elif !defined(RGFW_WINDOWS)
-    return (void *)platform.window->src.window;
 #else
-    return platform.window->src.hwnd;
+    return (void*)platform.window->src.window;
 #endif
 }
 


### PR DESCRIPTION
`MultiByteToWideChar` should be defined for msvc AND mingw.

`win->src.window` is now used for all platforms