### PR TITLE
Math supporting Clang Vector Extension

### DIFF
--- a/examples/models/models_point_rendering.c
+++ b/examples/models/models_point_rendering.c
@@ -102,15 +102,15 @@ int main()
                     for (int i = 0; i < numPoints; i++)
                     {
                         Vector3 pos = {
-                            .x = mesh.vertices[i*3 + 0],
-                            .y = mesh.vertices[i*3 + 1],
-                            .z = mesh.vertices[i*3 + 2],
+                            mesh.vertices[i*3 + 0],
+                            mesh.vertices[i*3 + 1],
+                            mesh.vertices[i*3 + 2],
                         };
                         Color color = {
-                            .r = mesh.colors[i*4 + 0],
-                            .g = mesh.colors[i*4 + 1],
-                            .b = mesh.colors[i*4 + 2],
-                            .a = mesh.colors[i*4 + 3],
+                            mesh.colors[i*4 + 0],
+                            mesh.colors[i*4 + 1],
+                            mesh.colors[i*4 + 2],
+                            mesh.colors[i*4 + 3],
                         };
                         
                         DrawPoint3D(pos, color);
@@ -159,9 +159,9 @@ Mesh GenMeshPoints(int numPoints)
     // https://en.wikipedia.org/wiki/Spherical_coordinate_system
     for (int i = 0; i < numPoints; i++)
     {
-        float theta = PI*rand()/RAND_MAX;
-        float phi = 2.0f*PI*rand()/RAND_MAX;
-        float r = 10.0f*rand()/RAND_MAX;
+        float theta = PI*rand()/(float)RAND_MAX;
+        float phi = 2.0f*PI*rand()/(float)RAND_MAX;
+        float r = 10.0f*rand()/(float)RAND_MAX;
         
         mesh.vertices[i*3 + 0] = r*sin(theta)*cos(phi);
         mesh.vertices[i*3 + 1] = r*sin(theta)*sin(phi);

--- a/examples/shaders/shaders_deferred_render.c
+++ b/examples/shaders/shaders_deferred_render.c
@@ -155,9 +155,9 @@ int main(void)
     for (int i = 0; i < MAX_CUBES; i++)
     {
         cubePositions[i] = (Vector3){
-            .x = (float)(rand()%10) - 5,
-            .y = (float)(rand()%5),
-            .z = (float)(rand()%10) - 5,
+            (float)(rand()%10) - 5,
+            (float)(rand()%5),
+            (float)(rand()%10) - 5,
         };
         
         cubeRotations[i] = (float)(rand()%360);

--- a/examples/shaders/shaders_fog.c
+++ b/examples/shaders/shaders_fog.c
@@ -114,7 +114,7 @@ int main(void)
         modelA.transform = MatrixMultiply(modelA.transform, MatrixRotateZ(0.012f));
 
         // Update the light shader with the camera view position
-        SetShaderValue(shader, shader.locs[SHADER_LOC_VECTOR_VIEW], &camera.position.x, SHADER_UNIFORM_VEC3);
+        SetShaderValue(shader, shader.locs[SHADER_LOC_VECTOR_VIEW], (float*)&camera.position, SHADER_UNIFORM_VEC3);
         //----------------------------------------------------------------------------------
 
         // Draw

--- a/examples/shaders/shaders_hybrid_render.c
+++ b/examples/shaders/shaders_hybrid_render.c
@@ -68,7 +68,7 @@ int main(void)
     marchLocs.screenCenter = GetShaderLocation(shdrRaymarch, "screenCenter");
 
     // Transfer screenCenter position to shader. Which is used to calculate ray direction. 
-    Vector2 screenCenter = {.x = screenWidth/2.0f, .y = screenHeight/2.0f};
+    Vector2 screenCenter = { screenWidth/2.0f, screenHeight/2.0f};
     SetShaderValue(shdrRaymarch, marchLocs.screenCenter , &screenCenter , SHADER_UNIFORM_VEC2);
 
     // Use Customized function to create writable depth texture buffer

--- a/examples/shaders/shaders_spotlight.c
+++ b/examples/shaders/shaders_spotlight.c
@@ -135,7 +135,7 @@ int main(void)
         spots[i].inner = 28.0f * (i + 1);
         spots[i].radius = 48.0f * (i + 1);
 
-        SetShaderValue(shdrSpot, spots[i].positionLoc, &spots[i].position.x, SHADER_UNIFORM_VEC2);
+        SetShaderValue(shdrSpot, spots[i].positionLoc, (float*)&spots[i].position, SHADER_UNIFORM_VEC2);
         SetShaderValue(shdrSpot, spots[i].innerLoc, &spots[i].inner, SHADER_UNIFORM_FLOAT);
         SetShaderValue(shdrSpot, spots[i].radiusLoc, &spots[i].radius, SHADER_UNIFORM_FLOAT);
     }
@@ -173,7 +173,7 @@ int main(void)
                 if (spots[i].position.y > (screenHeight - 64)) spots[i].speed.y = -spots[i].speed.y;
             }
 
-            SetShaderValue(shdrSpot, spots[i].positionLoc, &spots[i].position.x, SHADER_UNIFORM_VEC2);
+            SetShaderValue(shdrSpot, spots[i].positionLoc, (float*)&spots[i].position, SHADER_UNIFORM_VEC2);
         }
 
         // Draw

