### PR TITLE
[rcore] [SDL2] Fix show, hide, focus and unfocus window/flags states

### DIFF
--- a/src/platforms/rcore_desktop_sdl.c
+++ b/src/platforms/rcore_desktop_sdl.c
@@ -1427,7 +1427,7 @@ void PollInputEvents(void)
 
             // Window events are also polled (Minimized, maximized, close...)
 
-        #ifndef PLATFORM_DESKTOP_SDL3
+            #ifndef PLATFORM_DESKTOP_SDL3
             // SDL3 states:
             //     The SDL_WINDOWEVENT_* events have been moved to top level events,
             //     and SDL_WINDOWEVENT has been removed.
@@ -1437,7 +1437,7 @@ void PollInputEvents(void)
             {
                 switch (event.window.event)
                 {
-        #endif
+            #endif
                     case SDL_WINDOWEVENT_RESIZED:
                     case SDL_WINDOWEVENT_SIZE_CHANGED:
                     {
@@ -1466,6 +1466,7 @@ void PollInputEvents(void)
                         }
                         #endif
                     } break;
+
                     case SDL_WINDOWEVENT_ENTER:
                     {
                         CORE.Input.Mouse.cursorOnScreen = true;
@@ -1474,6 +1475,7 @@ void PollInputEvents(void)
                     {
                         CORE.Input.Mouse.cursorOnScreen = false;
                     } break;
+
                     case SDL_WINDOWEVENT_MINIMIZED:
                     {
                         if ((CORE.Window.flags & FLAG_WINDOW_MINIMIZED) == 0) CORE.Window.flags |= FLAG_WINDOW_MINIMIZED;
@@ -1496,13 +1498,26 @@ void PollInputEvents(void)
                         }
                         #endif
                     } break;
+
                     case SDL_WINDOWEVENT_HIDDEN:
-                    case SDL_WINDOWEVENT_FOCUS_LOST:
+                    {
+                        if ((CORE.Window.flags & FLAG_WINDOW_HIDDEN) == 0) CORE.Window.flags |= FLAG_WINDOW_HIDDEN;
+                    } break;
                     case SDL_WINDOWEVENT_SHOWN:
+                    {
+                        if ((CORE.Window.flags & FLAG_WINDOW_HIDDEN) > 0) CORE.Window.flags &= ~FLAG_WINDOW_HIDDEN;
+                    } break;
+
                     case SDL_WINDOWEVENT_FOCUS_GAINED:
-            #if defined(PLATFORM_DESKTOP_SDL3)
-                        break;
-            #else
+                    {
+                        if ((CORE.Window.flags & FLAG_WINDOW_UNFOCUSED) > 0) CORE.Window.flags &= ~FLAG_WINDOW_UNFOCUSED;
+                    } break;
+                    case SDL_WINDOWEVENT_FOCUS_LOST:
+                    {
+                        if ((CORE.Window.flags & FLAG_WINDOW_UNFOCUSED) == 0) CORE.Window.flags |= FLAG_WINDOW_UNFOCUSED;
+                    } break;
+
+            #ifndef PLATFORM_DESKTOP_SDL3
                     default: break;
                 }
             } break;


### PR DESCRIPTION
Fixes show, hide, focus and unfocus window/flags states on `PLATFORM_DESKTOP_SDL`, and `IsWindowHidden()` ([ref](https://github.com/raysan5/raylib/blob/79facde3535af1f35942eec38f02f2851de618ab/src/rcore.c#L761-L764)) and `IsWindowFocused()` ([ref](https://github.com/raysan5/raylib/blob/79facde3535af1f35942eec38f02f2851de618ab/src/rcore.c#L779-L782)) that were INOP on `PLATFORM_DESKTOP_SDL` because the platform was missing event handling for `SDL_WINDOWEVENT_HIDDEN`, `SDL_WINDOWEVENT_SHOWN`, `SDL_WINDOWEVENT_FOCUS_GAINED` and `SDL_WINDOWEVENT_FOCUS_LOST` ([ref](https://github.com/raysan5/raylib/blob/bdfbd6e8cc77b755d6552f90028ba8262d79ab92/src/platforms/rcore_desktop_sdl.c#L1499-L1502)).

This PR was tested with `SDL2.30.10` on `Linux Mint 22.0`. `SDL3` wasn't tested but should work since these changes share the same events and the handling is agnostic.

<details>
<summary>The PR can be tested with:</summary>
<br>

```
#include "raylib.h"
int main(void) {
    InitWindow(800, 450, "test");
    SetTargetFPS(60);

    double interval = 2.0;

    while (!WindowShouldClose()) {

        // Show and Hide the window every two seconds:
        if (GetTime() > interval) {
            if (IsWindowHidden()) {
                ClearWindowState(FLAG_WINDOW_HIDDEN);
            } else {
                SetWindowState(FLAG_WINDOW_HIDDEN);
            }
            interval += 2.0;
        }

        TraceLog(LOG_INFO, "Hidden %i.  Focused %i.", IsWindowHidden(), IsWindowFocused());

        BeginDrawing();
        ClearBackground(RAYWHITE);
        EndDrawing();
     }
    CloseWindow();
    return 0;
}
```
</details>