### PR TITLE
[raymath] Clang Vector Extension support

### DIFF
--- a/examples/models/models_point_rendering.c
+++ b/examples/models/models_point_rendering.c
@@ -159,9 +159,9 @@ Mesh GenMeshPoints(int numPoints)
     // https://en.wikipedia.org/wiki/Spherical_coordinate_system
     for (int i = 0; i < numPoints; i++)
     {
-        float theta = PI*rand()/RAND_MAX;
-        float phi = 2.0f*PI*rand()/RAND_MAX;
-        float r = 10.0f*rand()/RAND_MAX;
+        float theta = PI*rand()/(float)RAND_MAX;
+        float phi = 2.0f*PI*rand()/(float)RAND_MAX;
+        float r = 10.0f*rand()/(float)RAND_MAX;
         
         mesh.vertices[i*3 + 0] = r*sin(theta)*cos(phi);
         mesh.vertices[i*3 + 1] = r*sin(theta)*sin(phi);

--- a/examples/models/models_point_rendering.c
+++ b/examples/models/models_point_rendering.c
@@ -102,9 +102,9 @@ int main()
                     for (int i = 0; i < numPoints; i++)
                     {
                         Vector3 pos = {
-                            .x = mesh.vertices[i*3 + 0],
-                            .y = mesh.vertices[i*3 + 1],
-                            .z = mesh.vertices[i*3 + 2],
+                            mesh.vertices[i*3 + 0],
+                            mesh.vertices[i*3 + 1],
+                            mesh.vertices[i*3 + 2],
                         };
                         Color color = {
                             .r = mesh.colors[i*4 + 0],

--- a/examples/shaders/shaders_deferred_render.c
+++ b/examples/shaders/shaders_deferred_render.c
@@ -155,9 +155,9 @@ int main(void)
     for (int i = 0; i < MAX_CUBES; i++)
     {
         cubePositions[i] = (Vector3){
-            .x = (float)(rand()%10) - 5,
-            .y = (float)(rand()%5),
-            .z = (float)(rand()%10) - 5,
+            (float)(rand()%10) - 5,
+            (float)(rand()%5),
+            (float)(rand()%10) - 5,
         };
         
         cubeRotations[i] = (float)(rand()%360);

--- a/examples/shaders/shaders_fog.c
+++ b/examples/shaders/shaders_fog.c
@@ -114,7 +114,7 @@ int main(void)
         modelA.transform = MatrixMultiply(modelA.transform, MatrixRotateZ(0.012f));
 
         // Update the light shader with the camera view position
-        SetShaderValue(shader, shader.locs[SHADER_LOC_VECTOR_VIEW], &camera.position.x, SHADER_UNIFORM_VEC3);
+        SetShaderValue(shader, shader.locs[SHADER_LOC_VECTOR_VIEW], &camera.position, SHADER_UNIFORM_VEC3);
         //----------------------------------------------------------------------------------
 
         // Draw

--- a/examples/shaders/shaders_hybrid_render.c
+++ b/examples/shaders/shaders_hybrid_render.c
@@ -68,7 +68,7 @@ int main(void)
     marchLocs.screenCenter = GetShaderLocation(shdrRaymarch, "screenCenter");
 
     // Transfer screenCenter position to shader. Which is used to calculate ray direction. 
-    Vector2 screenCenter = {.x = screenWidth/2.0f, .y = screenHeight/2.0f};
+    Vector2 screenCenter = { screenWidth/2.0f, screenHeight/2.0f};
     SetShaderValue(shdrRaymarch, marchLocs.screenCenter , &screenCenter , SHADER_UNIFORM_VEC2);
 
     // Use Customized function to create writable depth texture buffer

--- a/examples/shaders/shaders_spotlight.c
+++ b/examples/shaders/shaders_spotlight.c
@@ -135,7 +135,7 @@ int main(void)
         spots[i].inner = 28.0f * (i + 1);
         spots[i].radius = 48.0f * (i + 1);
 
-        SetShaderValue(shdrSpot, spots[i].positionLoc, &spots[i].position.x, SHADER_UNIFORM_VEC2);
+        SetShaderValue(shdrSpot, spots[i].positionLoc, &spots[i].position, SHADER_UNIFORM_VEC2);
         SetShaderValue(shdrSpot, spots[i].innerLoc, &spots[i].inner, SHADER_UNIFORM_FLOAT);
         SetShaderValue(shdrSpot, spots[i].radiusLoc, &spots[i].radius, SHADER_UNIFORM_FLOAT);
     }
@@ -173,7 +173,7 @@ int main(void)
                 if (spots[i].position.y > (screenHeight - 64)) spots[i].speed.y = -spots[i].speed.y;
             }
 
-            SetShaderValue(shdrSpot, spots[i].positionLoc, &spots[i].position.x, SHADER_UNIFORM_VEC2);
+            SetShaderValue(shdrSpot, spots[i].positionLoc, &spots[i].position, SHADER_UNIFORM_VEC2);
         }
 
         // Draw

--- a/examples/shapes/raygui.h
+++ b/examples/shapes/raygui.h
@@ -3722,7 +3722,7 @@ int GuiColorPicker(Rectangle bounds, const char *text, Color *color)
     // NOTE: this conversion can cause low hue-resolution, if the r, g and b value are very similar, which causes the hue bar to shift around when only the GuiColorPanel is used.
     Vector3 hsv = ConvertRGBtoHSV(RAYGUI_CLITERAL(Vector3){ (*color).r/255.0f, (*color).g/255.0f, (*color).b/255.0f });
 
-    GuiColorBarHue(boundsHue, NULL, &hsv.x);
+    GuiColorBarHue(boundsHue, NULL, (float*)&hsv);
 
     //color.a = (unsigned char)(GuiColorBarAlpha(boundsAlpha, (float)color.a/255.0f)*255.0f);
     Vector3 rgb = ConvertHSVtoRGB(hsv);
@@ -3756,7 +3756,7 @@ int GuiColorPickerHSV(Rectangle bounds, const char *text, Vector3 *colorHsv)
 
     const Rectangle boundsHue = { (float)bounds.x + bounds.width + GuiGetStyle(COLORPICKER, HUEBAR_PADDING), (float)bounds.y, (float)GuiGetStyle(COLORPICKER, HUEBAR_WIDTH), (float)bounds.height };
 
-    GuiColorBarHue(boundsHue, NULL, &colorHsv->x);
+    GuiColorBarHue(boundsHue, NULL, (float*)&colorHsv);
 
     return result;
 }

