### PR TITLE
[shell] [web] Temporary workaround for `shell.html` `<canvas>` CSS width

### DIFF
--- a/src/shell.html
+++ b/src/shell.html
@@ -79,7 +79,7 @@ jwE50AGjLCVuS8Yt4H7OgZLKK5EKOsLviEWJSL/+0uMi7gLUSBseYwqEbXvSHCec1CJvZPyHCmYQffaB
       canvas.emscripten {
         border: 0px none;
         background: black;
-        width: 100%;
+        /* width: 100%; */
       }
 
       .spinner {
@@ -285,6 +285,10 @@ jwE50AGjLCVuS8Yt4H7OgZLKK5EKOsLviEWJSL/+0uMi7gLUSBseYwqEbXvSHCec1CJvZPyHCmYQffaB
                 }
 
                 statusElement.innerHTML = text;
+
+                // Temporary workaround for "canvas.emscripten { width: 100%; }" CSS not working with current emscripten (3.1.70)
+                // Revert this change when the issue is fixed upstream
+                document.getElementById('canvas').style.width = '100%';
             },
             totalDependencies: 0,
             monitorRunDependencies: function(left) {


### PR DESCRIPTION
Ref: #4464

Temporary workaround for `canvas.emscripten { width: 100%; }` CSS not working with current emscripten (`3.1.70`).
**Revert this change when the issue is fixed upstream.**

1. Found out that the `<canvas>` width can be resized with CSS, but only after it's loaded.
2. The issue could be related to `$GLFW_Window: function` that now takes the framebuffer's width/height as separated parameters ([ref1](https://github.com/emscripten-core/emscripten/blob/dab87027494b547358253a0336259ac629b80d89/src/library_glfw.js#L40), [ref2](https://github.com/emscripten-core/emscripten/blob/dab87027494b547358253a0336259ac629b80d89/src/library_glfw.js#L1114-L1115)).
3. Hooked this workaround to `Module.setStatus` because it was the only Module option I found that runs (consistently) after the canvas finishes loading.