### PR TITLE
GetKeyName prototype

### DIFF
--- a/projects/Notepad++/raylib_npp_parser/raylib_to_parse.h
+++ b/projects/Notepad++/raylib_npp_parser/raylib_to_parse.h
@@ -216,6 +216,7 @@ RLAPI bool IsKeyUp(int key);                                  // Check if a key 
 RLAPI int GetKeyPressed(void);                                // Get key pressed (keycode), call it multiple times for keys queued, returns 0 when the queue is empty
 RLAPI int GetCharPressed(void);                               // Get char pressed (unicode), call it multiple times for chars queued, returns 0 when the queue is empty
 RLAPI void SetExitKey(int key);                               // Set a custom key to exit program (default is ESC)
+RLAPI const char *GetKeyName(int key);                        // Get name of a QWERTY key on the current keyboard layout (eg returns string "q" for KEY_A on an AZERTY keyboard)
 
 // Input-related functions: gamepads
 RLAPI bool IsGamepadAvailable(int gamepad);                                        // Check if a gamepad is available

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1178,6 +1178,7 @@ RLAPI bool IsKeyUp(int key);                                  // Check if a key 
 RLAPI int GetKeyPressed(void);                                // Get key pressed (keycode), call it multiple times for keys queued, returns 0 when the queue is empty
 RLAPI int GetCharPressed(void);                               // Get char pressed (unicode), call it multiple times for chars queued, returns 0 when the queue is empty
 RLAPI void SetExitKey(int key);                               // Set a custom key to exit program (default is ESC)
+RLAPI const char *GetKeyName(int key);                        // Get name of a QWERTY key on the current keyboard layout (eg returns string "q" for KEY_A on an AZERTY keyboard)
 
 // Input-related functions: gamepads
 RLAPI bool IsGamepadAvailable(int gamepad);                                        // Check if a gamepad is available


### PR DESCRIPTION
Further fixing this issue: [#4019](https://github.com/raysan5/raylib/issues/4019)
(Because implementation [#4161](https://github.com/raysan5/raylib/pull/4161) lacked a prototype)

See [my lengthier comment over there](https://github.com/raysan5/raylib/issues/4019#issuecomment-2503846566).