### PR TITLE
fix(rtextures): TCC not being able to compile due to: 'emmintrin.h' not found

### DIFF
--- a/src/rtextures.c
+++ b/src/rtextures.c
@@ -124,10 +124,6 @@
 #endif
 
 // Image fileformats not supported by default
-#if defined(__TINYC__)
-    #define STBI_NO_SIMD
-#endif
-
 #if (defined(SUPPORT_FILEFORMAT_BMP) || \
      defined(SUPPORT_FILEFORMAT_PNG) || \
      defined(SUPPORT_FILEFORMAT_TGA) || \
@@ -148,6 +144,10 @@
     #define STBI_REALLOC RL_REALLOC
 
     #define STBI_NO_THREAD_LOCALS
+
+    #if defined(__TINYC__)
+        #define STBI_NO_SIMD
+    #endif
 
     #define STB_IMAGE_IMPLEMENTATION
     #include "external/stb_image.h"         // Required for: stbi_load_from_file()
@@ -218,6 +218,9 @@
     #pragma GCC diagnostic ignored "-Wunused-function"
 #endif
 
+#if defined(__TINYC__)
+    #define STBIR_NO_SIMD
+#endif
 #define STB_IMAGE_RESIZE_IMPLEMENTATION
 #include "external/stb_image_resize2.h"     // Required for: stbir_resize_uint8_linear() [ImageResize()]
 


### PR DESCRIPTION
Define STBIR_NO_SIMD when `__TINYC__` is defined so stb_image_resize2 will not include *mmintrin headers which are not supported by all compilers.

There are similar checks for `__TINYC__` already elsewhere in raylib and they are also mostly there to disable SIMD headers.

Additionally, move similar check for stb_image, to be a little bit deeper. Before it was defining STBI_NO_SIMD without including stb_image itself. It was also clashing with note, causing said note to make no sense.

Fixes: https://github.com/raysan5/raylib/discussions/2994
Reference: https://github.com/nothings/stb/issues/1738