### PR TITLE
[rshapes] Fix pixel offset issue with `DrawRectangleLines`

### DIFF
--- a/src/rshapes.c
+++ b/src/rshapes.c
@@ -807,22 +807,25 @@ void DrawRectangleGradientEx(Rectangle rec, Color topLeft, Color bottomLeft, Col
 // but it solves another issue: https://github.com/raysan5/raylib/issues/3884
 void DrawRectangleLines(int posX, int posY, int width, int height, Color color)
 {
-    Matrix mat = rlGetMatrixModelview();
-    float zoomFactor = 0.5f/mat.m0;
+    Matrix mat = rlGetMatrixTransform();
+    float xOffset = 0.5f/mat.m0;
+    float yOffset = 0.5f/mat.m5;
+
     rlBegin(RL_LINES);
         rlColor4ub(color.r, color.g, color.b, color.a);
-        rlVertex2f((float)posX - zoomFactor, (float)posY);
-        rlVertex2f((float)posX + (float)width + zoomFactor, (float)posY);
+        rlVertex2f((float)posX + xOffset, (float)posY + yOffset);
+        rlVertex2f((float)posX + (float)width - xOffset, (float)posY + yOffset);
 
-        rlVertex2f((float)posX + (float)width, (float)posY - zoomFactor);
-        rlVertex2f((float)posX + (float)width, (float)posY + (float)height + zoomFactor);
+        rlVertex2f((float)posX + (float)width - xOffset, (float)posY + yOffset);
+        rlVertex2f((float)posX + (float)width - xOffset, (float)posY + (float)height - yOffset);
 
-        rlVertex2f((float)posX + (float)width + zoomFactor, (float)posY + (float)height);
-        rlVertex2f((float)posX - zoomFactor, (float)posY + (float)height);
+        rlVertex2f((float)posX + (float)width - xOffset, (float)posY + (float)height - yOffset);
+        rlVertex2f((float)posX + xOffset, (float)posY + (float)height - yOffset);
 
-        rlVertex2f((float)posX, (float)posY + (float)height + zoomFactor);
-        rlVertex2f((float)posX, (float)posY - zoomFactor);
+        rlVertex2f((float)posX + xOffset, (float)posY + (float)height - yOffset);
+        rlVertex2f((float)posX + xOffset, (float)posY + yOffset);
     rlEnd();
+
 /*
 // Previous implementation, it has issues... but it does not require view matrix...
 #if defined(SUPPORT_QUADS_DRAW_MODE)
@@ -845,7 +848,7 @@ void DrawRectangleLines(int posX, int posY, int width, int height, Color color)
         rlVertex2f((float)posX + 1, (float)posY + (float)height);
         rlVertex2f((float)posX + 1, (float)posY + 1);
     rlEnd();
-//#endif
+#endif
 */
 }
 


### PR DESCRIPTION
As requested here (https://github.com/raysan5/raylib/pull/4666#issuecomment-2578790857), here is the fix for `DrawRectangleLines`.

And good news! This fix also handles scale transformations!

There was initially a small error in applying the offsets, which has been corrected.

But most importantly, strangely, the function `rlGetMatrixModelview()` seems to only return the first matrix of the transformation stack, which could be considered just the view matrix if we want to put it that way...

However, by calling `rlGetMatrixTransform()`, we seem to get the actual 'modelView' matrix, which corresponds to all the accumulated transformation matrices on the stack.

Here’s a little example:
```c
BeginDrawing();  // rlLoadIdentity();

rlPushMatrix();
rlScalef(2, 5, 1);

Matrix mv = rlGetMatrixModelview();    //< m0 = 1 | m5 = 1
Matrix t = rlGetMatrixTransform();     //< m0 = 2 | m5 = 5

rlPopMatrix();
```

So, I simply replaced the call to `rlGetMatrixModelview()` with `rlGetMatrixTransform()`, fixed how the offsets are applied, and added consideration for `m5` in non-uniform scales along both axes.

___

Maybe `rlGetMatrixModelview()` is misleading in its name? It's up to you to tell me.

Also, maybe this adjustment could be applied to all other line drawing functions? I’m not sure how relevant that could be, so feel free to share your thoughts on that too.

If that’s the case, for `DrawRectangleRoundedLinesEx()`, it would still require some testing to be sure of what we are doing.

___

Here is an example with a 10x10 square scaled using `rlScalef(5, 2, 1);`:
![image](https://github.com/user-attachments/assets/1dcd5a11-559b-459e-b3f0-7e252db22bb6)

The red is at a transparency of `127`, so we can see the black underneath.