### PR TITLE
[RCORE] Fix GCC 14 cast issue

### DIFF
--- a/src/rcore.c
+++ b/src/rcore.c
@@ -1931,7 +1931,7 @@ bool IsFileExtension(const char *fileName, const char *ext)
     {
 #if defined(SUPPORT_MODULE_RTEXT) && defined(SUPPORT_TEXT_MANIPULATION)
         int extCount = 0;
-        const char **checkExts = TextSplit(ext, ';', &extCount); // WARNING: Module required: rtext
+        char **checkExts = TextSplit(ext, ';', &extCount); // WARNING: Module required: rtext
 
         char fileExtLower[MAX_FILE_EXTENSION_LENGTH + 1] = { 0 };
         strncpy(fileExtLower, TextToLower(fileExt), MAX_FILE_EXTENSION_LENGTH); // WARNING: Module required: rtext


### PR DESCRIPTION
Fixes #4679
GCC doesn't like casting a char handle (char**) to a const char handle (const char**) for some reason.