### PR TITLE
Add the D Object Oriented Raylib wrapper to the list of BINDINGS.md

### DIFF
--- a/BINDINGS.md
+++ b/BINDINGS.md
@@ -93,6 +93,7 @@ These are utility wrappers for specific languages, they are not required to use 
 | [raylib-cpp](https://github.com/robloach/raylib-cpp) | **5.5**        | [C++](https://en.wikipedia.org/wiki/C%2B%2B) | Zlib    |
 | [claylib](https://github.com/defun-games/claylib)    | 4.5            | [Common Lisp](https://common-lisp.net)       | Zlib    |
 | [rayed-bqn](https://github.com/Brian-ED/rayed-bqn)   | **5.0**        | [BQN](https://mlochbaum.github.io/BQN)       | MIT     |
+| [DOOR](https://github.com/Brian-ED/rayed-bqn)        | 4.0            | [D](https://dlang.org)                       | MIT     |
 
 ### Older or Unmaintained Language Bindings
 


### PR DESCRIPTION
DOOR, or D Object Oriented Raylib, is a work in progress wrapper + various utilities for raylib users who program with the D programming language.