--- a/src/platforms/rcore_desktop_glfw.c
+++ b/src/platforms/rcore_desktop_glfw.c
@@ -949,9 +949,10 @@ Vector2 GetWindowPosition(void)
 // Get window scale DPI factor for current monitor
 Vector2 GetWindowScaleDPI(void)
 {
-    Vector2 scale = {0};
-    glfwGetWindowContentScale(platform.handle, &scale.x, &scale.y);
-    return scale;
+    float x;
+    float y;
+    glfwGetWindowContentScale(platform.handle, &x, &y);
+    return (Vector2){ x, y};
 }
 
 // Set clipboard text content

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -212,25 +212,37 @@
 #endif
 
 // Vector2, 2 components
+#ifdef __clang__
+typedef float Vector2 __attribute__((ext_vector_type(2)));
+#else
 typedef struct Vector2 {
     float x;                // Vector x component
     float y;                // Vector y component
 } Vector2;
+#endif
 
 // Vector3, 3 components
+#ifdef __clang__
+typedef float Vector3 __attribute__((ext_vector_type(3)));
+#else
 typedef struct Vector3 {
     float x;                // Vector x component
     float y;                // Vector y component
     float z;                // Vector z component
 } Vector3;
+#endif
 
 // Vector4, 4 components
+#ifdef __clang__
+typedef float Vector4 __attribute__((ext_vector_type(4)));
+#else
 typedef struct Vector4 {
     float x;                // Vector x component
     float y;                // Vector y component
     float z;                // Vector z component
     float w;                // Vector w component
 } Vector4;
+#endif
 
 // Quaternion, 4 components (Vector4 alias)
 typedef Vector4 Quaternion;

