### PR TITLE
[build] CMake: Don't build for wayland by default

### DIFF
--- a/CMakeOptions.txt
+++ b/CMakeOptions.txt
@@ -21,7 +21,7 @@ cmake_dependent_option(USE_AUDIO "Build raylib with audio module" ON CUSTOMIZE_B
 enum_option(USE_EXTERNAL_GLFW "OFF;IF_POSSIBLE;ON" "Link raylib against system GLFW instead of embedded one")
 
 # GLFW build options
-option(GLFW_BUILD_WAYLAND "Build the bundled GLFW with Wayland support" ON)
+option(GLFW_BUILD_WAYLAND "Build the bundled GLFW with Wayland support" OFF)
 option(GLFW_BUILD_X11 "Build the bundled GLFW with X11 support" ON)
 
 option(INCLUDE_EVERYTHING "Include everything disabled by default (for CI usage" OFF)


### PR DESCRIPTION
This is to align with the behavior of #4369, see #4371 for rationale on disabling Wayland by default.