### PR TITLE
[RCORE] Make some config defines settable by build systems

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -43,29 +43,42 @@
 //------------------------------------------------------------------------------------
 // Camera module is included (rcamera.h) and multiple predefined cameras are available: free, 1st/3rd person, orbital
 #define SUPPORT_CAMERA_SYSTEM           1
+
 // Gestures module is included (rgestures.h) to support gestures detection: tap, hold, swipe, drag
 #define SUPPORT_GESTURES_SYSTEM         1
+
 // Include pseudo-random numbers generator (rprand.h), based on Xoshiro128** and SplitMix64
 #define SUPPORT_RPRAND_GENERATOR        1
+
 // Mouse gestures are directly mapped like touches and processed by gestures system
 #define SUPPORT_MOUSE_GESTURES          1
+
 // Reconfigure standard input to receive key inputs, works with SSH connection.
 #define SUPPORT_SSH_KEYBOARD_RPI        1
-// Setting a higher resolution can improve the accuracy of time-out intervals in wait functions.
+
+// The higher resolution can improve the accuracy of time-out intervals in wait functions.
 // However, it can also reduce overall system performance, because the thread scheduler switches tasks more often.
-#define SUPPORT_WINMM_HIGHRES_TIMER     1
+// You can disable this timer if needed using this define
+//#define DISABLE_WINMM_HIGHRES_TIMER     1
+
 // Use busy wait loop for timing sync, if not defined, a high-resolution timer is set up and used
 //#define SUPPORT_BUSY_WAIT_LOOP          1
+
 // Use a partial-busy wait loop, in this case frame sleeps for most of the time, but then runs a busy loop at the end for accuracy
 #define SUPPORT_PARTIALBUSY_WAIT_LOOP    1
-// Allow automatic screen capture of current screen pressing F12, defined in KeyCallback()
-#define SUPPORT_SCREEN_CAPTURE          1
-// Allow automatic gif recording of current screen pressing CTRL+F12, defined in KeyCallback()
-#define SUPPORT_GIF_RECORDING           1
+
+// Disable automatic screen capture of current screen pressing F12, defined in KeyCallback()
+#//define DISABLE_SCREEN_CAPTURE          1
+
+// Disable automatic gif recording of current screen pressing CTRL+F12, defined in KeyCallback()
+//#define  DISABLE_GIF_RECORDING           1
+
 // Support CompressData() and DecompressData() functions
 #define SUPPORT_COMPRESSION_API         1
+
 // Support automatic generated events, loading and recording of those events when required
 #define SUPPORT_AUTOMATION_EVENTS       1
+
 // Support custom frame control, only for advanced users
 // By default EndDrawing() does this job: draws everything + SwapScreenBuffer() + manage frame timing + PollInputEvents()
 // Enabling this flag allows manual control of the frame processes, use at your own risk

--- a/src/platforms/rcore_desktop_glfw.c
+++ b/src/platforms/rcore_desktop_glfw.c
@@ -64,7 +64,7 @@
     #define GLFW_NATIVE_INCLUDE_NONE // To avoid some symbols re-definition in windows.h
     #include "GLFW/glfw3native.h"
 
-    #if defined(SUPPORT_WINMM_HIGHRES_TIMER) && !defined(SUPPORT_BUSY_WAIT_LOOP)
+    #if !defined(DISABLE_WINMM_HIGHRES_TIMER) && !defined(SUPPORT_BUSY_WAIT_LOOP)
         // NOTE: Those functions require linking with winmm library
         //#pragma warning(disable: 4273)
         __declspec(dllimport) unsigned int __stdcall timeEndPeriod(unsigned int uPeriod);
@@ -1693,7 +1693,7 @@ void ClosePlatform(void)
     glfwDestroyWindow(platform.handle);
     glfwTerminate();
 
