### PR TITLE
[build]: Replace fatal ``errors`` with ``conditional warnings`` for Clipboard Image Support

### DIFF
--- a/src/rcore.c
+++ b/src/rcore.c
@@ -512,10 +512,27 @@ const char *TextFormat(const char *text, ...);              // Formatting of tex
     #define PLATFORM_DESKTOP_GLFW
 #endif
 
+// We're using `#pragma message` because `#warning` is not adopted by MSVC.
 #if defined(SUPPORT_CLIPBOARD_IMAGE)
-    #if !defined(SUPPORT_FILEFORMAT_BMP) || !defined(STBI_REQUIRED) || !defined(SUPPORT_MODULE_RTEXTURES)
-        #error "To enabled SUPPORT_CLIPBOARD_IMAGE, it also needs SUPPORT_FILEFORMAT_BMP, SUPPORT_MODULE_RTEXTURES and STBI_REQUIRED to be defined. It should have been defined earlier"
+    #if !defined(SUPPORT_MODULE_RTEXTURES)
+        #pragma message ("Warning: Enabling SUPPORT_CLIPBOARD_IMAGE requires SUPPORT_MODULE_RTEXTURES to work properly")
     #endif
+
+    // It's nice to have support Bitmap on Linux as well, but not as necessary as Windows
+    #if !defined(SUPPORT_FILEFORMAT_BMP) && defined(_WIN32)
+        #pragma message ("Warning: Enabling SUPPORT_CLIPBOARD_IMAGE requires SUPPORT_FILEFORMAT_BMP, specially on Windows")
+    #endif
+
+    // From what I've tested applications on Wayland saves images on clipboard as PNG.
+    #if (!defined(SUPPORT_FILEFORMAT_PNG) || !defined(SUPPORT_FILEFORMAT_JPG)) && !defined(_WIN32)
+        #pragma message ("Warning: Getting image from the clipboard might not work without SUPPORT_FILEFORMAT_PNG or SUPPORT_FILEFORMAT_JPG")
+    #endif
+
+    // Not needed because `rtexture.c` will automatically defined STBI_REQUIRED when any SUPPORT_FILEFORMAT_* is defined.
+    // #if !defined(STBI_REQUIRED)
+    //     #pragma message ("Warning: "STBI_REQUIRED is not defined, that means we can't load images from clipbard"
+    // #endif
+
 #endif // SUPPORT_CLIPBOARD_IMAGE
 
 // Include platform-specific submodules


### PR DESCRIPTION
Fixes [#4459](https://github.com/raysan5/raylib/pull/4459#issuecomment-2466821215)

Conditional compilation warnings instead of warnings to inform developers about the necessary dependencies when enabling clipboard image support (e.g. SUPPORT_MODULE_RTEXTURES, specific image formats , etc ...).  

This allows for more flexible configuration while still alerting users, although subtely.

NOTE: [6.10.7 C standard](https://open-std.org/jtc1/sc22/wg14/www/docs/n3096.pdf) says that any unrecognized ``#pragma`` should be ignores, so it should be no problem is case of less common C compilers. 