### PR TITLE
[rlgl] Updated instanced rendering support loading

### DIFF
--- a/src/rlgl.h
+++ b/src/rlgl.h
@@ -2472,25 +2472,37 @@ void rlLoadExtensions(void *loader)
         }
 
         // Check instanced rendering support
-        if (strcmp(extList[i], (const char *)"GL_ANGLE_instanced_arrays") == 0)         // Web ANGLE
-        {
-            glDrawArraysInstanced = (PFNGLDRAWARRAYSINSTANCEDEXTPROC)((rlglLoadProc)loader)("glDrawArraysInstancedANGLE");
-            glDrawElementsInstanced = (PFNGLDRAWELEMENTSINSTANCEDEXTPROC)((rlglLoadProc)loader)("glDrawElementsInstancedANGLE");
-            glVertexAttribDivisor = (PFNGLVERTEXATTRIBDIVISOREXTPROC)((rlglLoadProc)loader)("glVertexAttribDivisorANGLE");
-
-            if ((glDrawArraysInstanced != NULL) && (glDrawElementsInstanced != NULL) && (glVertexAttribDivisor != NULL)) RLGL.ExtSupported.instancing = true;
-        }
-        else
-        {
-            if ((strcmp(extList[i], (const char *)"GL_EXT_draw_instanced") == 0) &&     // Standard EXT
-                (strcmp(extList[i], (const char *)"GL_EXT_instanced_arrays") == 0))
-            {
+        if (strstr(extList[i], (const char*)"instanced_arrays") != NULL) {   //Broad check for instanced_arrays
+            //Specific check
+            if (strcmp(extList[i], (const char*)"GL_ANGLE_instanced_arrays") == 0) {    //ANGLE
+                glDrawArraysInstanced = (PFNGLDRAWARRAYSINSTANCEDEXTPROC)((rlglLoadProc)loader)("glDrawArraysInstancedANGLE");
+                glDrawElementsInstanced = (PFNGLDRAWELEMENTSINSTANCEDEXTPROC)((rlglLoadProc)loader)("glDrawElementsInstancedANGLE");
+                glVertexAttribDivisor = (PFNGLVERTEXATTRIBDIVISOREXTPROC)((rlglLoadProc)loader)("glVertexAttribDivisorANGLE");
+            }
+            else if (strcmp(extList[i], (const char*)"GL_EXT_instanced_arrays") == 0) { //EXT
                 glDrawArraysInstanced = (PFNGLDRAWARRAYSINSTANCEDEXTPROC)((rlglLoadProc)loader)("glDrawArraysInstancedEXT");
                 glDrawElementsInstanced = (PFNGLDRAWELEMENTSINSTANCEDEXTPROC)((rlglLoadProc)loader)("glDrawElementsInstancedEXT");
                 glVertexAttribDivisor = (PFNGLVERTEXATTRIBDIVISOREXTPROC)((rlglLoadProc)loader)("glVertexAttribDivisorEXT");
-
-                if ((glDrawArraysInstanced != NULL) && (glDrawElementsInstanced != NULL) && (glVertexAttribDivisor != NULL)) RLGL.ExtSupported.instancing = true;
+            } else if (strcmp(extList[i], (const char*)"GL_NV_instanced_arrays") == 0) { //NVIDIA GLES
+                glDrawArraysInstanced = (PFNGLDRAWARRAYSINSTANCEDEXTPROC)((rlglLoadProc)loader)("glDrawArraysInstancedNV");
+        	    glDrawElementsInstanced = (PFNGLDRAWELEMENTSINSTANCEDEXTPROC)((rlglLoadProc)loader)("glDrawElementsInstancedNV");
+        	    glVertexAttribDivisor = (PFNGLVERTEXATTRIBDIVISOREXTPROC)((rlglLoadProc)loader)("glVertexAttribDivisorNV");
             }
+            //The feature will only be marked as supported if the elements from GL_XXX_instanced_arrays are present
+            if ((glDrawArraysInstanced != NULL) && (glDrawElementsInstanced != NULL) && (glVertexAttribDivisor != NULL)) RLGL.ExtSupported.instancing = true;
+        } else if (strstr(extList[i], (const char*)"draw_instanced") != NULL) {
+        
+            //GL_ANGLE_draw_instanced doesn't exist
+            if (strcmp(extList[i], (const char*)"GL_EXT_draw_instanced") == 0) {
+                glDrawArraysInstanced = (PFNGLDRAWARRAYSINSTANCEDEXTPROC)((rlglLoadProc)loader)("glDrawArraysInstancedEXT");
+                glDrawElementsInstanced = (PFNGLDRAWELEMENTSINSTANCEDEXTPROC)((rlglLoadProc)loader)("glDrawElementsInstancedEXT");
+            } else if (strcmp(extList[i], (const char*)"GL_NV_draw_instanced") == 0) {
+                glDrawArraysInstanced = (PFNGLDRAWARRAYSINSTANCEDEXTPROC)((rlglLoadProc)loader)("glDrawArraysInstancedNV");
+                glDrawElementsInstanced = (PFNGLDRAWELEMENTSINSTANCEDEXTPROC)((rlglLoadProc)loader)("glDrawElementsInstancedNV");
+            }
+        
+            //But the functions will at least be loaded if only GL_XX_EXT_draw_instanced exist
+            if ((glDrawArraysInstanced != NULL) && (glDrawElementsInstanced != NULL) && (glVertexAttribDivisor != NULL)) RLGL.ExtSupported.instancing = true;     
         }
 
         // Check NPOT textures support


### PR DESCRIPTION
Hi!

The the function loading for this was kinda broken before, with an impossible condition (unless you were using ANGLE). This fixes that and includes the GL_NV versions of the extensions, that are supported by all modern NVIDIA GPUs when running on Desktop using its GLES mode (that is a better alternative to ANGLE on systems that support it).

I opted by only marking the support flag if GL_XXX_instanced_arrays is present, but still loading the function pointers if only GL_XXX_draw_instanced is, just in case the user isn't using the vertex attribute functionality and for some reason the GPU only supports one of the extensions (although I can't find instanced of that being a thing, if one is supported, both seems to be). If that's not OK, let me know the proper wanted behavior, so I can change it.