### PR TITLE
Update xcode-frameworks dependency for latest zig

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -6,7 +6,7 @@
     .dependencies = .{
         .xcode_frameworks = .{
             .url = "git+https://github.com/hexops/xcode-frameworks#9a45f3ac977fd25dff77e58c6de1870b6808c4a7",
-            .hash = "122007ebf8ade1abcff8e6ce3d10a103da80b3798de3903c2da7f25eb6b530282bec",
+            .hash = "122098b9174895f9708bc824b0f9e550c401892c40a900006459acf2cbf78acd99bb",
             .lazy = true,
         },
         .emsdk = .{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -6,7 +6,7 @@
     .dependencies = .{
         .xcode_frameworks = .{
             .url = "git+https://github.com/hexops/xcode-frameworks#9a45f3ac977fd25dff77e58c6de1870b6808c4a7",
-            .hash = "12208da4dfcd9b53fb367375fb612ec73f38e53015f1ce6ae6d6e8437a637078e170",
+            .hash = "122007ebf8ade1abcff8e6ce3d10a103da80b3798de3903c2da7f25eb6b530282bec",
             .lazy = true,
         },
         .emsdk = .{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,7 +5,7 @@
 
     .dependencies = .{
         .xcode_frameworks = .{
-            .url = "git+https://github.com/hexops/xcode-frameworks#a6bf82e032d4d9923ad5c222d466710fcc05f249",
+            .url = "git+https://github.com/hexops/xcode-frameworks#9a45f3ac977fd25dff77e58c6de1870b6808c4a7",
             .hash = "12208da4dfcd9b53fb367375fb612ec73f38e53015f1ce6ae6d6e8437a637078e170",
             .lazy = true,
         },


### PR DESCRIPTION
When building on Mac via zig, the xcode-frameworks dependency is out of date and therefore fails to build.

This PR updates that dependency to the latest version, which builds correctly.

It should only affect macs. I have only been able to test it on an M1 mac, but I do not think there is any architecture difference in this regard.