### PR TITLE
[rcore][GLFW] Fix warning on windows in MSVC

### DIFF
--- a/src/platforms/rcore_desktop_glfw.c
+++ b/src/platforms/rcore_desktop_glfw.c
@@ -65,8 +65,9 @@
 
     #if defined(SUPPORT_WINMM_HIGHRES_TIMER) && !defined(SUPPORT_BUSY_WAIT_LOOP)
         // NOTE: Those functions require linking with winmm library
-        unsigned int __stdcall timeBeginPeriod(unsigned int uPeriod);
+#pragma warning( disable : 4273 )
         unsigned int __stdcall timeEndPeriod(unsigned int uPeriod);
+#pragma warning(default : 4273) 
     #endif
 #endif
 #if defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__)


### PR DESCRIPTION
There is an error with the forward declaration of the winMM functions when building on MSVC. Inconsistent DLL linkage.
This is not a critical warning, so this PR disables it.
This PR also removes the timeBeginPeriod declaration as it is no longer needed.