### PR TITLE
Add TextInvert and TextClear functions

### DIFF
--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1513,6 +1513,8 @@ RLAPI const char *TextToLower(const char *text);                      // Get low
 RLAPI const char *TextToPascal(const char *text);                     // Get Pascal case notation version of provided string
 RLAPI const char *TextToSnake(const char *text);                      // Get Snake case notation version of provided string
 RLAPI const char *TextToCamel(const char *text);                      // Get Camel case notation version of provided string
+RLAPI const char *TextInvert(const char *text);                       // Get inverted version of provided string
+RLAPI void TextClear(char *text);                                     // Clear the contents of provided string
 
 RLAPI int TextToInteger(const char *text);                            // Get integer value from text (negative values not supported)
 RLAPI float TextToFloat(const char *text);                            // Get float value from text (negative values not supported)

--- a/src/rtext.c
+++ b/src/rtext.c
@@ -1841,6 +1841,44 @@ const char *TextToCamel(const char *text)
     return buffer;
 }
 
+// Get inverted version of provided string
+const char *TextInvert(const char *text)
+{
+    static char buffer[MAX_TEXT_BUFFER_LENGTH] = {0};
+    memset(buffer, 0, MAX_TEXT_BUFFER_LENGTH);
+
+    if (text != NULL) {
+        int textLen = TextLength(text);
+        
+        if (textLen > MAX_TEXT_BUFFER_LENGTH) {
+            return NULL;
+        }
+
+        for (int i = 0; (i < textLen); i++) {
+            buffer[i] = text[textLen - i - 1]; // Invert string
+        }
+
+        // Securing the null terminator at the end of the inverted string
+        buffer[textLen] = '\0';
+    }
+
+    return buffer;
+}
+
+// Clear the content of the provided string
+void TextClear(char *text)
+{
+    if (text != NULL) {
+        int length = TextLength(text);
+
+        // Clearing text content
+        memset(text, 0, length);
+
+        // We set the null-terminator at the start of the cleared string
+        text[0] = '\0';
+    }
+}
+
 // Encode text codepoint into UTF-8 text
 // REQUIRES: memcpy()
 // WARNING: Allocated memory must be manually freed


### PR DESCRIPTION
Added the ‘TextInvert’ function to revert a text string, and the ‘TextClear’ function to clean up its contents. This is to give more functions for string manipulation in raylib. Any suggestions for changes, additions, etc., I will take them into account.