### PR TITLE
[rcore] Add `GetMonitorScale()`

### DIFF
--- a/src/platforms/rcore_android.c
+++ b/src/platforms/rcore_android.c
@@ -480,6 +480,13 @@ int GetMonitorRefreshRate(int monitor)
     return 0;
 }
 
+// Get specified monitor scale
+Vector2 GetMonitorScale(int monitor)
+{
+    TRACELOG(LOG_WARNING, "GetMonitorScale() not implemented on target platform");
+    return 0;
+}
+
 // Get the human-readable, UTF-8 encoded name of the selected monitor
 const char *GetMonitorName(int monitor)
 {

--- a/src/platforms/rcore_android.c
+++ b/src/platforms/rcore_android.c
@@ -484,7 +484,7 @@ int GetMonitorRefreshRate(int monitor)
 Vector2 GetMonitorScale(int monitor)
 {
     TRACELOG(LOG_WARNING, "GetMonitorScale() not implemented on target platform");
-    return 0;
+    return (Vector2){ 1.0f, 1.0f };
 }
 
 // Get the human-readable, UTF-8 encoded name of the selected monitor

--- a/src/platforms/rcore_desktop_glfw.c
+++ b/src/platforms/rcore_desktop_glfw.c
@@ -921,6 +921,19 @@ int GetMonitorRefreshRate(int monitor)
     return refresh;
 }
 
+// Get specified monitor scale
+Vector2 GetMonitorScale(int monitor)
+{
+    Vector2 scale = { 1.0f, 1.0f };
+    int monitorCount = 0;
+    GLFWmonitor **monitors = glfwGetMonitors(&monitorCount);
+
+    if ((monitor >= 0) && (monitor < monitorCount)) glfwGetMonitorContentScale(monitors[monitor], &scale.x, &scale.y);
+    else TRACELOG(LOG_WARNING, "GLFW: Failed to find selected monitor");
+
+    return scale;
+}
+
 // Get the human-readable, UTF-8 encoded name of the selected monitor
 const char *GetMonitorName(int monitor)
 {

--- a/src/platforms/rcore_desktop_rgfw.c
+++ b/src/platforms/rcore_desktop_rgfw.c
@@ -633,7 +633,7 @@ int GetMonitorRefreshRate(int monitor)
 Vector2 GetMonitorScale(int monitor)
 {
     TRACELOG(LOG_WARNING, "GetMonitorScale() not implemented on target platform");
-    return 0;
+    return (Vector2){ 1.0f, 1.0f };
 }
 
 // Get the human-readable, UTF-8 encoded name of the selected monitor

--- a/src/platforms/rcore_desktop_rgfw.c
+++ b/src/platforms/rcore_desktop_rgfw.c
@@ -629,6 +629,13 @@ int GetMonitorRefreshRate(int monitor)
     return 0;
 }
 
+// Get specified monitor scale
+Vector2 GetMonitorScale(int monitor)
+{
+    TRACELOG(LOG_WARNING, "GetMonitorScale() not implemented on target platform");
+    return 0;
+}
+
 // Get the human-readable, UTF-8 encoded name of the selected monitor
 const char *GetMonitorName(int monitor)
 {

--- a/src/platforms/rcore_desktop_sdl.c
+++ b/src/platforms/rcore_desktop_sdl.c
@@ -1036,6 +1036,13 @@ int GetMonitorRefreshRate(int monitor)
     return refresh;
 }
 
+// Get specified monitor scale
+Vector2 GetMonitorScale(int monitor)
+{
+    TRACELOG(LOG_WARNING, "GetMonitorScale() not implemented on target platform");
+    return 0;
+}
+
 // Get the human-readable, UTF-8 encoded name of the selected monitor
 const char *GetMonitorName(int monitor)
 {

--- a/src/platforms/rcore_desktop_sdl.c
+++ b/src/platforms/rcore_desktop_sdl.c
@@ -1040,7 +1040,7 @@ int GetMonitorRefreshRate(int monitor)
 Vector2 GetMonitorScale(int monitor)
 {
     TRACELOG(LOG_WARNING, "GetMonitorScale() not implemented on target platform");
-    return 0;
+    return (Vector2){ 1.0f, 1.0f };
 }
 
 // Get the human-readable, UTF-8 encoded name of the selected monitor

--- a/src/platforms/rcore_drm.c
+++ b/src/platforms/rcore_drm.c
@@ -466,6 +466,13 @@ int GetMonitorRefreshRate(int monitor)
     return refresh;
 }
 
+// Get specified monitor scale
+Vector2 GetMonitorScale(int monitor)
+{
+    TRACELOG(LOG_WARNING, "GetMonitorScale() not implemented on target platform");
+    return 0;
+}
+
 // Get the human-readable, UTF-8 encoded name of the selected monitor
 const char *GetMonitorName(int monitor)
 {

--- a/src/platforms/rcore_drm.c
+++ b/src/platforms/rcore_drm.c
@@ -470,7 +470,7 @@ int GetMonitorRefreshRate(int monitor)
 Vector2 GetMonitorScale(int monitor)
 {
     TRACELOG(LOG_WARNING, "GetMonitorScale() not implemented on target platform");
-    return 0;
+    return (Vector2){ 1.0f, 1.0f };
 }
 
 // Get the human-readable, UTF-8 encoded name of the selected monitor

--- a/src/platforms/rcore_template.c
+++ b/src/platforms/rcore_template.c
@@ -257,6 +257,13 @@ int GetMonitorRefreshRate(int monitor)
     return 0;
 }
 
