### PR TITLE
[Examples] Add support for normal transformation to the GPU skinning example

### DIFF
--- a/examples/models/resources/shaders/glsl330/skinning.vs
+++ b/examples/models/resources/shaders/glsl330/skinning.vs
@@ -6,16 +6,19 @@
 in vec3 vertexPosition;
 in vec2 vertexTexCoord;
 in vec4 vertexColor;
+in vec3 vertexNormal;
 in vec4 vertexBoneIds;
 in vec4 vertexBoneWeights;
 
 // Input uniform values
 uniform mat4 mvp;
+uniform mat4 matNormal;
 uniform mat4 boneMatrices[MAX_BONE_NUM];
 
 // Output vertex attributes (to fragment shader)
 out vec2 fragTexCoord;
 out vec4 fragColor;
+out vec3 fragNormal;
 
 void main()
 {
@@ -29,9 +32,18 @@ void main()
         vertexBoneWeights.y*(boneMatrices[boneIndex1]*vec4(vertexPosition, 1.0)) + 
         vertexBoneWeights.z*(boneMatrices[boneIndex2]*vec4(vertexPosition, 1.0)) + 
         vertexBoneWeights.w*(boneMatrices[boneIndex3]*vec4(vertexPosition, 1.0));
-    
+
+    vec4 skinnedNormal =
+        vertexBoneWeights.x*(boneMatrices[boneIndex0]*vec4(vertexNormal, 0.0)) +
+        vertexBoneWeights.y*(boneMatrices[boneIndex1]*vec4(vertexNormal, 0.0)) + 
+        vertexBoneWeights.z*(boneMatrices[boneIndex2]*vec4(vertexNormal, 0.0)) + 
+        vertexBoneWeights.w*(boneMatrices[boneIndex3]*vec4(vertexNormal, 0.0));
+    skinnedNormal.w = 0.0;
+
     fragTexCoord = vertexTexCoord;
     fragColor = vertexColor;
+
+    fragNormal = normalize(vec3(matNormal*skinnedNormal));
 
     gl_Position = mvp*skinnedPosition;
 }


### PR DESCRIPTION
The GPU skinning example only transformed the vertex data in the shader, it did not show how to also transform the normal data. Even though the normals are not used by the fragment shader, I feel it is important to have an example of how to transform the normals by the skin transforms for people that do want to eventually use lighting on GPU skinned meshes.

This PR transforms the normal and passes it to the fragment shader.