### PR TITLE
[rcore] [web] Adds `SetWindowOpacity()` implementation for `PLATFORM_WEB`

### DIFF
--- a/src/platforms/rcore_web.c
+++ b/src/platforms/rcore_web.c
@@ -673,7 +673,9 @@ void SetWindowSize(int width, int height)
 // Set window opacity, value opacity is between 0.0 and 1.0
 void SetWindowOpacity(float opacity)
 {
-    TRACELOG(LOG_WARNING, "SetWindowOpacity() not available on target platform");
+    if (opacity >= 1.0f) opacity = 1.0f;
+    else if (opacity <= 0.0f) opacity = 0.0f;
+    EM_ASM({ document.getElementById('canvas').style.opacity = $0; }, opacity);
 }
 
 // Set window focused


### PR DESCRIPTION
This implementation matches the desktop behavior: the whole canvas ("window") gets the opacity effect. It can be tested with:
```
#include "raylib.h"
int main(void) {
    InitWindow(800, 450, "test");
    SetTargetFPS(60);
    while (!WindowShouldClose()) {

        if (IsKeyPressed(KEY_ONE)) SetWindowOpacity(0.0f);
        if (IsKeyPressed(KEY_TWO)) SetWindowOpacity(0.5f);
        if (IsKeyPressed(KEY_THREE)) SetWindowOpacity(1.0f);

        BeginDrawing();
        ClearBackground(RAYWHITE);
        DrawText("test", 20, 20, 20, RED);
        EndDrawing();
    }
    CloseWindow();
    return 0;
}
```