### PR TITLE
[Examples] Fix colors in lighting shaders

### DIFF
--- a/examples/shaders/resources/shaders/glsl100/lighting.fs
+++ b/examples/shaders/resources/shaders/glsl100/lighting.fs
@@ -40,6 +40,8 @@ void main()
     vec3 viewD = normalize(viewPos - fragPosition);
     vec3 specular = vec3(0.0);
 
+    vec4 tint = colDiffuse * fragColor;
+
     // NOTE: Implement here your fragment shader code
 
     for (int i = 0; i < MAX_LIGHTS; i++)
@@ -67,7 +69,7 @@ void main()
         }
     }
 
-    vec4 finalColor = (texelColor*((colDiffuse + vec4(specular, 1.0))*vec4(lightDot, 1.0)));
+    vec4 finalColor = (texelColor*((tint + vec4(specular, 1.0))*vec4(lightDot, 1.0)));
     finalColor += texelColor*(ambient/10.0);
 
     // Gamma correction

--- a/examples/shaders/resources/shaders/glsl120/lighting.fs
+++ b/examples/shaders/resources/shaders/glsl120/lighting.fs
@@ -38,6 +38,8 @@ void main()
     vec3 viewD = normalize(viewPos - fragPosition);
     vec3 specular = vec3(0.0);
 
+    vec4 tint = colDiffuse * fragColor;
+
     // NOTE: Implement here your fragment shader code
 
     for (int i = 0; i < MAX_LIGHTS; i++)
@@ -65,7 +67,7 @@ void main()
         }
     }
 
-    vec4 finalColor = (texelColor*((colDiffuse + vec4(specular, 1.0))*vec4(lightDot, 1.0)));
+    vec4 finalColor = (texelColor*((tint + vec4(specular, 1.0))*vec4(lightDot, 1.0)));
     finalColor += texelColor*(ambient/10.0);
 
     // Gamma correction

--- a/examples/shaders/resources/shaders/glsl330/lighting.fs
+++ b/examples/shaders/resources/shaders/glsl330/lighting.fs
@@ -3,7 +3,7 @@
 // Input vertex attributes (from vertex shader)
 in vec3 fragPosition;
 in vec2 fragTexCoord;
-//in vec4 fragColor;
+in vec4 fragColor;
 in vec3 fragNormal;
 
 // Input uniform values
@@ -41,6 +41,8 @@ void main()
     vec3 viewD = normalize(viewPos - fragPosition);
     vec3 specular = vec3(0.0);
 
+    vec4 tint = colDiffuse * fragColor;
+
     // NOTE: Implement here your fragment shader code
 
     for (int i = 0; i < MAX_LIGHTS; i++)
@@ -68,8 +70,8 @@ void main()
         }
     }
 
-    finalColor = (texelColor*((colDiffuse + vec4(specular, 1.0))*vec4(lightDot, 1.0)));
-    finalColor += texelColor*(ambient/10.0)*colDiffuse;
+    finalColor = (texelColor*((tint + vec4(specular, 1.0))*vec4(lightDot, 1.0)));
+    finalColor += texelColor*(ambient/10.0)*tint;
 
     // Gamma correction
     finalColor = pow(finalColor, vec4(1.0/2.2));


### PR DESCRIPTION
There is a small regression with the lighting example/shader from previous versions with the new 5.5 example,
5.0 used meshes since the batch did not support normals. This meant that the tint was passed to the shader as the 'colDiffuse' uniform.
uses shapes, since the batch system does now support normals. Shapes do't set colDiffuse from the tint, they apply the tint as vertex colors.

The example lighting fragment shader does not use the fragColor, only colDiffuse, so this means that the tint is now ignored where it was not before.

This PR fixes the example lighting shaders to use both frag and diffuse colors so they work with shapes and meshes.