### PR TITLE
Update BINDINGS.md: raylib-python-cffi is on v5.0

### DIFF
--- a/BINDINGS.md
+++ b/BINDINGS.md
@@ -54,7 +54,7 @@ Some people ported raylib to other languages in the form of bindings or wrappers
 | [Ray4Laz](https://github.com/GuvaCode/Ray4Laz)                                           | **5.5**          | [Free Pascal](https://en.wikipedia.org/wiki/Free_Pascal)             | Zlib                 |
 | [Raylib.4.0.Pascal](https://github.com/sysrpl/Raylib.4.0.Pascal)                         | 4.0              | [Free Pascal](https://en.wikipedia.org/wiki/Free_Pascal)             | Zlib                 |
 | [pyraylib](https://github.com/Ho011/pyraylib)                                            | 3.7              | [Python](https://www.python.org)                                     | Zlib                 |
-| [raylib-python-cffi](https://github.com/electronstudio/raylib-python-cffi)               | 4.2              | [Python](https://www.python.org)                                     | EPL-2.0              |
+| [raylib-python-cffi](https://github.com/electronstudio/raylib-python-cffi)               | 5.0              | [Python](https://www.python.org)                                     | EPL-2.0              |
 | [raylibpyctbg](https://github.com/overdev/raylibpyctbg)                                  | 4.5              | [Python](https://www.python.org)                                     | MIT                  |
 | [raylib-py](https://github.com/overdev/raylib-py)                                        | **5.0b1**        | [Python](https://www.python.org)                                     | MIT                  |
 | [raylib-python-ctypes](https://github.com/sDos280/raylib-python-ctypes)                  | 4.6-dev          | [Python](https://www.python.org)                                     | MIT                  |


### PR DESCRIPTION
According to https://github.com/electronstudio/raylib-python-cffi