### PR TITLE
[rcore] [web] Add implementation to `GetWindowScaleDPI()` for `PLATFORM_WEB`

### DIFF
--- a/src/platforms/rcore_web.c
+++ b/src/platforms/rcore_web.c
@@ -771,8 +771,11 @@ Vector2 GetWindowPosition(void)
 // Get window scale DPI factor for current monitor
 Vector2 GetWindowScaleDPI(void)
 {
-    TRACELOG(LOG_WARNING, "GetWindowScaleDPI() not implemented on target platform");
-    return (Vector2){ 1.0f, 1.0f };
+    // NOTE: Returned scale is relative to the current monitor where the browser window is located
+    Vector2 scale = { 1.0f, 1.0f };
+    scale.x = (float)EM_ASM_DOUBLE( { return window.devicePixelRatio; } );
+    scale.y = scale.x;
+    return scale;
 }
 
 // Set clipboard text content


### PR DESCRIPTION
Ref: [doc](https://developer.mozilla.org/en-US/docs/Web/API/Window/devicePixelRatio), #4525. The PR can be tested with:

```
#include "raylib.h"
int main(void) {
    InitWindow(800, 450, "test");
    SetTargetFPS(60);
    while (!WindowShouldClose()) {

        const Vector2 scale = GetWindowScaleDPI();

        BeginDrawing();
        ClearBackground(RAYWHITE);
        DrawText(TextFormat("scale %fx%f", scale.x, scale.y), 20, 20, 20, BLACK);
        EndDrawing();
    }
    CloseWindow();
    return 0;
}
```