### PR TITLE
[rcore] [web] Adds `MaximizeWindow()` and `RestoreWindow()` implementation for `PLATFORM_WEB`

### DIFF
--- a/src/platforms/rcore_web.c
+++ b/src/platforms/rcore_web.c
@@ -74,6 +74,8 @@
 typedef struct {
     GLFWwindow *handle;                 // GLFW window handle (graphic device)
     bool ourFullscreen;                 // Internal var to filter our handling of fullscreen vs the user handling of fullscreen
+    int unmaximizedWidth;               // Internal var to store the unmaximized window (canvas) width
+    int unmaximizedHeight;              // Internal var to store the unmaximized window (canvas) height
 } PlatformData;
 
 //----------------------------------------------------------------------------------
@@ -317,7 +319,16 @@ void ToggleBorderlessWindowed(void)
 // Set window state: maximized, if resizable
 void MaximizeWindow(void)
 {
-    TRACELOG(LOG_WARNING, "MaximizeWindow() not available on target platform");
+    if (glfwGetWindowAttrib(platform.handle, GLFW_RESIZABLE) == GLFW_TRUE)
+    {
+        platform.unmaximizedWidth = CORE.Window.screen.width;
+        platform.unmaximizedHeight = CORE.Window.screen.height;
+
+        const int tabWidth = EM_ASM_INT( { return window.innerWidth;  }, 0);
+        const int tabHeight = EM_ASM_INT( { return window.innerHeight; }, 0);
+
+        if (tabWidth && tabHeight) glfwSetWindowSize(platform.handle, tabWidth, tabHeight);
+    }
 }
 
 // Set window state: minimized
@@ -329,7 +340,10 @@ void MinimizeWindow(void)
 // Set window state: not minimized/maximized
 void RestoreWindow(void)
 {
-    TRACELOG(LOG_WARNING, "RestoreWindow() not available on target platform");
+    if (glfwGetWindowAttrib(platform.handle, GLFW_RESIZABLE) == GLFW_TRUE)
+    {
+        if (platform.unmaximizedWidth && platform.unmaximizedHeight) glfwSetWindowSize(platform.handle, platform.unmaximizedWidth, platform.unmaximizedHeight);
+    }
 }
 
 // Set window configuration state using flags


### PR DESCRIPTION
Ref: #4394

This `MaximizeWindow()` implementation matches the desktop behavior (which is changing the window/canvas area without applying any scale), handles `RestoreWindow()` and integrates with the `WindowSizeCallback` (to seamlessly update the viewport, render, fbo and screen values). The PR can be tested with:
```
// Note: usage of `minshell.html` is recommended since it won't force canvas CSS overrides

#include "raylib.h"
int main(void) {
    InitWindow(800, 450, "test");
    SetTargetFPS(60);

    SetWindowState(FLAG_WINDOW_RESIZABLE);

    while (!WindowShouldClose()) {

        if (IsKeyPressed(KEY_ONE)) { MaximizeWindow(); }
        if (IsKeyPressed(KEY_TWO)) { RestoreWindow(); }

        BeginDrawing();
        ClearBackground(RAYWHITE);
        DrawText("test", 20, 20, 20, BLACK);
        EndDrawing();
    }
    CloseWindow();
    return 0;
}
```


