### PR TITLE
fix typo in #4451

### DIFF
--- a/src/platforms/rcore_web.c
+++ b/src/platforms/rcore_web.c
@@ -667,6 +667,9 @@ void SetWindowMaxSize(int width, int height)
 // Set window dimensions
 void SetWindowSize(int width, int height)
 {
+    CORE.Window.screen.width = width;
+    CORE.Window.screen.height = height;
+
     glfwSetWindowSize(platform.handle, width, height);
 }
 


### PR DESCRIPTION
I had a typo that caused the compilation to fail.

I believe it should be added because the timing of when `WindowSizeCallback` is called may be platform-dependent, similar to #3929.

<details>

<summary>Test case same as #4452</summary>

```c
// Note: usage of `minshell.html` is recommended since it won't force canvas CSS overrides

#include "raylib.h"
int main(void) {
    InitWindow(800, 450, "test");
    SetTargetFPS(60);

    SetWindowState(FLAG_WINDOW_RESIZABLE);

    while (!WindowShouldClose()) {

        if (IsKeyPressed(KEY_ONE)) SetWindowSize(400, 200);

        BeginDrawing();
        ClearBackground(RAYWHITE);
        DrawText(TextFormat("window size %i x %i", GetScreenWidth(), GetScreenHeight()), 20, 20, 20, BLACK);
        EndDrawing();
    }
    CloseWindow();
    return 0;
}
```

</details>