### PR TITLE
[rcore] fix: In certain cases the connector status is reported UNKNOWN

### DIFF
--- a/src/platforms/rcore_drm.c
+++ b/src/platforms/rcore_drm.c
@@ -763,8 +763,10 @@ int InitPlatform(void)
 
         drmModeConnector *con = drmModeGetConnector(platform.fd, res->connectors[i]);
         TRACELOG(LOG_TRACE, "DISPLAY: Connector modes detected: %i", con->count_modes);
-
-        if ((con->connection == DRM_MODE_CONNECTED) && (con->encoder_id))
+        
+        // In certain cases the status of the conneciton is reported as UKNOWN, but it is still connected.
+        // This might be a hardware or software limitation like on Raspberry Pi Zero with composite output.
+        if (((con->connection == DRM_MODE_CONNECTED) || (con->connection == DRM_MODE_UNKNOWNCONNECTION)) && (con->encoder_id))
         {
             TRACELOG(LOG_TRACE, "DISPLAY: DRM mode connected");
             platform.connector = con;


### PR DESCRIPTION
Provides solution for an issue described in #4293 

where on certain platforms the DRM connector cannot be found:

```
INFO: DISPLAY: No graphic card set, trying platform-gpu-card
INFO: DISPLAY: Failed to open platform-gpu-card, trying card1
INFO: DISPLAY: Failed to open graphic card1, trying card0
TRACE: DISPLAY: Connectors found: 1
TRACE: DISPLAY: Connector index 0
TRACE: DISPLAY: Connector modes detected: 4
TRACE: DISPLAY: DRM mode NOT connected (deleting)
WARNING: DISPLAY: No suitable DRM connector found
WARNING: TEXTURE: Failed to load texture
WARNING: TEXTURE: Failed to load default texture
```

because the connector status is unknown as can bee seen on `modetest -c output`:

```
trying to open device 'vc4'...done
Connectors:
id	encoder	status		name		size (mm)	modes	encoders
45	44	unknown	Composite-1    	0x0		4	44
  modes:
	index name refresh (Hz) hdisp hss hse htot vdisp vss vse vtot
  #0 720x480i 29.97 720 736 800 858 480 486 492 525 13500 flags: nhsync, nvsync, interlace; type: preferred, driver
  #1 720x576i 25.00 720 732 796 864 576 581 587 625 13500 flags: nhsync, nvsync, interlace; type: driver
  #2 720x288 50.08 720 740 804 864 288 290 293 312 13500 flags: ; type: driver
  #3 720x240 60.05 720 734 798 858 240 243 246 262 13500 flags: ; type: driver
  props:
```

and is not considered for operation.

