### PR TITLE
[rcore] Add filtering folders to `LoadDirectoryFilesEx()`/`ScanDirectoryFiles()`

### DIFF
--- a/src/raylib.h
+++ b/src/raylib.h
@@ -194,6 +194,10 @@
 #define MAGENTA    CLITERAL(Color){ 255, 0, 255, 255 }     // Magenta
 #define RAYWHITE   CLITERAL(Color){ 245, 245, 245, 255 }   // My own White (raylib logo)
 
+// Filter string used in ScanDirectoryFiles, ScanDirectoryFilesRecursively and
+// LoadDirectoryFilesEx to include directories in the result array
+#define FILTER_FOLDER "/DIR"
+
 //----------------------------------------------------------------------------------
 // Structures Definition
 //----------------------------------------------------------------------------------

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -194,10 +194,6 @@
 #define MAGENTA    CLITERAL(Color){ 255, 0, 255, 255 }     // Magenta
 #define RAYWHITE   CLITERAL(Color){ 245, 245, 245, 255 }   // My own White (raylib logo)
 
-// Filter string used in ScanDirectoryFiles, ScanDirectoryFilesRecursively and
-// LoadDirectoryFilesEx to include directories in the result array
-#define FILTER_FOLDER "/DIR"
-
 //----------------------------------------------------------------------------------
 // Structures Definition
 //----------------------------------------------------------------------------------
@@ -1130,7 +1126,7 @@ RLAPI bool ChangeDirectory(const char *dir);                      // Change work
 RLAPI bool IsPathFile(const char *path);                          // Check if a given path is a file or a directory
 RLAPI bool IsFileNameValid(const char *fileName);                 // Check if fileName is valid for the platform/OS
 RLAPI FilePathList LoadDirectoryFiles(const char *dirPath);       // Load directory filepaths
-RLAPI FilePathList LoadDirectoryFilesEx(const char *basePath, const char *filter, bool scanSubdirs); // Load directory filepaths with extension filtering and recursive directory scan
+RLAPI FilePathList LoadDirectoryFilesEx(const char *basePath, const char *filter, bool scanSubdirs); // Load directory filepaths with extension filtering and recursive directory scan. Use "/DIR" in the filter string to include directories in the result
 RLAPI void UnloadDirectoryFiles(FilePathList files);              // Unload filepaths
 RLAPI bool IsFileDropped(void);                                   // Check if a file has been dropped into window
 RLAPI FilePathList LoadDroppedFiles(void);                        // Load dropped filepaths

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -3313,10 +3313,21 @@ static void ScanDirectoryFiles(const char *basePath, FilePathList *files, const 
 
                 if (filter != NULL)
                 {
-                    if (IsFileExtension(path, filter))
+                    if (IsPathFile(path))
                     {
-                        strcpy(files->paths[files->count], path);
-                        files->count++;
+                        if (IsFileExtension(path, filter))
+                        {
+                            strcpy(files->paths[files->count], path);
+                            files->count++;
+                        }
+                    }
+                    else
+                    {
+                        if (TextFindIndex(filter, FILTER_FOLDER) >= 0)
+                        {
+                            strcpy(files->paths[files->count], path);
+                            files->count++;
+                        }
                     }
                 }
                 else
@@ -3376,7 +3387,22 @@ static void ScanDirectoryFilesRecursively(const char *basePath, FilePathList *fi
                         break;
                     }
                 }
-                else ScanDirectoryFilesRecursively(path, files, filter);
+                else 
+                {
+                    if (filter != NULL && TextFindIndex(filter, FILTER_FOLDER) >= 0)
+                    {
+                        strcpy(files->paths[files->count], path);
+                        files->count++;
+                    }
+                    
+                    if (files->count >= files->capacity)
+                    {
+                        TRACELOG(LOG_WARNING, "FILEIO: Maximum filepath scan capacity reached (%i files)", files->capacity);
+                        break;
+                    }
+
+                    ScanDirectoryFilesRecursively(path, files, filter);
+                }
             }
         }
 

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -247,6 +247,10 @@ unsigned int __stdcall timeEndPeriod(unsigned int uPeriod);
     #define MAX_AUTOMATION_EVENTS      16384        // Maximum number of automation events to record
 #endif
 
+#ifndef FILTER_FOLDER
+    #define FILTER_FOLDER             "/DIR"        // Filter string used in ScanDirectoryFiles, ScanDirectoryFilesRecursively and LoadDirectoryFilesEx to include directories in the result array
+#endif
+
 // Flags operation macros
 #define FLAG_SET(n, f) ((n) |= (f))
 #define FLAG_CLEAR(n, f) ((n) &= ~(f))


### PR DESCRIPTION
Right now LoadDirectoryFiles and LoadDirectoryFilesEx only return either all folders and all files (when no filter is passed) or a list of files filtered by file extension.
For use in a file browser (like raygui\examples\custom_file_dialog) it is useful to gather a list of files with a particular extension and also all folders in a location (so the user can navigate further).

This change implements this by adding a FILTER_FOLDER define.
The define can be used as a filter and will match all folders. The contents of the define are chosen as to never match a file extension on Linux and Windows.

So for example you can do
`LoadDirectoryFilesEx(%RAYLIB_SRC_DIR%, FILTER_FOLDER";.c", false);`
which results in
```
..\raylib\src\external
..\raylib\src\platforms
..\raylib\src\raudio.c
..\raylib\src\rcore.c
..\raylib\src\rglfw.c
..\raylib\src\rmodels.c
..\raylib\src\rshapes.c
..\raylib\src\rtext.c
..\raylib\src\rtextures.c
..\raylib\src\utils.c
```

As a side effect this fixes one "bug" (at least I assume it was not intended behaviour):
LoadDirectoryFiles(Ex) would previously return folders which also matched the file extension. So `LoadDirectoryFilesEx(RAYLIB_SRC_DIR, ".c", false);` would match a folder with a name like "code.c". 
With this change it does not do that any more (only if FILTER_FOLDER would have been passed as well).

Existing calls to LoadDirectoryFilesEx should not be affected otherwise and return the same results as before.

Btw. I did not see a place to add tests, but I am happy to provide some if needed.