### PR TITLE
[rglfw] fix: suppress warning: "_GNU_SOURCE" redefined

### DIFF
--- a/src/external/glfw/src/posix_poll.c
+++ b/src/external/glfw/src/posix_poll.c
@@ -24,7 +24,9 @@
 //
 //========================================================================
 
-#define _GNU_SOURCE
+#if !defined(_GNU_SOURCE)
+    #define _GNU_SOURCE
+#endif
 
 #include "internal.h"
 

--- a/src/external/glfw/src/wl_window.c
+++ b/src/external/glfw/src/wl_window.c
@@ -25,7 +25,9 @@
 //
 //========================================================================
 
-#define _GNU_SOURCE
+#if !defined(_GNU_SOURCE)
+    #define _GNU_SOURCE
+#endif
 
 #include "internal.h"
 


### PR DESCRIPTION
When compiling rglfw.c with recent versions of GCC or Clang following warning appears:

```
$ git clone https://github.com/raysan5/raylib.git
$ cd raylib/src
$ make rglfw.o CC=gcc
gcc  -c rglfw.c -Wall -D_GNU_SOURCE -DPLATFORM_DESKTOP_GLFW -DGRAPHICS_API_OPENGL_33 -Wno-missing-braces -Werror=pointer-arith -fno-strict-aliasing -std=c99 -fPIC -O1 -Werror=implicit-function-declaration -D_GLFW_X11  -I.  -Iexternal/glfw/include
In file included from rglfw.c:99:
external/glfw/src/posix_poll.c:27:9: warning: "_GNU_SOURCE" redefined
   27 | #define _GNU_SOURCE
      |         ^~~~~~~~~~~
<command-line>: note: this is the location of the previous definition
```
This PR suppresses said warning by checking, if _GNU_SOURCE has NOT been defined, and only then defining it. It does not change any behavior, just suppresses the warning.

Raylib already handles similar cases elsewhere in it's source tree (e.g. in [rcore.c](https://github.com/raysan5/raylib/blob/7bfc8e8ca75882de434c601c4294ca1774b69278/src/rcore.c#L159-L161)) so this is nothing new.