### PR TITLE
[examples] Update `core_input_gamepad` example

### DIFF
--- a/examples/core/core_input_gamepad.c
+++ b/examples/core/core_input_gamepad.c
@@ -20,9 +20,9 @@
 #include "raylib.h"
 
 // NOTE: Gamepad name ID depends on drivers and OS
-#define XBOX360_LEGACY_NAME_ID  "Xbox Controller"
-#define XBOX360_NAME_ID     "Xbox 360 Controller"
-#define PS3_NAME_ID         "Sony PLAYSTATION(R)3 Controller"
+#define XBOX_ALIAS_1 "xbox"
+#define XBOX_ALIAS_2 "x-box"
+#define PS_ALIAS     "playstation"
 
 //------------------------------------------------------------------------------------
 // Program main entry point
@@ -67,7 +67,7 @@ int main(void)
             {
                 DrawText(TextFormat("GP%d: %s", gamepad, GetGamepadName(gamepad)), 10, 10, 10, BLACK);
 
-                if (TextIsEqual(GetGamepadName(gamepad), XBOX360_LEGACY_NAME_ID) || TextIsEqual(GetGamepadName(gamepad), XBOX360_NAME_ID))
+                if (TextFindIndex(TextToLower(GetGamepadName(gamepad)), XBOX_ALIAS_1) > -1 || TextFindIndex(TextToLower(GetGamepadName(gamepad)), XBOX_ALIAS_2) > -1)
                 {
                     DrawTexture(texXboxPad, 0, 0, DARKGRAY);
 
@@ -120,7 +120,7 @@ int main(void)
                     //DrawText(TextFormat("Xbox axis LT: %02.02f", GetGamepadAxisMovement(gamepad, GAMEPAD_AXIS_LEFT_TRIGGER)), 10, 40, 10, BLACK);
                     //DrawText(TextFormat("Xbox axis RT: %02.02f", GetGamepadAxisMovement(gamepad, GAMEPAD_AXIS_RIGHT_TRIGGER)), 10, 60, 10, BLACK);
                 }
-                else if (TextIsEqual(GetGamepadName(gamepad), PS3_NAME_ID))
+                else if (TextFindIndex(TextToLower(GetGamepadName(gamepad)), PS_ALIAS) > -1)
                 {
                     DrawTexture(texPs3Pad, 0, 0, DARKGRAY);
 


### PR DESCRIPTION
Relaxes the detection criteira so any compatible gamepad can get detected/displayed on the example. Currently it's too restrictive to those three specific strings, which leaves lots of compatible gamepads ([ref](https://github.com/mdqinc/SDL_GameControllerDB/blob/master/gamecontrollerdb.txt)) appearing as if they were not supported.

Examples of compatible gamepads that appear unsupported on the example: [1](https://github.com/mdqinc/SDL_GameControllerDB/blob/master/gamecontrollerdb.txt#L108), [2](https://github.com/mdqinc/SDL_GameControllerDB/blob/master/gamecontrollerdb.txt#L128), [3](https://github.com/mdqinc/SDL_GameControllerDB/blob/master/gamecontrollerdb.txt#L184), [4](https://github.com/mdqinc/SDL_GameControllerDB/blob/master/gamecontrollerdb.txt#L242), [5](https://github.com/mdqinc/SDL_GameControllerDB/blob/master/gamecontrollerdb.txt#L395), [6](https://github.com/mdqinc/SDL_GameControllerDB/blob/master/gamecontrollerdb.txt#L395), [7](https://github.com/mdqinc/SDL_GameControllerDB/blob/master/gamecontrollerdb.txt#L395), [8](https://github.com/mdqinc/SDL_GameControllerDB/blob/master/gamecontrollerdb.txt#L654), [9](https://github.com/mdqinc/SDL_GameControllerDB/blob/master/gamecontrollerdb.txt#L718), [10](https://github.com/mdqinc/SDL_GameControllerDB/blob/master/gamecontrollerdb.txt#L903), etc.