### PR TITLE
[rmodels] Fix crash when NULL is passed to LoadImageFromCgltfImage

### DIFF
--- a/src/rmodels.c
+++ b/src/rmodels.c
@@ -5069,6 +5069,8 @@ static Image LoadImageFromCgltfImage(cgltf_image *cgltfImage, const char *texPat
 {
     Image image = { 0 };
 
+    if (cgltfImage == NULL) return image;
+
     if (cgltfImage->uri != NULL)     // Check if image data is provided as an uri (base64 or path)
     {
         if ((strlen(cgltfImage->uri) > 5) &&


### PR DESCRIPTION
This fixes a crash that can happen when null is passed to LoadImageFromCgltfImage. There is a case where the argument is null in LoadGLTF. A possible fix is to check if the it is null in LoadImageFromCgltfImage.