### PR TITLE
[rshapes] Allow `DrawRectangleRounded()` to draw rectangles with a size < 1

### DIFF
--- a/src/rshapes.c
+++ b/src/rshapes.c
@@ -887,7 +887,7 @@ void DrawRectangleLinesEx(Rectangle rec, float lineThick, Color color)
 void DrawRectangleRounded(Rectangle rec, float roundness, int segments, Color color)
 {
     // Not a rounded rectangle
-    if ((roundness <= 0.0f) || (rec.width < 1) || (rec.height < 1 ))
+    if (roundness <= 0.0f)
     {
         DrawRectangleRec(rec, color);
         return;


### PR DESCRIPTION
As discussed in #4673 this removes the fallback to `DrawRectangle()` if the width or height is < 1.

Rounded rectangles with a size < 1 can already be drawn without issues if the check is removed and this behavior is desirable in cases where rounded rectangles are placed in between fractional world coordinates.