### PR TITLE
[rcore] Adds implementation to `SetGamepadVibration()` on `PLATFORM_WEB` and updates it on `PLATFORM_DESKTOP_SDL` to handle duration

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -81,7 +81,7 @@
 #define MAX_GAMEPADS                    4       // Maximum number of gamepads supported
 #define MAX_GAMEPAD_AXIS                8       // Maximum number of axis supported (per gamepad)
 #define MAX_GAMEPAD_BUTTONS            32       // Maximum number of buttons supported (per gamepad)
-#define MAX_GAMEPAD_VIBRATION_TIME   2000       // Maximum vibration time in ms
+#define MAX_GAMEPAD_VIBRATION_TIME      2.0f    // Maximum vibration time in seconds
 #define MAX_TOUCH_POINTS                8       // Maximum number of touch points supported
 #define MAX_KEY_PRESSED_QUEUE          16       // Maximum number of keys in the key input queue
 #define MAX_CHAR_PRESSED_QUEUE         16       // Maximum number of characters in the char input queue

--- a/src/config.h
+++ b/src/config.h
@@ -81,7 +81,7 @@
 #define MAX_GAMEPADS                    4       // Maximum number of gamepads supported
 #define MAX_GAMEPAD_AXIS                8       // Maximum number of axis supported (per gamepad)
 #define MAX_GAMEPAD_BUTTONS            32       // Maximum number of buttons supported (per gamepad)
-#define MAX_GAMEPAD_VIBRATION_TIME      2.0f    // Maximum vibration time in seconds
+#define MAX_GAMEPAD_VIBRATION_TIME   2000       // Maximum vibration time in ms
 #define MAX_TOUCH_POINTS                8       // Maximum number of touch points supported
 #define MAX_KEY_PRESSED_QUEUE          16       // Maximum number of keys in the key input queue
 #define MAX_CHAR_PRESSED_QUEUE         16       // Maximum number of characters in the char input queue

--- a/src/platforms/rcore_android.c
+++ b/src/platforms/rcore_android.c
@@ -615,7 +615,7 @@ int SetGamepadMappings(const char *mappings)
 }
 
 // Set gamepad vibration
-void SetGamepadVibration(int gamepad, float low, float high, int duration)
+void SetGamepadVibration(int gamepad, float leftMotor, float rightMotor, int duration)
 {
     TRACELOG(LOG_WARNING, "GamepadSetVibration() not implemented on target platform");
 }

--- a/src/platforms/rcore_android.c
+++ b/src/platforms/rcore_android.c
@@ -615,7 +615,7 @@ int SetGamepadMappings(const char *mappings)
 }
 
 // Set gamepad vibration
-void SetGamepadVibration(int gamepad, float leftMotor, float rightMotor)
+void SetGamepadVibration(int gamepad, float low, float high, int duration)
 {
     TRACELOG(LOG_WARNING, "GamepadSetVibration() not implemented on target platform");
 }

--- a/src/platforms/rcore_android.c
+++ b/src/platforms/rcore_android.c
@@ -615,7 +615,7 @@ int SetGamepadMappings(const char *mappings)
 }
 
 // Set gamepad vibration
-void SetGamepadVibration(int gamepad, float leftMotor, float rightMotor, int duration)
+void SetGamepadVibration(int gamepad, float leftMotor, float rightMotor, float duration)
 {
     TRACELOG(LOG_WARNING, "GamepadSetVibration() not implemented on target platform");
 }

--- a/src/platforms/rcore_desktop_glfw.c
+++ b/src/platforms/rcore_desktop_glfw.c
@@ -1060,7 +1060,7 @@ int SetGamepadMappings(const char *mappings)
 }
 
 // Set gamepad vibration
-void SetGamepadVibration(int gamepad, float leftMotor, float rightMotor, int duration)
+void SetGamepadVibration(int gamepad, float leftMotor, float rightMotor, float duration)
 {
     TRACELOG(LOG_WARNING, "GamepadSetVibration() not available on target platform");
 }

