### PR TITLE
[examples] removed extra update command

### DIFF
--- a/examples/models/models_gpu_skinning.c
+++ b/examples/models/models_gpu_skinning.c
@@ -81,7 +81,6 @@ int main(void)
         // Update model animation
         ModelAnimation anim = modelAnimations[animIndex];
         animCurrentFrame = (animCurrentFrame + 1)%anim.frameCount;
-        UpdateModelAnimationBoneMatrices(characterModel, anim, animCurrentFrame);
         //----------------------------------------------------------------------------------
 
         // Draw


### PR DESCRIPTION
Brought up by another user and then confirmed by Jeff, this call to `UpdateModelAnimationBoneMatrices` is not needed as it's performed in the loop before any rendering and can be removed