### PR TITLE
[build] CMake: Set minimum CMake version to 3.12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.12)
 project(raylib)
 
 # Avoid excessive expansion of variables in conditionals. In particular, if


### PR DESCRIPTION
This PR fixes two issues regarding CMakeLists.txt:

1. Compatibility with future versions of CMake: Compatibility with CMake version < 3.10 will be removed from a future version of CMake. Calls to [cmake_minimum_required(VERSION)](https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html#command:cmake_minimum_required) that do not specify at least 3.10 as their policy version will produce a **deprecation warning** in CMake 3.31 and above.

2. **Build failure** with CMake < 3.12: Building raylib with the previously specified minimum CMake version of 3.5 **fails** because [cmake/ParseConfigHeader.cmake](https://github.com/raysan5/raylib/blob/c53dd8a9310ad34f730ea853478dc77c8caff23d/cmake/ParseConfigHeader.cmake#L12) uses `list(TRANSFORM...` which was [introduced](https://cmake.org/cmake/help/latest/command/list.html#transform) in version 3.12.

Therefore, this PR sets the minimum required CMake version to 3.12 (released in 2018).

I tested this change with several CMake versions:
- In 3.5, 3.6, and 3.11, the build previously failed with multiple errors. It now produces a clear and friendly message "CMake 3.12 or higher is required.  You are running version 3.5.0".
- In 3.12 and 3.31, the build succeeds as expected.