### PR TITLE
Update rmodels.c - 'fix' for GenMeshSphere artifact

### DIFF
--- a/src/rmodels.c
+++ b/src/rmodels.c
@@ -2820,6 +2820,7 @@ Mesh GenMeshSphere(float radius, int rings, int slices)
 
     if ((rings >= 3) && (slices >= 3))
     {
+        par_shapes_set_epsilon_degenerate_sphere(0.0);
         par_shapes_mesh *sphere = par_shapes_create_parametric_sphere(slices, rings);
         par_shapes_scale(sphere, radius, radius, radius);
         // NOTE: Soft normals are computed internally


### PR DESCRIPTION
When creating a new sphere mesh with high number of slices/rings the top and bottom parts of the generated sphere are removed. This happens because the triangles in those parts, due to high resolution, end up being very small and are removed as part of the 'par_shapes' library's optimization. Adding par_shapes_set_epsilon_degenerate_sphere(0.0); before generating the sphere mesh sets the threshold for removal of small triangles is removed and the sphere is returned to raylib correctly.