### PR TITLE
[rlgl] Preserve texture on mode switching

### DIFF
--- a/examples/textures/textures_polygon.c
+++ b/examples/textures/textures_polygon.c
@@ -88,9 +88,9 @@ int main(void)
         BeginDrawing();
 
             ClearBackground(RAYWHITE);
-
+ 
             DrawText("textured polygon", 20, 20, 20, DARKGRAY);
-
+  
             DrawTexturePoly(texture, (Vector2){ GetScreenWidth()/2.0f, GetScreenHeight()/2.0f },
                             positions, texcoords, MAX_POINTS, WHITE);
 
@@ -104,7 +104,7 @@ int main(void)
 
     CloseWindow();          // Close window and OpenGL context
     //--------------------------------------------------------------------------------------
-
+ 
     return 0;
 }
 
@@ -115,8 +115,7 @@ void DrawTexturePoly(Texture2D texture, Vector2 center, Vector2 *points, Vector2
 {
     rlSetTexture(texture.id);
 
-    // Texturing is only supported on RL_QUADS
-    rlBegin(RL_QUADS);
+    rlBegin(RL_TRIANGLES);
 
         rlColor4ub(tint.r, tint.g, tint.b, tint.a);
 
@@ -127,9 +126,6 @@ void DrawTexturePoly(Texture2D texture, Vector2 center, Vector2 *points, Vector2
 
             rlTexCoord2f(texcoords[i].x, texcoords[i].y);
             rlVertex2f(points[i].x + center.x, points[i].y + center.y);
-
-            rlTexCoord2f(texcoords[i + 1].x, texcoords[i + 1].y);
-            rlVertex2f(points[i + 1].x + center.x, points[i + 1].y + center.y);
 
             rlTexCoord2f(texcoords[i + 1].x, texcoords[i + 1].y);
             rlVertex2f(points[i + 1].x + center.x, points[i + 1].y + center.y);

--- a/examples/textures/textures_polygon.c
+++ b/examples/textures/textures_polygon.c
@@ -88,9 +88,9 @@ int main(void)
         BeginDrawing();
 
             ClearBackground(RAYWHITE);
- 
+
             DrawText("textured polygon", 20, 20, 20, DARKGRAY);
-  
+
             DrawTexturePoly(texture, (Vector2){ GetScreenWidth()/2.0f, GetScreenHeight()/2.0f },
                             positions, texcoords, MAX_POINTS, WHITE);
 
@@ -104,7 +104,7 @@ int main(void)
 
     CloseWindow();          // Close window and OpenGL context
     //--------------------------------------------------------------------------------------
- 
+
     return 0;
 }
 

--- a/src/rlgl.h
+++ b/src/rlgl.h
@@ -1451,7 +1451,7 @@ void rlBegin(int mode)
     if (RLGL.currentBatch->draws[RLGL.currentBatch->drawCounter - 1].mode != mode)
     {
         int currentTexture = RLGL.currentBatch->draws[RLGL.currentBatch->drawCounter - 1].textureId;
-            if (RLGL.currentBatch->draws[RLGL.currentBatch->drawCounter - 1].vertexCount > 0)
+        if (RLGL.currentBatch->draws[RLGL.currentBatch->drawCounter - 1].vertexCount > 0)
         {
             // Make sure current RLGL.currentBatch->draws[i].vertexCount is aligned a multiple of 4,
             // that way, following QUADS drawing will keep aligned with index processing

--- a/src/rlgl.h
+++ b/src/rlgl.h
@@ -1450,7 +1450,8 @@ void rlBegin(int mode)
     // NOTE: In all three cases, vertex are accumulated over default internal vertex buffer
     if (RLGL.currentBatch->draws[RLGL.currentBatch->drawCounter - 1].mode != mode)
     {
-        if (RLGL.currentBatch->draws[RLGL.currentBatch->drawCounter - 1].vertexCount > 0)
+        int currentTexture = RLGL.currentBatch->draws[RLGL.currentBatch->drawCounter - 1].textureId;
+            if (RLGL.currentBatch->draws[RLGL.currentBatch->drawCounter - 1].vertexCount > 0)
         {
             // Make sure current RLGL.currentBatch->draws[i].vertexCount is aligned a multiple of 4,
             // that way, following QUADS drawing will keep aligned with index processing
@@ -1472,13 +1473,14 @@ void rlBegin(int mode)
 
         RLGL.currentBatch->draws[RLGL.currentBatch->drawCounter - 1].mode = mode;
         RLGL.currentBatch->draws[RLGL.currentBatch->drawCounter - 1].vertexCount = 0;
-        RLGL.currentBatch->draws[RLGL.currentBatch->drawCounter - 1].textureId = RLGL.State.defaultTextureId;
+        RLGL.currentBatch->draws[RLGL.currentBatch->drawCounter - 1].textureId = currentTexture;
     }
 }
 
 // Finish vertex providing
 void rlEnd(void)
 {
+    rlSetTexture(RLGL.State.defaultTextureId);
     // NOTE: Depth increment is dependant on rlOrtho(): z-near and z-far values,
     // as well as depth buffer bit-depth (16bit or 24bit or 32bit)
     // Correct increment formula would be: depthInc = (zfar - znear)/pow(2, bits)


### PR DESCRIPTION
`rlBegin` resets texture to default when drawing mode switches. This PR makes `rlBegin` preserve texture. Since many routines expect texture to be default if not explicitly specified, `rlEnd` now resets texture to default.

Fixes https://github.com/raysan5/raylib/issues/4347