### PR TITLE
[examples] Update examples to be consistent

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1671,7 +1671,7 @@ Detailed changes:
 [examples] ADDED: models_waving_cubes, by @codecat
 [examples] ADDED: models_solar_system, by @aldrinmartoq
 [examples] ADDED: shaders_fog, by @chriscamacho
-[examples] ADDED: shaders_texture_waves, by @Anata
+[examples] ADDED: shaders_texture_waves, by @anatagawa
 [examples] ADDED: shaders_basic_lighting, by @chriscamacho
 [examples] ADDED: shaders_simple_mask, by @chriscamacho
 [examples] ADDED: audio_multichannel_sound, by @chriscamacho

--- a/examples/README.md
+++ b/examples/README.md
@@ -80,7 +80,7 @@ Examples using raylib shapes drawing functionality, provided by raylib [shapes](
 | 47 | [shapes_draw_circle_sector](shapes/shapes_draw_circle_sector.c) | <img src="shapes/shapes_draw_circle_sector.png" alt="shapes_draw_circle_sector" width="80"> | ⭐️⭐️⭐️☆ | 2.5 | 2.5 | [Vlad Adrian](https://github.com/demizdor) |
 | 48 | [shapes_draw_rectangle_rounded](shapes/shapes_draw_rectangle_rounded.c) | <img src="shapes/shapes_draw_rectangle_rounded.png" alt="shapes_draw_rectangle_rounded" width="80"> | ⭐️⭐️⭐️☆ | 2.5 | 2.5 | [Vlad Adrian](https://github.com/demizdor) |
 | 49 | [shapes_top_down_lights](shapes/shapes_top_down_lights.c) | <img src="shapes/shapes_top_down_lights.png" alt="shapes_top_down_lights" width="80"> | ⭐️⭐️⭐️⭐️ | **4.2** | **4.2** | [Jeffery Myers](https://github.com/JeffM2501) |
-| 50 | [shapes_rectangle_advanced](shapes/shapes_rectangle_advanced.c) | <img src="shapes/shapes_rectangle_advanced.png" alt="shapes_rectangle_advanced" width="80"> | ⭐️⭐️⭐️⭐️⭐️| **5.0** | **5.0** | [ExCyber](https://github.com/evertonse) |
+| 50 | [shapes_rectangle_advanced](shapes/shapes_rectangle_advanced.c) | <img src="shapes/shapes_rectangle_advanced.png" alt="shapes_rectangle_advanced" width="80"> | ⭐️⭐️⭐️⭐️ | **5.0** | **5.0** | [ExCyber](https://github.com/evertonse) |
 
 ### category: textures
 

--- a/examples/audio/audio_mixed_processor.c
+++ b/examples/audio/audio_mixed_processor.c
@@ -11,7 +11,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2023 hkc (@hatkidchan)
+*   Copyright (c) 2023-2025 hkc (@hatkidchan)
 *
 ********************************************************************************************/
 #include "raylib.h"

--- a/examples/audio/audio_module_playing.c
+++ b/examples/audio/audio_module_playing.c
@@ -9,7 +9,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2016-2024 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2016-2025 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/audio/audio_music_stream.c
+++ b/examples/audio/audio_music_stream.c
@@ -9,7 +9,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2015-2024 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2015-2025 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/audio/audio_raw_stream.c
+++ b/examples/audio/audio_raw_stream.c
@@ -11,7 +11,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2015-2024 Ramon Santamaria (@raysan5) and James Hofmann (@triplefox)
+*   Copyright (c) 2015-2025 Ramon Santamaria (@raysan5) and James Hofmann (@triplefox)
 *
 ********************************************************************************************/
 

--- a/examples/audio/audio_sound_loading.c
+++ b/examples/audio/audio_sound_loading.c
@@ -9,7 +9,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2014-2024 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2014-2025 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/audio/audio_sound_multi.c
+++ b/examples/audio/audio_sound_multi.c
@@ -9,7 +9,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2023 Jeffery Myers (@JeffM2501)
+*   Copyright (c) 2023-2025 Jeffery Myers (@JeffM2501)
 *
 ********************************************************************************************/
 

--- a/examples/audio/audio_sound_multi.c
+++ b/examples/audio/audio_sound_multi.c
@@ -6,6 +6,8 @@
 *
 *   Example originally created with raylib 4.6, last time updated with raylib 4.6
 *
+*   Example contributed by Jeffery Myers (@JeffM2501) and reviewed by Ramon Santamaria (@raysan5)
+*
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *

--- a/examples/audio/audio_sound_multi.c
+++ b/examples/audio/audio_sound_multi.c
@@ -4,7 +4,7 @@
 *
 *   Example complexity rating: [★★☆☆] 2/4
 *
-*   Example originally created with raylib 4.6
+*   Example originally created with raylib 4.6, last time updated with raylib 4.6
 *
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software

--- a/examples/audio/audio_stream_effects.c
+++ b/examples/audio/audio_stream_effects.c
@@ -9,7 +9,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2022-2024 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2022-2025 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/core/core_2d_camera.c
+++ b/examples/core/core_2d_camera.c
@@ -9,7 +9,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2016-2024 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2016-2025 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/core/core_2d_camera_mouse_zoom.c
+++ b/examples/core/core_2d_camera_mouse_zoom.c
@@ -6,6 +6,8 @@
 *
 *   Example originally created with raylib 4.2, last time updated with raylib 4.2
 *
+*   Example contributed by Jeffery Myers (@JeffM2501) and reviewed by Ramon Santamaria (@raysan5)
+*
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *

--- a/examples/core/core_2d_camera_mouse_zoom.c
+++ b/examples/core/core_2d_camera_mouse_zoom.c
@@ -11,7 +11,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2022-2024 Jeffery Myers (@JeffM2501)
+*   Copyright (c) 2022-2025 Jeffery Myers (@JeffM2501)
 *
 ********************************************************************************************/
 

--- a/examples/core/core_2d_camera_platformer.c
+++ b/examples/core/core_2d_camera_platformer.c
@@ -11,7 +11,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2019-2024 arvyy (@arvyy)
+*   Copyright (c) 2019-2025 arvyy (@arvyy)
 *
 ********************************************************************************************/
 

--- a/examples/core/core_2d_camera_split_screen.c
+++ b/examples/core/core_2d_camera_split_screen.c
@@ -14,7 +14,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2023 Gabriel dos Santos Sanches (@gabrielssanches)
+*   Copyright (c) 2023-2025 Gabriel dos Santos Sanches (@gabrielssanches)
 *
 ********************************************************************************************/
 

--- a/examples/core/core_3d_camera_first_person.c
+++ b/examples/core/core_3d_camera_first_person.c
@@ -9,7 +9,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2015-2024 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2015-2025 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/core/core_3d_camera_free.c
+++ b/examples/core/core_3d_camera_free.c
@@ -9,7 +9,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2015-2024 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2015-2025 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/core/core_3d_camera_mode.c
+++ b/examples/core/core_3d_camera_mode.c
@@ -9,7 +9,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2014-2024 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2014-2025 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/core/core_3d_camera_split_screen.c
+++ b/examples/core/core_3d_camera_split_screen.c
@@ -11,7 +11,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2021-2024 Jeffery Myers (@JeffM2501)
+*   Copyright (c) 2021-2025 Jeffery Myers (@JeffM2501)
 *
 ********************************************************************************************/
 

--- a/examples/core/core_3d_picking.c
+++ b/examples/core/core_3d_picking.c
@@ -9,7 +9,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2015-2024 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2015-2025 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/core/core_automation_events.c
+++ b/examples/core/core_automation_events.c
@@ -11,7 +11,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2023 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2023-2025 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/core/core_basic_screen_manager.c
+++ b/examples/core/core_basic_screen_manager.c
@@ -11,7 +11,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2021-2024 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2021-2025 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/core/core_basic_window.c
+++ b/examples/core/core_basic_window.c
@@ -22,7 +22,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2013-2024 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2013-2025 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/core/core_basic_window_web.c
+++ b/examples/core/core_basic_window_web.c
@@ -11,7 +11,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2015-2024 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2015-2025 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/core/core_custom_frame_control.c
+++ b/examples/core/core_custom_frame_control.c
@@ -24,7 +24,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2021-2024 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2021-2025 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/core/core_custom_logging.c
+++ b/examples/core/core_custom_logging.c
@@ -11,7 +11,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2018-2024 Pablo Marcos Oltra (@pamarcos) and Ramon Santamaria (@raysan5)
+*   Copyright (c) 2018-2025 Pablo Marcos Oltra (@pamarcos) and Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/core/core_drop_files.c
+++ b/examples/core/core_drop_files.c
@@ -11,7 +11,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2015-2024 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2015-2025 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/core/core_input_gamepad.c
+++ b/examples/core/core_input_gamepad.c
@@ -15,7 +15,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2013-2024 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2013-2025 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/core/core_input_gestures.c
+++ b/examples/core/core_input_gestures.c
@@ -9,7 +9,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2016-2024 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2016-2025 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/core/core_input_gestures_web.c
+++ b/examples/core/core_input_gestures_web.c
@@ -9,7 +9,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2023 ubkp (@ubkp)
+*   Copyright (c) 2023-2025 ubkp (@ubkp)
 *
 ********************************************************************************************/
 

--- a/examples/core/core_input_keys.c
+++ b/examples/core/core_input_keys.c
@@ -9,7 +9,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2014-2024 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2014-2025 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/core/core_input_mouse_wheel.c
+++ b/examples/core/core_input_mouse_wheel.c
@@ -9,7 +9,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2014-2024 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2014-2025 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/core/core_input_multitouch.c
+++ b/examples/core/core_input_multitouch.c
@@ -11,7 +11,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2019-2024 Berni (@Berni8k) and Ramon Santamaria (@raysan5)
+*   Copyright (c) 2019-2025 Berni (@Berni8k) and Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/core/core_input_virtual_controls.c
+++ b/examples/core/core_input_virtual_controls.c
@@ -12,7 +12,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2024 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2024-2025 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/core/core_loading_thread.c
+++ b/examples/core/core_loading_thread.c
@@ -11,7 +11,7 @@
 *
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *
-*   Copyright (c) 2014-2024 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2014-2025 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/core/core_random_sequence.c
+++ b/examples/core/core_random_sequence.c
@@ -9,7 +9,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2023 Dalton Overmyer (@REDl3east)
+*   Copyright (c) 2023-2025 Dalton Overmyer (@REDl3east)
 *
 ********************************************************************************************/
 

--- a/examples/core/core_random_values.c
+++ b/examples/core/core_random_values.c
@@ -9,7 +9,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2014-2024 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2014-2025 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/core/core_scissor_test.c
+++ b/examples/core/core_scissor_test.c
@@ -11,7 +11,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2019-2024 Chris Dill (@MysteriousSpace)
+*   Copyright (c) 2019-2025 Chris Dill (@MysteriousSpace)
 *
 ********************************************************************************************/
 

--- a/examples/core/core_smooth_pixelperfect.c
+++ b/examples/core/core_smooth_pixelperfect.c
@@ -12,7 +12,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2021-2024 Giancamillo Alessandroni (@NotManyIdeasDev) and Ramon Santamaria (@raysan5)
+*   Copyright (c) 2021-2025 Giancamillo Alessandroni (@NotManyIdeasDev) and Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/core/core_storage_values.c
+++ b/examples/core/core_storage_values.c
@@ -9,7 +9,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2015-2024 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2015-2025 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/core/core_vr_simulator.c
+++ b/examples/core/core_vr_simulator.c
@@ -9,7 +9,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2017-2024 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2017-2025 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/core/core_window_flags.c
+++ b/examples/core/core_window_flags.c
@@ -9,7 +9,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2020-2024 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2020-2025 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/core/core_window_letterbox.c
+++ b/examples/core/core_window_letterbox.c
@@ -11,7 +11,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2019-2024 Anata (@anatagawa) and Ramon Santamaria (@raysan5)
+*   Copyright (c) 2019-2025 Anata (@anatagawa) and Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/core/core_window_should_close.c
+++ b/examples/core/core_window_should_close.c
@@ -9,7 +9,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2013-2024 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2013-2025 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/core/core_world_screen.c
+++ b/examples/core/core_world_screen.c
@@ -9,7 +9,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2015-2024 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2015-2025 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/examples_template.c
+++ b/examples/examples_template.c
@@ -58,14 +58,14 @@
 *
 *   raylib [core] example - Basic window
 *
-*   Example originally created with raylib 4.5, last time updated with raylib 4.5
+*   Example originally created with raylib 5.5, last time updated with raylib 5.5
 *
 *   Example contributed by <user_name> (@<user_github>) and reviewed by Ramon Santamaria (@raysan5)
 *
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2023 <user_name> (@<user_github>)
+*   Copyright (c) <year_created>-<year_updated> <user_name> (@<user_github>)
 *
 ********************************************************************************************/
 

--- a/examples/models/models_animation.c
+++ b/examples/models/models_animation.c
@@ -11,7 +11,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2019-2024 Culacant (@culacant) and Ramon Santamaria (@raysan5)
+*   Copyright (c) 2019-2025 Culacant (@culacant) and Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************
 *

--- a/examples/models/models_billboard.c
+++ b/examples/models/models_billboard.c
@@ -9,7 +9,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2015-2024 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2015-2025 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/models/models_bone_socket.c
+++ b/examples/models/models_bone_socket.c
@@ -9,7 +9,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2024 iP (@ipzaur)
+*   Copyright (c) 2024-2025 iP (@ipzaur)
 *
 ********************************************************************************************/
 

--- a/examples/models/models_box_collisions.c
+++ b/examples/models/models_box_collisions.c
@@ -9,7 +9,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2015-2024 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2015-2025 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/models/models_cubicmap.c
+++ b/examples/models/models_cubicmap.c
@@ -9,7 +9,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2015-2024 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2015-2025 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/models/models_draw_cube_texture.c
+++ b/examples/models/models_draw_cube_texture.c
@@ -9,7 +9,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2022-2024 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2022-2025 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/models/models_first_person_maze.c
+++ b/examples/models/models_first_person_maze.c
@@ -9,7 +9,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2019-2024 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2019-2025 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/models/models_geometric_shapes.c
+++ b/examples/models/models_geometric_shapes.c
@@ -9,7 +9,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2014-2024 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2014-2025 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/models/models_gpu_skinning.c
+++ b/examples/models/models_gpu_skinning.c
@@ -9,7 +9,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2024 Daniel Holden (@orangeduck)
+*   Copyright (c) 2024-2025 Daniel Holden (@orangeduck)
 * 
 *   Note: Due to limitations in the Apple OpenGL driver, this feature does not work on MacOS
 *

--- a/examples/models/models_heightmap.c
+++ b/examples/models/models_heightmap.c
@@ -9,7 +9,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2015-2024 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2015-2025 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/models/models_loading.c
+++ b/examples/models/models_loading.c
@@ -22,7 +22,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2014-2024 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2014-2025 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/models/models_loading_gltf.c
+++ b/examples/models/models_loading_gltf.c
@@ -16,7 +16,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2020-2024 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2020-2025 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/models/models_loading_m3d.c
+++ b/examples/models/models_loading_m3d.c
@@ -15,7 +15,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2022-2024 bzt (@bztsrc)
+*   Copyright (c) 2022-2025 bzt (@bztsrc)
 *
 ********************************************************************************************/
 

--- a/examples/models/models_loading_vox.c
+++ b/examples/models/models_loading_vox.c
@@ -11,7 +11,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2021-2024 Johann Nadalutti (@procfxgen) and Ramon Santamaria (@raysan5)
+*   Copyright (c) 2021-2025 Johann Nadalutti (@procfxgen) and Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/models/models_mesh_generation.c
+++ b/examples/models/models_mesh_generation.c
@@ -9,7 +9,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2017-2024 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2017-2025 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/models/models_mesh_picking.c
+++ b/examples/models/models_mesh_picking.c
@@ -11,7 +11,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2017-2024 Joel Davis (@joeld42) and Ramon Santamaria (@raysan5)
+*   Copyright (c) 2017-2025 Joel Davis (@joeld42) and Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/models/models_orthographic_projection.c
+++ b/examples/models/models_orthographic_projection.c
@@ -11,7 +11,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2018-2024 Max Danielsson (@autious) and Ramon Santamaria (@raysan5)
+*   Copyright (c) 2018-2025 Max Danielsson (@autious) and Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/models/models_point_rendering.c
+++ b/examples/models/models_point_rendering.c
@@ -9,7 +9,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2024 Reese Gallagher (@satchelfrost)
+*   Copyright (c) 2024-2025 Reese Gallagher (@satchelfrost)
 *
 ********************************************************************************************/
 

--- a/examples/models/models_rlgl_solar_system.c
+++ b/examples/models/models_rlgl_solar_system.c
@@ -11,7 +11,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2018-2024 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2018-2025 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/models/models_skybox.c
+++ b/examples/models/models_skybox.c
@@ -9,7 +9,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2017-2024 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2017-2025 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/models/models_tesseract_view.c
+++ b/examples/models/models_tesseract_view.c
@@ -6,10 +6,12 @@
 *
 *   Example originally created with raylib 5.6-dev, last time updated with raylib 5.6-dev
 *
+*   Example contributed by Timothy van der Valk (@arceryz) and reviewed by Ramon Santamaria (@raysan5)
+*
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2024-2025 raylib contributor (?) & Ramon Santamaria (@raysan5)
+*   Copyright (c) 2024-2025 Timothy van der Valk (@arceryz) and Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/models/models_waving_cubes.c
+++ b/examples/models/models_waving_cubes.c
@@ -11,7 +11,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2019-2024 Codecat (@codecat) and Ramon Santamaria (@raysan5)
+*   Copyright (c) 2019-2025 Codecat (@codecat) and Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/models/models_yaw_pitch_roll.c
+++ b/examples/models/models_yaw_pitch_roll.c
@@ -11,7 +11,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2017-2024 Berni (@Berni8k) and Ramon Santamaria (@raysan5)
+*   Copyright (c) 2017-2025 Berni (@Berni8k) and Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/others/easings_testbed.c
+++ b/examples/others/easings_testbed.c
@@ -9,7 +9,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2019-2024 Juan Miguel López (@flashback-fx ) and Ramon Santamaria (@raysan5)
+*   Copyright (c) 2019-2024 Juan Miguel López (@flashback-fx) and Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/others/easings_testbed.c
+++ b/examples/others/easings_testbed.c
@@ -9,7 +9,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2019-2024 Juan Miguel López (@flashback-fx) and Ramon Santamaria (@raysan5)
+*   Copyright (c) 2019-2025 Juan Miguel López (@flashback-fx) and Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/others/embedded_files_loading.c
+++ b/examples/others/embedded_files_loading.c
@@ -9,7 +9,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2020-2024 Kristian Holmgren (@defutura) and Ramon Santamaria (@raysan5)
+*   Copyright (c) 2020-2025 Kristian Holmgren (@defutura) and Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/others/raylib_opengl_interop.c
+++ b/examples/others/raylib_opengl_interop.c
@@ -9,7 +9,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2021-2024 Stephan Soller (@arkanis) and Ramon Santamaria (@raysan5)
+*   Copyright (c) 2021-2025 Stephan Soller (@arkanis) and Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************
 *

--- a/examples/others/raymath_vector_angle.c
+++ b/examples/others/raymath_vector_angle.c
@@ -7,7 +7,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2023 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2023-2025 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
  

--- a/examples/others/rlgl_compute_shader.c
+++ b/examples/others/rlgl_compute_shader.c
@@ -12,7 +12,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2021-2024 Teddy Astie (@tsnake41)
+*   Copyright (c) 2021-2025 Teddy Astie (@tsnake41)
 *
 ********************************************************************************************/
 

--- a/examples/others/rlgl_standalone.c
+++ b/examples/others/rlgl_standalone.c
@@ -31,7 +31,7 @@
 *   This example is licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software:
 *
-*   Copyright (c) 2014-2024 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2014-2025 Ramon Santamaria (@raysan5)
 *
 *   This software is provided "as-is", without any express or implied warranty. In no event
 *   will the authors be held liable for any damages arising from the use of this software.

--- a/examples/others/rlgl_standalone.c
+++ b/examples/others/rlgl_standalone.c
@@ -5,6 +5,8 @@
 *   rlgl library is an abstraction layer for multiple OpenGL versions (1.1, 2.1, 3.3 Core, ES 2.0)
 *   that provides a pseudo-OpenGL 1.1 immediate-mode style API (rlVertex, rlTranslate, rlRotate...)
 *
+*   Example originally created with raylib 1.6, last time updated with raylib 4.0
+*
 *   WARNING: This example is intended only for PLATFORM_DESKTOP and OpenGL 3.3 Core profile.
 *       It could work on other platforms if redesigned for those platforms (out-of-scope)
 *

--- a/examples/shaders/shaders_basic_lighting.c
+++ b/examples/shaders/shaders_basic_lighting.c
@@ -16,7 +16,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2019-2024 Chris Camacho (@codifies) and Ramon Santamaria (@raysan5)
+*   Copyright (c) 2019-2025 Chris Camacho (@codifies) and Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/shaders/shaders_basic_pbr.c
+++ b/examples/shaders/shaders_basic_pbr.c
@@ -9,7 +9,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2023-2024 Afan OLOVCIC (@_DevDad)
+*   Copyright (c) 2023-2025 Afan OLOVCIC (@_DevDad)
 *
 *   Model: "Old Rusty Car" (https://skfb.ly/LxRy) by Renafox, 
 *   licensed under Creative Commons Attribution-NonCommercial 

--- a/examples/shaders/shaders_custom_uniform.c
+++ b/examples/shaders/shaders_custom_uniform.c
@@ -16,7 +16,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2015-2024 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2015-2025 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/shaders/shaders_deferred_render.c
+++ b/examples/shaders/shaders_deferred_render.c
@@ -13,7 +13,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2023 Justin Andreas Lacoste (@27justin)
+*   Copyright (c) 2023-2025 Justin Andreas Lacoste (@27justin)
 *
 ********************************************************************************************/
 

--- a/examples/shaders/shaders_eratosthenes.c
+++ b/examples/shaders/shaders_eratosthenes.c
@@ -18,12 +18,12 @@
 *
 *   Example originally created with raylib 2.5, last time updated with raylib 4.0
 *
-*   Example contributed by ProfJski and reviewed by Ramon Santamaria (@raysan5)
+*   Example contributed by ProfJski (@ProfJski) and reviewed by Ramon Santamaria (@raysan5)
 *
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2019-2025 ProfJski and Ramon Santamaria (@raysan5)
+*   Copyright (c) 2019-2025 ProfJski (@ProfJski) and Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/shaders/shaders_eratosthenes.c
+++ b/examples/shaders/shaders_eratosthenes.c
@@ -23,7 +23,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2019-2024 ProfJski and Ramon Santamaria (@raysan5)
+*   Copyright (c) 2019-2025 ProfJski and Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/shaders/shaders_fog.c
+++ b/examples/shaders/shaders_fog.c
@@ -16,7 +16,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2019-2024 Chris Camacho (@chriscamacho) and Ramon Santamaria (@raysan5)
+*   Copyright (c) 2019-2025 Chris Camacho (@chriscamacho) and Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/shaders/shaders_hot_reloading.c
+++ b/examples/shaders/shaders_hot_reloading.c
@@ -12,7 +12,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2020-2024 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2020-2025 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/shaders/shaders_hybrid_render.c
+++ b/examples/shaders/shaders_hybrid_render.c
@@ -11,7 +11,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2022-2024 Buğra Alptekin Sarı (@BugraAlptekinSari)
+*   Copyright (c) 2022-2025 Buğra Alptekin Sarı (@BugraAlptekinSari)
 *
 ********************************************************************************************/
 

--- a/examples/shaders/shaders_julia_set.c
+++ b/examples/shaders/shaders_julia_set.c
@@ -16,7 +16,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2019-2024 Josh Colclough (@joshcol9232) and Ramon Santamaria (@raysan5)
+*   Copyright (c) 2019-2025 Josh Colclough (@joshcol9232) and Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/shaders/shaders_lightmap.c
+++ b/examples/shaders/shaders_lightmap.c
@@ -14,7 +14,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2019-2024 Jussi Viitala (@nullstare) and Ramon Santamaria (@raysan5)
+*   Copyright (c) 2019-2025 Jussi Viitala (@nullstare) and Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/shaders/shaders_lightmap.c
+++ b/examples/shaders/shaders_lightmap.c
@@ -9,6 +9,8 @@
 *
 *   NOTE: Shaders used in this example are #version 330 (OpenGL 3.3).
 *
+*   Example originally created with raylib 4.5, last time updated with raylib 4.5
+*
 *   Example contributed by Jussi Viitala (@nullstare) and reviewed by Ramon Santamaria (@raysan5)
 *
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,

--- a/examples/shaders/shaders_mesh_instancing.c
+++ b/examples/shaders/shaders_mesh_instancing.c
@@ -6,12 +6,12 @@
 *
 *   Example originally created with raylib 3.7, last time updated with raylib 4.2
 *
-*   Example contributed by @seanpringle and reviewed by Max (@moliad) and Ramon Santamaria (@raysan5)
+*   Example contributed by seanpringle (@seanpringle) and reviewed by Max (@moliad) and Ramon Santamaria (@raysan5)
 *
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2020-2024 @seanpringle, Max (@moliad) and Ramon Santamaria (@raysan5)
+*   Copyright (c) 2020-2024 seanpringle (@seanpringle), Max (@moliad) and Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/shaders/shaders_mesh_instancing.c
+++ b/examples/shaders/shaders_mesh_instancing.c
@@ -11,7 +11,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2020-2024 seanpringle (@seanpringle), Max (@moliad) and Ramon Santamaria (@raysan5)
+*   Copyright (c) 2020-2025 seanpringle (@seanpringle), Max (@moliad) and Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/shaders/shaders_model_shader.c
+++ b/examples/shaders/shaders_model_shader.c
@@ -16,7 +16,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2014-2024 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2014-2025 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/shaders/shaders_multi_sample2d.c
+++ b/examples/shaders/shaders_multi_sample2d.c
@@ -16,7 +16,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2020-2024 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2020-2025 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/shaders/shaders_palette_switch.c
+++ b/examples/shaders/shaders_palette_switch.c
@@ -18,7 +18,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2019-2024 Marco Lizza (@MarcoLizza) and Ramon Santamaria (@raysan5)
+*   Copyright (c) 2019-2025 Marco Lizza (@MarcoLizza) and Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/shaders/shaders_postprocessing.c
+++ b/examples/shaders/shaders_postprocessing.c
@@ -16,7 +16,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2015-2024 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2015-2025 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/shaders/shaders_raymarching.c
+++ b/examples/shaders/shaders_raymarching.c
@@ -12,7 +12,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2018-2024 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2018-2025 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/shaders/shaders_shadowmap.c
+++ b/examples/shaders/shaders_shadowmap.c
@@ -4,10 +4,12 @@
 *
 *   Example originally created with raylib 5.0, last time updated with raylib 5.0
 *
-*   Example contributed by @TheManTheMythTheGameDev and reviewed by Ramon Santamaria (@raysan5)
+*   Example contributed by TheManTheMythTheGameDev (@TheManTheMythTheGameDev) and reviewed by Ramon Santamaria (@raysan5)
 *
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
+*
+*   Copyright (c) 2023 TheManTheMythTheGameDev (@TheManTheMythTheGameDev)
 *
 ********************************************************************************************/
 

--- a/examples/shaders/shaders_shadowmap.c
+++ b/examples/shaders/shaders_shadowmap.c
@@ -9,7 +9,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2023 TheManTheMythTheGameDev (@TheManTheMythTheGameDev)
+*   Copyright (c) 2023-2025 TheManTheMythTheGameDev (@TheManTheMythTheGameDev)
 *
 ********************************************************************************************/
 

--- a/examples/shaders/shaders_shapes_textures.c
+++ b/examples/shaders/shaders_shapes_textures.c
@@ -16,7 +16,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2015-2024 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2015-2025 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/shaders/shaders_simple_mask.c
+++ b/examples/shaders/shaders_simple_mask.c
@@ -11,7 +11,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2019-2024 Chris Camacho (@chriscamacho) and Ramon Santamaria (@raysan5)
+*   Copyright (c) 2019-2025 Chris Camacho (@chriscamacho) and Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************
 *

--- a/examples/shaders/shaders_spotlight.c
+++ b/examples/shaders/shaders_spotlight.c
@@ -11,7 +11,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2019-2024 Chris Camacho (@chriscamacho) and Ramon Santamaria (@raysan5)
+*   Copyright (c) 2019-2025 Chris Camacho (@chriscamacho) and Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************
 *

--- a/examples/shaders/shaders_texture_drawing.c
+++ b/examples/shaders/shaders_texture_drawing.c
@@ -13,7 +13,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2019-2024 Michał Ciesielski and Ramon Santamaria (@raysan5)
+*   Copyright (c) 2019-2025 Michał Ciesielski and Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/shaders/shaders_texture_drawing.c
+++ b/examples/shaders/shaders_texture_drawing.c
@@ -8,12 +8,12 @@
 *
 *   Example originally created with raylib 2.0, last time updated with raylib 3.7
 *
-*   Example contributed by Michał Ciesielski and reviewed by Ramon Santamaria (@raysan5)
+*   Example contributed by Michał Ciesielski (@ciessielski) and reviewed by Ramon Santamaria (@raysan5)
 *
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2019-2025 Michał Ciesielski and Ramon Santamaria (@raysan5)
+*   Copyright (c) 2019-2025 Michał Ciesielski (@ciessielski) and Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/shaders/shaders_texture_outline.c
+++ b/examples/shaders/shaders_texture_outline.c
@@ -14,7 +14,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2021-2024 Samuel SKiff (@GoldenThumbs) and Ramon Santamaria (@raysan5)
+*   Copyright (c) 2021-2025 Samuel SKiff (@GoldenThumbs) and Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/shaders/shaders_texture_tiling.c
+++ b/examples/shaders/shaders_texture_tiling.c
@@ -6,6 +6,8 @@
 *
 *   Example demonstrates how to tile a texture on a 3D model using raylib.
 *
+*   Example originally created with raylib 4.5, last time updated with raylib 4.5
+*
 *   Example contributed by Luis Almeida (@luis605) and reviewed by Ramon Santamaria (@raysan5)
 *
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,

--- a/examples/shaders/shaders_texture_tiling.c
+++ b/examples/shaders/shaders_texture_tiling.c
@@ -11,7 +11,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2023 Luis Almeida (@luis605)
+*   Copyright (c) 2023-2025 Luis Almeida (@luis605)
 *
 ********************************************************************************************/
 

--- a/examples/shaders/shaders_texture_waves.c
+++ b/examples/shaders/shaders_texture_waves.c
@@ -18,7 +18,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2019-2024 Anata (@anatagawa) and Ramon Santamaria (@raysan5)
+*   Copyright (c) 2019-2025 Anata (@anatagawa) and Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/shaders/shaders_vertex_displacement.c
+++ b/examples/shaders/shaders_vertex_displacement.c
@@ -4,12 +4,12 @@
 *
 *   Example originally created with raylib 5.0, last time updated with raylib 4.5
 *
-*   Example contributed by <Alex ZH> (@ZzzhHe) and reviewed by Ramon Santamaria (@raysan5)
+*   Example contributed by Alex ZH (@ZzzhHe) and reviewed by Ramon Santamaria (@raysan5)
 *
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2023 <Alex ZH> (@ZzzhHe)
+*   Copyright (c) 2023 Alex ZH (@ZzzhHe)
 *
 ********************************************************************************************/
 

--- a/examples/shaders/shaders_vertex_displacement.c
+++ b/examples/shaders/shaders_vertex_displacement.c
@@ -9,7 +9,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2023 Alex ZH (@ZzzhHe)
+*   Copyright (c) 2023-2025 Alex ZH (@ZzzhHe)
 *
 ********************************************************************************************/
 

--- a/examples/shaders/shaders_write_depth.c
+++ b/examples/shaders/shaders_write_depth.c
@@ -11,7 +11,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2022-2024 Buğra Alptekin Sarı (@BugraAlptekinSari)
+*   Copyright (c) 2022-2025 Buğra Alptekin Sarı (@BugraAlptekinSari)
 *
 ********************************************************************************************/
 

--- a/examples/shapes/shapes_basic_shapes.c
+++ b/examples/shapes/shapes_basic_shapes.c
@@ -9,7 +9,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2014-2024 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2014-2025 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/shapes/shapes_bouncing_ball.c
+++ b/examples/shapes/shapes_bouncing_ball.c
@@ -9,7 +9,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2013-2024 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2013-2025 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/shapes/shapes_collision_area.c
+++ b/examples/shapes/shapes_collision_area.c
@@ -9,7 +9,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2013-2024 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2013-2025 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/shapes/shapes_colors_palette.c
+++ b/examples/shapes/shapes_colors_palette.c
@@ -9,7 +9,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2014-2024 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2014-2025 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/shapes/shapes_draw_circle_sector.c
+++ b/examples/shapes/shapes_draw_circle_sector.c
@@ -11,7 +11,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2018-2024 Vlad Adrian (@demizdor) and Ramon Santamaria (@raysan5)
+*   Copyright (c) 2018-2025 Vlad Adrian (@demizdor) and Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/shapes/shapes_draw_rectangle_rounded.c
+++ b/examples/shapes/shapes_draw_rectangle_rounded.c
@@ -11,7 +11,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2018-2024 Vlad Adrian (@demizdor) and Ramon Santamaria (@raysan5)
+*   Copyright (c) 2018-2025 Vlad Adrian (@demizdor) and Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/shapes/shapes_draw_ring.c
+++ b/examples/shapes/shapes_draw_ring.c
@@ -11,7 +11,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2018-2024 Vlad Adrian (@demizdor) and Ramon Santamaria (@raysan5)
+*   Copyright (c) 2018-2025 Vlad Adrian (@demizdor) and Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/shapes/shapes_easings_ball_anim.c
+++ b/examples/shapes/shapes_easings_ball_anim.c
@@ -9,7 +9,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2014-2024 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2014-2025 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/shapes/shapes_easings_box_anim.c
+++ b/examples/shapes/shapes_easings_box_anim.c
@@ -9,7 +9,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2014-2024 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2014-2025 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/shapes/shapes_easings_rectangle_array.c
+++ b/examples/shapes/shapes_easings_rectangle_array.c
@@ -12,7 +12,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2014-2024 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2014-2025 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/shapes/shapes_following_eyes.c
+++ b/examples/shapes/shapes_following_eyes.c
@@ -9,7 +9,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2013-2024 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2013-2025 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/shapes/shapes_lines_bezier.c
+++ b/examples/shapes/shapes_lines_bezier.c
@@ -9,7 +9,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2017-2024 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2017-2025 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/shapes/shapes_logo_raylib.c
+++ b/examples/shapes/shapes_logo_raylib.c
@@ -9,7 +9,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2014-2024 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2014-2025 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/shapes/shapes_logo_raylib_anim.c
+++ b/examples/shapes/shapes_logo_raylib_anim.c
@@ -9,7 +9,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2014-2024 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2014-2025 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/shapes/shapes_rectangle_advanced.c
+++ b/examples/shapes/shapes_rectangle_advanced.c
@@ -2,12 +2,16 @@
 *
 *   raylib [shapes] example - Rectangle advanced
 *
+*   Example complexity rating: [★★★★] 4/4
+*
 *   Example originally created with raylib 5.5, last time updated with raylib 5.5
+*
+*   Example contributed by Everton Jr. (@evertonse) and reviewed by Ramon Santamaria (@raysan5)
 *
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2024-2025 raylib contributors and Ramon Santamaria (@raysan5)
+*   Copyright (c) 2024-2025 Everton Jr. (@evertonse) and Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/shapes/shapes_rectangle_scaling.c
+++ b/examples/shapes/shapes_rectangle_scaling.c
@@ -11,7 +11,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2018-2024 Vlad Adrian (@demizdor) and Ramon Santamaria (@raysan5)
+*   Copyright (c) 2018-2025 Vlad Adrian (@demizdor) and Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/shapes/shapes_splines_drawing.c
+++ b/examples/shapes/shapes_splines_drawing.c
@@ -9,7 +9,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2023 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2023-2025 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/shapes/shapes_top_down_lights.c
+++ b/examples/shapes/shapes_top_down_lights.c
@@ -11,7 +11,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2022-2024 Jeffery Myers (@JeffM2501)
+*   Copyright (c) 2022-2025 Jeffery Myers (@JeffM2501)
 *
 ********************************************************************************************/
 

--- a/examples/shapes/shapes_top_down_lights.c
+++ b/examples/shapes/shapes_top_down_lights.c
@@ -6,7 +6,7 @@
 *
 *   Example originally created with raylib 4.2, last time updated with raylib 4.2
 *
-*   Example contributed by Vlad Adrian (@demizdor) and reviewed by Ramon Santamaria (@raysan5)
+*   Example contributed by Jeffery Myers (@JeffM2501) and reviewed by Ramon Santamaria (@raysan5)
 *
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software

--- a/examples/text/text_codepoints_loading.c
+++ b/examples/text/text_codepoints_loading.c
@@ -9,7 +9,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2022-2024 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2022-2025 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/text/text_draw_3d.c
+++ b/examples/text/text_draw_3d.c
@@ -24,7 +24,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2021-2024 Vlad Adrian (@demizdor)
+*   Copyright (c) 2021-2025 Vlad Adrian (@demizdor)
 *
 ********************************************************************************************/
 

--- a/examples/text/text_font_filters.c
+++ b/examples/text/text_font_filters.c
@@ -13,7 +13,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2015-2024 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2015-2025 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/text/text_font_loading.c
+++ b/examples/text/text_font_loading.c
@@ -18,7 +18,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2016-2024 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2016-2025 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/text/text_font_sdf.c
+++ b/examples/text/text_font_sdf.c
@@ -9,7 +9,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2015-2024 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2015-2025 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/text/text_font_spritefont.c
+++ b/examples/text/text_font_spritefont.c
@@ -19,7 +19,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2014-2024 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2014-2025 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/text/text_format_text.c
+++ b/examples/text/text_format_text.c
@@ -9,7 +9,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2014-2024 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2014-2025 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/text/text_input_box.c
+++ b/examples/text/text_input_box.c
@@ -9,7 +9,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2017-2024 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2017-2025 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/text/text_raylib_fonts.c
+++ b/examples/text/text_raylib_fonts.c
@@ -12,7 +12,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2017-2024 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2017-2025 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/text/text_rectangle_bounds.c
+++ b/examples/text/text_rectangle_bounds.c
@@ -11,7 +11,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2018-2024 Vlad Adrian (@demizdor) and Ramon Santamaria (@raysan5)
+*   Copyright (c) 2018-2025 Vlad Adrian (@demizdor) and Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/text/text_unicode.c
+++ b/examples/text/text_unicode.c
@@ -11,7 +11,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2019-2024 Vlad Adrian (@demizdor) and Ramon Santamaria (@raysan5)
+*   Copyright (c) 2019-2025 Vlad Adrian (@demizdor) and Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/text/text_writing_anim.c
+++ b/examples/text/text_writing_anim.c
@@ -9,7 +9,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2016-2024 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2016-2025 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/textures/textures_background_scrolling.c
+++ b/examples/textures/textures_background_scrolling.c
@@ -9,7 +9,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2019-2024 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2019-2025 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/textures/textures_blend_modes.c
+++ b/examples/textures/textures_blend_modes.c
@@ -13,7 +13,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2020-2024 Karlo Licudine (@accidentalrebel)
+*   Copyright (c) 2020-2025 Karlo Licudine (@accidentalrebel)
 *
 ********************************************************************************************/
 

--- a/examples/textures/textures_bunnymark.c
+++ b/examples/textures/textures_bunnymark.c
@@ -9,7 +9,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2014-2024 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2014-2025 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/textures/textures_draw_tiled.c
+++ b/examples/textures/textures_draw_tiled.c
@@ -11,7 +11,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2020-2024 Vlad Adrian (@demizdor) and Ramon Santamaria (@raysan5)
+*   Copyright (c) 2020-2025 Vlad Adrian (@demizdor) and Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/textures/textures_fog_of_war.c
+++ b/examples/textures/textures_fog_of_war.c
@@ -9,7 +9,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2018-2024 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2018-2025 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/textures/textures_gif_player.c
+++ b/examples/textures/textures_gif_player.c
@@ -9,7 +9,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2021-2024 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2021-2025 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/textures/textures_image_channel.c
+++ b/examples/textures/textures_image_channel.c
@@ -6,12 +6,12 @@
 *
 *   Example originally created with raylib 5.1-dev, last time updated with raylib 5.1-dev
 *
-*   Example contributed by Bruno Cabral (github.com/brccabral) and reviewed by Ramon Santamaria (@raysan5)
+*   Example contributed by Bruno Cabral (@brccabral) and reviewed by Ramon Santamaria (@raysan5)
 *
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2024-2024 Bruno Cabral (github.com/brccabral) and Ramon Santamaria (@raysan5)
+*   Copyright (c) 2024-2024 Bruno Cabral (@brccabral) and Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/textures/textures_image_channel.c
+++ b/examples/textures/textures_image_channel.c
@@ -11,7 +11,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2024-2024 Bruno Cabral (@brccabral) and Ramon Santamaria (@raysan5)
+*   Copyright (c) 2024-2025 Bruno Cabral (@brccabral) and Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/textures/textures_image_drawing.c
+++ b/examples/textures/textures_image_drawing.c
@@ -11,7 +11,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2016-2024 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2016-2025 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/textures/textures_image_generation.c
+++ b/examples/textures/textures_image_generation.c
@@ -11,7 +11,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2017-2024 Wilhem Barbier (@nounoursheureux) and Ramon Santamaria (@raysan5)
+*   Copyright (c) 2017-2025 Wilhem Barbier (@nounoursheureux) and Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/textures/textures_image_generation.c
+++ b/examples/textures/textures_image_generation.c
@@ -6,10 +6,12 @@
 *
 *   Example originally created with raylib 1.8, last time updated with raylib 1.8
 *
+*   Example contributed by Wilhem Barbier (@nounoursheureux) and reviewed by Ramon Santamaria (@raysan5)
+*
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2O17-2024 Wilhem Barbier (@nounoursheureux) and Ramon Santamaria (@raysan5)
+*   Copyright (c) 2017-2024 Wilhem Barbier (@nounoursheureux) and Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/textures/textures_image_kernel.c
+++ b/examples/textures/textures_image_kernel.c
@@ -4,6 +4,8 @@
 *
 *   NOTE: Images are loaded in CPU memory (RAM); textures are loaded in GPU memory (VRAM)
 *
+*   Example contributed by Karim Salem (@kimo-s) and reviewed by Ramon Santamaria (@raysan5)
+*
 *   Example originally created with raylib 1.3, last time updated with raylib 1.3
 *
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,

--- a/examples/textures/textures_image_kernel.c
+++ b/examples/textures/textures_image_kernel.c
@@ -11,7 +11,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2015-2024 Karim Salem (@kimo-s)
+*   Copyright (c) 2015-2025 Karim Salem (@kimo-s)
 *
 ********************************************************************************************/
 

--- a/examples/textures/textures_image_loading.c
+++ b/examples/textures/textures_image_loading.c
@@ -11,7 +11,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2015-2024 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2015-2025 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/textures/textures_image_processing.c
+++ b/examples/textures/textures_image_processing.c
@@ -11,7 +11,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2016-2024 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2016-2025 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/textures/textures_image_rotate.c
+++ b/examples/textures/textures_image_rotate.c
@@ -7,7 +7,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2014-2024 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2014-2025 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/textures/textures_image_text.c
+++ b/examples/textures/textures_image_text.c
@@ -9,7 +9,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2017-2024 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2017-2025 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/textures/textures_logo_raylib.c
+++ b/examples/textures/textures_logo_raylib.c
@@ -9,7 +9,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2014-2024 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2014-2025 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/textures/textures_mouse_painting.c
+++ b/examples/textures/textures_mouse_painting.c
@@ -11,7 +11,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2019-2024 Chris Dill (@MysteriousSpace) and Ramon Santamaria (@raysan5)
+*   Copyright (c) 2019-2025 Chris Dill (@MysteriousSpace) and Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/textures/textures_npatch_drawing.c
+++ b/examples/textures/textures_npatch_drawing.c
@@ -13,7 +13,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2018-2024 Jorge A. Gomes (@overdev) and Ramon Santamaria (@raysan5)
+*   Copyright (c) 2018-2025 Jorge A. Gomes (@overdev) and Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/textures/textures_particles_blending.c
+++ b/examples/textures/textures_particles_blending.c
@@ -9,7 +9,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2017-2024 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2017-2025 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/textures/textures_polygon.c
+++ b/examples/textures/textures_polygon.c
@@ -11,7 +11,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2021-2024 Chris Camacho (@codifies) and Ramon Santamaria (@raysan5)
+*   Copyright (c) 2021-2025 Chris Camacho (@codifies) and Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/textures/textures_raw_data.c
+++ b/examples/textures/textures_raw_data.c
@@ -11,7 +11,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2015-2024 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2015-2025 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/textures/textures_sprite_anim.c
+++ b/examples/textures/textures_sprite_anim.c
@@ -9,7 +9,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2014-2024 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2014-2025 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/textures/textures_sprite_button.c
+++ b/examples/textures/textures_sprite_button.c
@@ -9,7 +9,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2019-2024 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2019-2025 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/textures/textures_sprite_explosion.c
+++ b/examples/textures/textures_sprite_explosion.c
@@ -9,7 +9,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2019-2024 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2019-2025 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/textures/textures_sprite_explosion.c
+++ b/examples/textures/textures_sprite_explosion.c
@@ -9,7 +9,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2019-2024 Anata and Ramon Santamaria (@raysan5)
+*   Copyright (c) 2019-2024 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/textures/textures_srcrec_dstrec.c
+++ b/examples/textures/textures_srcrec_dstrec.c
@@ -9,7 +9,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2015-2024 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2015-2025 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/textures/textures_textured_curve.c
+++ b/examples/textures/textures_textured_curve.c
@@ -11,7 +11,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2022-2024 Jeffery Myers (@JeffM2501) and Ramon Santamaria (@raysan5)
+*   Copyright (c) 2022-2025 Jeffery Myers (@JeffM2501) and Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/textures/textures_textured_curve.c
+++ b/examples/textures/textures_textured_curve.c
@@ -6,12 +6,12 @@
 *
 *   Example originally created with raylib 4.5, last time updated with raylib 4.5
 *
-*   Example contributed by Jeffery Myers and reviewed by Ramon Santamaria (@raysan5)
+*   Example contributed by Jeffery Myers (@JeffM2501) and reviewed by Ramon Santamaria (@raysan5)
 *
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2022-2024 Jeffery Myers and Ramon Santamaria (@raysan5)
+*   Copyright (c) 2022-2024 Jeffery Myers (@JeffM2501) and Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 

--- a/examples/textures/textures_to_image.c
+++ b/examples/textures/textures_to_image.c
@@ -11,7 +11,7 @@
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
-*   Copyright (c) 2015-2024 Ramon Santamaria (@raysan5)
+*   Copyright (c) 2015-2025 Ramon Santamaria (@raysan5)
 *
 ********************************************************************************************/
 


### PR DESCRIPTION
# CHANGES

The first commit, [**Update examples inconsistencies**](https://github.com/raysan5/raylib/commit/36832369689f6e0d6627e7ebe9000e774d94df4f), aims to update inconsistencies as discussed in Discord.
Changes:
- CHANGELOG: Change "@Anata" to "@anatagawa".
- examples/README.md: Change an example with 5-stars to have 4-stars.
- examples/\*/\*.c: Update inconsistencies.

The second commit, [**Happy new years, examples!**](https://github.com/raysan5/raylib/commit/2d024e777cd3309e60b62ab0961a7efbf956c4e4), aims to fix all the copyright years to 2025.

The second commit also convert from format `Copyright (c) <YEAR>` to `Copyright (c) <YEAR_CREATED>-<YEAR_UPDATED>`.

The third commit, [**Missed one inconsistency**](https://github.com/raysan5/raylib/commit/0022f86e1e36e2ff0e616ec36f936d44efd8b945), and fourth commit, [**Update final few examples inconsistencies**](https://github.com/raysan5/raylib/commit/4bf45899e3e75aa8b4e018a70fc0935683cecb0a) appends the changes to the first commit.

The fourth commit also updates the examples/example_template.c file to use current raylib version and use `Copyright (c) <YEAR_CREATED>-<YEAR_UPDATED>` format as the template.