### PR TITLE
[rtextures] fix bad behaviour of GenImageGradientLinear with certain angle values.

### DIFF
--- a/src/rtextures.c
+++ b/src/rtextures.c
@@ -827,16 +827,27 @@ Image GenImageGradientLinear(int width, int height, int direction, Color start, 
     float cosDir = cosf(radianDirection);
     float sinDir = sinf(radianDirection);
 
+    // Calculate how far the top-left pixel is along the gradient direction from the center of said gradient
+    float startingPos = 0.5 - (cosDir*width/2) - (sinDir*height/2);
+    // With directions that lie in the first or third quadrant (i.e. from top-left to 
+    // bottom-right or vice-versa), pixel (0, 0) is the farthest point on the gradient
+    // (i.e. the pixel which should become one of the gradient's ends color); while for
+    // directions that lie in the second or fourth quadrant, that point is pixel (width, 0).
+    float maxPosValue = 
+            ((signbit(sinDir) != 0) == (signbit(cosDir) != 0))
+            ? fabs(startingPos)
+            : fabs(startingPos+width*cosDir);
     for (int i = 0; i < width; i++)
     {
         for (int j = 0; j < height; j++)
         {
             // Calculate the relative position of the pixel along the gradient direction
-            float pos = (i*cosDir + j*sinDir)/(width*cosDir + height*sinDir);
+            float pos = (startingPos + (i*cosDir + j*sinDir)) / maxPosValue;
 
             float factor = pos;
-            factor = (factor > 1.0f)? 1.0f : factor;  // Clamp to [0,1]
-            factor = (factor < 0.0f)? 0.0f : factor;  // Clamp to [0,1]
+            factor = (factor > 1.0f)? 1.0f : factor;  // Clamp to [-1,1]
+            factor = (factor < -1.0f)? -1.0f : factor;  // Clamp to [-1,1]
+            factor = factor / 2 + 0.5f;
 
             // Generate the color for this pixel
             pixels[j*width + i].r = (int)((float)end.r*factor + (float)start.r*(1.0f - factor));


### PR DESCRIPTION
The gradient generated with GenImageGradientLinear would have unexpected artifacts when the direction parameter would resolve to an angle having cosine and sine of different signs (it also contains a division by something which can approach zero with specific angles).

This is a bit of a blunt attempt at a solution, given that it's my first for this kind of work, feedback would be much appreciated ^^.

I've left a long winded comment explaining some of the rationale, but I couldn't manage to make it clearer than it got.

Here is a comparison of a minimal example with a rotating gradient:

https://github.com/user-attachments/assets/ba92ef1c-77c0-4ae5-9478-11725674d58f

<details>
  <summary>Example code:</summary>
```c
int main(int argc, char **argv)
{
    InitWindow(1000, 500, "Window");

    double angle = 0;

    Image bg_old = GenImageGradientLinear(400, 400, angle, BLUE, DARKPURPLE);
    Image bg_new = GenImageGradientLinearNew(400, 400, angle, BLUE, DARKPURPLE);
    Texture2D bg_old_texture = LoadTextureFromImage(bg_old);
    Texture2D bg_new_texture = LoadTextureFromImage(bg_new);
    UnloadImage(bg_old);
    UnloadImage(bg_new);

    while (!WindowShouldClose()) {
        BeginDrawing();
        ClearBackground(BLANK);

        angle = fmod(GetTime() * 50, 360);
        DrawText(TextFormat("Angle: %.2f", angle), 400, 8, 32, WHITE);

        bg_old = GenImageGradientLinear(400, 400, angle, BLUE, DARKPURPLE);
        bg_new = GenImageGradientLinearNew(400, 400, angle, BLUE, DARKPURPLE);
        UpdateTexture(bg_old_texture, bg_old.data);
        UpdateTexture(bg_new_texture, bg_new.data);

        DrawTexture(bg_old_texture, 50, 50, WHITE);
        UnloadImage(bg_old);
        DrawText("before", 200, 458, 26, WHITE);

        DrawTexture(bg_new_texture, 550, 50, WHITE);
        UnloadImage(bg_new);
        DrawText("after", 700, 458, 26, WHITE);

        EndDrawing();
    }

    CloseWindow();

    return 0;
}
```
</details>
