### PR TITLE
[rlgl] Added a way to get information about the amount of draw calls

### DIFF
--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1088,6 +1088,7 @@ RLAPI int GetFPS(void);                                           // Get current
 RLAPI void SwapScreenBuffer(void);                                // Swap back buffer with front buffer (screen drawing)
 RLAPI void PollInputEvents(void);                                 // Register all input events
 RLAPI void WaitTime(double seconds);                              // Wait for some time (halt program execution)
+RLAPI int GetDrawCalls(void);                                     // Returns draw calls made during the last tick
 
 // Random values generation functions
 RLAPI void SetRandomSeed(unsigned int seed);                      // Set the seed for the random number generator

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -955,6 +955,7 @@ void EndDrawing(void)
         CORE.Time.frame += waitTime;    // Total frame time: update + draw + wait
     }
 
+    rlSwapDrawCallsCounter();
     PollInputEvents();      // Poll user events (before next frame update)
 #endif
 
@@ -1752,6 +1753,13 @@ void WaitTime(double seconds)
         while (GetTime() < destinationTime) { }
     #endif
 #endif
+}
+
+// Returns the draw calls of the previous tick
+// This is because we don't know the full count until the current tick ends
+int GetDrawCalls(void)
+{
+    return rlGetPreviousDrawCalls();
 }
 
 //----------------------------------------------------------------------------------

--- a/src/rlgl.h
+++ b/src/rlgl.h
@@ -718,6 +718,8 @@ RLAPI int rlGetFramebufferHeight(void);                 // Get default framebuff
 RLAPI unsigned int rlGetTextureIdDefault(void);         // Get default texture id
 RLAPI unsigned int rlGetShaderIdDefault(void);          // Get default shader id
 RLAPI int *rlGetShaderLocsDefault(void);                // Get default shader locations
+RLAPI int rlGetPreviousDrawCalls(void);                 // Get previous ticks draw calls
+RLAPI void rlSwapDrawCallsCounter(void);                // Swap previous with current draw calls (marks end of a tick)
 
 // Render batch management
 // NOTE: rlgl provides a default render batch to behave like OpenGL 1.1 immediate mode
@@ -1087,6 +1089,8 @@ typedef struct rlglData {
 
         int framebufferWidth;               // Current framebuffer width
         int framebufferHeight;              // Current framebuffer height
+        int currentDrawCalls;               // Draw calls made in the current tick (might be incomplete)
+        int previousDrawCalls;              // Draw calls made during the last tick
 
     } State;            // Renderer state
     struct {
@@ -1109,6 +1113,7 @@ typedef struct rlglData {
 
         float maxAnisotropyLevel;           // Maximum anisotropy level supported (minimum is 2.0f)
         int maxDepthBits;                   // Maximum bits for depth component
+
 
     } ExtSupported;     // Extensions supported flags
 } rlglData;
@@ -2724,6 +2729,20 @@ int *rlGetShaderLocsDefault(void)
     return locs;
 }
 
+// Get previous ticks draw calls
+RLAPI int rlGetPreviousDrawCalls(void)
+{
+    return RLGL.State.previousDrawCalls;
+}
+
+// Swap previous with current draw calls (marks end of a tick)
+RLAPI void rlSwapDrawCallsCounter(void)
+{
+    RLGL.State.previousDrawCalls = RLGL.State.currentDrawCalls;
+    RLGL.State.currentDrawCalls = 0; // Reset counter
+}
+
+
 // Render batch management
 //------------------------------------------------------------------------------------------------
 // Load render batch
@@ -2983,6 +3002,7 @@ void rlDrawRenderBatch(rlRenderBatch *batch)
         // Draw buffers
         if (RLGL.State.vertexCounter > 0)
         {
+            RLGL.State.currentDrawCalls++;
             // Set current shader and upload current MVP matrix
             glUseProgram(RLGL.State.currentShaderId);
 


### PR DESCRIPTION
Non invasive way to get information about the amount of draw calls made during each tick.
Its under the custom frame control features as its done automatically per default if no custom frame control is chosen.
Accessor exist so it can be adapted to custom frame control