--- a/examples/shapes/raygui.h
+++ b/examples/shapes/raygui.h
@@ -3722,7 +3722,7 @@ int GuiColorPicker(Rectangle bounds, const char *text, Color *color)
     // NOTE: this conversion can cause low hue-resolution, if the r, g and b value are very similar, which causes the hue bar to shift around when only the GuiColorPanel is used.
     Vector3 hsv = ConvertRGBtoHSV(RAYGUI_CLITERAL(Vector3){ (*color).r/255.0f, (*color).g/255.0f, (*color).b/255.0f });
 
-    GuiColorBarHue(boundsHue, NULL, &hsv.x);
+    GuiColorBarHue(boundsHue, NULL, (float*)&hsv);
 
     //color.a = (unsigned char)(GuiColorBarAlpha(boundsAlpha, (float)color.a/255.0f)*255.0f);
     Vector3 rgb = ConvertHSVtoRGB(hsv);
@@ -3756,7 +3756,7 @@ int GuiColorPickerHSV(Rectangle bounds, const char *text, Vector3 *colorHsv)
 
     const Rectangle boundsHue = { (float)bounds.x + bounds.width + GuiGetStyle(COLORPICKER, HUEBAR_PADDING), (float)bounds.y, (float)GuiGetStyle(COLORPICKER, HUEBAR_WIDTH), (float)bounds.height };
 
-    GuiColorBarHue(boundsHue, NULL, &colorHsv->x);
+    GuiColorBarHue(boundsHue, NULL, (float*)&colorHsv);
 
     return result;
 }

--- a/src/platforms/rcore_desktop_glfw.c
+++ b/src/platforms/rcore_desktop_glfw.c
@@ -949,9 +949,10 @@ Vector2 GetWindowPosition(void)
 // Get window scale DPI factor for current monitor
 Vector2 GetWindowScaleDPI(void)
 {
-    Vector2 scale = {0};
-    glfwGetWindowContentScale(platform.handle, &scale.x, &scale.y);
-    return scale;
+    float x;
+    float y;
+    glfwGetWindowContentScale(platform.handle, &x, &y);
+    return (Vector2){ x, y };
 }
 
 // Set clipboard text content

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -212,35 +212,54 @@
 #endif
 
 // Vector2, 2 components
+#ifdef __clang__
+typedef float Vector2 __attribute__((ext_vector_type(2)));
+#else
 typedef struct Vector2 {
     float x;                // Vector x component
     float y;                // Vector y component
 } Vector2;
+#endif
 
 // Vector3, 3 components
+#ifdef __clang__
+typedef float Vector3 __attribute__((ext_vector_type(3)));
+#else
 typedef struct Vector3 {
     float x;                // Vector x component
     float y;                // Vector y component
     float z;                // Vector z component
 } Vector3;
+#endif
 
 // Vector4, 4 components
