### PR TITLE
Add LoadModelEx and UploadModel functions

### DIFF
--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1552,8 +1552,10 @@ RLAPI void DrawGrid(int slices, float spacing);                                 
 
 // Model management functions
 RLAPI Model LoadModel(const char *fileName);                                                // Load model from files (meshes and materials)
+RLAPI Model LoadModelEx(const char *fileName, bool upload);                                 // Load model from files (meshes and materials) with option to auto uploading meshes to GPU or not
 RLAPI Model LoadModelFromMesh(Mesh mesh);                                                   // Load model from generated mesh (default material)
 RLAPI bool IsModelValid(Model model);                                                       // Check if a model is valid (loaded in GPU, VAO/VBOs)
+RLAPI void UploadModel(const Model *model, bool dynamic);                                   // Upload model data to GPU (VRAM)
 RLAPI void UnloadModel(Model model);                                                        // Unload model (including meshes) from memory (RAM and/or VRAM)
 RLAPI BoundingBox GetModelBoundingBox(Model model);                                         // Compute model bounding box limits (considers all meshes)
 


### PR DESCRIPTION
To enable custom model and mesh batching in projects that use the official raylib and instancing, it is essential to have control over whether or not meshes are automatically uploaded to the GPU. In my opinion, this is the cleanest solution for achieving that flexibility.

New functions added:
// Load model from files (mesh and material) without automatically uploading vertex data to the GPU
Model LoadModelEx(const char *fileName, bool upload) 

// Upload model data to the GPU (RAM and/or VRAM) 
void UploadModel(const Model *model, bool dynamic)

The existing LoadModel function now calls LoadModelEx with upload = true.

Additionally, fixed LoadOBJ to match the behavior of other load functions by not automatically uploading meshes.