### PR TITLE
Using canvas id provided by Module for event binding

### DIFF
--- a/examples/core/core_input_mouse.c
+++ b/examples/core/core_input_mouse.c
@@ -2,12 +2,12 @@
 *
 *   raylib [core] example - Mouse input
 *
-*   Example originally created with raylib 1.0, last time updated with raylib 4.0
+*   Example originally created with raylib 1.0, last time updated with raylib 5.5
 *
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2014-2024 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2014-2025 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 
@@ -27,6 +27,7 @@ int main(void)
 
     Vector2 ballPosition = { -100.0f, -100.0f };
     Color ballColor = DARKBLUE;
+    int isCursorHidden = 0;
 
     SetTargetFPS(60);               // Set our game to run at 60 frames-per-second
     //---------------------------------------------------------------------------------------
@@ -36,6 +37,20 @@ int main(void)
     {
         // Update
         //----------------------------------------------------------------------------------
+        if (IsKeyPressed(KEY_H))
+        {
+            if (isCursorHidden == 0)
+            {
+                HideCursor();
+                isCursorHidden = 1;
+            }
+            else
+            {
+                ShowCursor();
+                isCursorHidden = 0;
+            }
+        }
+        
         ballPosition = GetMousePosition();
 
         if (IsMouseButtonPressed(MOUSE_BUTTON_LEFT)) ballColor = MAROON;
@@ -56,6 +71,10 @@ int main(void)
             DrawCircleV(ballPosition, 40, ballColor);
 
             DrawText("move ball with mouse and click mouse button to change color", 10, 10, 20, DARKGRAY);
+            DrawText("Press 'H' to toggle cursor visibility", 10, 30, 20, DARKGRAY);
+
+            if (isCursorHidden == 1) DrawText("CURSOR HIDDEN", 20, 60, 20, RED);
+            else DrawText("CURSOR VISIBLE", 20, 60, 20, LIME);
 
         EndDrawing();
         //----------------------------------------------------------------------------------


### PR DESCRIPTION
This change is replacing the hardcoded "#canvas" element references in rcore_web to allow using canvas elements that use different names (which is necessary when using multiple canvas elements on one page).

Also adding a cursor hiding example to test this functionality in browser.