+#ifdef __clang__
+typedef float Vector4 __attribute__((ext_vector_type(4)));
+#else
 typedef struct Vector4 {
     float x;                // Vector x component
     float y;                // Vector y component
     float z;                // Vector z component
     float w;                // Vector w component
 } Vector4;
+#endif
 
 // Quaternion, 4 components (Vector4 alias)
 typedef Vector4 Quaternion;
 
 // Matrix, 4x4 components, column major, OpenGL style, right-handed
 typedef struct Matrix {
+union {
+struct {
     float m0, m4, m8, m12;  // Matrix first row (4 components)
     float m1, m5, m9, m13;  // Matrix second row (4 components)
     float m2, m6, m10, m14; // Matrix third row (4 components)
     float m3, m7, m11, m15; // Matrix fourth row (4 components)
+};
+struct {
+    Vector4 r0, r1, r2, r3; // Matrix rows (4 rows)
+};
+};
 } Matrix;
 
 // Color, 4 components, R8G8B8A8 (32bit)

--- a/src/raymath.hpp
+++ b/src/raymath.hpp
@@ -1,0 +1,403 @@
+/**********************************************************************************************
+*
+*   raymath v2.0 C++ operators - Math functions to work with Vector2, Vector3, Matrix and Quaternions
+*
+*   CONVENTIONS:
+*     - Matrix structure is defined as row-major (memory layout) but parameters naming AND all
+*       math operations performed by the library consider the structure as it was column-major
+*       It is like transposed versions of the matrices are used for all the maths
+*       It benefits some functions making them cache-friendly and also avoids matrix
+*       transpositions sometimes required by OpenGL
+*       Example: In memory order, row0 is [m0 m4 m8 m12] but in semantic math row0 is [m0 m1 m2 m3]
+*     - Functions are always self-contained, no function use another raymath function inside,
+*       required code is directly re-implemented inside
+*     - Functions input parameters are always received by value (2 unavoidable exceptions)
+*     - Functions use always a "result" variable for return (except C++ operators)
+*     - Functions are always defined inline
+*     - Angles are always in radians (DEG2RAD/RAD2DEG macros provided for convenience)
+*     - No compound literals used to make sure libray is compatible with C++
+*
+*   CONFIGURATION:
+*       #define RAYMATH_IMPLEMENTATION
+*           Generates the implementation of the library into the included file.
+*           If not defined, the library is in header only mode and can be included in other headers
+*           or source files without problems. But only ONE file should hold the implementation.
+*
+*       #define RAYMATH_STATIC_INLINE
+*           Define static inline functions code, so #include header suffices for use.
+*           This may use up lots of memory.
+*
+*       #define RAYMATH_DISABLE_CPP_OPERATORS
+*           Disables C++ operator overloads for raymath types.
+*
+*   LICENSE: zlib/libpng
+*
+*   Copyright (c) 2015-2024 Ramon Santamaria (@raysan5)
+*
+*   This software is provided "as-is", without any express or implied warranty. In no event
+*   will the authors be held liable for any damages arising from the use of this software.
+*
+*   Permission is granted to anyone to use this software for any purpose, including commercial
+*   applications, and to alter it and redistribute it freely, subject to the following restrictions:
+*
+*     1. The origin of this software must not be misrepresented; you must not claim that you
+*     wrote the original software. If you use this software in a product, an acknowledgment
+*     in the product documentation would be appreciated but is not required.
+*
+*     2. Altered source versions must be plainly marked as such, and must not be misrepresented
+*     as being the original software.
+*
+*     3. This notice may not be removed or altered from any source distribution.
+*
+**********************************************************************************************/
+
+#ifndef RAYMATH_HPP
+#define RAYMATH_HPP
+
+// Optional C++ math operators
+//-------------------------------------------------------------------------------
+
+// Vector2 operators
+static constexpr Vector2 Vector2Zeros = { 0, 0 };
+static constexpr Vector2 Vector2Ones = { 1, 1 };
+static constexpr Vector2 Vector2UnitX = { 1, 0 };
+static constexpr Vector2 Vector2UnitY = { 0, 1 };
+
+inline Vector2 operator + (const Vector2& lhs, const Vector2& rhs)
+{
+    return Vector2Add(lhs, rhs);
+}
+
+inline const Vector2& operator += (Vector2& lhs, const Vector2& rhs)
+{
+    lhs = Vector2Add(lhs, rhs);
+    return lhs;
+}
+
+inline Vector2 operator - (const Vector2& lhs, const Vector2& rhs)
+{
+    return Vector2Subtract(lhs, rhs);
+}
+
+inline const Vector2& operator -= (Vector2& lhs, const Vector2& rhs)
+{
+    lhs = Vector2Subtract(lhs, rhs);
+    return lhs;
+}
+
+inline Vector2 operator * (const Vector2& lhs, const float& rhs)
+{
+    return Vector2Scale(lhs, rhs);
+}
+
+inline const Vector2& operator *= (Vector2& lhs, const float& rhs)
+{
+    lhs = Vector2Scale(lhs, rhs);
+    return lhs;
+}
+
+inline Vector2 operator * (const Vector2& lhs, const Vector2& rhs)
+{
+    return Vector2Multiply(lhs, rhs);
+}
+
+inline const Vector2& operator *= (Vector2& lhs, const Vector2& rhs)
+{
+    lhs = Vector2Multiply(lhs, rhs);
+    return lhs;
+}
+
+inline Vector2 operator * (const Vector2& lhs, const Matrix& rhs)
+{
+    return Vector2Transform(lhs, rhs);
+}
+
+inline const Vector2& operator -= (Vector2& lhs, const Matrix& rhs)
+{
+    lhs = Vector2Transform(lhs, rhs);
+    return lhs;
+}
+
+inline Vector2 operator / (const Vector2& lhs, const float& rhs)
+{
+    return Vector2Scale(lhs, 1.0f / rhs);
+}
+
+inline const Vector2& operator /= (Vector2& lhs, const float& rhs)
+{
+    lhs = Vector2Scale(lhs, rhs);
+    return lhs;
+}
+
+inline Vector2 operator / (const Vector2& lhs, const Vector2& rhs)
+{
+    return Vector2Divide(lhs, rhs);
+}
+
+inline const Vector2& operator /= (Vector2& lhs, const Vector2& rhs)
+{
+    lhs = Vector2Divide(lhs, rhs);
+    return lhs;
+}
+
+inline bool operator == (const Vector2& lhs, const Vector2& rhs)
+{
+    return FloatEquals(lhs.x, rhs.x) && FloatEquals(lhs.y, rhs.y);
+}
+
+inline bool operator != (const Vector2& lhs, const Vector2& rhs)
+{
+    return !FloatEquals(lhs.x, rhs.x) || !FloatEquals(lhs.y, rhs.y);
+}
+
+// Vector3 operators
+static constexpr Vector3 Vector3Zeros = { 0, 0, 0 };
+static constexpr Vector3 Vector3Ones = { 1, 1, 1 };
+static constexpr Vector3 Vector3UnitX = { 1, 0, 0 };
+static constexpr Vector3 Vector3UnitY = { 0, 1, 0 };
+static constexpr Vector3 Vector3UnitZ = { 0, 0, 1 };
+
+inline Vector3 operator + (const Vector3& lhs, const Vector3& rhs)
+{
+    return Vector3Add(lhs, rhs);
+}
+
+inline const Vector3& operator += (Vector3& lhs, const Vector3& rhs)
+{
+    lhs = Vector3Add(lhs, rhs);
+    return lhs;
+}
+
+inline Vector3 operator - (const Vector3& lhs, const Vector3& rhs)
+{
+    return Vector3Subtract(lhs, rhs);
+}
+
+inline const Vector3& operator -= (Vector3& lhs, const Vector3& rhs)
+{
+    lhs = Vector3Subtract(lhs, rhs);
+    return lhs;
+}
+
+inline Vector3 operator * (const Vector3& lhs, const float& rhs)
+{
+    return Vector3Scale(lhs, rhs);
+}
+
+inline const Vector3& operator *= (Vector3& lhs, const float& rhs)
+{
+    lhs = Vector3Scale(lhs, rhs);
+    return lhs;
+}
+
+inline Vector3 operator * (const Vector3& lhs, const Vector3& rhs)
+{
+    return Vector3Multiply(lhs, rhs);
+}
+
+inline const Vector3& operator *= (Vector3& lhs, const Vector3& rhs)
+{
+    lhs = Vector3Multiply(lhs, rhs);
+    return lhs;
+}
+
+inline Vector3 operator * (const Vector3& lhs, const Matrix& rhs)
+{
+    return Vector3Transform(lhs, rhs);
+}
+
+inline const Vector3& operator -= (Vector3& lhs, const Matrix& rhs)
+{
+    lhs = Vector3Transform(lhs, rhs);
+    return lhs;
+}
+
+inline Vector3 operator / (const Vector3& lhs, const float& rhs)
+{
+    return Vector3Scale(lhs, 1.0f / rhs);
+}
+
+inline const Vector3& operator /= (Vector3& lhs, const float& rhs)
+{
+    lhs = Vector3Scale(lhs, rhs);
+    return lhs;
+}
+
+inline Vector3 operator / (const Vector3& lhs, const Vector3& rhs)
+{
+    return Vector3Divide(lhs, rhs);
+}
+
+inline const Vector3& operator /= (Vector3& lhs, const Vector3& rhs)
+{
+    lhs = Vector3Divide(lhs, rhs);
+    return lhs;
+}
+
+inline bool operator == (const Vector3& lhs, const Vector3& rhs)
+{
+    return FloatEquals(lhs.x, rhs.x) && FloatEquals(lhs.y, rhs.y) && FloatEquals(lhs.z, rhs.z);
+}
+
+inline bool operator != (const Vector3& lhs, const Vector3& rhs)
+{
+    return !FloatEquals(lhs.x, rhs.x) || !FloatEquals(lhs.y, rhs.y) || !FloatEquals(lhs.z, rhs.z);
+}
+
+// Vector4 operators
+static constexpr Vector4 Vector4Zeros = { 0, 0, 0, 0 };
+static constexpr Vector4 Vector4Ones = { 1, 1, 1, 1 };
+static constexpr Vector4 Vector4UnitX = { 1, 0, 0, 0 };
+static constexpr Vector4 Vector4UnitY = { 0, 1, 0, 0 };
+static constexpr Vector4 Vector4UnitZ = { 0, 0, 1, 0 };
+static constexpr Vector4 Vector4UnitW = { 0, 0, 0, 1 };
+
+inline Vector4 operator + (const Vector4& lhs, const Vector4& rhs)
+{
+    return Vector4Add(lhs, rhs);
+}
+
+inline const Vector4& operator += (Vector4& lhs, const Vector4& rhs)
+{
+    lhs = Vector4Add(lhs, rhs);
+    return lhs;
+}
+
+inline Vector4 operator - (const Vector4& lhs, const Vector4& rhs)
+{
+    return Vector4Subtract(lhs, rhs);
+}
+
+inline const Vector4& operator -= (Vector4& lhs, const Vector4& rhs)
+{
+    lhs = Vector4Subtract(lhs, rhs);
+    return lhs;
+}
+
+inline Vector4 operator * (const Vector4& lhs, const float& rhs)
+{
+    return Vector4Scale(lhs, rhs);
+}
+
+inline const Vector4& operator *= (Vector4& lhs, const float& rhs)
+{
+    lhs = Vector4Scale(lhs, rhs);
+    return lhs;
+}
+
+inline Vector4 operator * (const Vector4& lhs, const Vector4& rhs)
+{
+    return Vector4Multiply(lhs, rhs);
+}
+
+inline const Vector4& operator *= (Vector4& lhs, const Vector4& rhs)
+{
+    lhs = Vector4Multiply(lhs, rhs);
+    return lhs;
+}
+
+inline Vector4 operator / (const Vector4& lhs, const float& rhs)
+{
+    return Vector4Scale(lhs, 1.0f / rhs);
+}
+
+inline const Vector4& operator /= (Vector4& lhs, const float& rhs)
+{
+    lhs = Vector4Scale(lhs, rhs);
+    return lhs;
+}
+
+inline Vector4 operator / (const Vector4& lhs, const Vector4& rhs)
+{
+    return Vector4Divide(lhs, rhs);
+}
+
+inline const Vector4& operator /= (Vector4& lhs, const Vector4& rhs)
+{
+    lhs = Vector4Divide(lhs, rhs);
+    return lhs;
+}
+
+inline bool operator == (const Vector4& lhs, const Vector4& rhs)
+{
+    return FloatEquals(lhs.x, rhs.x) && FloatEquals(lhs.y, rhs.y) && FloatEquals(lhs.z, rhs.z) && FloatEquals(lhs.w, rhs.w);
+}
+
+inline bool operator != (const Vector4& lhs, const Vector4& rhs)
+{
+    return !FloatEquals(lhs.x, rhs.x) || !FloatEquals(lhs.y, rhs.y) || !FloatEquals(lhs.z, rhs.z) || !FloatEquals(lhs.w, rhs.w);
+}
+
+// Quaternion operators
+static constexpr Quaternion QuaternionZeros = { 0, 0, 0, 0 };
+static constexpr Quaternion QuaternionOnes = { 1, 1, 1, 1 };
+static constexpr Quaternion QuaternionUnitX = { 0, 0, 0, 1 };
+
+inline Quaternion operator + (const Quaternion& lhs, const float& rhs)
+{
+    return QuaternionAddValue(lhs, rhs);
+}
+
+inline const Quaternion& operator += (Quaternion& lhs, const float& rhs)
+{
+    lhs = QuaternionAddValue(lhs, rhs);
+    return lhs;
+}
+
+inline Quaternion operator - (const Quaternion& lhs, const float& rhs)
+{
+    return QuaternionSubtractValue(lhs, rhs);
+}
+
+inline const Quaternion& operator -= (Quaternion& lhs, const float& rhs)
+{
+    lhs = QuaternionSubtractValue(lhs, rhs);
+    return lhs;
+}
+
+inline Quaternion operator * (const Quaternion& lhs, const Matrix& rhs)
+{
+    return QuaternionTransform(lhs, rhs);
+}
+
+inline const Quaternion& operator *= (Quaternion& lhs, const Matrix& rhs)
+{
+    lhs = QuaternionTransform(lhs, rhs);
+    return lhs;
+}
+
+// Matrix operators
+inline Matrix operator + (const Matrix& lhs, const Matrix& rhs)
+{
+    return MatrixAdd(lhs, rhs);
+}
+
+inline const Matrix& operator += (Matrix& lhs, const Matrix& rhs)
+{
+    lhs = MatrixAdd(lhs, rhs);
+    return lhs;
+}
+
+inline Matrix operator - (const Matrix& lhs, const Matrix& rhs)
+{
+    return MatrixSubtract(lhs, rhs);
+}
+
+inline const Matrix& operator -= (Matrix& lhs, const Matrix& rhs)
+{
+    lhs = MatrixSubtract(lhs, rhs);
+    return lhs;
+}
+
+inline Matrix operator * (const Matrix& lhs, const Matrix& rhs)
+{
+    return MatrixMultiply(lhs, rhs);
+}
+
+inline const Matrix& operator *= (Matrix& lhs, const Matrix& rhs)
+{
+    lhs = MatrixMultiply(lhs, rhs);
+    return lhs;
+}
+//-------------------------------------------------------------------------------
+#endif RAYMATH_HPP

