### PR TITLE
[raymath] Fix for issue 4454, `MatrixDecompose()` gave incorrect output for certain scale and rotations

### DIFF
--- a/src/raymath.h
+++ b/src/raymath.h
@@ -2569,7 +2569,13 @@ RMAPI void MatrixDecompose(Matrix mat, Vector3 *translation, Quaternion *rotatio
     if (!FloatEquals(det, 0))
     {
         clone.m0 /= s.x;
+        clone.m4 /= s.x;
+        clone.m8 /= s.x;
+        clone.m1 /= s.y;
         clone.m5 /= s.y;
+        clone.m9 /= s.y;
+        clone.m2 /= s.z;
+        clone.m6 /= s.z;
         clone.m10 /= s.z;
 
         // Extract rotation


### PR DESCRIPTION
For transform matrices with certain ranges of rotation angles and scaling factors, `MatrixDecompose()` would give incorrect answers.

I narrowed down the issue to where the scaling factors are removed from the cloned transform, before the rotation is extracted: the scale factors needed to be taken into account for extra matrix members.

The models_loading_gltf example still works correctly after this fix.

Further tests and discussion here: https://github.com/raysan5/raylib/issues/4454
