### PR TITLE
[rlgl] Small cleaning

### DIFF
--- a/src/rlgl.h
+++ b/src/rlgl.h
@@ -474,6 +474,18 @@ typedef enum {
     RL_PIXELFORMAT_COMPRESSED_ASTC_8x8_RGBA        // 2 bpp
 } rlPixelFormat;
 
+// Texture parameters: filter mode
+// NOTE 1: Filtering considers mipmaps if available in the texture
+// NOTE 2: Filter is accordingly set for minification and magnification
+typedef enum {
+    RL_TEXTURE_FILTER_POINT = 0,        // No filter, just pixel approximation
+    RL_TEXTURE_FILTER_BILINEAR,         // Linear filtering
+    RL_TEXTURE_FILTER_TRILINEAR,        // Trilinear filtering (linear with mipmaps)
+    RL_TEXTURE_FILTER_ANISOTROPIC_4X,   // Anisotropic filtering 4x
+    RL_TEXTURE_FILTER_ANISOTROPIC_8X,   // Anisotropic filtering 8x
+    RL_TEXTURE_FILTER_ANISOTROPIC_16X,  // Anisotropic filtering 16x
+} rlTextureFilter;
+
 // Color blending modes (pre-defined)
 typedef enum {
     RL_BLEND_ALPHA = 0,                 // Blend textures considering alpha (default)

--- a/src/rlgl.h
+++ b/src/rlgl.h
@@ -474,18 +474,6 @@ typedef enum {
     RL_PIXELFORMAT_COMPRESSED_ASTC_8x8_RGBA        // 2 bpp
 } rlPixelFormat;
 
-// Texture parameters: filter mode
-// NOTE 1: Filtering considers mipmaps if available in the texture
-// NOTE 2: Filter is accordingly set for minification and magnification
-typedef enum {
-    RL_TEXTURE_FILTER_POINT = 0,        // No filter, just pixel approximation
-    RL_TEXTURE_FILTER_BILINEAR,         // Linear filtering
-    RL_TEXTURE_FILTER_TRILINEAR,        // Trilinear filtering (linear with mipmaps)
-    RL_TEXTURE_FILTER_ANISOTROPIC_4X,   // Anisotropic filtering 4x
-    RL_TEXTURE_FILTER_ANISOTROPIC_8X,   // Anisotropic filtering 8x
-    RL_TEXTURE_FILTER_ANISOTROPIC_16X,  // Anisotropic filtering 16x
-} rlTextureFilter;
-
 // Color blending modes (pre-defined)
 typedef enum {
     RL_BLEND_ALPHA = 0,                 // Blend textures considering alpha (default)

--- a/src/rlgl.h
+++ b/src/rlgl.h
@@ -754,7 +754,7 @@ RLAPI void rlUpdateTexture(unsigned int id, int offsetX, int offsetY, int width,
 RLAPI void rlGetGlTextureFormats(int format, unsigned int *glInternalFormat, unsigned int *glFormat, unsigned int *glType); // Get OpenGL internal formats
 RLAPI const char *rlGetPixelFormatName(unsigned int format);              // Get name string for pixel format
 RLAPI void rlUnloadTexture(unsigned int id);                              // Unload texture from GPU memory
-RLAPI void rlGenTextureMipmaps(unsigned int id, int width, int height, int format, int *mipmaps); // Generate mipmap data for selected texture
+RLAPI void rlGenTextureMipmaps(unsigned int id, int width, int height, int *mipmaps); // Generate mipmap data for selected texture
 RLAPI void *rlReadTexturePixels(unsigned int id, int width, int height, int format); // Read texture pixel data
 RLAPI unsigned char *rlReadScreenPixels(int width, int height);           // Read screen pixel data (color buffer)
 
@@ -3577,7 +3577,7 @@ void rlUnloadTexture(unsigned int id)
 
 // Generate mipmap data for selected texture
 // NOTE: Only supports GPU mipmap generation
-void rlGenTextureMipmaps(unsigned int id, int width, int height, int format, int *mipmaps)
+void rlGenTextureMipmaps(unsigned int id, int width, int height, int *mipmaps)
 {
 #if defined(GRAPHICS_API_OPENGL_33) || defined(GRAPHICS_API_OPENGL_ES2)
     glBindTexture(GL_TEXTURE_2D, id);

--- a/src/rtextures.c
+++ b/src/rtextures.c
@@ -4353,7 +4353,7 @@ void GenTextureMipmaps(Texture2D *texture)
 {
     // NOTE: NPOT textures support check inside function
     // On WebGL (OpenGL ES 2.0) NPOT textures support is limited
-    rlGenTextureMipmaps(texture->id, texture->width, texture->height, texture->format, &texture->mipmaps);
+    rlGenTextureMipmaps(texture->id, texture->width, texture->height, &texture->mipmaps);
 }
 
 // Set texture scaling filter mode


### PR DESCRIPTION
I simply removed the `int format` parameter from `rlGenTextureMipmaps()`, which was unused, as well as the `rlTextureFilter` enum, which was also unused in `rlgl.h` and wasn't referenced anywhere else in the library. In any case, `TextureFilter` replaces it.