### PR TITLE
[build] Makefile: throw an error when trying to build SHARED library

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -665,6 +665,9 @@ raylib: $(OBJS)
 ifeq ($(TARGET_PLATFORM),$(filter $(TARGET_PLATFORM),PLATFORM_WEB PLATFORM_WEB_RGFW))
     # Compile raylib libray for web
     #$(CC) $(OBJS) -r -o $(RAYLIB_RELEASE_PATH)/lib$(RAYLIB_LIB_NAME).bc
+    ifeq ($(RAYLIB_LIBTYPE),SHARED)
+		@echo "Error: $(TARGET_PLATFORM) does not support SHARED libraries. Try RAYLIB_LIBTYPE=STATIC instead." && exit 1
+    endif
 	$(AR) rcs $(RAYLIB_RELEASE_PATH)/lib$(RAYLIB_LIB_NAME).web.a $(OBJS)
 	@echo "raylib library generated (lib$(RAYLIB_LIB_NAME).web.a)!"
 else
@@ -823,7 +826,7 @@ ifeq ($(ROOT),root)
 		@echo "This function currently works on GNU/Linux systems. Add yours today (^;"
     endif
 else
-	@echo "Error: Root permissions needed for installation. Try sudo make install"
+	@echo "Error: Root permissions needed for installation. Try sudo make install" && exit 1
 endif
 
 # Remove raylib dev files installed on the system
@@ -850,7 +853,7 @@ ifeq ($(ROOT),root)
 		@echo "This function currently works on GNU/Linux systems. Add yours today (^;"
     endif
 else
-	@echo "Error: Root permissions needed for uninstallation. Try sudo make uninstall"
+	@echo "Error: Root permissions needed for uninstallation. Try sudo make uninstall" && exit 1
 endif
 
 .PHONY: clean_shell_cmd clean_shell_sh


### PR DESCRIPTION
[see linked issue for more context]

When asking Makefile to create SHARED library for WEB
```
~/raylib/src $ make TARGET_PLATFORM=PLATFORM_WEB RAYLIB_LIBTYPE=SHARED
```
it would instead silently create STATIC library thus not fulfilling the request as expected

This commit adds an error in this case and stops further execution which fixes this issue.

This is not consistent with Cmake, because Cmake throws the warning and does not stop, but Cmake can easily recover from this case and people probably does not even notice it. However, Makefile is something that you have to handle yourself and you have to recover from any issues so having an error and aborting with exit code 1 is more expected. Otherwise people may spend a lot of time debugging Makefile in order to understand what's even going on.

Fixes: https://github.com/raysan5/raylib/issues/4717