### PR TITLE
Fixed grammar mistakes in core_3d_camera_first_person.c

### DIFF
--- a/examples/core/core_3d_camera_first_person.c
+++ b/examples/core/core_3d_camera_first_person.c
@@ -115,7 +115,7 @@ int main(void)
 
         // Update camera computes movement internally depending on the camera mode
         // Some default standard keyboard/mouse inputs are hardcoded to simplify use
-        // For advance camera controls, it's reecommended to compute camera movement manually
+        // For advanced camera controls, it's recommended to compute camera movement manually
         UpdateCamera(&camera, cameraMode);                  // Update camera
 
 /*


### PR DESCRIPTION
Changed line 118 from, "// For advance camera controls, it's reecommended to compute camera movement manually", to, "// For advanced camera controls, it's recommended to compute camera movement manually".