+// Get specified monitor scale
+Vector2 GetMonitorScale(int monitor)
+{
+    TRACELOG(LOG_WARNING, "GetMonitorScale() not implemented on target platform");
+    return 0;
+}
+
 // Get the human-readable, UTF-8 encoded name of the selected monitor
 const char *GetMonitorName(int monitor)
 {

--- a/src/platforms/rcore_template.c
+++ b/src/platforms/rcore_template.c
@@ -261,7 +261,7 @@ int GetMonitorRefreshRate(int monitor)
 Vector2 GetMonitorScale(int monitor)
 {
     TRACELOG(LOG_WARNING, "GetMonitorScale() not implemented on target platform");
-    return 0;
+    return (Vector2){ 1.0f, 1.0f };
 }
 
 // Get the human-readable, UTF-8 encoded name of the selected monitor

--- a/src/platforms/rcore_web.c
+++ b/src/platforms/rcore_web.c
@@ -751,6 +751,13 @@ int GetMonitorRefreshRate(int monitor)
     return 0;
 }
 
+// Get specified monitor scale
+Vector2 GetMonitorScale(int monitor)
+{
+    TRACELOG(LOG_WARNING, "GetMonitorScale() not implemented on target platform");
+    return 0;
+}
+
 // Get the human-readable, UTF-8 encoded name of the selected monitor
 const char *GetMonitorName(int monitor)
 {

--- a/src/platforms/rcore_web.c
+++ b/src/platforms/rcore_web.c
@@ -755,7 +755,7 @@ int GetMonitorRefreshRate(int monitor)
 Vector2 GetMonitorScale(int monitor)
 {
     TRACELOG(LOG_WARNING, "GetMonitorScale() not implemented on target platform");
-    return 0;
+    return (Vector2){ 1.0f, 1.0f };
 }
 
 // Get the human-readable, UTF-8 encoded name of the selected monitor

--- a/src/platforms/rcore_web.c
+++ b/src/platforms/rcore_web.c
@@ -754,8 +754,11 @@ int GetMonitorRefreshRate(int monitor)
 // Get specified monitor scale
 Vector2 GetMonitorScale(int monitor)
 {
-    TRACELOG(LOG_WARNING, "GetMonitorScale() not implemented on target platform");
-    return (Vector2){ 1.0f, 1.0f };
+    // NOTE: Returned scale is relative to the current monitor where the browser window is located
+    Vector2 scale = { 1.0f, 1.0f };
+    scale.x = (float)EM_ASM_DOUBLE( { return window.devicePixelRatio; } );
+    scale.y = scale.x;
+    return scale;
 }
 
 // Get the human-readable, UTF-8 encoded name of the selected monitor

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1006,6 +1006,7 @@ RLAPI int GetMonitorHeight(int monitor);                          // Get specifi
 RLAPI int GetMonitorPhysicalWidth(int monitor);                   // Get specified monitor physical width in millimetres
 RLAPI int GetMonitorPhysicalHeight(int monitor);                  // Get specified monitor physical height in millimetres
 RLAPI int GetMonitorRefreshRate(int monitor);                     // Get specified monitor refresh rate
+RLAPI Vector2 GetMonitorScale(int monitor);                       // Get specified monitor scale
 RLAPI Vector2 GetWindowPosition(void);                            // Get window position XY on monitor
 RLAPI Vector2 GetWindowScaleDPI(void);                            // Get window scale DPI factor
 RLAPI const char *GetMonitorName(int monitor);                    // Get the human-readable, UTF-8 encoded name of the specified monitor


### PR DESCRIPTION
Ref: #4522

Necessary to allow the user to factor in arbitrary user defined/applied monitor scales ([GLFW ref](https://www.glfw.org/docs/3.3/group__monitor.html#gad3152e84465fa620b601265ebfcdb21b), [SDL3 ref](https://wiki.libsdl.org/SDL3/SDL_GetDisplayContentScale), [Web ref](https://developer.mozilla.org/en-US/docs/Web/API/Window/devicePixelRatio)).
Note: this is different from `GetWindowScaleDPI` ([GLFW ref](https://www.glfw.org/docs/3.3/group__window.html#gaf5d31de9c19c4f994facea64d2b3106c), [SDL3 ref](https://wiki.libsdl.org/SDL3/SDL_GetWindowDisplayScale)).
The PR can be tested with:
```
#include "raylib.h"
int main(void) {
    InitWindow(800, 450, "test");
    SetTargetFPS(60);
    while (!WindowShouldClose()) {

        const Vector2 monitorScale = GetMonitorScale(GetCurrentMonitor());

        BeginDrawing();
        ClearBackground(RAYWHITE);
        DrawText(TextFormat("monitor scale %fx%f", monitorScale.x, monitorScale.y), 20, 20, 20, BLACK);
        EndDrawing();
    }
    CloseWindow();
    return 0;
}
```