--- a/src/rcamera.h
+++ b/src/rcamera.h
@@ -77,26 +77,65 @@
 // NOTE: Below types are required for standalone usage
 //----------------------------------------------------------------------------------
 #if defined(RCAMERA_STANDALONE)
-    // Vector2, 2 components
+    #if !defined(RL_VECTOR2_TYPE)
+    // Vector2 type
+    #ifdef __clang__
+    typedef float Vector2 __attribute__((ext_vector_type(2)));
+    #else
     typedef struct Vector2 {
-        float x;                // Vector x component
-        float y;                // Vector y component
+        float x;
+        float y;
     } Vector2;
+    #endif
+    #define RL_VECTOR2_TYPE
+    #endif
 
-    // Vector3, 3 components
+    #if !defined(RL_VECTOR3_TYPE)
+    // Vector3 type
+    #ifdef __clang__
+    typedef float Vector3 __attribute__((ext_vector_type(3)));
+    #else
     typedef struct Vector3 {
-        float x;                // Vector x component
-        float y;                // Vector y component
-        float z;                // Vector z component
+        float x;
+        float y;
+        float z;
     } Vector3;
+    #endif
+    #define RL_VECTOR3_TYPE
+    #endif
 
+    #if !defined(RL_VECTOR4_TYPE)
+    // Vector4 type
+    #ifdef __clang__
+    typedef float Vector4 __attribute__((ext_vector_type(4)));
+    #else
+    typedef struct Vector4 {
+        float x;
+        float y;
+        float z;
+        float w;
+    } Vector4;
+    #endif
+    #define RL_VECTOR4_TYPE
+    #endif
+
+    #if !defined(RL_MATRIX_TYPE)
     // Matrix, 4x4 components, column major, OpenGL style, right-handed
     typedef struct Matrix {
+    union {
+    struct {
         float m0, m4, m8, m12;  // Matrix first row (4 components)
         float m1, m5, m9, m13;  // Matrix second row (4 components)
         float m2, m6, m10, m14; // Matrix third row (4 components)
         float m3, m7, m11, m15; // Matrix fourth row (4 components)
+    };
+    struct {
+        Vector4 r0, r1, r2, r3; // Matrix rows (4 rows)
+    };
+    };
     } Matrix;