-#if defined(_WIN32) && defined(SUPPORT_WINMM_HIGHRES_TIMER) && !defined(SUPPORT_BUSY_WAIT_LOOP)
+#if defined(_WIN32) && !defined(DISABLE_WINMM_HIGHRES_TIMER) && !defined(SUPPORT_BUSY_WAIT_LOOP)
     timeEndPeriod(1);           // Restore time period
 #endif
 }

--- a/src/platforms/rcore_desktop_sdl.c
+++ b/src/platforms/rcore_desktop_sdl.c
@@ -1939,7 +1939,7 @@ int InitPlatform(void)
     // NOTE: No need to call InitTimer(), let SDL manage it internally
     CORE.Time.previous = GetTime();     // Get time as double
 
-    #if defined(_WIN32) && defined(SUPPORT_WINMM_HIGHRES_TIMER) && !defined(SUPPORT_BUSY_WAIT_LOOP)
+    #if defined(_WIN32) && !defined(DISABLE_WINMM_HIGHRES_TIMER) && !defined(SUPPORT_BUSY_WAIT_LOOP)
     SDL_SetHint(SDL_HINT_TIMER_RESOLUTION, "1"); // SDL equivalent of timeBeginPeriod() and timeEndPeriod()
     #endif
     //----------------------------------------------------------------------------

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -41,11 +41,11 @@
 *       #define SUPPORT_PARTIALBUSY_WAIT_LOOP
 *           Use a partial-busy wait loop, in this case frame sleeps for most of the time and runs a busy-wait-loop at the end
 *
-*       #define SUPPORT_SCREEN_CAPTURE
-*           Allow automatic screen capture of current screen pressing F12, defined in KeyCallback()
+*       #define DISABLE_SCREEN_CAPTURE
+*           Disable automatic screen capture of current screen pressing F12, defined in KeyCallback()
 *
-*       #define SUPPORT_GIF_RECORDING
-*           Allow automatic gif recording of current screen pressing CTRL+F12, defined in KeyCallback()
+*       #define DISABLE_GIF_RECORDING
+*           Disable automatic gif recording of current screen pressing CTRL+F12, defined in KeyCallback()
 *
 *       #define SUPPORT_COMPRESSION_API
 *           Support CompressData() and DecompressData() functions, those functions use zlib implementation
@@ -126,7 +126,7 @@
     #include "rcamera.h"            // Camera system functionality
 #endif
 
-#if defined(SUPPORT_GIF_RECORDING)
+#if !defined(DISABLE_GIF_RECORDING)
     #define MSF_GIF_MALLOC(contextPointer, newSize) RL_MALLOC(newSize)
     #define MSF_GIF_REALLOC(contextPointer, oldMemory, oldSize, newSize) RL_REALLOC(oldMemory, newSize)
     #define MSF_GIF_FREE(contextPointer, oldMemory, oldSize) RL_FREE(oldMemory)
@@ -377,11 +377,11 @@ CoreData CORE = { 0 };                      // Global CORE state context
 // NOTE: Useful to allow Texture, RenderTexture, Font.texture, Mesh.vaoId/vboId, Shader loading
 bool isGpuReady = false;
 
-#if defined(SUPPORT_SCREEN_CAPTURE)
+#if !defined(DISABLE_SCREEN_CAPTURE)
 static int screenshotCounter = 0;           // Screenshots counter
 #endif
 
-#if defined(SUPPORT_GIF_RECORDING)
+#if !defined(DISABLE_GIF_RECORDING)
 static unsigned int gifFrameCounter = 0;    // GIF frames counter
 static bool gifRecording = false;           // GIF recording state
 static MsfGifState gifState = { 0 };        // MSGIF context state
