### PR TITLE
[rcore_web]: Fix Touch pointCount reduction

### DIFF
--- a/src/platforms/rcore_web.c
+++ b/src/platforms/rcore_web.c
@@ -1812,7 +1812,23 @@ static EM_BOOL EmscriptenTouchCallback(int eventType, const EmscriptenTouchEvent
 
     if (eventType == EMSCRIPTEN_EVENT_TOUCHEND)
     {
-        CORE.Input.Touch.pointCount--;
+        // Identify the EMSCRIPTEN_EVENT_TOUCHEND and remove it from the list
+        for (int i = 0; i < CORE.Input.Touch.pointCount; i++)
+        {
+            if (touchEvent->touches[i].isChanged)
+            {
+                // Move all touch points one position up
+                for (int j = i; j < CORE.Input.Touch.pointCount - 1; j++)
+                {
+                    CORE.Input.Touch.pointId[j] = CORE.Input.Touch.pointId[j + 1];
+                    CORE.Input.Touch.position[j] = CORE.Input.Touch.position[j + 1];
+                }
+                // Decrease touch points count to remove the last one
+                CORE.Input.Touch.pointCount--;
+                break;
+            }
+        }
+        // Clamp pointCount to avoid negative values
         if (CORE.Input.Touch.pointCount < 0) CORE.Input.Touch.pointCount = 0;
     }
 


### PR DESCRIPTION
Issue:

1. Player touches position ```{ 10, 10 }``` on the screen.
- CORE.Input.Touch.pointCount = 1
- Vector = ```[{10,10}]```

2. Player touches position ```{ 100, 100 }``` on the screen with another finger.
- CORE.Input.Touch.pointCount = 2
- Vector = ```[{ 10, 10 } , { 100, 100 }]```

3. Player release first finger from position ```{ 10, 10  }```.
- CORE.Input.Touch.pointCount = 1
- Vector = ```[{ 10, 10 } , { 100, 100 }]```

4. When the game try to access the position 0 it gets the wrong values as the Vector is not in order.

Solution:

1. Identify the index touch that was changed: ```if (touchEvent->touches[i].isChanged)```.
2. Move all touch values available one position up.
3. Reduce ```CORE.Input.Touch.pointCount```.



