### PR TITLE
[rmodels] Fixed null pointer dereference in LoadGLTF

### DIFF
--- a/src/rmodels.c
+++ b/src/rmodels.c
@@ -5664,7 +5664,7 @@ static Model LoadGLTF(const char *fileName)
                 }
 
                 // Load primitive indices data (if provided)
-                if (mesh->primitives[p].indices != NULL && mesh->primitives[p].indices->buffer_view != NULL)
+                if ((mesh->primitives[p].indices != NULL) && (mesh->primitives[p].indices->buffer_view != NULL))
                 {
                     cgltf_accessor *attribute = mesh->primitives[p].indices;
 

--- a/src/rmodels.c
+++ b/src/rmodels.c
@@ -5664,7 +5664,7 @@ static Model LoadGLTF(const char *fileName)
                 }
 
                 // Load primitive indices data (if provided)
-                if (mesh->primitives[p].indices != NULL)
+                if (mesh->primitives[p].indices != NULL && mesh->primitives[p].indices->buffer_view != NULL)
                 {
                     cgltf_accessor *attribute = mesh->primitives[p].indices;
 


### PR DESCRIPTION
This is the last I've found so far :)

I was able to get it to crash here when loading a file:
![image](https://github.com/user-attachments/assets/edd086ae-1c1a-415e-ac70-44640106395d)