--- a/src/raymath.h
+++ b/src/raymath.h
@@ -263,73 +263,110 @@ RMAPI Vector2 Vector2One(void)
 // Add two vectors (v1 + v2)
 RMAPI Vector2 Vector2Add(Vector2 v1, Vector2 v2)
 {
+#ifdef __clang__
+    return v1 + v2;
+#else
     Vector2 result = { v1.x + v2.x, v1.y + v2.y };
 
     return result;
+#endif
 }
 
 // Add vector and float value
 RMAPI Vector2 Vector2AddValue(Vector2 v, float add)
 {
+#ifdef __clang__
+    return v + add;
+#else
     Vector2 result = { v.x + add, v.y + add };
 
     return result;
+#endif
 }
 
 // Subtract two vectors (v1 - v2)
 RMAPI Vector2 Vector2Subtract(Vector2 v1, Vector2 v2)
 {
+#ifdef __clang__
+    return v1 - v2;
+#else
     Vector2 result = { v1.x - v2.x, v1.y - v2.y };
 
     return result;
+#endif
 }
 
 // Subtract vector by float value
 RMAPI Vector2 Vector2SubtractValue(Vector2 v, float sub)
 {
+#ifdef __clang__
+    return v - sub;
+#else
     Vector2 result = { v.x - sub, v.y - sub };
 
     return result;
-}
-
-// Calculate vector length
-RMAPI float Vector2Length(Vector2 v)
-{
-    float result = sqrtf((v.x*v.x) + (v.y*v.y));
-
-    return result;
+#endif
 }
 
 // Calculate vector square length
 RMAPI float Vector2LengthSqr(Vector2 v)
 {
+#ifdef __clang__
+    Vector2 tmp = v * v;
+    return tmp[0] + tmp[1];
+#else
     float result = (v.x*v.x) + (v.y*v.y);
+    return result;
+#endif
+}
+
+// Calculate vector length
+RMAPI float Vector2Length(Vector2 v)
+{
+#ifdef __clang__
+    return __builtin_elementwise_sqrt(Vector2LengthSqr(v));
+#else
+    float result = sqrtf((v.x*v.x) + (v.y*v.y));
 
     return result;
+#endif
 }
 
 // Calculate two vectors dot product
 RMAPI float Vector2DotProduct(Vector2 v1, Vector2 v2)
 {
+#ifdef __clang__
+    Vector2 tmp = v1 * v2;
+    return tmp[0] + tmp[1];
+#else
     float result = (v1.x*v2.x + v1.y*v2.y);
 
     return result;
+#endif
 }
 
 // Calculate distance between two vectors
 RMAPI float Vector2Distance(Vector2 v1, Vector2 v2)
 {
+#ifdef __clang__
+    return Vector2Length(v1 - v2);
+#else
     float result = sqrtf((v1.x - v2.x)*(v1.x - v2.x) + (v1.y - v2.y)*(v1.y - v2.y));
 
     return result;
+#endif
 }
 
 // Calculate square distance between two vectors
 RMAPI float Vector2DistanceSqr(Vector2 v1, Vector2 v2)
 {
+#ifdef __clang__
+    return Vector2LengthSqr(v1 - v2);
+#else
     float result = ((v1.x - v2.x)*(v1.x - v2.x) + (v1.y - v2.y)*(v1.y - v2.y));
 
     return result;
+#endif
 }
 
 // Calculate angle between two vectors