--- a/src/platforms/rcore_desktop_glfw.c
+++ b/src/platforms/rcore_desktop_glfw.c
@@ -1060,7 +1060,7 @@ int SetGamepadMappings(const char *mappings)
 }
 
 // Set gamepad vibration
-void SetGamepadVibration(int gamepad, float low, float high, int duration)
+void SetGamepadVibration(int gamepad, float leftMotor, float rightMotor, int duration)
 {
     TRACELOG(LOG_WARNING, "GamepadSetVibration() not available on target platform");
 }

--- a/src/platforms/rcore_desktop_glfw.c
+++ b/src/platforms/rcore_desktop_glfw.c
@@ -1060,7 +1060,7 @@ int SetGamepadMappings(const char *mappings)
 }
 
 // Set gamepad vibration
-void SetGamepadVibration(int gamepad, float leftMotor, float rightMotor)
+void SetGamepadVibration(int gamepad, float low, float high, int duration)
 {
     TRACELOG(LOG_WARNING, "GamepadSetVibration() not available on target platform");
 }

--- a/src/platforms/rcore_desktop_sdl.c
+++ b/src/platforms/rcore_desktop_sdl.c
@@ -953,17 +953,16 @@ int SetGamepadMappings(const char *mappings)
 }
 
 // Set gamepad vibration
-void SetGamepadVibration(int gamepad, float leftMotor, float rightMotor)
+void SetGamepadVibration(int gamepad, float low, float high, int duration)
 {
-    // Limit input values to between 0.0f and 1.0f
-    leftMotor  = (0.0f > leftMotor)? 0.0f : leftMotor;
-    rightMotor = (0.0f > rightMotor)? 0.0f : rightMotor;
-    leftMotor  = (1.0f < leftMotor)? 1.0f : leftMotor;
-    rightMotor = (1.0f < rightMotor)? 1.0f : rightMotor;
-
-    if (IsGamepadAvailable(gamepad))
+    if ((gamepad < MAX_GAMEPADS) && CORE.Input.Gamepad.ready[gamepad] && (duration > 0))
     {
-        SDL_GameControllerRumble(platform.gamepad[gamepad], (Uint16)(leftMotor*65535.0f), (Uint16)(rightMotor*65535.0f), (Uint32)(MAX_GAMEPAD_VIBRATION_TIME*1000.0f));
+        if (low < 0.0f) low = 0.0f;
+        if (low > 1.0f) low = 1.0f;
+        if (high < 0.0f) high = 0.0f;
+        if (high > 1.0f) high = 1.0f;
+
+        SDL_GameControllerRumble(platform.gamepad[gamepad], (Uint16)(low*65535.0f), (Uint16)(high*65535.0f), (Uint32)duration);
     }
 }
 

--- a/src/platforms/rcore_desktop_sdl.c
+++ b/src/platforms/rcore_desktop_sdl.c
@@ -953,9 +953,9 @@ int SetGamepadMappings(const char *mappings)
 }
 
 // Set gamepad vibration
