### PR TITLE
[rmodels] Fix normal transform in `UpdateModelAnimationBones`

### DIFF
--- a/src/rmodels.c
+++ b/src/rmodels.c
@@ -2297,13 +2297,12 @@ void UpdateModelAnimationBones(Model model, ModelAnimation anim, int frame)
             Quaternion outRotation = anim.framePoses[frame][boneId].rotation;
             Vector3 outScale = anim.framePoses[frame][boneId].scale;
 
-            Vector3 invTranslation = Vector3RotateByQuaternion(Vector3Negate(inTranslation), QuaternionInvert(inRotation));
             Quaternion invRotation = QuaternionInvert(inRotation);
+            Vector3 invTranslation = Vector3RotateByQuaternion(Vector3Negate(inTranslation), invRotation);
             Vector3 invScale = Vector3Divide((Vector3){ 1.0f, 1.0f, 1.0f }, inScale);
 
-            Vector3 boneTranslation = Vector3Add(
-                Vector3RotateByQuaternion(Vector3Multiply(outScale, invTranslation),
-                outRotation), outTranslation);
+            Vector3 boneTranslation = Vector3Add(Vector3RotateByQuaternion(
+                Vector3Multiply(outScale, invTranslation), outRotation), outTranslation);
             Quaternion boneRotation = QuaternionMultiply(outRotation, invRotation);
             Vector3 boneScale = Vector3Multiply(outScale, invScale);
 

--- a/src/rmodels.c
+++ b/src/rmodels.c
@@ -2380,7 +2380,7 @@ void UpdateModelAnimation(Model model, ModelAnimation anim, int frame)
                 if (mesh.normals != NULL)
                 {
                     animNormal = (Vector3){ mesh.normals[vCounter], mesh.normals[vCounter + 1], mesh.normals[vCounter + 2] };
-                    animNormal = Vector3Transform(animNormal,model.meshes[m].boneMatrices[boneId]);
+                    animNormal = Vector3Transform(animNormal, MatrixTranspose(MatrixInvert(model.meshes[m].boneMatrices[boneId])));
                     mesh.animNormals[vCounter] += animNormal.x*boneWeight;
                     mesh.animNormals[vCounter + 1] += animNormal.y*boneWeight;
                     mesh.animNormals[vCounter + 2] += animNormal.z*boneWeight;


### PR DESCRIPTION
As requested here: https://github.com/raysan5/raylib/issues/4581#issuecomment-2560162214

I fixed the function by transforming the normals using only the rotational part of the transformation matrix, obtained via its inverse transpose.

I also simplified the inversion of the quaternion `inRotation`, which was being calculated twice within the same scope.

**Edit**: the examples `models_animation`, `models_bone_socket`, and `models_loading_gltf` were successfully (re)tested.