### PR TITLE
[rcore] [web] Fix an oversight on `MaximizeWindow()` for `PLATFORM_WEB`

### DIFF
--- a/src/platforms/rcore_web.c
+++ b/src/platforms/rcore_web.c
@@ -319,7 +319,7 @@ void ToggleBorderlessWindowed(void)
 // Set window state: maximized, if resizable
 void MaximizeWindow(void)
 {
-    if (glfwGetWindowAttrib(platform.handle, GLFW_RESIZABLE) == GLFW_TRUE)
+    if (glfwGetWindowAttrib(platform.handle, GLFW_RESIZABLE) == GLFW_TRUE && !(CORE.Window.flags & FLAG_WINDOW_MAXIMIZED))
     {
         platform.unmaximizedWidth = CORE.Window.screen.width;
         platform.unmaximizedHeight = CORE.Window.screen.height;
@@ -342,7 +342,7 @@ void MinimizeWindow(void)
 // Set window state: not minimized/maximized
 void RestoreWindow(void)
 {
-    if (glfwGetWindowAttrib(platform.handle, GLFW_RESIZABLE) == GLFW_TRUE)
+    if (glfwGetWindowAttrib(platform.handle, GLFW_RESIZABLE) == GLFW_TRUE && (CORE.Window.flags & FLAG_WINDOW_MAXIMIZED))
     {
         if (platform.unmaximizedWidth && platform.unmaximizedHeight) glfwSetWindowSize(platform.handle, platform.unmaximizedWidth, platform.unmaximizedHeight);
 


### PR DESCRIPTION
Sorry, there was an oversight on my part when commiting #4402.

If the user `SetWindowState(FLAG_WINDOW_MAXIMIZED)` then `MaximizeWindow()`, the `platform.unmaximizedWidth/Height` will be overridden and `ClearWindowState(FLAG_WINDOW_MAXIMIZED)` or `RestoreWindow()` won't be able to restore the canvas ("window") to the unmaximized size. This can be fixed with additional flag checks.

The fix can be tested with:
```
// Note: usage of `minshell.html` is recommended since it won't force canvas CSS overrides

#include "raylib.h"
int main(void) {
    InitWindow(800, 450, "test");
    SetTargetFPS(60);

    SetWindowState(FLAG_WINDOW_RESIZABLE);

    while (!WindowShouldClose()) {

        // Press 1, 2, 3 or 1, 2, 4:

        if (IsKeyPressed(KEY_ONE)) SetWindowState(FLAG_WINDOW_MAXIMIZED);
        if (IsKeyPressed(KEY_TWO)) MaximizeWindow();
        if (IsKeyPressed(KEY_THREE)) ClearWindowState(FLAG_WINDOW_MAXIMIZED);
        if (IsKeyPressed(KEY_FOUR)) RestoreWindow();

        BeginDrawing();
        ClearBackground(RAYWHITE);
        DrawText("test", 20, 20, 20, BLACK);
        EndDrawing();
    }
    CloseWindow();
    return 0;
}
```