### PR TITLE
[Shaders] Have the base fragment shader use the vertex color

### DIFF
--- a/examples/shaders/resources/shaders/glsl330/base.fs
+++ b/examples/shaders/resources/shaders/glsl330/base.fs
@@ -20,6 +20,9 @@ void main()
 
     // NOTE: Implement here your fragment shader code
 
-    finalColor = texelColor*colDiffuse;
+    // final color is the color from the texture 
+    //    times the tint color (colDiffuse)
+    //    times the fragment color (interpolated vertex color)
+    finalColor = texelColor*colDiffuse*fragColor;
 }
 


### PR DESCRIPTION
This PR has the base fragment shader for the examples use the vertex color in addition to the tint color. This provides a better example of what the default shader is doing.
I also added some more comments to the finalColor computation to explain what is happening.

If having the base shader ignore vertex color is intended in order to keep the shader simple, please reject this PR.