### PR TITLE
[rcore] [GLFW] [SDL2] Updates `CORE.Window.eventWaiting` and `FLAG_WINDOW_ALWAYS_RUN` handling

### DIFF
--- a/src/platforms/rcore_desktop_glfw.c
+++ b/src/platforms/rcore_desktop_glfw.c
@@ -1248,11 +1248,12 @@ void PollInputEvents(void)
 
     CORE.Window.resizedLastFrame = false;
 
-    if (CORE.Window.eventWaiting) glfwWaitEvents();     // Wait for in input events before continue (drawing is paused)
+    if ((CORE.Window.eventWaiting) || (IsWindowState(FLAG_WINDOW_MINIMIZED) && !IsWindowState(FLAG_WINDOW_ALWAYS_RUN)))
+    {
+        glfwWaitEvents();     // Wait for in input events before continue (drawing is paused)
+        CORE.Time.previous = GetTime();
+    }
     else glfwPollEvents();      // Poll input events: keyboard/mouse/window events (callbacks) -> Update keys state
-
-    // While window minimized, stop loop execution
-    while (IsWindowState(FLAG_WINDOW_MINIMIZED) && !IsWindowState(FLAG_WINDOW_ALWAYS_RUN)) glfwWaitEvents();
 
     CORE.Window.shouldClose = glfwWindowShouldClose(platform.handle);
 
@@ -1739,12 +1740,7 @@ static void WindowContentScaleCallback(GLFWwindow *window, float scalex, float s
 static void WindowIconifyCallback(GLFWwindow *window, int iconified)
 {
     if (iconified) CORE.Window.flags |= FLAG_WINDOW_MINIMIZED;  // The window was iconified
-    else
-    {
-        CORE.Window.flags &= ~FLAG_WINDOW_MINIMIZED;           // The window was restored
-
-        if ((CORE.Window.flags & FLAG_WINDOW_ALWAYS_RUN) == 0) CORE.Time.previous = GetTime();
-    }
+    else CORE.Window.flags &= ~FLAG_WINDOW_MINIMIZED;           // The window was restored
 }
 
 // GLFW3 WindowMaximize Callback, runs when window is maximized/restored

--- a/src/platforms/rcore_desktop_sdl.c
+++ b/src/platforms/rcore_desktop_sdl.c
@@ -1378,8 +1378,11 @@ void PollInputEvents(void)
 
     CORE.Window.resizedLastFrame = false;
 
-    if ((CORE.Window.eventWaiting) || (((CORE.Window.flags & FLAG_WINDOW_MINIMIZED) > 0) && ((CORE.Window.flags & FLAG_WINDOW_ALWAYS_RUN) == 0))) SDL_WaitEvent(NULL);
-    if (CORE.Window.eventWaiting) CORE.Time.previous = GetTime();
+    if ((CORE.Window.eventWaiting) || (((CORE.Window.flags & FLAG_WINDOW_MINIMIZED) > 0) && ((CORE.Window.flags & FLAG_WINDOW_ALWAYS_RUN) == 0)))
+    {
+        SDL_WaitEvent(NULL);
+        CORE.Time.previous = GetTime();
+    }
 
     SDL_Event event = { 0 };
     while (SDL_PollEvent(&event) != 0)
@@ -1500,8 +1503,6 @@ void PollInputEvents(void)
                             if ((CORE.Window.flags & SDL_WINDOW_MAXIMIZED) > 0) CORE.Window.flags &= ~SDL_WINDOW_MAXIMIZED;
                         }
                         #endif
-
-                        if ((CORE.Window.flags & FLAG_WINDOW_ALWAYS_RUN) == 0) CORE.Time.previous = GetTime();
                     } break;
 
                     case SDL_WINDOWEVENT_HIDDEN:

--- a/src/platforms/rcore_desktop_sdl.c
+++ b/src/platforms/rcore_desktop_sdl.c
@@ -1378,7 +1378,8 @@ void PollInputEvents(void)
 
     CORE.Window.resizedLastFrame = false;
 
-    if (((CORE.Window.flags & FLAG_WINDOW_MINIMIZED) > 0) && ((CORE.Window.flags & FLAG_WINDOW_ALWAYS_RUN) == 0)) SDL_WaitEvent(NULL);
+    if ((CORE.Window.eventWaiting) || (((CORE.Window.flags & FLAG_WINDOW_MINIMIZED) > 0) && ((CORE.Window.flags & FLAG_WINDOW_ALWAYS_RUN) == 0))) SDL_WaitEvent(NULL);
+    if (CORE.Window.eventWaiting) CORE.Time.previous = GetTime();
 
     SDL_Event event = { 0 };
     while (SDL_PollEvent(&event) != 0)


### PR DESCRIPTION
Changes:
1. Fixes `EnableEventWaiting()` and `DisableEventWaiting()` ([ref](https://github.com/raysan5/raylib/blob/7ecc47d12e5f4c322af3d16615a08ba9bc47c4c2/src/rcore.c#L843-L853)) that were inop on `SDL`;
2. Adds a `GetFrameTime()` reset for `CORE.Window.eventWaiting` on `SDL` and `GLFW`;
3. Simplifies/optimizes/unifies `FLAG_WINDOW_ALWAYS_RUN` and `CORE.Window.eventWaiting` handling for `SDL` and `GLFW`.

Tested on `Linux Mint 22.0` with `GLFW` and `SDL2.30.10`, but should work on `SDL3` as well.
<details>
<summary>Test case:</summary>
<br>

```
#include "raylib.h"
int main(void) {
    InitWindow(800, 450, "test");
    SetTargetFPS(60);
    while (!WindowShouldClose()) {

        if (IsKeyPressed(KEY_ONE)) { EnableEventWaiting();  TraceLog(LOG_INFO, "[1] EVENT WAITING ON" ); }
        if (IsKeyPressed(KEY_TWO)) { DisableEventWaiting(); TraceLog(LOG_INFO, "[2] EVENT WAITING OFF"); }

        if (IsKeyPressed(KEY_THREE)) { MinimizeWindow();                         TraceLog(LOG_INFO, "[3] MINIMIZED"     ); }
        if (IsKeyPressed(KEY_FOUR))  { SetWindowState(FLAG_WINDOW_ALWAYS_RUN);   TraceLog(LOG_INFO, "[4] ALWAYS RUN ON" ); }
        if (IsKeyPressed(KEY_FIVE))  { ClearWindowState(FLAG_WINDOW_ALWAYS_RUN); TraceLog(LOG_INFO, "[5] ALWAYS RUN OFF"); }

        TraceLog(LOG_INFO, "GetTime():%f   GetFrameTime():%f", GetTime(), GetFrameTime());

        BeginDrawing();
        ClearBackground(RAYWHITE);
        EndDrawing();
    }
    CloseWindow();
    return 0;
}
```
</details>