### PR TITLE
[rCore_GLFW] Fix a typecast warning in glfw clipboard access

### DIFF
--- a/src/platforms/rcore_desktop_glfw.c
+++ b/src/platforms/rcore_desktop_glfw.c
@@ -988,7 +988,7 @@ Image GetClipboardImage(void)
     }
     else
     {
-        image = LoadImageFromMemory(".bmp", fileData, dataSize);
+        image = LoadImageFromMemory(".bmp", fileData, (int)dataSize);
     }
     return image;
 }


### PR DESCRIPTION
This PR fixes a typecast warning in the GLFW clipboard functions (raylib image can't read a 64 bit size).