### PR TITLE
[rTextures] Fix Casting Warnings

### DIFF
--- a/src/rtextures.c
+++ b/src/rtextures.c
@@ -828,15 +828,15 @@ Image GenImageGradientLinear(int width, int height, int direction, Color start, 
     float sinDir = sinf(radianDirection);
 
     // Calculate how far the top-left pixel is along the gradient direction from the center of said gradient
-    float startingPos = 0.5 - (cosDir*width/2) - (sinDir*height/2);
+    float startingPos = 0.5f - (cosDir*width/2) - (sinDir*height/2);
     // With directions that lie in the first or third quadrant (i.e. from top-left to 
     // bottom-right or vice-versa), pixel (0, 0) is the farthest point on the gradient
     // (i.e. the pixel which should become one of the gradient's ends color); while for
     // directions that lie in the second or fourth quadrant, that point is pixel (width, 0).
     float maxPosValue = 
             ((signbit(sinDir) != 0) == (signbit(cosDir) != 0))
-            ? fabs(startingPos)
-            : fabs(startingPos+width*cosDir);
+            ? fabsf(startingPos)
+            : fabsf(startingPos+width*cosDir);
     for (int i = 0; i < width; i++)
     {
         for (int j = 0; j < height; j++)


### PR DESCRIPTION
This PR fixes some double to float casting warnings in rTextures.