### PR TITLE
Change implicit conversion to explicit conversion to remove warning

### DIFF
--- a/src/external/par_shapes.h
+++ b/src/external/par_shapes.h
@@ -1130,7 +1130,7 @@ static par_shapes__rule* par_shapes__pick_rule(const char* name,
             total += rule->weight;
         }
     }
-    float r = (float) rand() / RAND_MAX;
+    float r = (float) rand() / (float) RAND_MAX;
     float t = 0;
     for (int i = 0; i < nrules; i++) {
         rule = rules + i;


### PR DESCRIPTION
I was using raylib in one of my project which i was compiling with clang and clang showed an warning about the implicit conversion. So making a PR to get rid of the warning and to help the project in a negligible way.