-void SetGamepadVibration(int gamepad, float leftMotor, float rightMotor, int duration)
+void SetGamepadVibration(int gamepad, float leftMotor, float rightMotor, float duration)
 {
-    if ((gamepad < MAX_GAMEPADS) && CORE.Input.Gamepad.ready[gamepad] && (duration > 0))
+    if ((gamepad < MAX_GAMEPADS) && CORE.Input.Gamepad.ready[gamepad] && (duration > 0.0f))
     {
         if (leftMotor < 0.0f) leftMotor = 0.0f;
         if (leftMotor > 1.0f) leftMotor = 1.0f;
@@ -963,7 +963,7 @@ void SetGamepadVibration(int gamepad, float leftMotor, float rightMotor, int dur
         if (rightMotor > 1.0f) rightMotor = 1.0f;
         if (duration > MAX_GAMEPAD_VIBRATION_TIME) duration = MAX_GAMEPAD_VIBRATION_TIME;
 
-        SDL_GameControllerRumble(platform.gamepad[gamepad], (Uint16)(leftMotor*65535.0f), (Uint16)(rightMotor*65535.0f), (Uint32)duration);
+        SDL_GameControllerRumble(platform.gamepad[gamepad], (Uint16)(leftMotor*65535.0f), (Uint16)(rightMotor*65535.0f), (Uint32)(duration*1000.0f));
     }
 }
 

--- a/src/platforms/rcore_desktop_sdl.c
+++ b/src/platforms/rcore_desktop_sdl.c
@@ -961,6 +961,7 @@ void SetGamepadVibration(int gamepad, float low, float high, int duration)
         if (low > 1.0f) low = 1.0f;
         if (high < 0.0f) high = 0.0f;
         if (high > 1.0f) high = 1.0f;
+        if (duration > MAX_GAMEPAD_VIBRATION_TIME) duration = MAX_GAMEPAD_VIBRATION_TIME;
 
         SDL_GameControllerRumble(platform.gamepad[gamepad], (Uint16)(low*65535.0f), (Uint16)(high*65535.0f), (Uint32)duration);
     }

--- a/src/platforms/rcore_desktop_sdl.c
+++ b/src/platforms/rcore_desktop_sdl.c
@@ -953,17 +953,17 @@ int SetGamepadMappings(const char *mappings)
 }
 
 // Set gamepad vibration
-void SetGamepadVibration(int gamepad, float low, float high, int duration)
+void SetGamepadVibration(int gamepad, float leftMotor, float rightMotor, int duration)
 {
     if ((gamepad < MAX_GAMEPADS) && CORE.Input.Gamepad.ready[gamepad] && (duration > 0))
     {
-        if (low < 0.0f) low = 0.0f;
-        if (low > 1.0f) low = 1.0f;
-        if (high < 0.0f) high = 0.0f;
-        if (high > 1.0f) high = 1.0f;
+        if (leftMotor < 0.0f) leftMotor = 0.0f;
+        if (leftMotor > 1.0f) leftMotor = 1.0f;
+        if (rightMotor < 0.0f) rightMotor = 0.0f;
+        if (rightMotor > 1.0f) rightMotor = 1.0f;
         if (duration > MAX_GAMEPAD_VIBRATION_TIME) duration = MAX_GAMEPAD_VIBRATION_TIME;
 
-        SDL_GameControllerRumble(platform.gamepad[gamepad], (Uint16)(low*65535.0f), (Uint16)(high*65535.0f), (Uint32)duration);
+        SDL_GameControllerRumble(platform.gamepad[gamepad], (Uint16)(leftMotor*65535.0f), (Uint16)(rightMotor*65535.0f), (Uint32)duration);
     }
 }
 

--- a/src/platforms/rcore_drm.c
+++ b/src/platforms/rcore_drm.c
@@ -610,7 +610,7 @@ int SetGamepadMappings(const char *mappings)
 }
 
 // Set gamepad vibration
-void SetGamepadVibration(int gamepad, float low, float high, int duration)
+void SetGamepadVibration(int gamepad, float leftMotor, float rightMotor, int duration)
 {
     TRACELOG(LOG_WARNING, "GamepadSetVibration() not implemented on target platform");
 }

--- a/src/platforms/rcore_drm.c
+++ b/src/platforms/rcore_drm.c
@@ -610,7 +610,7 @@ int SetGamepadMappings(const char *mappings)
 }
 
 // Set gamepad vibration
-void SetGamepadVibration(int gamepad, float leftMotor, float rightMotor)
+void SetGamepadVibration(int gamepad, float low, float high, int duration)
 {
     TRACELOG(LOG_WARNING, "GamepadSetVibration() not implemented on target platform");
 }
@@ -763,7 +763,7 @@ int InitPlatform(void)
 
         drmModeConnector *con = drmModeGetConnector(platform.fd, res->connectors[i]);
         TRACELOG(LOG_TRACE, "DISPLAY: Connector modes detected: %i", con->count_modes);
