### PR TITLE
add SIMD variation for raymath

### DIFF
--- a/src/raymath.h
+++ b/src/raymath.h
@@ -171,13 +171,13 @@ typedef struct float16 {
 #include <math.h>       // Required for: sinf(), cosf(), tan(), atan2f(), sqrtf(), floor(), fminf(), fmaxf(), fabsf()
 
 #if defined(RL_USE_SIMD)
-  #if defined(__SSE2__)
-    #include <emmintrin.h> // Required for: _mm_set_ps(), _mm_mul_ps(), _mm_add_ps(), _mm_cvtss_f32()
-  #endif
+    #if defined(__SSE2__)
+        #include <emmintrin.h> // Required for: _mm_set_ps(), _mm_mul_ps(), _mm_add_ps(), _mm_cvtss_f32()
+    #endif
 
-  #if defined(__SSE3__)
-    #include <pmmintrin.h> // Required for: _mm_hadd_ps()
-  #endif
+    #if defined(__SSE3__)
+        #include <pmmintrin.h> // Required for: _mm_hadd_ps()
+    #endif
 #endif
 
 //----------------------------------------------------------------------------------
@@ -717,23 +717,27 @@ RMAPI float Vector3LengthSqr(const Vector3 v)
 // Calculate two vectors dot product
 RMAPI float Vector3DotProduct(Vector3 v1, Vector3 v2)
 {
+    float result = 0.0f;
+
 #if defined(__SSE2__) && defined(RL_USE_SIMD)
     __m128 vecA = _mm_set_ps(0.0f, v1.z, v1.y, v1.x);
     __m128 vecB = _mm_set_ps(0.0f, v2.z, v2.y, v2.x);
 
     __m128 mul = _mm_mul_ps(vecA, vecB);
 
-  #if defined(__SSE3__)
-    __m128 sum = _mm_hadd_ps(mul, mul);
-    sum = _mm_hadd_ps(sum, sum);
-  #else // Non __SSE3__
-    __m128 sum1 = _mm_add_ps(mul, _mm_shuffle_ps(mul, mul, _MM_SHUFFLE(2, 3, 0, 1)));
-    __m128 sum = _mm_add_ps(sum1, _mm_shuffle_ps(sum1, sum1, _MM_SHUFFLE(1, 0, 3, 2)));
-  #endif
-    return _mm_cvtss_f32(sum);
+    #if defined(__SSE3__)
+        __m128 sum = _mm_hadd_ps(mul, mul);
+        sum = _mm_hadd_ps(sum, sum);
+    #else // Non __SSE3__
+        __m128 sum1 = _mm_add_ps(mul, _mm_shuffle_ps(mul, mul, _MM_SHUFFLE(2, 3, 0, 1)));
+        __m128 sum = _mm_add_ps(sum1, _mm_shuffle_ps(sum1, sum1, _MM_SHUFFLE(1, 0, 3, 2)));
+    #endif
+
+    result = _mm_cvtss_f32(sum);
 #else // Non SIMD
-    return v1.x*v2.x + v1.y*v2.y + v1.z*v2.z;
+    result = (v1.x*v2.x + v1.y*v2.y + v1.z*v2.z);
 #endif
+    return result;
 }
 
 // Calculate distance between two vectors


### PR DESCRIPTION
Adds a SIMD variation for Vector3DotProduct function in raymath.h
From benchmarking, it seems to yield rather positive results for cases when optimization flag is not set to 3 (i.e. `-O3` in gcc)

Difference table shown below only accounts for the three optimization flags, 0, 3 and unspecified (different from 0 on most compilers), however after more benchmarking any value that isn't 3 yields results that are 3.5-4 times faster than the regular, scalar implementation. 

From my personal benchmark:

Difference table (total time (seconds) all SIMD-benches took divided by total time all NON-SIMD benches took, divided by total number of benches)
| SSE2 | SSE3+ | Optimization |
| :-----: | :-------: | -------------------: |
| 4.3004121542045191 | 4.1910432371902164 | Unspecified |
| 4.2972077569411935 | 4.1736242200387377 | O0 |
| 2.0833783368893704 | 3.6495343887653497 | O2 |
| 1.0013451060953036 | 1.0001179220686744 | O3 |

Benchmark error:
| NON-SIMD | SSE2 | Optimization |
| :--------------: | :------: | ------------------: |
| 0.9600781359602621 | 1.0000908393252022 | O0 |
| 1.0001020218841774 | 1.0000023063319816 | O2 |
| 1.0351980200002622 | 0.9993839602792374 | O3 |

Benchmarking code that was used to yield the results in the table:
```c
#include <stdio.h>
#include <stdlib.h>
#include <time.h>

#define RAYMATH_IMPLEMENTATION
#include "raymath.h" /* note: this is raymath in the master branch of raylib, not the version with the SIMD implementation */

#if defined(__SSE2__)
  #warning "will use SSE2"
  #include <emmintrin.h>
#endif

#if defined(__SSE3__)
  #warning "will use SSE3"
  #include <pmmintrin.h>
#endif

float dot_product_sse(Vector3 v1, Vector3 v2) {
#if defined(__SSE2__)
    __m128 vecA = _mm_set_ps(0.0f, v1.z, v1.y, v1.x);
    __m128 vecB = _mm_set_ps(0.0f, v2.z, v2.y, v2.x);

    __m128 mul = _mm_mul_ps(vecA, vecB);

  #if defined(__SSE3__)
    __m128 sum = _mm_hadd_ps(mul, mul);
    sum = _mm_hadd_ps(sum, sum);
  #else
    __m128 sum1 = _mm_add_ps(mul, _mm_shuffle_ps(mul, mul, _MM_SHUFFLE(2, 3, 0, 1)));
    __m128 sum = _mm_add_ps(sum1, _mm_shuffle_ps(sum1, sum1, _MM_SHUFFLE(1, 0, 3, 2)));
  #endif
    return _mm_cvtss_f32(sum);
#else
    return v1.x*v2.x + v1.y*v2.y + v1.z*v2.z;
#endif
}

#define FANCYPRINT_FOR(x) \
    printf("%s\n", #x); \
    printf("\tDone in %.16f seconds\n", elapsed_time); \
    printf("\tPer exec time: %.16f seconds\n", elapsed_time / NUM_REPEATS); \
    printf("\n")

#define RAND_UNIFORM() (float)rand() / (float)RAND_MAX

/* shamelessly stolen from https://github.com/camel-cdr/cauldron/blob/main/cauldron/bench.h */
#define BENCH_VOLATILE_REG(x) asm volatile("" : "+r"(x) : "r"(x) : "memory")

/* how much to call each function per bench */
#define NUM_REPEATS 1000000

/* how much benches to make */
#define NUM_BENCHES 10000

double bench_default_dot(Vector3 vec1, Vector3 vec2) {
    float res;

    clock_t start_time = clock();

    for (int i = 0; i < NUM_REPEATS; ++i) {
        res = Vector3DotProduct(vec1, vec2);
        BENCH_VOLATILE_REG(res);
    }

    double elapsed_time = (double)(clock() - start_time) / CLOCKS_PER_SEC;
    // FANCYPRINT_FOR(Default);

    return elapsed_time / NUM_REPEATS;
}

double bench_simd_dot(Vector3 vec1, Vector3 vec2) {
    float res;

    clock_t start_time = clock();

    for (int i = 0; i < NUM_REPEATS; ++i) {
        res = dot_product_sse(vec1, vec2);
        BENCH_VOLATILE_REG(res);
    }

    double elapsed_time = (double)(clock() - start_time) / CLOCKS_PER_SEC;
    // FANCYPRINT_FOR(SIMD);

    return elapsed_time / NUM_REPEATS;
}

int main(void) {
    srand(time(NULL));
    double res1 = 0, res2 = 0;

    double avg_diff = 0;

    for (int i = 0; i < NUM_BENCHES; ++i) {
        Vector3 vec1 = {RAND_UNIFORM(), RAND_UNIFORM(), RAND_UNIFORM()};
        Vector3 vec2 = {RAND_UNIFORM(), RAND_UNIFORM(), RAND_UNIFORM()};

        res1 = bench_default_dot(vec1, vec2);
        res2 = bench_simd_dot(vec1, vec2);
        avg_diff += (res2 / res1) / NUM_BENCHES;
    }

    printf("avg diff: %.16f", avg_diff);
    /************************************
     * error with self (NON-SIMD):
     *   gcc main.c -lraylib -mno-sse2 -O0
     *    0.9600781359602621
     *
     *   gcc main.c -lraylib -mno-sse2 -O3
     *    1.0351980200002622
     *
     * error with self (SIMD):
     *   gcc main.c -lraylib -O3
     *    0.9993839602792374
     *    0.9997983351164231
     *
     *   gcc main.c -lraylib -lm -O0
     *    1.0000908393252022
     *    0.9998860434158373
     *
     * results:
     *   gcc main.c -lraylib -msse4.1
     *    4.1910432371902164
     *
     *   gcc main.c -lraylib -msse4.1 -O0
     *    4.1736242200387377
     *
     *   gcc main.c -lraylib -msse4.1 -O3
     *    1.0001179220686744
     *
     *   gcc main.c -lraylib -msse2
     *    4.3004121542045191
     *
     *   gcc main.c -lraylib -msse2 -O0
     *    4.2972077569411935
     *
     *   gcc main.c -lraylib -msse2 -O3
     *    1.0013451060953036
     ************************************/

    return 0;
}
```

All done on this CPU:
```cpufetch
Name:                12th Gen Intel(R) Core(TM) i5-12400F
Microarchitecture:   Alder Lake
Technology:          10nm
Max Frequency:       4.400 GHz
Cores:               6 cores (12 threads)
AVX:                 AVX,AVX2
FMA:                 FMA3
L1i Size:            32KB (192KB Total)
L1d Size:            48KB (288KB Total)
L2 Size:             1.25MB (7.5MB Total)
L3 Size:             18MB
Peak Performance:    844.80 GFLOP/s
```

The plan is to bring SIMD, whenever it might be beneficial for performance, to `raymath.h`.

The SIMD implementation itself might not be ideal, though. I introduced a new define into `raymath.h`, `RL_USE_SIMD`. When defined, the SIMD will be used if possible. From benchmarking the results on `-O3` seem to be identical, but just in case, user should be able to specify that they DON'T want SIMD at all, just in case. This way, existing projects should not break by this change at ALL.

Please let me know what you think! :)