### PR TITLE
fix: fixes issue while downloading the binaries from gh

### DIFF
--- a/projects/CMake/CMakeLists.txt
+++ b/projects/CMake/CMakeLists.txt
@@ -5,7 +5,7 @@ project(example)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 # Dependencies
-set(RAYLIB_VERSION 5.5)
+set(RAYLIB_VERSION 5.0)
 find_package(raylib ${RAYLIB_VERSION} QUIET) # QUIET or REQUIRED
 if (NOT raylib_FOUND) # If there's none, fetch and build raylib
   include(FetchContent)


### PR DESCRIPTION
The resource at the URL 
https://github.com/raysan5/raylib/archive/refs/tags/5.5.tar.gz Cannot be found, so the download fails and the lib cannot be added via URL.