-        
+
         // In certain cases the status of the conneciton is reported as UKNOWN, but it is still connected.
         // This might be a hardware or software limitation like on Raspberry Pi Zero with composite output.
         if (((con->connection == DRM_MODE_CONNECTED) || (con->connection == DRM_MODE_UNKNOWNCONNECTION)) && (con->encoder_id))

--- a/src/platforms/rcore_drm.c
+++ b/src/platforms/rcore_drm.c
@@ -610,7 +610,7 @@ int SetGamepadMappings(const char *mappings)
 }
 
 // Set gamepad vibration
-void SetGamepadVibration(int gamepad, float leftMotor, float rightMotor, int duration)
+void SetGamepadVibration(int gamepad, float leftMotor, float rightMotor, float duration)
 {
     TRACELOG(LOG_WARNING, "GamepadSetVibration() not implemented on target platform");
 }

--- a/src/platforms/rcore_web.c
+++ b/src/platforms/rcore_web.c
@@ -892,7 +892,7 @@ int SetGamepadMappings(const char *mappings)
 }
 
 // Set gamepad vibration
-void SetGamepadVibration(int gamepad, float leftMotor, float rightMotor)
+void SetGamepadVibration(int gamepad, float low, float high, int duration)
 {
     TRACELOG(LOG_WARNING, "GamepadSetVibration() not implemented on target platform");
 }

--- a/src/platforms/rcore_web.c
+++ b/src/platforms/rcore_web.c
@@ -892,7 +892,7 @@ int SetGamepadMappings(const char *mappings)
 }
 
 // Set gamepad vibration
-void SetGamepadVibration(int gamepad, float leftMotor, float rightMotor, int duration)
+void SetGamepadVibration(int gamepad, float leftMotor, float rightMotor, float duration)
 {
     TRACELOG(LOG_WARNING, "GamepadSetVibration() not implemented on target platform");
 }

--- a/src/platforms/rcore_web.c
+++ b/src/platforms/rcore_web.c
@@ -892,7 +892,7 @@ int SetGamepadMappings(const char *mappings)
 }
 
 // Set gamepad vibration
-void SetGamepadVibration(int gamepad, float low, float high, int duration)
+void SetGamepadVibration(int gamepad, float leftMotor, float rightMotor, int duration)
 {
     TRACELOG(LOG_WARNING, "GamepadSetVibration() not implemented on target platform");
 }

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1184,7 +1184,7 @@ RLAPI int GetGamepadButtonPressed(void);                                        
 RLAPI int GetGamepadAxisCount(int gamepad);                                        // Get gamepad axis count for a gamepad
 RLAPI float GetGamepadAxisMovement(int gamepad, int axis);                         // Get axis movement value for a gamepad axis
 RLAPI int SetGamepadMappings(const char *mappings);                                // Set internal gamepad mappings (SDL_GameControllerDB)
-RLAPI void SetGamepadVibration(int gamepad, float low, float high, int duration);  // Set gamepad vibration for both motors (duration in ms)
+RLAPI void SetGamepadVibration(int gamepad, float leftMotor, float rightMotor, int duration) // Set gamepad vibration for both motors (duration in ms)
 
 // Input-related functions: mouse
 RLAPI bool IsMouseButtonPressed(int button);                  // Check if a mouse button has been pressed once

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1184,7 +1184,7 @@ RLAPI int GetGamepadButtonPressed(void);                                        
 RLAPI int GetGamepadAxisCount(int gamepad);                                        // Get gamepad axis count for a gamepad
 RLAPI float GetGamepadAxisMovement(int gamepad, int axis);                         // Get axis movement value for a gamepad axis
 RLAPI int SetGamepadMappings(const char *mappings);                                // Set internal gamepad mappings (SDL_GameControllerDB)
