### PR TITLE
[rtext] New pair of functions to automatically prefetch all possible codepoints of any font (except empty ones)

### DIFF
--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1463,6 +1463,8 @@ RLAPI int GetPixelDataSize(int width, int height, int format);              // G
 
 // Font loading/unloading functions
 RLAPI Font GetFontDefault(void);                                                            // Get the default Font
+RLAPI int GetFontAvailableCodepoints(const char *fileName, int **codepoints);               // Get number of available codepoints of font file and update the array of codepoints themselves
+RLAPI int GetFontAvailableCodepointsFromMemory(const char *fileType, const unsigned char *fileData, int dataSize, int **codepoints); // Get number of available codepoints of font data and update the array of codepoints themselves
 RLAPI Font LoadFont(const char *fileName);                                                  // Load font from file into GPU memory (VRAM)
 RLAPI Font LoadFontEx(const char *fileName, int fontSize, int *codepoints, int codepointCount); // Load font from file with extended parameters, use NULL for codepoints and 0 for codepointCount to load the default character set, font size is provided in pixels height
 RLAPI Font LoadFontFromImage(Image image, Color key, int firstChar);                        // Load font from Image (XNA style)

--- a/src/rtext.c
+++ b/src/rtext.c
@@ -115,6 +115,7 @@
 #ifndef MAX_TEXTSPLIT_COUNT
     #define MAX_TEXTSPLIT_COUNT                  128        // Maximum number of substrings to split: TextSplit()
 #endif
+#define MAX_GLYPHS                             65536        // Maximum number of glyphs in a font that need to be scanned
 
 //----------------------------------------------------------------------------------
 // Types and Structures Definition


### PR DESCRIPTION
Hi @raysan5. Thanks for the cool set of libs! And this is my first PR ever, so I apologize if I'm forming something wrong.

I've tried all the appropriate functions to load fonts, but I still haven't found how to load a font with all available glyphs at once.

After analyzing the code, I realized that the `LoadFontEx` or `LoadFontFromMemory` functions, when specifying `NULL, 0` for codepoints in the arguments, load only 95 glyphs (although according to the words from the cheatsheet 

> use NULL for codepoints and 0 for codepointCount to load the default character set

I thought `default` was a full set of all available characters). But it turns out that to load fully all available glyphs, I have to manually collect an array of codepoints, but this is obviously very time-consuming and inconvenient.

So I propose these two functions, which can be used to pre-count the number of available glyphs and automatically collect an array of codepoints. And then use them for `LoadFontEx` or `LoadFontFromMemory` functions. For example like this:
```
int *codepoints;
int codepointsCount = GetFontAvailableCodepoints("data/font.ttf", &codepoints);
fontDefault = LoadFontEx("data/font.ttf", (int)(fontSize*fontScale), codepoints, codepointsCount);
free(codepoints);
```
Of course, before writing these two functions, I tried changing the code of the `LoadFontEx` etc. functions (where I met places about the number of codepoints), so that when arguments `NULL, 0` were specified, the font would load all available glyphs/codepoints at once, not just 95 pieces, but it turned out to be not so simple. Besides, it wasn't good decision, because some glyphs were not loaded correctly, so I decided not to touch the existing code, and probably it's better to leave 95 glyphs for those who don't need Unicode.

That's why it's better to first collect the necessary codepoints into an array and pass them when loading the font using additional functions, it's safer. And these two functions do it automatically and I didn't find any problems. At least the labels and text boxes in raygui display unicode glyphs well when typing text. I tried it on several fonts (only TTF though). I haven't done anything with the BDF type yet, because I just switched from 5.0 to 5.5 and discovered this new type, which honestly I've never heard of it before 🙂

Of course, we could just rasterize all 65536 possible glyphs of any font, but that's too memory expensive (if I understand correctly, empty glyphs will be rasterized as well). And these new functions allow to collect only the available glyphs in a font, not all 65536.

I don't know if you'll accept my PR, but I will definitely use these functions for myself, because fonts are different, and it's very inconvenient to choose codepoints for each random font. But stb_truetype still allows to pre-gather an array of codepoints before rasterization. Besides, I've seen enough requests for correct and automatic unicode text on the web. So it may be useful.