### PR TITLE
[rcore] [web] Fix `SetWindowSize()` for `PLATFORM_WEB`

### DIFF
--- a/src/platforms/rcore_web.c
+++ b/src/platforms/rcore_web.c
@@ -667,9 +667,6 @@ void SetWindowMaxSize(int width, int height)
 // Set window dimensions
 void SetWindowSize(int width, int height)
 {
-    CORE.Window.screen.width = width;
-    CORE.Window.Screen.height = height;
-
     glfwSetWindowSize(platform.handle, width, height);
 }
 


### PR DESCRIPTION
Reverts #4451 for `PLATFORM_WEB`.

The window size is properly set by `WindowSizeCallback` ([ref](https://github.com/raysan5/raylib/blob/3bad05aa7bd319eaaae937928b396b46f4886e3e/src/platforms/rcore_web.c#L1394)) after updating the viewport, render and fbo.

<details>
<summary>Test case:</summary>

```
// Note: usage of `minshell.html` is recommended since it won't force canvas CSS overrides

#include "raylib.h"
int main(void) {
    InitWindow(800, 450, "test");
    SetTargetFPS(60);

    SetWindowState(FLAG_WINDOW_RESIZABLE);

    while (!WindowShouldClose()) {

        if (IsKeyPressed(KEY_ONE)) SetWindowSize(400, 200);

        BeginDrawing();
        ClearBackground(RAYWHITE);
        DrawText(TextFormat("window size %i x %i", GetScreenWidth(), GetScreenHeight()), 20, 20, 20, BLACK);
        EndDrawing();
    }
    CloseWindow();
    return 0;
}
```