### PR TITLE
[rtext] Centralize Text

### DIFF
--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1485,7 +1485,9 @@ RLAPI void DrawTextCodepoints(Font font, const int *codepoints, int codepointCou
 // Text font info functions
 RLAPI void SetTextLineSpacing(int spacing);                                                 // Set vertical line spacing when drawing with line-breaks
 RLAPI int MeasureText(const char *text, int fontSize);                                      // Measure string width for default font
+RLAPI Vector2 CentralizeText(const char *text, int fontSize, Vector2 anchorPosition, Vector2 areaSize); // Gives you the position (Vector2) for your text so it will be Centered in specific area for default font
 RLAPI Vector2 MeasureTextEx(Font font, const char *text, float fontSize, float spacing);    // Measure string size for Font
+RLAPI Vector2 CentralizeTextEx(Font font, const char *text, float fontSize, float spacing, Vector2 anchorPosition, Vector2 areaSize); // Gives you the position (Vector2) for your text so it will be Centered in specific area for Font
 RLAPI int GetGlyphIndex(Font font, int codepoint);                                          // Get glyph index position in font for a codepoint (unicode character), fallback to '?' if not found
 RLAPI GlyphInfo GetGlyphInfo(Font font, int codepoint);                                     // Get glyph font info data for a codepoint (unicode character), fallback to '?' if not found
 RLAPI Rectangle GetGlyphAtlasRec(Font font, int codepoint);                                 // Get glyph rectangle in font atlas for a codepoint (unicode character), fallback to '?' if not found

--- a/src/rtext.c
+++ b/src/rtext.c
@@ -1277,6 +1277,24 @@ int MeasureText(const char *text, int fontSize)
     return (int)textSize.x;
 }
 
+// Gives you the position (Vector2) for your text so it will be Centered in specific area for default font
+Vector2 CentralizeText(const char *text, int fontSize, Vector2 anchorPosition, Vector2 areaSize)
+{
+    Vector2 textPosition = { 0.0f, 0.0f };
+
+    // Check if default font has been loaded
+    if (GetFontDefault().texture.id != 0)
+    {
+        int defaultFontSize = 10;   // Default Font chars height in pixel
+        if (fontSize < defaultFontSize) fontSize = defaultFontSize;
+        int spacing = fontSize/defaultFontSize;
+
+        textPosition = CentralizeTextEx(GetFontDefault(), text, (float)fontSize, (float)spacing, anchorPosition, areaSize);
+    }
+
+    return textPosition;
+}
+
 // Measure string size for Font
 Vector2 MeasureTextEx(Font font, const char *text, float fontSize, float spacing)
 {
@@ -1332,6 +1350,18 @@ Vector2 MeasureTextEx(Font font, const char *text, float fontSize, float spacing
     textSize.y = textHeight;
 
     return textSize;
+}
+
+// Gives you the position (Vector2) for your text so it will be Centered in specific area for Font
+Vector2 CentralizeTextEx(Font font, const char *text, float fontSize, float spacing, Vector2 anchorPosition, Vector2 areaSize)
+{
+    Vector2 textPosition = { 0 };
+    Vector2 textSize = MeasureTextEx(font, text, fontSize, spacing);
+
+    textPosition.x = anchorPosition.x + ((areaSize.x - textSize.x) / 2.0f);
+    textPosition.y = anchorPosition.y + ((areaSize.y - textSize.y) / 2.0f);
+
+    return textPosition;
 }
 
 // Get index position for a unicode character on font


### PR DESCRIPTION
Added two methods into rtext.c (and the methods declarations into raylib.h) -

1. CentralizeText (for default font)
2. CentralizeTextEx (for specific font)

Used the same logic as in "MeasureText" and "MeasureTextEx" methods:
In the "CentralizeText" method - check if the default font has been loaded, 
If it doesn't - return the zero vector. 
If it does - modify the fontSize, calculate the spacing, and then call the "CentralizeTextEx" method to calculate the desired textPosition. 