### PR TITLE
Make sure DrawRectangleLinesEx accounts for square tiles

### DIFF
--- a/src/rshapes.c
+++ b/src/rshapes.c
@@ -828,8 +828,8 @@ void DrawRectangleLinesEx(Rectangle rec, float lineThick, Color color)
 {
     if ((lineThick > rec.width) || (lineThick > rec.height))
     {
-        if (rec.width > rec.height) lineThick = rec.height/2;
-        else if (rec.width < rec.height) lineThick = rec.width/2;
+        if (rec.width >= rec.height) lineThick = rec.height/2;
+        else if (rec.width <= rec.height) lineThick = rec.width/2;
     }
 
     // When rec = { x, y, 8.0f, 6.0f } and lineThick = 2, the following


### PR DESCRIPTION
Currently when the thickness is greater than the width or the height a comparison between the rec.width and rec.height is made. The line thickness then becomes half of whatever is smaller. At the moment this doesn't account for if the rec.width and rec.height are equal. Which could potentially be pretty common for people making tile-based games. ( I accidentally ran into this )