@@ -721,7 +721,7 @@ void InitWindow(int width, int height, const char *title)
 // Close window and unload OpenGL context
 void CloseWindow(void)
 {
-#if defined(SUPPORT_GIF_RECORDING)
+#if !defined(DISABLE_GIF_RECORDING)
     if (gifRecording)
     {
         MsfGifResult result = msf_gif_end(&gifState);
@@ -888,7 +888,7 @@ void EndDrawing(void)
 {
     rlDrawRenderBatchActive();      // Update and draw internal render batch
 
-#if defined(SUPPORT_GIF_RECORDING)
+#if !defined(DISABLE_GIF_RECORDING)
     // Draw record indicator
     if (gifRecording)
     {
@@ -958,10 +958,10 @@ void EndDrawing(void)
     PollInputEvents();      // Poll user events (before next frame update)
 #endif
 
-#if defined(SUPPORT_SCREEN_CAPTURE)
-    if (IsKeyPressed(KEY_F12))
+#if !defined(DISABLE_SCREEN_CAPTURE)
+    if (IsKeyPressed(KEY_F11))
     {
-#if defined(SUPPORT_GIF_RECORDING)
+#if !defined(DISABLE_GIF_RECORDING)
         if (IsKeyDown(KEY_LEFT_CONTROL))
         {
             if (gifRecording)
@@ -988,13 +988,13 @@ void EndDrawing(void)
             }
         }
         else
-#endif  // SUPPORT_GIF_RECORDING
+#endif  // ! DISABLE_GIF_RECORDING
         {
             TakeScreenshot(TextFormat("screenshot%03i.png", screenshotCounter));
             screenshotCounter++;
         }
     }
-#endif  // SUPPORT_SCREEN_CAPTURE
+#endif  // ! DISABLE_SCREEN_CAPTURE
 
     CORE.Time.frameCounter++;
 }
@@ -3094,7 +3094,7 @@ void PlayAutomationEvent(AutomationEvent event)
             case WINDOW_RESIZE: SetWindowSize(event.params[0], event.params[1]); break;
 
             // Custom event
-    #if defined(SUPPORT_SCREEN_CAPTURE)
+    #if !defined(DISABLE_SCREEN_CAPTURE)
             case ACTION_TAKE_SCREENSHOT:
             {
                 TakeScreenshot(TextFormat("screenshot%03i.png", screenshotCounter));
@@ -3516,7 +3516,7 @@ void InitTimer(void)
     // However, it can also reduce overall system performance, because the thread scheduler switches tasks more often
     // High resolutions can also prevent the CPU power management system from entering power-saving modes
     // Setting a higher resolution does not improve the accuracy of the high-resolution performance counter
-#if defined(_WIN32) && defined(SUPPORT_WINMM_HIGHRES_TIMER) && !defined(SUPPORT_BUSY_WAIT_LOOP) && !defined(PLATFORM_DESKTOP_SDL)
+#if defined(_WIN32) && !defined(DISABLE_WINMM_HIGHRES_TIMER) && !defined(SUPPORT_BUSY_WAIT_LOOP) && !defined(PLATFORM_DESKTOP_SDL)
     timeBeginPeriod(1);                 // Setup high-resolution timer to 1ms (granularity of 1-2 ms)
 #endif
 


### PR DESCRIPTION
The way config.h and it's 'SUPPORT_FEATURE' flags are setup right now makes it impossible for build systems to change these flags without fully redefining every feature in config.h. This is not easy for people to do, and is counter to raylib's simple design.

This PR takes 3 of those flags and reverses the sense of them, turning them from SUPPORT_ flags to DISABLE_ flags.
* Screen Capture
* GIF recording
* High Resolution Timer

This means that by default raylib will enable the code that implements these features, unless the build system defines the specific DISABLE_ feature flag.

By reversing these defines, it makes it very easy for people to simply add the things they want to turn off to a makefile or project. Raylib has gone from 'add stuff to it' to 'remove stuff you don't need from it'.

I simply picked 3 flags that made the most sense to disable, if this concept is accepted we can apply it additional features.
The big ones here are screen capture and gif recording since they use a specific key that people may want to use for other features (this is my use case)