### PR TITLE
[rcore] [SDL] Fix #4388

### DIFF
--- a/src/platforms/rcore_desktop_sdl.c
+++ b/src/platforms/rcore_desktop_sdl.c
@@ -1609,7 +1609,6 @@ int InitPlatform(void)
     //----------------------------------------------------------------------------
     // Define base path for storage
     CORE.Storage.basePath = SDL_GetBasePath(); // Alternative: GetWorkingDirectory();
-    CHDIR(CORE.Storage.basePath);
     //----------------------------------------------------------------------------
 
     TRACELOG(LOG_INFO, "PLATFORM: DESKTOP (SDL): Initialized successfully");


### PR DESCRIPTION
Removes the `CHDIR` so `PLATFORM_DESKTOP_SDL` is in line with `PLATFORM_DESKTOP_GLFW` ([ref](https://github.com/raysan5/raylib/blob/d6399622a0280bc8ea458104b946f1860d928156/src/platforms/rcore_desktop_glfw.c#L1638-L1641)). Fixes #4388.