### PR TITLE
[Raymath] Add matrix operators to raymath for C++

### DIFF
--- a/src/raymath.h
+++ b/src/raymath.h
@@ -2899,35 +2899,35 @@ inline const Quaternion& operator *= (Quaternion& lhs, const Matrix& rhs)
 // Matrix operators
 inline Matrix operator + (const Matrix& lhs, const Matrix& rhs)
 {
-....return MatrixAdd(lhs, rhs);
+    return MatrixAdd(lhs, rhs);
 }
 
 inline const Matrix& operator += (Matrix& lhs, const Matrix& rhs)
 {
-....lhs = MatrixAdd(lhs, rhs);
-....return lhs;
+    lhs = MatrixAdd(lhs, rhs);
+    return lhs;
 }
 
 inline Matrix operator - (const Matrix& lhs, const Matrix& rhs)
 {
-....return MatrixSubtract(lhs, rhs);
+    return MatrixSubtract(lhs, rhs);
 }
 
 inline const Matrix& operator -= (Matrix& lhs, const Matrix& rhs)
 {
-....lhs = MatrixSubtract(lhs, rhs);
-....return lhs;
+    lhs = MatrixSubtract(lhs, rhs);
+    return lhs;
 }
 
 inline Matrix operator * (const Matrix& lhs, const Matrix& rhs)
 {
-....return MatrixMultiply(lhs, rhs);
+    return MatrixMultiply(lhs, rhs);
 }
 
 inline const Matrix& operator *= (Matrix& lhs, const Matrix& rhs)
 {
-....lhs = MatrixMultiply(lhs, rhs);
-....return lhs;
+    lhs = MatrixMultiply(lhs, rhs);
+    return lhs;
 }
 //-------------------------------------------------------------------------------
 #endif  // C++ operators

--- a/src/raymath.h
+++ b/src/raymath.h
@@ -2895,6 +2895,40 @@ inline const Quaternion& operator *= (Quaternion& lhs, const Matrix& rhs)
     lhs = QuaternionTransform(lhs, rhs);
     return lhs;
 }
+
+// Matrix operators
+inline Matrix operator + (const Matrix& lhs, const Matrix& rhs)
+{
+....return MatrixAdd(lhs, rhs);
+}
+
+inline const Matrix& operator += (Matrix& lhs, const Matrix& rhs)
+{
+....lhs = MatrixAdd(lhs, rhs);
+....return lhs;
+}
+
+inline Matrix operator - (const Matrix& lhs, const Matrix& rhs)
+{
+....return MatrixSubtract(lhs, rhs);
+}
+
+inline const Matrix& operator -= (Matrix& lhs, const Matrix& rhs)
+{
+....lhs = MatrixSubtract(lhs, rhs);
+....return lhs;
+}
+
+inline Matrix operator * (const Matrix& lhs, const Matrix& rhs)
+{
+....return MatrixMultiply(lhs, rhs);
+}
+
+inline const Matrix& operator *= (Matrix& lhs, const Matrix& rhs)
+{
+....lhs = MatrixMultiply(lhs, rhs);
+....return lhs;
+}
 //-------------------------------------------------------------------------------
 #endif  // C++ operators
 


### PR DESCRIPTION
This PR extends the last one for C++ operators in raymath and adds matrix operators.