### PR TITLE
[rtext] Fix default font alpha on Big Endian systems

### DIFF
--- a/src/rtext.c
+++ b/src/rtext.c
@@ -247,7 +247,11 @@ extern void LoadFontDefault(void)
                 // we must consider data as little-endian order (alpha + gray)
                 ((unsigned short *)imFont.data)[i + j] = 0xffff;
             }
+            #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
             else ((unsigned short *)imFont.data)[i + j] = 0x00ff;
+            #else
+            else ((unsigned short *)imFont.data)[i + j] = 0xff00;
+            #endif
         }
 
         counter++;

--- a/src/rtext.c
+++ b/src/rtext.c
@@ -247,11 +247,11 @@ extern void LoadFontDefault(void)
                 // we must consider data as little-endian order (alpha + gray)
                 ((unsigned short *)imFont.data)[i + j] = 0xffff;
             }
-            #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
-            else ((unsigned short *)imFont.data)[i + j] = 0x00ff;
-            #else
-            else ((unsigned short *)imFont.data)[i + j] = 0xff00;
-            #endif
+            else 
+            { 
+                ((unsigned char *)imFont.data)[(i + j)*sizeof(short)] = 0xFF;
+                ((unsigned char *)imFont.data)[(i + j)*sizeof(short) + 1] = 0x00;
+            }
         }
 
         counter++;


### PR DESCRIPTION
Alpha was broken for rtext's default font on Big Endian
Before
![imagem](https://github.com/user-attachments/assets/8212b89c-b419-4f79-b5e7-c7bcd3969c9d)
After
![imagem](https://github.com/user-attachments/assets/50eb1bf4-89c8-4957-a17a-94f2fb9e2e4c)
