### PR TITLE
Fix negative X output value in MeasureTextEx

### DIFF
--- a/src/rtext.c
+++ b/src/rtext.c
@@ -1327,7 +1327,7 @@ Vector2 MeasureTextEx(Font font, const char *text, float fontSize, float spacing
 
     if (tempTextWidth < textWidth) tempTextWidth = textWidth;
 
-    textSize.x = tempTextWidth*scaleFactor + (float)((tempByteCounter - 1)*spacing);
+    if (size > 0) textSize.x = tempTextWidth*scaleFactor + (float)((tempByteCounter - 1)*spacing);
     textSize.y = textHeight;
 
     return textSize;


### PR DESCRIPTION
MeasureTextEx used to output negative X for empty strings with non-zero spacing, for example

```
#include <raylib.h>
#include <stdio.h>

int main()
{
	InitWindow(400, 600, "Raylib window");
	printf("%f \n", MeasureTextEx(GetFontDefault(), "", 10.0f, 0).x); // 0
	printf("%f \n", MeasureTextEx(GetFontDefault(), "", 10.0f, 1).x); // -1
	printf("%f \n", MeasureTextEx(GetFontDefault(), "", 10.0f, 2).x); // -2
	printf("%f \n", MeasureTextEx(GetFontDefault(), "", 10.0f, 15).x); // -15
	CloseWindow();
}
```