-RLAPI void SetGamepadVibration(int gamepad, float leftMotor, float rightMotor, int duration); // Set gamepad vibration for both motors (duration in ms)
+RLAPI void SetGamepadVibration(int gamepad, float leftMotor, float rightMotor, float duration); // Set gamepad vibration for both motors (duration in seconds)
 
 // Input-related functions: mouse
 RLAPI bool IsMouseButtonPressed(int button);                  // Check if a mouse button has been pressed once

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1184,7 +1184,7 @@ RLAPI int GetGamepadButtonPressed(void);                                        
 RLAPI int GetGamepadAxisCount(int gamepad);                                        // Get gamepad axis count for a gamepad
 RLAPI float GetGamepadAxisMovement(int gamepad, int axis);                         // Get axis movement value for a gamepad axis
 RLAPI int SetGamepadMappings(const char *mappings);                                // Set internal gamepad mappings (SDL_GameControllerDB)
-RLAPI void SetGamepadVibration(int gamepad, float leftMotor, float rightMotor, int duration) // Set gamepad vibration for both motors (duration in ms)
+RLAPI void SetGamepadVibration(int gamepad, float leftMotor, float rightMotor, int duration); // Set gamepad vibration for both motors (duration in ms)
 
 // Input-related functions: mouse
 RLAPI bool IsMouseButtonPressed(int button);                  // Check if a mouse button has been pressed once

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1184,7 +1184,7 @@ RLAPI int GetGamepadButtonPressed(void);                                        
 RLAPI int GetGamepadAxisCount(int gamepad);                                        // Get gamepad axis count for a gamepad
 RLAPI float GetGamepadAxisMovement(int gamepad, int axis);                         // Get axis movement value for a gamepad axis
 RLAPI int SetGamepadMappings(const char *mappings);                                // Set internal gamepad mappings (SDL_GameControllerDB)
-RLAPI void SetGamepadVibration(int gamepad, float leftMotor, float rightMotor);    // Set gamepad vibration for both motors
+RLAPI void SetGamepadVibration(int gamepad, float low, float high, int duration);  // Set gamepad vibration for both motors (duration in ms)
 
 // Input-related functions: mouse
 RLAPI bool IsMouseButtonPressed(int button);                  // Check if a mouse button has been pressed once


### PR DESCRIPTION
Updated `SetGamepadVibration()` to handle duration (in ms) on `PLATFORM_DESKTOP_SDL`. Also renamed the `left/rightMotor` parameters to `low/high` as it's more commonly referenced ([ref](https://wiki.libsdl.org/SDL2/SDL_GameControllerRumble)). Since a new parameter was added, **this is a breaking change.**

The PR can be tested with:
```
#include "raylib.h"
int main(void) {
    InitWindow(800, 450, "test");
    SetTargetFPS(60);
    while (!WindowShouldClose()) {

        if (IsGamepadButtonPressed(0, GAMEPAD_BUTTON_RIGHT_FACE_UP)) SetGamepadVibration(0, 1.0f, 1.0f, 300);
        if (IsGamepadButtonPressed(0, GAMEPAD_BUTTON_RIGHT_FACE_RIGHT)) SetGamepadVibration(0, 0.0f, 1.0f, 300);
        if (IsGamepadButtonPressed(0, GAMEPAD_BUTTON_RIGHT_FACE_LEFT)) SetGamepadVibration(0, 1.0f, 0.0f, 300);
        if (IsGamepadButtonPressed(0, GAMEPAD_BUTTON_RIGHT_FACE_DOWN)) SetGamepadVibration(0, 0.0f, 0.0f, 300);
        if (IsGamepadButtonPressed(0, GAMEPAD_BUTTON_MIDDLE)) SetGamepadVibration(0, 1.0f, 1.0f, 0);

        BeginDrawing();
        ClearBackground(RAYWHITE);
        DrawText("Pres X, Y, B, A, Middle", 20, 20, 20, BLACK);
        EndDrawing();
    }
    CloseWindow();
    return 0;
}
```