### PR TITLE
[zig] Fix build.zig bug

### DIFF
--- a/src/build.zig
+++ b/src/build.zig
@@ -336,7 +336,12 @@ pub const LinuxDisplayBackend = enum {
     Both,
 };
 
-pub const PlatformBackend = enum { glfw, rgfw, sdl, drm };
+pub const PlatformBackend = enum {
+    glfw,
+    rgfw,
+    sdl,
+    drm,
+};
 
 pub fn build(b: *std.Build) !void {
     // Standard target options allows the person running `zig build` to choose

--- a/src/build.zig
+++ b/src/build.zig
@@ -47,7 +47,7 @@ fn setDesktopPlatform(raylib: *std.Build.Step.Compile, platform: PlatformBackend
         .glfw => raylib.defineCMacro("PLATFORM_DESKTOP_GLFW", null),
         .rgfw => raylib.defineCMacro("PLATFORM_DESKTOP_RGFW", null),
         .sdl => raylib.defineCMacro("PLATFORM_DESKTOP_SDL", null),
-        else => {}
+        else => {},
     }
 }
 
@@ -74,11 +74,12 @@ fn compileRaylib(b: *std.Build, target: std.Build.ResolvedTarget, optimize: std.
         while (lines.next()) |line| {
             if (!std.mem.containsAtLeast(u8, line, 1, "SUPPORT")) continue;
             if (std.mem.startsWith(u8, line, "//")) continue;
+            if (std.mem.startsWith(u8, line, "#if")) continue;
 
             var flag = std.mem.trimLeft(u8, line, " \t"); // Trim whitespace
             flag = flag["#define ".len - 1 ..]; // Remove #define
             flag = std.mem.trimLeft(u8, flag, " \t"); // Trim whitespace
-            flag = flag[0..std.mem.indexOf(u8, flag, " ").?]; // Flag is only one word, so capture till space
+            flag = flag[0 .. std.mem.indexOf(u8, flag, " ") orelse continue]; // Flag is only one word, so capture till space
             flag = try std.fmt.allocPrint(b.allocator, "-D{s}", .{flag}); // Prepend with -D
 
             // If user specifies the flag skip it
@@ -301,6 +302,7 @@ pub const Options = struct {
     shared: bool = false,
     linux_display_backend: LinuxDisplayBackend = .Both,
     opengl_version: OpenglVersion = .auto,
+    /// config should be a list of cflags, eg, "-DSUPPORT_CUSTOM_FRAME_CONTROL"
     config: ?[]const u8 = null,
 
     raygui_dependency_name: []const u8 = "raygui",
@@ -334,12 +336,7 @@ pub const LinuxDisplayBackend = enum {
     Both,
 };
 
-pub const PlatformBackend = enum {
-    glfw,
-    rgfw,
-    sdl,
-    drm
-};
+pub const PlatformBackend = enum { glfw, rgfw, sdl, drm };
 
 pub fn build(b: *std.Build) !void {
     // Standard target options allows the person running `zig build` to choose


### PR DESCRIPTION
Before this change, building raylib using the `config` options field fails.
```zig
    const ray = b.dependency("raylib", .{
        .target = target,
        .optimize = optimize,
        .config = @as([]const u8, "-DSUPPORT_CUSTOM_FRAME_CONTROL"),
    });
```

```
Robert@Roberts-MacBook-Pro-2 ~/z/dev (master)> zig build
thread 1133588 panic: attempt to use null value
/Users/Robert/.cache/zig/p/1220cda9f85d36e6f5be4bac65430b056c4e3d4ab3fafcf71c73ec6b1853e8a20856/src/build.zig:81:58: 0x10a8dfba5 in compileRaylib (build)
            flag = flag[0..std.mem.indexOf(u8, flag, " ").?]; // Flag is only one word, so capture till space
                                                         ^
/Users/Robert/.cache/zig/p/1220cda9f85d36e6f5be4bac65430b056c4e3d4ab3fafcf71c73ec6b1853e8a20856/src/build.zig:369:34: 0x10a8e5219 in build (build)
    const lib = try compileRaylib(b, target, optimize, options);
                                 ^
/Users/Robert/.cache/zig/p/1220cda9f85d36e6f5be4bac65430b056c4e3d4ab3fafcf71c73ec6b1853e8a20856/build.zig:6:21: 0x10a8e6af4 in build (build)
    try raylib.build(b);
                    ^
/usr/local/Cellar/zig/0.13.0/lib/zig/std/Build.zig:2117:43: 0x10a86c484 in runBuild__anon_15294 (build)
        .ErrorUnion => try build_zig.build(b),
                                          ^
/usr/local/Cellar/zig/0.13.0/lib/zig/std/Build.zig:2097:29: 0x10a823ab9 in dependencyInner__anon_14532 (build)
        sub_builder.runBuild(bz) catch @panic("unhandled error");
                            ^
/usr/local/Cellar/zig/0.13.0/lib/zig/std/Build.zig:1954:35: 0x10a7d7c00 in dependency__anon_11228 (build)
            return dependencyInner(b, name, pkg.build_root, if (@hasDecl(pkg, "build_zig")) pkg.build_zig else null, pkg_hash, pkg.deps, args);
                                  ^
/Users/Robert/zig/dev/build.zig:98:29: 0x10a7d2f68 in build (build)
    const ray = b.dependency("raylib", .{
                            ^
/usr/local/Cellar/zig/0.13.0/lib/zig/std/Build.zig:2117:43: 0x10a7b58c0 in runBuild__anon_8431 (build)
        .ErrorUnion => try build_zig.build(b),
                                          ^
/usr/local/Cellar/zig/0.13.0/lib/zig/compiler/build_runner.zig:301:29: 0x10a7b0424 in main (build)
        try builder.runBuild(root);
                            ^
/usr/local/Cellar/zig/0.13.0/lib/zig/std/start.zig:524:37: 0x10a7b808b in main (build)
            const result = root.main() catch |err| {
                                    ^
???:?:?: 0x7ff8049af30f in ??? (???)
Unwind information for `???:0x7ff8049af30f` was not available, trace may be incomplete

???:?:?: 0x0 in ??? (???)
error: the following build command crashed:
/Users/Robert/zig/dev/.zig-cache/o/1e0d00ce3951a8ebfb69b30e398dd680/build /usr/local/Cellar/zig/0.13.0/bin/zig /Users/Robert/zig/dev /Users/Robert/zig/dev/.zig-cache /Users/Robert/.cache/zig --seed 0xd202b3c9 -Z7e6f5d7f6781950c
```

The code get broken by this line in `config.h`
```c
#ifdef RL_SUPPORT_MESH_GPU_SKINNING
```

To fix this, I made the following changes
* build.zig now skips processing any config.h lines that start with `#if`, 
* build.zig now `continue`s rather than panics if `std.mem.indexOf(u8, flag, " ")` fails. 

I also added a comment that the `config` option should be a list of cflags, since I had initially assumed this option was meant to be a path to a custom `config.h` file. I didn't realize my mistake until reading thru the build code very closely, so a clarifying comment should help explain how this field ought to be properly used. 