### PR TITLE
Add a way to get GLFWwindow and RGFW_window pointers

### DIFF
--- a/src/platforms/rcore_android.c
+++ b/src/platforms/rcore_android.c
@@ -424,6 +424,12 @@ void *GetWindowHandle(void)
     return NULL;
 }
 
+void *GetPlatformHandle(void) 
+{
+    TRACELOG(LOG_WARNING, "GetPlatformHandle() not implemented on target platform");
+    return NULL;
+}
+
 // Get number of monitors
 int GetMonitorCount(void)
 {

--- a/src/platforms/rcore_desktop_glfw.c
+++ b/src/platforms/rcore_desktop_glfw.c
@@ -721,6 +721,11 @@ void *GetWindowHandle(void)
     return NULL;
 }
 
+void *GetPlatformHandle(void) 
+{
+    return platform.handle;
+}
+
 // Get number of monitors
 int GetMonitorCount(void)
 {

--- a/src/platforms/rcore_desktop_glfw.c
+++ b/src/platforms/rcore_desktop_glfw.c
@@ -723,7 +723,7 @@ void *GetWindowHandle(void)
 
 void *GetPlatformHandle(void) 
 {
-    return platform.handle;
+    return (void*)platform.handle;
 }
 
 // Get number of monitors

--- a/src/platforms/rcore_desktop_rgfw.c
+++ b/src/platforms/rcore_desktop_rgfw.c
@@ -541,6 +541,12 @@ void *GetWindowHandle(void)
 #endif
 }
 
+void *GetPlatformHandle(void) 
+{
+    TRACELOG(LOG_WARNING, "GetPlatformHandle() not implemented on target platform");
+    return NULL;
+}
+
 // Get number of monitors
 int GetMonitorCount(void)
 {

--- a/src/platforms/rcore_desktop_rgfw.c
+++ b/src/platforms/rcore_desktop_rgfw.c
@@ -543,8 +543,7 @@ void *GetWindowHandle(void)
 
 void *GetPlatformHandle(void) 
 {
-    TRACELOG(LOG_WARNING, "GetPlatformHandle() not implemented on target platform");
-    return NULL;
+    return (void*)platform.window;
 }
 
 // Get number of monitors

--- a/src/platforms/rcore_desktop_sdl.c
+++ b/src/platforms/rcore_desktop_sdl.c
@@ -682,6 +682,12 @@ void *GetWindowHandle(void)
     return (void *)platform.window;
 }
 
+void *GetPlatformHandle(void) 
+{
+    TRACELOG(LOG_WARNING, "GetPlatformHandle() not implemented on target platform");
+    return NULL;
+}
+
 // Get number of monitors
 int GetMonitorCount(void)
 {

--- a/src/platforms/rcore_drm.c
+++ b/src/platforms/rcore_drm.c
@@ -364,6 +364,12 @@ void *GetWindowHandle(void)
     return NULL;
 }
 
+void *GetPlatformHandle(void) 
+{
+    TRACELOG(LOG_WARNING, "GetPlatformHandle() not implemented on target platform");
+    return NULL;
+}
+
 // Get number of monitors
 int GetMonitorCount(void)
 {

--- a/src/platforms/rcore_template.c
+++ b/src/platforms/rcore_template.c
@@ -201,6 +201,12 @@ void *GetWindowHandle(void)
     return NULL;
 }
 
+void *GetPlatformHandle(void) 
+{
+    TRACELOG(LOG_WARNING, "GetPlatformHandle() not implemented on target platform");
+    return NULL;
+}
+
 // Get number of monitors
 int GetMonitorCount(void)
 {

--- a/src/platforms/rcore_web.c
+++ b/src/platforms/rcore_web.c
@@ -655,6 +655,12 @@ void *GetWindowHandle(void)
     return NULL;
 }
 
+void *GetPlatformHandle(void) 
+{
+    TRACELOG(LOG_WARNING, "GetPlatformHandle() not implemented on target platform");
+    return NULL;
+}
+
 // Get number of monitors
 int GetMonitorCount(void)
 {

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -984,6 +984,7 @@ RLAPI void SetWindowSize(int width, int height);                  // Set window 
 RLAPI void SetWindowOpacity(float opacity);                       // Set window opacity [0.0f..1.0f] (only PLATFORM_DESKTOP)
 RLAPI void SetWindowFocused(void);                                // Set window focused (only PLATFORM_DESKTOP)
 RLAPI void *GetWindowHandle(void);                                // Get native window handle
+RLAPI void *GetPlatformHandle(void);                              // Get platform handle (GLFWwindow*, only PLATFORM_DESKTOP)
 RLAPI int GetScreenWidth(void);                                   // Get current screen width
 RLAPI int GetScreenHeight(void);                                  // Get current screen height
 RLAPI int GetRenderWidth(void);                                   // Get current render width (it considers HiDPI)


### PR DESCRIPTION
Right now, there's no way to get the underlying GLFWwindow structure ([unless you're on Linux](https://github.com/raysan5/raylib/blob/fd961deba76c7c4939440fa6e6574eb86e68c5fb/src/platforms/rcore_desktop_glfw.c#L714)). This is especially useful when trying to get something like ImGui to work with Raylib without using any of the existing wrappers (espeically since they don't support docking & multiple viewports properly).

This could possibly be expanded for other platforms too, such as Android & SDL. For the rcore_desktop_sdl platform, GetWindowHandle returns the SDL_Window pointer, so perhaps this could return the GLContext?

Don't know if this functionality is actually wanted by anyone but myself, but opening just in case.