### PR TITLE
Fixing an OBJ loader bug that fragmented the loaded meshes

### DIFF
--- a/src/rmodels.c
+++ b/src/rmodels.c
@@ -4244,7 +4244,7 @@ static Model LoadOBJ(const char *fileName)
     // walk all the faces
     for (unsigned int faceId = 0; faceId < objAttributes.num_faces; faceId++)
     {
-        if (faceVertIndex >= nextShapeEnd)
+        if (faceId >= nextShapeEnd)
         {
             // try to find the last vert in the next shape
             nextShape++;
@@ -4295,7 +4295,7 @@ static Model LoadOBJ(const char *fileName)
     for (unsigned int faceId = 0; faceId < objAttributes.num_faces; faceId++)
     {
         bool newMesh = false; // do we need a new mesh?
-        if (faceVertIndex >= nextShapeEnd)
+        if (faceId >= nextShapeEnd)
         {
             // try to find the last vert in the next shape
             nextShape++;
@@ -4357,7 +4357,7 @@ static Model LoadOBJ(const char *fileName)
     for (unsigned int faceId = 0; faceId < objAttributes.num_faces; faceId++)
     {
         bool newMesh = false; // do we need a new mesh?
-        if (faceVertIndex >= nextShapeEnd)
+        if (faceId >= nextShapeEnd)
         {
             // try to find the last vert in the next shape
             nextShape++;


### PR DESCRIPTION
The nextShapeEnd integer is a pointer in the OBJ data structures. The faceVertIndex is a vertex index counter for the mesh we are about to create. Both integers are not compatible, which causes the code to finish the meshes too early, thus writing the OBJ data incompletely into the target meshes.

It wasn't noticed because for the last mesh, it process all remaining data, causing the last mesh to contain all remaining triangles.

This would have been noticed if the OBJ meshes used different textures for each mesh.

![mesh-debugging](https://github.com/user-attachments/assets/0f782efc-40ab-4359-8335-3f2d077d90b7)
