### PR TITLE
Add src/raygui.c to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,6 @@ docgen_tmp/
 
 # Parser stuff
 parser/raylib_parser
+
+# Raygui auto-generated source file
+src/raygui.c


### PR DESCRIPTION
Hi,

While building with `RAYLIB_MODULE_RAYGUI=TRUE`, Makefile generates additional build artifact here: `./src/raygui.c` Said file isn't excluded from git repo which is a bit annoying when embeding raylib inside of another repository.

This PR fixes mentioned issue. 