### PR TITLE
[rshapes] Fix pixel offset issue with line drawing

### DIFF
--- a/src/rshapes.c
+++ b/src/rshapes.c
@@ -1141,8 +1141,7 @@ void DrawRectangleRoundedLinesEx(Rectangle rec, float roundness, int segments, f
     }
 
     float stepLength = 90.0f/(float)segments;
-    const float outerRadius = radius + lineThick - 0.5f;
-    const float innerRadius = radius - 0.5f;
+    const float outerRadius = radius + lineThick, innerRadius = radius;
 
     /*
     Quick sketch to make sense of all of this,

--- a/src/rshapes.c
+++ b/src/rshapes.c
@@ -1141,7 +1141,8 @@ void DrawRectangleRoundedLinesEx(Rectangle rec, float roundness, int segments, f
     }
 
     float stepLength = 90.0f/(float)segments;
-    const float outerRadius = radius + lineThick, innerRadius = radius;
+    const float outerRadius = radius + lineThick - 0.5f;
+    const float innerRadius = radius - 0.5f;
 
     /*
     Quick sketch to make sense of all of this,
@@ -1162,20 +1163,20 @@ void DrawRectangleRoundedLinesEx(Rectangle rec, float roundness, int segments, f
     const Vector2 point[16] = {
         {(float)rec.x + innerRadius + 0.5f, rec.y - lineThick + 0.5f}, 
         {(float)(rec.x + rec.width) - innerRadius - 0.5f, rec.y - lineThick + 0.5f}, 
-        {rec.x + rec.width + lineThick - 0.5f, (float)rec.y + innerRadius - 0.5f}, // PO, P1, P2
-        {rec.x + rec.width + lineThick - 0.5f, (float)(rec.y + rec.height) - innerRadius + 0.5f}, 
+        {rec.x + rec.width + lineThick - 0.5f, (float)rec.y + innerRadius + 0.5f}, // PO, P1, P2
+        {rec.x + rec.width + lineThick - 0.5f, (float)(rec.y + rec.height) - innerRadius - 0.5f}, 
         {(float)(rec.x + rec.width) - innerRadius - 0.5f, rec.y + rec.height + lineThick - 0.5f}, // P3, P4
         {(float)rec.x + innerRadius + 0.5f, rec.y + rec.height + lineThick - 0.5f}, 
         {rec.x - lineThick + 0.5f, (float)(rec.y + rec.height) - innerRadius - 0.5f}, 
         {rec.x - lineThick + 0.5f, (float)rec.y + innerRadius + 0.5f}, // P5, P6, P7
         {(float)rec.x + innerRadius + 0.5f, rec.y + 0.5f}, 
         {(float)(rec.x + rec.width) - innerRadius - 0.5f, rec.y + 0.5f}, // P8, P9
-        {rec.x + rec.width - 0.5f, (float)rec.y + innerRadius - 0.5f}, 
-        {rec.x + rec.width - 0.5f, (float)(rec.y + rec.height) - innerRadius + 0.5f}, // P10, P11
+        {rec.x + rec.width - 0.5f, (float)rec.y + innerRadius + 0.5f}, 
+        {rec.x + rec.width - 0.5f, (float)(rec.y + rec.height) - innerRadius - 0.5f}, // P10, P11
         {(float)(rec.x + rec.width) - innerRadius - 0.5f, rec.y + rec.height - 0.5f}, 
         {(float)rec.x + innerRadius + 0.5f, rec.y + rec.height - 0.5f}, // P12, P13
-        {rec.x + 0.5f, (float)(rec.y + rec.height) - innerRadius + 0.5f}, 
-        {rec.x + 0.5f, (float)rec.y + innerRadius - 0.5f} // P14, P15
+        {rec.x + 0.5f, (float)(rec.y + rec.height) - innerRadius - 0.5f}, 
+        {rec.x + 0.5f, (float)rec.y + innerRadius + 0.5f} // P14, P15
     };
 
     const Vector2 centers[4] = {

--- a/src/rshapes.c
+++ b/src/rshapes.c
@@ -1160,18 +1160,29 @@ void DrawRectangleRoundedLinesEx(Rectangle rec, float roundness, int segments, f
            P5 ================== P4
     */
     const Vector2 point[16] = {
-        {(float)rec.x + innerRadius, rec.y - lineThick}, {(float)(rec.x + rec.width) - innerRadius, rec.y - lineThick}, { rec.x + rec.width + lineThick, (float)rec.y + innerRadius }, // PO, P1, P2
-        {rec.x + rec.width + lineThick, (float)(rec.y + rec.height) - innerRadius}, {(float)(rec.x + rec.width) - innerRadius, rec.y + rec.height + lineThick}, // P3, P4
-        {(float)rec.x + innerRadius, rec.y + rec.height + lineThick}, { rec.x - lineThick, (float)(rec.y + rec.height) - innerRadius}, {rec.x - lineThick, (float)rec.y + innerRadius}, // P5, P6, P7
-        {(float)rec.x + innerRadius, rec.y}, {(float)(rec.x + rec.width) - innerRadius, rec.y}, // P8, P9
-        { rec.x + rec.width, (float)rec.y + innerRadius }, {rec.x + rec.width, (float)(rec.y + rec.height) - innerRadius}, // P10, P11
-        {(float)(rec.x + rec.width) - innerRadius, rec.y + rec.height}, {(float)rec.x + innerRadius, rec.y + rec.height}, // P12, P13
-        { rec.x, (float)(rec.y + rec.height) - innerRadius}, {rec.x, (float)rec.y + innerRadius} // P14, P15
+        {(float)rec.x + innerRadius + 0.5f, rec.y - lineThick + 0.5f}, 
+        {(float)(rec.x + rec.width) - innerRadius - 0.5f, rec.y - lineThick + 0.5f}, 
+        {rec.x + rec.width + lineThick - 0.5f, (float)rec.y + innerRadius - 0.5f}, // PO, P1, P2
+        {rec.x + rec.width + lineThick - 0.5f, (float)(rec.y + rec.height) - innerRadius + 0.5f}, 
+        {(float)(rec.x + rec.width) - innerRadius - 0.5f, rec.y + rec.height + lineThick - 0.5f}, // P3, P4
+        {(float)rec.x + innerRadius + 0.5f, rec.y + rec.height + lineThick - 0.5f}, 
+        {rec.x - lineThick + 0.5f, (float)(rec.y + rec.height) - innerRadius - 0.5f}, 
+        {rec.x - lineThick + 0.5f, (float)rec.y + innerRadius + 0.5f}, // P5, P6, P7
+        {(float)rec.x + innerRadius + 0.5f, rec.y + 0.5f}, 
+        {(float)(rec.x + rec.width) - innerRadius - 0.5f, rec.y + 0.5f}, // P8, P9
+        {rec.x + rec.width - 0.5f, (float)rec.y + innerRadius - 0.5f}, 
+        {rec.x + rec.width - 0.5f, (float)(rec.y + rec.height) - innerRadius + 0.5f}, // P10, P11
+        {(float)(rec.x + rec.width) - innerRadius - 0.5f, rec.y + rec.height - 0.5f}, 
+        {(float)rec.x + innerRadius + 0.5f, rec.y + rec.height - 0.5f}, // P12, P13
+        {rec.x + 0.5f, (float)(rec.y + rec.height) - innerRadius + 0.5f}, 
+        {rec.x + 0.5f, (float)rec.y + innerRadius - 0.5f} // P14, P15
     };
 
     const Vector2 centers[4] = {
-        {(float)rec.x + innerRadius, (float)rec.y + innerRadius}, {(float)(rec.x + rec.width) - innerRadius, (float)rec.y + innerRadius}, // P16, P17
-        {(float)(rec.x + rec.width) - innerRadius, (float)(rec.y + rec.height) - innerRadius}, {(float)rec.x + innerRadius, (float)(rec.y + rec.height) - innerRadius} // P18, P19
+        {(float)rec.x + innerRadius + 0.5f, (float)rec.y + innerRadius + 0.5f}, 
+        {(float)(rec.x + rec.width) - innerRadius - 0.5f, (float)rec.y + innerRadius + 0.5f}, // P16, P17
+        {(float)(rec.x + rec.width) - innerRadius - 0.5f, (float)(rec.y + rec.height) - innerRadius - 0.5f}, 
+        {(float)rec.x + innerRadius + 0.5f, (float)(rec.y + rec.height) - innerRadius - 0.5f} // P18, P19
     };
 
     const float angles[4] = { 180.0f, 270.0f, 0.0f, 90.0f };


