### PR TITLE
Enhancement VSCode Makefile to support multiple .c files

### DIFF
--- a/projects/VSCode/Makefile
+++ b/projects/VSCode/Makefile
@@ -352,9 +352,9 @@ SRC_DIR = src
 OBJ_DIR = obj
 
 # Define all object files from source files
-SRC = $(call rwildcard, *.c, *.h)
+SRC = $(call rwildcard, ./, *.c, *.h)
 #OBJS = $(SRC:$(SRC_DIR)/%.c=$(OBJ_DIR)/%.o)
-OBJS ?= main.c
+OBJS = $(patsubst %.c,%.o,$(filter %.c,$(SRC)))
 
 # For Android platform we call a custom Makefile.Android
 ifeq ($(PLATFORM),PLATFORM_ANDROID)


### PR DESCRIPTION
### Fix VSCode Makefile to support multiple `.c` files

This pull request updates the Makefile used for the VSCode project setup to allow compiling multiple `.c` files, instead of just `main.c`. Here's what I changed:

1. **SRC definition**:
The issue here was that the `rwildcard` function requires two parameters: the first one is the root directory, and the second is the file type. Originally, the directory wasn't specified, so it didn't return any files. With the update, it now correctly searches for all `.c` and `.h` files in the project by specifying the root directory (`./`).

2. **OBJS definition**:
This change dynamically converts every `.c` file found in `SRC` into its corresponding object file (`.o`), rather than being limited to just `main.c`.

### Why this change?
With these updates, the Makefile can now handle any number of `.c` files automatically, which is more flexible for larger projects. Also, these changes are specific to the VSCode setup, so other IDE configurations remain unaffected.
