### PR TITLE
[build][Zig] Remove `addRaylib` and fix `raygui` builds when using raylib as dep

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -11,36 +11,6 @@ comptime {
         @compileError("Raylib requires zig version " ++ min_ver);
 }
 
-// NOTE(freakmangd): I don't like using a global here, but it prevents having to
-// get the flags a second time when adding raygui
-var raylib_flags_arr: std.ArrayListUnmanaged([]const u8) = .{};
-
-// This has been tested with zig version 0.13.0
-pub fn addRaylib(b: *std.Build, target: std.Build.ResolvedTarget, optimize: std.builtin.OptimizeMode, options: Options) !*std.Build.Step.Compile {
-    const raylib_dep = b.dependencyFromBuildZig(@This(), .{
-        .target = target,
-        .optimize = optimize,
-        .raudio = options.raudio,
-        .rmodels = options.rmodels,
-        .rshapes = options.rshapes,
-        .rtext = options.rtext,
-        .rtextures = options.rtextures,
-        .platform = options.platform,
-        .shared = options.shared,
-        .linux_display_backend = options.linux_display_backend,
-        .opengl_version = options.opengl_version,
-        .config = options.config,
-    });
-    const raylib = raylib_dep.artifact("raylib");
-
-    if (options.raygui) {
-        const raygui_dep = b.dependency(options.raygui_dependency_name, .{});
-        addRaygui(b, raylib, raygui_dep);
-    }
-
-    return raylib;
-}
-
 fn setDesktopPlatform(raylib: *std.Build.Step.Compile, platform: PlatformBackend) void {
     raylib.defineCMacro("PLATFORM_DESKTOP", null);
 
@@ -107,21 +77,26 @@ const config_h_flags = outer: {
 };
 
 fn compileRaylib(b: *std.Build, target: std.Build.ResolvedTarget, optimize: std.builtin.OptimizeMode, options: Options) !*std.Build.Step.Compile {
-    raylib_flags_arr.clearRetainingCapacity();
+    var raylib_flags_arr = std.ArrayList([]const u8).init(b.allocator);
+    defer raylib_flags_arr.deinit();
 
-    const shared_flags = &[_][]const u8{
-        "-fPIC",
-        "-DBUILD_LIBTYPE_SHARED",
-    };
-    try raylib_flags_arr.appendSlice(b.allocator, &[_][]const u8{
+    try raylib_flags_arr.appendSlice(&[_][]const u8{
         "-std=gnu99",
         "-D_GNU_SOURCE",
         "-DGL_SILENCE_DEPRECATION=199309L",
         "-fno-sanitize=undefined", // https://github.com/raysan5/raylib/issues/3674
     });
+
+    if (options.shared) {
+        try raylib_flags_arr.appendSlice(&[_][]const u8{
+            "-fPIC",
+            "-DBUILD_LIBTYPE_SHARED",
+        });
+    }
+
     if (options.config.len > 0) {
         // Sets a flag indiciating the use of a custom `config.h`
-        try raylib_flags_arr.append(b.allocator, "-DEXTERNAL_CONFIG_FLAGS");
+        try raylib_flags_arr.append("-DEXTERNAL_CONFIG_FLAGS");
 
         // Splits a space-separated list of config flags into multiple flags
         //
@@ -131,7 +106,7 @@ fn compileRaylib(b: *std.Build, target: std.Build.ResolvedTarget, optimize: std.
 
         // Apply config flags supplied by the user
         while (config_iter.next()) |config_flag|
-            try raylib_flags_arr.append(b.allocator, config_flag);
+            try raylib_flags_arr.append(config_flag);
 
         // Apply all relevant configs from `src/config.h` *except* the user-specified ones
         //
@@ -149,12 +124,8 @@ fn compileRaylib(b: *std.Build, target: std.Build.ResolvedTarget, optimize: std.
             }
 
             // Otherwise, append default value from config.h to compile flags
-            try raylib_flags_arr.append(b.allocator, flag);
+            try raylib_flags_arr.append(flag);
         }
-    }
-
-    if (options.shared) {
-        try raylib_flags_arr.appendSlice(b.allocator, shared_flags);
     }
 
     const raylib = if (options.shared)
@@ -288,7 +259,7 @@ fn compileRaylib(b: *std.Build, target: std.Build.ResolvedTarget, optimize: std.
             }
 
             // On macos rglfw.c include Objective-C files.
-            try raylib_flags_arr.append(b.allocator, "-ObjC");
+            try raylib_flags_arr.append("-ObjC");
             raylib.root_module.addCSourceFile(.{
                 .file = b.path("src/rglfw.c"),
                 .flags = raylib_flags_arr.items,
@@ -327,25 +298,19 @@ fn compileRaylib(b: *std.Build, target: std.Build.ResolvedTarget, optimize: std.
         .flags = raylib_flags_arr.items,
     });
 
-    return raylib;
-}
+    if (options.raygui) {
+        const raygui_dep = b.dependency(options.raygui_dependency_name, .{});
 
-/// This function does not need to be called if you passed .raygui = true to addRaylib
-pub fn addRaygui(b: *std.Build, raylib: *std.Build.Step.Compile, raygui_dep: *std.Build.Dependency) void {
-    if (raylib_flags_arr.items.len == 0) {
-        @panic(
-            \\argument 2 `raylib` in `addRaygui` must come from b.dependency("raylib", ...).artifact("raylib")
-        );
+        var gen_step = b.addWriteFiles();
+        raylib.step.dependOn(&gen_step.step);
+
+        const raygui_c_path = gen_step.add("raygui.c", "#define RAYGUI_IMPLEMENTATION\n#include \"raygui.h\"\n");
+        raylib.addCSourceFile(.{ .file = raygui_c_path, .flags = raylib_flags_arr.items });
+        raylib.addIncludePath(raygui_dep.path("src"));
+        raylib.installHeader(raygui_dep.path("src/raygui.h"), "raygui.h");
     }
 
-    var gen_step = b.addWriteFiles();
-    raylib.step.dependOn(&gen_step.step);
-
-    const raygui_c_path = gen_step.add("raygui.c", "#define RAYGUI_IMPLEMENTATION\n#include \"raygui.h\"\n");
-    raylib.addCSourceFile(.{ .file = raygui_c_path, .flags = raylib_flags_arr.items });
-    raylib.addIncludePath(raygui_dep.path("src"));
-
-    raylib.installHeader(raygui_dep.path("src/raygui.h"), "raygui.h");
+    return raylib;
 }
 
 pub const Options = struct {


### PR DESCRIPTION
- addRaylib just duplicates what adding raylib as dependency already does
  so it do not needs to exist
- move raygui build to standard build process when flag is enabled. this
  works correctly when using raylib as dependency and having raygui as
  dependency as well. problem with previous approach was that raygui was in
  options but it was doing nothing because you had to also use addRaygui for
  it to be effective

For how the dependency should be included normally in other projects using zig builds, its as simple as this (on top of including raylib in build.zig.zon)

```zig
const target = b.standardTargetOptions(.{});
const optimize = b.standardOptimizeOption(.{});

// This is the whole thing
const raylib_dep = b.dependency("raylib", .{ .target = target, .optimize = optimize, .shared = true });
const raylib = raylib_dep.artifact("raylib");
b.installArtifact(raylib)
```