+    #define RL_MATRIX_TYPE
+    #endif
 
     // Camera type, defines a camera position/orientation in 3d space
     typedef struct Camera3D {

--- a/src/rlgl.h
+++ b/src/rlgl.h
@@ -366,13 +366,35 @@
 typedef enum bool { false = 0, true = !false } bool;
 #endif
 
+#if !defined(RL_VECTOR4_TYPE)
+// Vector4 type
+#ifdef __clang__
+typedef float Vector4 __attribute__((ext_vector_type(4)));
+#else
+typedef struct Vector4 {
+    float x;
+    float y;
+    float z;
+    float w;
+} Vector4;
+#endif
+#define RL_VECTOR4_TYPE
+#endif
+
 #if !defined(RL_MATRIX_TYPE)
-// Matrix, 4x4 components, column major, OpenGL style, right handed
+// Matrix type (OpenGL style 4x4 - right handed, column major)
 typedef struct Matrix {
-    float m0, m4, m8, m12;      // Matrix first row (4 components)
-    float m1, m5, m9, m13;      // Matrix second row (4 components)
-    float m2, m6, m10, m14;     // Matrix third row (4 components)
-    float m3, m7, m11, m15;     // Matrix fourth row (4 components)
+union {
+struct {
+    float m0, m4, m8, m12;  // Matrix first row (4 components)
+    float m1, m5, m9, m13;  // Matrix second row (4 components)
+    float m2, m6, m10, m14; // Matrix third row (4 components)
+    float m3, m7, m11, m15; // Matrix fourth row (4 components)
+};
+struct {
+    Vector4 r0, r1, r2, r3; // Matrix rows (4 rows)
+};
+};
 } Matrix;
 #define RL_MATRIX_TYPE
 #endif


### PR DESCRIPTION
**Changes**
- Restructure Raymath and simplify most of the code to use already existing inline functions without changing the exposed interface
- Add minor missing Vector/Quaternion functions
- silence example type cast warning
- add Vector4.r0-Vector4.r3 rows to matrix type
- use vector type definitions with ext_vector_type if CMAKE_C_COMPILER=clang
- minor fixes for examples see **Possible conflicts**
- move C++ operators to raymath.hpp

**Test/Examples**
- Every example included runs without a flaw adapted to vector extensions

**Possible conflicts**
- Vector3 storage size change from 12 to 16 bytes
- initializer list .= element not working for ext_vector_type
- address of vector element

**Notes**
I am sorry to open another PR after the earlier closed #4473 that should solve all of the concerns with the one before.
How do I benchmark the changes with examples? Do I have to disable GLFW vsync in texture_bunnymark or is there another existing benchmark program?
Please don't just reject and close it without reading the code.