### PR TITLE
[rModels] Fix bad triangles in DrawCylinder

### DIFF
--- a/src/rmodels.c
+++ b/src/rmodels.c
@@ -603,7 +603,7 @@ void DrawCylinder(Vector3 position, float radiusTop, float radiusBottom, float h
             for (int i = 0; i < sides; i++)
             {
                 rlVertex3f(0, 0, 0);
-                rlVertex3f(sinf(DEG2RAD*i*angleStep)*radiusBottom, 0, cosf(DEG2RAD*(i+1)*angleStep)*radiusBottom);
+                rlVertex3f(sinf(DEG2RAD*(i+1)*angleStep)*radiusBottom, 0, cosf(DEG2RAD*(i+1)*angleStep)*radiusBottom);
                 rlVertex3f(sinf(DEG2RAD*i*angleStep)*radiusBottom, 0, cosf(DEG2RAD*i*angleStep)*radiusBottom);
             }
 


### PR DESCRIPTION
The lower Y cap of the cylinder in DrawCylinder has a small mistake and does not draw properly.
this PR fixes it up to render correctly.
![image](https://github.com/user-attachments/assets/ea4ecd05-c1d6-40e1-9139-30540023c880)
