### PR TITLE
[build] [web] Fix examples `Makefile` for `PLATFORM_WEB`

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -197,7 +197,8 @@ ifeq ($(TARGET_PLATFORM),PLATFORM_ANDROID)
     MAKE = mingw32-make
 endif
 ifeq ($(TARGET_PLATFORM),PLATFORM_WEB)
-    ifneq (, $(shell type emmake))
+	EMMAKE != type emmake
+    ifneq (, $(EMMAKE))
         MAKE = emmake make
     else
         MAKE = mingw32-make
@@ -455,7 +456,7 @@ ifeq ($(TARGET_PLATFORM),PLATFORM_DESKTOP_RGFW)
     ifeq ($(PLATFORM_OS),OSX)
         # Libraries for Debian GNU/Linux desktop compiling
         # NOTE: Required packages: libegl1-mesa-dev
-        LDLIBS = ../src/libraylib.a -lm 
+        LDLIBS = ../src/libraylib.a -lm
         LDLIBS += -framework Foundation -framework AppKit -framework OpenGL -framework CoreVideo
     endif
 endif

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -197,7 +197,7 @@ ifeq ($(TARGET_PLATFORM),PLATFORM_ANDROID)
     MAKE = mingw32-make
 endif
 ifeq ($(TARGET_PLATFORM),PLATFORM_WEB)
-	EMMAKE != type emmake
+    EMMAKE != type emmake
     ifneq (, $(EMMAKE))
         MAKE = emmake make
     else

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -197,7 +197,11 @@ ifeq ($(TARGET_PLATFORM),PLATFORM_ANDROID)
     MAKE = mingw32-make
 endif
 ifeq ($(TARGET_PLATFORM),PLATFORM_WEB)
-    MAKE = mingw32-make
+    ifneq (, $(shell type emmake))
+        MAKE = emmake make
+    else
+        MAKE = mingw32-make
+    endif
 endif
 
 # Define compiler flags: CFLAGS


### PR DESCRIPTION
[eb04154](https://github.com/raysan5/raylib/commit/eb04154c98616f0355b0035945a58fa7b56d59e2) changed `emmake make` to `mingw32-make` for `PLATFORM_WEB`. However, `mingw32-make` isn't always present (e.g.: Linux hosts), which leads to these:
```
~/raylib-master/examples$ make PLATFORM=PLATFORM_WEB core/core_basic_window
find . -type f -executable -delete
rm -fv *.o
Cleaning done
mingw32-make -f Makefile.Web core/core_basic_window
make: mingw32-make: No such file or directory
make: *** [Makefile:660: core/core_basic_window] Error 127
```

Since `emmake` is usually provided by Emscripten's `emsdk`, this PR checks if `emmake` is present. If it is, uses it. If not, falls back to `mingw32-make`.