### PR TITLE
[rcore][SDL] Fix disabled cursor mouse inputs

### DIFF
--- a/src/platforms/rcore_desktop_sdl.c
+++ b/src/platforms/rcore_desktop_sdl.c
@@ -1025,7 +1025,7 @@ void PollInputEvents(void)
     CORE.Input.Mouse.currentWheelMove.y = 0;
 
     // Register previous mouse position
-    if (platform.cursorRelative) CORE.Input.Mouse.currentPosition = (Vector2){ 0.0f, 0.0f };
+    if (platform.cursorRelative) CORE.Input.Mouse.previousPosition = (Vector2){ 0.0f, 0.0f };
     else CORE.Input.Mouse.previousPosition = CORE.Input.Mouse.currentPosition;
 
     // Reset last gamepad button/axis registered state

--- a/src/platforms/rcore_desktop_sdl.c
+++ b/src/platforms/rcore_desktop_sdl.c
@@ -1025,7 +1025,11 @@ void PollInputEvents(void)
     CORE.Input.Mouse.currentWheelMove.y = 0;
 
     // Register previous mouse position
-    if (platform.cursorRelative) CORE.Input.Mouse.previousPosition = (Vector2){ 0.0f, 0.0f };
+    if (platform.cursorRelative)
+    {
+        CORE.Input.Mouse.previousPosition = (Vector2){ 0.0f, 0.0f };
+        CORE.Input.Mouse.currentPosition = (Vector2){ 0.0f, 0.0f };
+    }
     else CORE.Input.Mouse.previousPosition = CORE.Input.Mouse.currentPosition;
 
     // Reset last gamepad button/axis registered state


### PR DESCRIPTION
The mouse inputs gotten from GetMouseDelta on the SDL2 platform of Raylib currently do not match the GLFW platform at all, and this patch fixes that. Now First Person cameras can actually work on the SDL2 platform. 