### PR TITLE
[raudio] Fixed buffer overflow when loading WAV files

### DIFF
--- a/src/raudio.c
+++ b/src/raudio.c
@@ -801,10 +801,10 @@ Wave LoadWaveFromMemory(const char *fileType, const unsigned char *fileData, int
             wave.sampleRate = wav.sampleRate;
             wave.sampleSize = 16;
             wave.channels = wav.channels;
-            wave.data = (short *)RL_MALLOC(wave.frameCount*wave.channels*sizeof(short));
+            wave.data = (short *)RL_MALLOC((size_t)wave.frameCount*wave.channels*sizeof(short));
 
             // NOTE: We are forcing conversion to 16bit sample size on reading
-            drwav_read_pcm_frames_s16(&wav, wav.totalPCMFrameCount, wave.data);
+            drwav_read_pcm_frames_s16(&wav, wave.frameCount, wave.data);
         }
         else TRACELOG(LOG_WARNING, "WAVE: Failed to load WAV data");
 


### PR DESCRIPTION
This PR fixes a heap buffer overflow in raudio that can be triggered by a WAV file with a very large frame count. This is the result of two separate issues. The first is an integer overflow in the call to malloc since the unsigned integer can be overflowed when multiplied by the maximum number of channels (256). The second is using the 64-bit value for frame count even though it is cast to an unsigned int when allocating the buffer.

To fix this, I cast the frame count to a size_t in the malloc call, and I used 32-bit value for the number of frames to be written to the buffer. I recognize that issues like these aren't critical since the assets are almost always trusted, but it is nice to fix in case anyone wants to incorporate user-generated content into their game.