### PR TITLE
[rl_gputex] Correctly load mipmaps from DDS files

### DIFF
--- a/src/external/rl_gputex.h
+++ b/src/external/rl_gputex.h
@@ -185,6 +185,7 @@ void *rl_load_dds_from_memory(const unsigned char *file_data, unsigned int file_
                 if (header->ddspf.flags == 0x40)        // No alpha channel
                 {
                     int data_size = image_pixel_size*sizeof(unsigned short);
+                    if (header->mipmap_count > 1) data_size = data_size + data_size / 3;
                     image_data = RL_MALLOC(data_size);
 
                     memcpy(image_data, file_data_ptr, data_size);
@@ -196,6 +197,7 @@ void *rl_load_dds_from_memory(const unsigned char *file_data, unsigned int file_
                     if (header->ddspf.a_bit_mask == 0x8000)     // 1bit alpha
                     {
                         int data_size = image_pixel_size*sizeof(unsigned short);
+                        if (header->mipmap_count > 1) data_size = data_size + data_size / 3;
                         image_data = RL_MALLOC(data_size);
 
                         memcpy(image_data, file_data_ptr, data_size);
@@ -215,6 +217,7 @@ void *rl_load_dds_from_memory(const unsigned char *file_data, unsigned int file_
                     else if (header->ddspf.a_bit_mask == 0xf000)   // 4bit alpha
                     {
                         int data_size = image_pixel_size*sizeof(unsigned short);
+                        if (header->mipmap_count > 1) data_size = data_size + data_size / 3;
                         image_data = RL_MALLOC(data_size);
 
                         memcpy(image_data, file_data_ptr, data_size);
@@ -236,6 +239,7 @@ void *rl_load_dds_from_memory(const unsigned char *file_data, unsigned int file_
             else if ((header->ddspf.flags == 0x40) && (header->ddspf.rgb_bit_count == 24))   // DDS_RGB, no compressed
             {
                 int data_size = image_pixel_size*3*sizeof(unsigned char);
+                if (header->mipmap_count > 1) data_size = data_size + data_size / 3;
                 image_data = RL_MALLOC(data_size);
 
                 memcpy(image_data, file_data_ptr, data_size);
@@ -245,6 +249,7 @@ void *rl_load_dds_from_memory(const unsigned char *file_data, unsigned int file_
             else if ((header->ddspf.flags == 0x41) && (header->ddspf.rgb_bit_count == 32)) // DDS_RGBA, no compressed
             {
                 int data_size = image_pixel_size*4*sizeof(unsigned char);
+                if (header->mipmap_count > 1) data_size = data_size + data_size / 3;
                 image_data = RL_MALLOC(data_size);
 
                 memcpy(image_data, file_data_ptr, data_size);
@@ -265,9 +270,11 @@ void *rl_load_dds_from_memory(const unsigned char *file_data, unsigned int file_
             }
             else if (((header->ddspf.flags == 0x04) || (header->ddspf.flags == 0x05)) && (header->ddspf.fourcc > 0)) // Compressed
             {
-                // NOTE: This forces only 1 mipmap to be loaded which is not really correct but it works
-                int data_size = (header->pitch_or_linear_size < file_size - 0x80) ? header->pitch_or_linear_size : file_size - 0x80;
-                *mips = 1;
+                int data_size = 0;
+
+                // Calculate data size, including all mipmaps
+                if (header->mipmap_count > 1) data_size = header->pitch_or_linear_size + header->pitch_or_linear_size / 3;
+                else data_size = header->pitch_or_linear_size;
 
                 image_data = RL_MALLOC(data_size*sizeof(unsigned char));
 


### PR DESCRIPTION
Correctly calculate the size of all mipmaps when loading compressed and uncompressed DDS files. This properly fixes #3446 and cleans up the mess #3483 made. The root issue arose from the fact that mipmap sizes were calculated incorrectly. I'm going to write the math down here in case anyone cares.

## How the original mistake happened

When working with "normal" linear numbers, the following applies:

```c
(x) + (x / 2) + (x / (2 ^ 2)) + (x / (2 ^ 3)) + ... + (1)
```

is equal to

```c
(x + x) - 1
```

So, with actual numbers

```c
1024 + 512 + 256 + 128 + 64 + 32 + 16 + 8 + 4 + 2 + 1 = (1024 + 1024) - 1 = 2047
```

While mipmaps dimensions do half for every level, i.e. level0 is 1024x1024, level1 is 512x512, and so on; this actually means that the number of pixels (and thus the number of bytes) is quarted.

While, in plain notation, the formula looks quite similar, the following does **NOT** hold:

```c
(x^2) + ((x/2) ^ 2) + ((x / (2^2)) ^ 2) + ... + (1) = ((x^2) + (x^2) - 1)
```

So

```c
(1024^2) + (512^2) + (256^2) + (128^2) + ... + 1 != (1024 + 1024) - 1 = 2047
```

## How I fixed it

This does not mean, however, that there is no shorthand for this kind of calculation. The actual formula is

```c
((x * x) + ((x * x) / 3)) - 1
```

The proof is out of the scope of this PR, but intuitively, we do the same calculation as with linear numbers, just that we skip every other summand. Starting from one, clearly:

```c
(1^2)                 =  1 = (1) + floor((1) / 3)

(1^2) + (2^2)         =  5 = (2^2) + floor((2^2) / 3)

// With linear numbers (**wrong**): 4 + 2 + 1 = 7
// With every other term omitted : 4 + 1 = 5


(1^2) + (2^2) + (4^2) = 21 = (4^2) + floor((4^2) / 3)

// With linear numbers (**wrong**): 16 + 8 + 4 + 2 + 1 = 31
// With every other term omitted : 16 + 4 + 1 = 21
```

Here we can see that the omitted terms, always add up to one third of the actual result (with rounding)

Analogously, the same logic applies to non-square textures, so the size with mipmaps is

```c
(width * height * bpp) + (width * height * bpp / 3)
// or
(top_level_size) + (top_level_size / 3)
```