### PR TITLE
setting MAX_LEVEL based on actual mipcount input

### DIFF
--- a/src/rlgl.h
+++ b/src/rlgl.h
@@ -3301,6 +3301,7 @@ unsigned int rlLoadTexture(const void *data, int width, int height, int format, 
         // Activate Trilinear filtering if mipmaps are available
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, mipmapCount);      //  user defined mip count would break without this.
     }
 #endif
 


### PR DESCRIPTION
if the user supplies less mips than would be generated normally the texture rendering will break. 
for example quake1&2 and halflife have 4 pre-generated mips included with the data, viewing those textures without this fix would result in visual errors.
