### PR TITLE
build.zig: Improve logic

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -9,3 +9,6 @@ pub fn build(b: *std.Build) !void {
 // expose helper functions to user's build.zig
 pub const addRaylib = raylib.addRaylib;
 pub const addRaygui = raylib.addRaygui;
+
+// expose options for compiling
+pub const RaylibOptions = raylib.Options;

--- a/src/build.zig
+++ b/src/build.zig
@@ -358,6 +358,7 @@ pub fn build(b: *std.Build) !void {
     const options = Options{
         .platform = b.option(PlatformBackend, "platform", "Choose the platform backedn for desktop target") orelse defaults.platform,
         .raudio = b.option(bool, "raudio", "Compile with audio support") orelse defaults.raudio,
+        .raygui = b.option(bool, "raygui", "Compile with raygui support") orelse defaults.raygui,
         .rmodels = b.option(bool, "rmodels", "Compile with models support") orelse defaults.rmodels,
         .rtext = b.option(bool, "rtext", "Compile with text support") orelse defaults.rtext,
         .rtextures = b.option(bool, "rtextures", "Compile with textures support") orelse defaults.rtextures,

--- a/src/build.zig
+++ b/src/build.zig
@@ -171,10 +171,10 @@ fn compileRaylib(b: *std.Build, target: std.Build.ResolvedTarget, optimize: std.
                 if (options.linux_display_backend == .Wayland or options.linux_display_backend == .Both) {
                     _ = b.findProgram(&.{"wayland-scanner"}, &.{}) catch {
                         std.log.err(
-                            \\ Wayland may not be installed on the system.
+                            \\ `wayland-scanner` may not be installed on the system.
                             \\ You can switch to X11 in your `build.zig` by changing `Options.linux_display_backend`
                         , .{});
-                        @panic("No Wayland");
+                        @panic("`wayland-scanner` not found");
                     };
                     raylib.defineCMacro("_GLFW_WAYLAND", null);
                     raylib.linkSystemLibrary("wayland-client");


### PR DESCRIPTION
Currently, the project was failing to build when trying `zig build` inside the `src/` dir instead of the root dir, due to hardcoding the path *from* the relative dir to `"src"`, such that the compiler will try to look for `$PROJECT_ROOT/src/src/<path>` instead of `$PROJECT_ROOT/src/<path>`. I tried to fix all such instances of `"src"` with the parent directory of `@src().file`.

Also, exposed the `Options` type so people can do more things with it.