### PR TITLE
Improve cross-compilation with zig builds

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,0 +1,24 @@
+.{
+    .name = "raylib",
+    .version = "5.5.0",
+    .minimum_zig_version = "0.13.0",
+
+    .dependencies = .{
+        .xcode_frameworks = .{
+            .url = "git+https://github.com/hexops/xcode-frameworks#a6bf82e032d4d9923ad5c222d466710fcc05f249",
+            .hash = "12208da4dfcd9b53fb367375fb612ec73f38e53015f1ce6ae6d6e8437a637078e170",
+            .lazy = true,
+        },
+        .emsdk = .{
+            .url = "git+https://github.com/emscripten-core/emsdk#3.1.50",
+            .hash = "1220e8fe9509f0843e5e22326300ca415c27afbfbba3992f3c3184d71613540b5564",
+            .lazy = true,
+        },
+    },
+
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+        "src",
+    },
+}


### PR DESCRIPTION
- Add xcode_frameworks when cross compiling for mac (ref: https://github.com/hexops/mach/blob/main/build.zig)
- Add emsdk when cross compiling for wasm (ref: https://github.com/floooh/sokol-zig/blob/master/build.zig)