### PR TITLE
Support separate dir for screenshots

### DIFF
--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1124,6 +1124,7 @@ RLAPI bool ExportDataAsCode(const unsigned char *data, int dataSize, const char 
 RLAPI char *LoadFileText(const char *fileName);                   // Load text data from file (read), returns a '\0' terminated string
 RLAPI void UnloadFileText(char *text);                            // Unload file text data allocated by LoadFileText()
 RLAPI bool SaveFileText(const char *fileName, char *text);        // Save text data to file (write), string must be '\0' terminated, returns true on success
+RLAPI bool SetScreenshotPath(const char *screenshotPath);         // Set directory where screenshots are stored, string must be '\0' terminated, dir must exist, returns true on success
 //------------------------------------------------------------------
 
 // File system functions

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -299,6 +299,7 @@ typedef struct CoreData {
     } Window;
     struct {
         const char *basePath;               // Base path for data storage
+        const char *screenshotPath;         // Path for screenshot storage
 
     } Storage;
     struct {
@@ -670,6 +671,10 @@ void InitWindow(int width, int height, const char *title)
     //--------------------------------------------------------------
     InitPlatform();
     //--------------------------------------------------------------
+
+    // Now that InitPlatform() has been made, we have a valid basePath.
+    // Lets default ScreenshotPath to it.
+    CORE.Storage.screenshotPath = CORE.Storage.basePath;
 
     // Initialize rlgl default data (buffers and shaders)
     // NOTE: CORE.Window.currentFbo.width and CORE.Window.currentFbo.height not used, just stored as globals in rlgl
@@ -1849,6 +1854,14 @@ void UnloadRandomSequence(int *sequence)
 #endif
 }
 
+bool SetScreenshotPath(const char *screenshotDir)
+{
+	// TODO: verify directory exist
+	CORE.Storage.screenshotPath = screenshotDir;
+
+	return true;
+}
+
 // Takes a screenshot of current screen
 // NOTE: Provided fileName should not contain paths, saving to working directory
 void TakeScreenshot(const char *fileName)
@@ -1862,7 +1875,7 @@ void TakeScreenshot(const char *fileName)
     Image image = { imgData, (int)((float)CORE.Window.render.width*scale.x), (int)((float)CORE.Window.render.height*scale.y), 1, PIXELFORMAT_UNCOMPRESSED_R8G8B8A8 };
 
     char path[512] = { 0 };
-    strcpy(path, TextFormat("%s/%s", CORE.Storage.basePath, GetFileName(fileName)));
+    strcpy(path, TextFormat("%s/%s", CORE.Storage.screenshotPath, GetFileName(fileName)));
 
     ExportImage(image, path);           // WARNING: Module required: rtextures
     RL_FREE(imgData);


### PR DESCRIPTION
Make it possible to steer where screenshots are stored.
Default to current behaviour (storing them at same path as the running process) to not break current users of raylib.

If one wants to change the location, we call SetScreenshotPath() before we call TakeScreenshot() like :

```
...
    SetScreenshotPath("/mnt/my-nifty-screenshots-directory");
    TakeScreenshot("my-nifty-screenshot.png");
...
```

SetScreenshotPath is "sticky" so next time we take screenshot it uses same path.