### PR TITLE
[rtext] Removed inaccurate comment about negatives not being supported with TextToFloat and TextToInt Methods

### DIFF
--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1520,8 +1520,8 @@ RLAPI const char *TextToPascal(const char *text);                               
 RLAPI const char *TextToSnake(const char *text);                                            // Get Snake case notation version of provided string
 RLAPI const char *TextToCamel(const char *text);                                            // Get Camel case notation version of provided string
 
-RLAPI int TextToInteger(const char *text);                                                  // Get integer value from text (negative values not supported)
-RLAPI float TextToFloat(const char *text);                                                  // Get float value from text (negative values not supported)
+RLAPI int TextToInteger(const char *text);                                                  // Get integer value from text
+RLAPI float TextToFloat(const char *text);                                                  // Get float value from text
 
 //------------------------------------------------------------------------------------
 // Basic 3d Shapes Drawing Functions (Module: models)


### PR DESCRIPTION
I was going to add negative support for these methods, however, after investigation, I've found that it is actually already supported.

[rtext.c:1444](https://github.com/raysan5/raylib/blob/1f704be4e4aba6b25e56bde3c30cc136b6e94049/src/rtext.c#L1444)