### PR TITLE
[rmodels] Fix null pointer dereference in LoadImageFromCgltfImage

### DIFF
--- a/src/rmodels.c
+++ b/src/rmodels.c
@@ -5110,7 +5110,7 @@ static Image LoadImageFromCgltfImage(cgltf_image *cgltfImage, const char *texPat
             image = LoadImage(TextFormat("%s/%s", texPath, cgltfImage->uri));
         }
     }
-    else if (cgltfImage->buffer_view->buffer->data != NULL)    // Check if image is provided as data buffer
+    else if (cgltfImage->buffer_view != NULL && cgltfImage->buffer_view->buffer->data != NULL)    // Check if image is provided as data buffer
     {
         unsigned char *data = RL_MALLOC(cgltfImage->buffer_view->size);
         int offset = (int)cgltfImage->buffer_view->offset;


### PR DESCRIPTION
This fixes a null pointer dereference when loading a texture from a GLB file. The fix is just to check if the buffer_view is NULL before checking if the data pointer is NULL.