@@ -362,47 +399,59 @@ RMAPI float Vector2LineAngle(Vector2 start, Vector2 end)
 // Scale vector (multiply by value)
 RMAPI Vector2 Vector2Scale(Vector2 v, float scale)
 {
+#ifdef __clang__
+    return v * scale;
+#else
     Vector2 result = { v.x*scale, v.y*scale };
 
     return result;
+#endif
 }
 
 // Multiply vector by vector
 RMAPI Vector2 Vector2Multiply(Vector2 v1, Vector2 v2)
 {
+#ifdef __clang__
+    return v1 * v2;
+#else
     Vector2 result = { v1.x*v2.x, v1.y*v2.y };
 
     return result;
+#endif
 }
 
 // Negate vector
 RMAPI Vector2 Vector2Negate(Vector2 v)
 {
+#ifdef __clang__
+    return -v;
+#else
     Vector2 result = { -v.x, -v.y };
 
     return result;
+#endif
 }
 
 // Divide vector by vector
 RMAPI Vector2 Vector2Divide(Vector2 v1, Vector2 v2)
 {
+#ifdef __clang__
+    return v1 / v2;
+#else
     Vector2 result = { v1.x/v2.x, v1.y/v2.y };
 
     return result;
+#endif
 }
 
 // Normalize provided vector
 RMAPI Vector2 Vector2Normalize(Vector2 v)
 {
     Vector2 result = { 0 };
-    float length = sqrtf((v.x*v.x) + (v.y*v.y));
+    float length = Vector2Length(v);
 
     if (length > 0)
-    {
-        float ilength = 1.0f/length;
-        result.x = v.x*ilength;
-        result.y = v.y*ilength;
-    }
+    	result = Vector2Scale(v, 1.0f/length);
 
     return result;
 }
@@ -625,41 +674,61 @@ RMAPI Vector3 Vector3AddValue(Vector3 v, float add)
 // Subtract two vectors
 RMAPI Vector3 Vector3Subtract(Vector3 v1, Vector3 v2)
 {
+#ifdef __clang__
+    return v1 - v2;
+#else
     Vector3 result = { v1.x - v2.x, v1.y - v2.y, v1.z - v2.z };
 
     return result;
+#endif
 }
 
 // Subtract vector by float value
 RMAPI Vector3 Vector3SubtractValue(Vector3 v, float sub)
 {
+#ifdef __clang__
+    return v - sub;
+#else
     Vector3 result = { v.x - sub, v.y - sub, v.z - sub };
 
     return result;
+#endif
 }
 
 // Multiply vector by scalar
 RMAPI Vector3 Vector3Scale(Vector3 v, float scalar)
 {
+#ifdef __clang__
+    return v * scalar;
+#else
     Vector3 result = { v.x*scalar, v.y*scalar, v.z*scalar };
 
     return result;
+#endif
 }
 
 // Multiply vector by vector
 RMAPI Vector3 Vector3Multiply(Vector3 v1, Vector3 v2)
 {
+#ifdef __clang__
+    return v1 * v2;
+#else
     Vector3 result = { v1.x*v2.x, v1.y*v2.y, v1.z*v2.z };
 
     return result;
+#endif
 }
 
 // Calculate two vectors cross product
 RMAPI Vector3 Vector3CrossProduct(Vector3 v1, Vector3 v2)
 {
+#ifdef __clang__
+    return v1.yzx * v2.zxy - v1.zxy * v2.yzx;
+#else
     Vector3 result = { v1.y*v2.z - v1.z*v2.y, v1.z*v2.x - v1.x*v2.z, v1.x*v2.y - v1.y*v2.x };
 
     return result;
+#endif
 }
 
 // Calculate one vector perpendicular vector
@@ -691,33 +760,51 @@ RMAPI Vector3 Vector3Perpendicular(Vector3 v)
     return result;
 }
 
