### PR TITLE
Make sure ShaderUniformDataType matches rlShaderUniformDataType

### DIFF
--- a/parser/output/raylib_api.json
+++ b/parser/output/raylib_api.json
@@ -2591,8 +2591,28 @@
           "description": "Shader uniform type: ivec4 (4 int)"
         },
         {
-          "name": "SHADER_UNIFORM_SAMPLER2D",
+          "name": "SHADER_UNIFORM_UINT",
           "value": 8,
+          "description": "Shader uniform type: unsigned int"
+        },
+        {
+          "name": "SHADER_UNIFORM_UIVEC2",
+          "value": 9,
+          "description": "Shader uniform type: uivec2 (2 unsigned int)"
+        },
+        {
+          "name": "SHADER_UNIFORM_UIVEC3",
+          "value": 10,
+          "description": "Shader uniform type: uivec3 (3 unsigned int)"
+        },
+        {
+          "name": "SHADER_UNIFORM_UIVEC4",
+          "value": 11,
+          "description": "Shader uniform type: uivec4 (4 unsigned int)"
+        },
+        {
+          "name": "SHADER_UNIFORM_SAMPLER2D",
+          "value": 12,
           "description": "Shader uniform type: sampler2d"
         }
       ]

--- a/parser/output/raylib_api.lua
+++ b/parser/output/raylib_api.lua
@@ -2591,8 +2591,28 @@ return {
           description = "Shader uniform type: ivec4 (4 int)"
         },
         {
-          name = "SHADER_UNIFORM_SAMPLER2D",
+          name = "SHADER_UNIFORM_UINT",
           value = 8,
+          description = "Shader uniform type: unsigned int"
+        },
+        {
+          name = "SHADER_UNIFORM_UIVEC2",
+          value = 9,
+          description = "Shader uniform type: uivec2 (2 unsigned int)"
+        },
+        {
+          name = "SHADER_UNIFORM_UIVEC3",
+          value = 10,
+          description = "Shader uniform type: uivec3 (3 unsigned int)"
+        },
+        {
+          name = "SHADER_UNIFORM_UIVEC4",
+          value = 11,
+          description = "Shader uniform type: uivec4 (4 unsigned int)"
+        },
+        {
+          name = "SHADER_UNIFORM_SAMPLER2D",
+          value = 12,
           description = "Shader uniform type: sampler2d"
         }
       }

--- a/parser/output/raylib_api.txt
+++ b/parser/output/raylib_api.txt
@@ -827,7 +827,7 @@ Enum 09: ShaderLocationIndex (29 values)
   Value[SHADER_LOC_VERTEX_BONEIDS]: 26
   Value[SHADER_LOC_VERTEX_BONEWEIGHTS]: 27
   Value[SHADER_LOC_BONE_MATRICES]: 28
-Enum 10: ShaderUniformDataType (9 values)
+Enum 10: ShaderUniformDataType (13 values)
   Name: ShaderUniformDataType
   Description: Shader uniform data type
   Value[SHADER_UNIFORM_FLOAT]: 0
@@ -838,7 +838,11 @@ Enum 10: ShaderUniformDataType (9 values)
   Value[SHADER_UNIFORM_IVEC2]: 5
   Value[SHADER_UNIFORM_IVEC3]: 6
   Value[SHADER_UNIFORM_IVEC4]: 7
-  Value[SHADER_UNIFORM_SAMPLER2D]: 8
+  Value[SHADER_UNIFORM_UINT]: 8
+  Value[SHADER_UNIFORM_UIVEC2]: 9
+  Value[SHADER_UNIFORM_UIVEC3]: 10
+  Value[SHADER_UNIFORM_UIVEC4]: 11
+  Value[SHADER_UNIFORM_SAMPLER2D]: 12
 Enum 11: ShaderAttributeDataType (4 values)
   Name: ShaderAttributeDataType
   Description: Shader attribute data types

--- a/parser/output/raylib_api.xml
+++ b/parser/output/raylib_api.xml
@@ -538,7 +538,7 @@
             <Value name="SHADER_LOC_VERTEX_BONEWEIGHTS" integer="27" desc="Shader location: vertex attribute: boneWeights" />
             <Value name="SHADER_LOC_BONE_MATRICES" integer="28" desc="Shader location: array of matrices uniform: boneMatrices" />
         </Enum>
-        <Enum name="ShaderUniformDataType" valueCount="9" desc="Shader uniform data type">
+        <Enum name="ShaderUniformDataType" valueCount="13" desc="Shader uniform data type">
             <Value name="SHADER_UNIFORM_FLOAT" integer="0" desc="Shader uniform type: float" />
             <Value name="SHADER_UNIFORM_VEC2" integer="1" desc="Shader uniform type: vec2 (2 float)" />
             <Value name="SHADER_UNIFORM_VEC3" integer="2" desc="Shader uniform type: vec3 (3 float)" />
@@ -547,7 +547,11 @@
             <Value name="SHADER_UNIFORM_IVEC2" integer="5" desc="Shader uniform type: ivec2 (2 int)" />
             <Value name="SHADER_UNIFORM_IVEC3" integer="6" desc="Shader uniform type: ivec3 (3 int)" />
             <Value name="SHADER_UNIFORM_IVEC4" integer="7" desc="Shader uniform type: ivec4 (4 int)" />
-            <Value name="SHADER_UNIFORM_SAMPLER2D" integer="8" desc="Shader uniform type: sampler2d" />
+            <Value name="SHADER_UNIFORM_UINT" integer="8" desc="Shader uniform type: unsigned int" />
+            <Value name="SHADER_UNIFORM_UIVEC2" integer="9" desc="Shader uniform type: uivec2 (2 unsigned int)" />
+            <Value name="SHADER_UNIFORM_UIVEC3" integer="10" desc="Shader uniform type: uivec3 (3 unsigned int)" />
+            <Value name="SHADER_UNIFORM_UIVEC4" integer="11" desc="Shader uniform type: uivec4 (4 unsigned int)" />
+            <Value name="SHADER_UNIFORM_SAMPLER2D" integer="12" desc="Shader uniform type: sampler2d" />
         </Enum>
         <Enum name="ShaderAttributeDataType" valueCount="4" desc="Shader attribute data types">
             <Value name="SHADER_ATTRIB_FLOAT" integer="0" desc="Shader attribute type: float" />

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -817,6 +817,10 @@ typedef enum {
     SHADER_UNIFORM_IVEC2,           // Shader uniform type: ivec2 (2 int)
     SHADER_UNIFORM_IVEC3,           // Shader uniform type: ivec3 (3 int)
     SHADER_UNIFORM_IVEC4,           // Shader uniform type: ivec4 (4 int)
+    SHADER_UNIFORM_UINT,            // Shader uniform type: unsigned int
+    SHADER_UNIFORM_UIVEC2,          // Shader uniform type: uivec2 (2 unsigned int)
+    SHADER_UNIFORM_UIVEC3,          // Shader uniform type: uivec3 (3 unsigned int)
+    SHADER_UNIFORM_UIVEC4,          // Shader uniform type: uivec4 (4 unsigned int)
     SHADER_UNIFORM_SAMPLER2D        // Shader uniform type: sampler2d
 } ShaderUniformDataType;
 


### PR DESCRIPTION
It seems like with version 5.5 ShaderUniformDataType and rlShaderUniformDataType went out of sync with the addition of RL_SHADER_UNIFORM_UIXXX caused  SHADER_UNIFORM_SAMPLER2D to be interpreted as RL_SHADER_UNIFORM_UINT in rlSetUniform.

Depending on how lenient your specific OpenGL version is that might work fine, but in my case this caused issues.  