### PR TITLE
[rcore_web] removed hardcoded sleep

### DIFF
--- a/src/platforms/rcore_web.c
+++ b/src/platforms/rcore_web.c
@@ -154,14 +154,15 @@ static const char *GetCanvasId(void);
 //----------------------------------------------------------------------------------
 
 // Check if application should close
+// This will always return false on a web-build as web builds have no control over this functionality
+// Sleep is handled in EndDrawing for sync code
 bool WindowShouldClose(void)
 {
     // Emterpreter-Async required to run sync code
     // https://github.com/emscripten-core/emscripten/wiki/Emterpreter#emterpreter-async-run-synchronous-code
-    // By default, this function is never called on a web-ready raylib example because we encapsulate
-    // frame code in a UpdateDrawFrame() function, to allow browser manage execution asynchronously
-    // but now emscripten allows sync code to be executed in an interpreted way, using emterpreter!
-    emscripten_sleep(16);
+    // This function should not called on a web-ready raylib build because you instead want to encapsulate
+    // frame code in an UpdateDrawFrame() function, to allow the browser to manage execution asynchronously
+    // using emscripten_set_main_loop
     return false;
 }
 


### PR DESCRIPTION
conversation from https://github.com/raysan5/raylib/issues/4712

There are 2 types of web-builds

1) Using `asyncify` -- the additional `emscripten_sleep(16)` is removed, EndDrawing still pauses properly
2) Using `set_main_loop` -- the additional `emscripten_sleep(16)` is removed, EndDrawing still adds an additional pause from the browser (i think should be handled in a different PR)