### PR DESCRIPTION
I propose here a fix for `DrawRectangleRoundedLinesEx` as discussed in this issue: https://github.com/raysan5/raylib/issues/4601.

The method used to calculate the points corresponds to this in pseudocode:
```c
vec2 tl = coord + 0.5
vec2 br = coord + size - 0.5
```

I was only able to test it on the following configurations:

- **NVIDIA GTX 980**  
  - Driver: 550.120  
  - System: Linux Mint 21.3

- **NVIDIA Quadro NVS 160M**  
  - Driver: 340.108  
  - System: Linux Mint 21.3
  
It would be nice to be able to test it on AMD and Intel hardware.

___

The same approach can also be applied to `DrawRectangleLines`.

However, as demonstrated in the issue linked above, this function applies an offset using `zoomFactor`, which causes other alignment issues and leads to incorrect rendering.

To obtain correct results with a scale of (1, 1) for `DrawRectangleLines`, it is currently necessary to eliminate the addition and subtraction of `zoomFactor` and follow the method described above.

Nevertheless, I have conducted several tests to address the offset with "non-identity" scaling, but, strangely, I have not yet achieved any convincing results.

___

**Additional note**: The current application of the `zoomFactor` offset in `DrawRectangleLines` only considers `matView.m0`, but shouldn’t it also take `matView.m5` into account for non-uniform scaling?

___

**I would like to gather opinions on the question of `DrawRectangleLines` before completing this draft.**