-// Calculate vector length
-RMAPI float Vector3Length(const Vector3 v)
-{
-    float result = sqrtf(v.x*v.x + v.y*v.y + v.z*v.z);
-
-    return result;
-}
-
 // Calculate vector square length
 RMAPI float Vector3LengthSqr(const Vector3 v)
 {
+#ifdef __clang__
+    Vector3 tmp = v*v;
+    return tmp[0] + tmp[1] + tmp[2];
+#else
     float result = v.x*v.x + v.y*v.y + v.z*v.z;
 
     return result;
+#endif
+}
+
+// Calculate vector length
+RMAPI float Vector3Length(const Vector3 v)
+{
+#ifdef __clang__
+    return sqrtf(Vector3LengthSqr(v));
+#else
+    float result = sqrtf(v.x*v.x + v.y*v.y + v.z*v.z);
+
+    return result;
+#endif
 }
 
 // Calculate two vectors dot product
 RMAPI float Vector3DotProduct(Vector3 v1, Vector3 v2)
 {
+#ifdef __clang__
+    Vector3 tmp = v1*v2;
+    return tmp[0] + tmp[1] + tmp[2];
+#else
     float result = (v1.x*v2.x + v1.y*v2.y + v1.z*v2.z);
 
     return result;
+#endif
 }
 
 // Calculate distance between two vectors
 RMAPI float Vector3Distance(Vector3 v1, Vector3 v2)
 {
+#ifdef __clang__
+    Vector3 dv = v2 - v1;
+    return Vector3Length(dv);
+#else
     float result = 0.0f;
 
     float dx = v2.x - v1.x;
@@ -726,11 +813,16 @@ RMAPI float Vector3Distance(Vector3 v1, Vector3 v2)
     result = sqrtf(dx*dx + dy*dy + dz*dz);
 
     return result;
+#endif
 }
 
 // Calculate square distance between two vectors
 RMAPI float Vector3DistanceSqr(Vector3 v1, Vector3 v2)
 {
+#ifdef __clang__
+    Vector3 dv = v2 - v1;
+    return Vector3LengthSqr(dv);
+#else
     float result = 0.0f;
 
     float dx = v2.x - v1.x;
@@ -739,6 +831,7 @@ RMAPI float Vector3DistanceSqr(Vector3 v1, Vector3 v2)
     result = dx*dx + dy*dy + dz*dz;
 
     return result;
+#endif
 }
 
 // Calculate angle between two vectors
@@ -757,9 +850,13 @@ RMAPI float Vector3Angle(Vector3 v1, Vector3 v2)
 // Negate provided vector (invert direction)
 RMAPI Vector3 Vector3Negate(Vector3 v)
 {
+#ifdef __clang__
+    return -v;
+#else
     Vector3 result = { -v.x, -v.y, -v.z };
 
     return result;
+#endif
 }
 
 // Divide vector by vector
@@ -775,15 +872,9 @@ RMAPI Vector3 Vector3Normalize(Vector3 v)
 {
     Vector3 result = v;
 
-    float length = sqrtf(v.x*v.x + v.y*v.y + v.z*v.z);
-    if (length != 0.0f)
-    {
-        float ilength = 1.0f/length;
-
-        result.x *= ilength;
-        result.y *= ilength;
-        result.z *= ilength;
-    }
+    float length = Vector3Length(v);
+    if (length > 0)
+        result = Vector3Scale(v, 1.0f/length);
 
     return result;
 }

--- a/src/raymath.h
+++ b/src/raymath.h
@@ -113,25 +113,36 @@
 // Types and Structures Definition
 //----------------------------------------------------------------------------------
 #if !defined(RL_VECTOR2_TYPE)
+#ifdef __clang__
+typedef float Vector2 __attribute__((ext_vector_type(2)));
+#else
 // Vector2 type
 typedef struct Vector2 {
     float x;
     float y;
 } Vector2;
+#endif
 #define RL_VECTOR2_TYPE
 #endif
 
 #if !defined(RL_VECTOR3_TYPE)
+#ifdef __clang__
+typedef float Vector3 __attribute__((ext_vector_type(3)));
+#else
 // Vector3 type
 typedef struct Vector3 {
     float x;
     float y;
     float z;
 } Vector3;
+#endif
 #define RL_VECTOR3_TYPE
 #endif
 
 #if !defined(RL_VECTOR4_TYPE)
+#ifdef __clang__
+typedef float Vector4 __attribute__((ext_vector_type(4)));
+#else
 // Vector4 type
 typedef struct Vector4 {
     float x;
@@ -139,6 +150,7 @@ typedef struct Vector4 {
     float z;
     float w;
 } Vector4;
+#endif
 #define RL_VECTOR4_TYPE
 #endif
 


### PR DESCRIPTION
- Replace src/raymath.h Vector type definitions with ext_vector_type ones for clang compiler to activate use
`cmake -DCMAKE_C_COMPILER=clang`
- silence example type cast warning

**TODO**
- check for Vector3 storage size change from 12 to 16 bytes complications