### PR TITLE
[rcore] fix ShaderUniformDataType to match rlgl

### DIFF
--- a/src/raylib.h
+++ b/src/raylib.h
@@ -817,6 +817,10 @@ typedef enum {
     SHADER_UNIFORM_IVEC2,           // Shader uniform type: ivec2 (2 int)
     SHADER_UNIFORM_IVEC3,           // Shader uniform type: ivec3 (3 int)
     SHADER_UNIFORM_IVEC4,           // Shader uniform type: ivec4 (4 int)
+    SHADER_UNIFORM_UINT,            // Shader uniform type: unsigned int
+    SHADER_UNIFORM_UIVEC2,          // Shader uniform type: uivec2 (2 unsigned int)
+    SHADER_UNIFORM_UIVEC3,          // Shader uniform type: uivec3 (3 unsigned int)
+    SHADER_UNIFORM_UIVEC4,          // Shader uniform type: uivec4 (4 unsigned int)
     SHADER_UNIFORM_SAMPLER2D        // Shader uniform type: sampler2d
 } ShaderUniformDataType;
 


### PR DESCRIPTION
This PR fixes bug with missing unsigned vectors from `rlShaderUniformDataType` in `ShaderUniformDataType` and causing `SAMPLER2D` from raylib to become `UINT` in rlgl.