### PR TITLE
[rtexture] Cubemap mipmap loading improvements

### DIFF
--- a/src/rtextures.c
+++ b/src/rtextures.c
@@ -4208,8 +4208,11 @@ TextureCubemap LoadTextureCubemap(Image image, int layout)
 
             Image mipmapped = ImageCopy(image);
         #if defined(SUPPORT_IMAGE_MANIPULATION)
-            ImageMipmaps(&mipmapped);
-            ImageMipmaps(&faces);
+            if (image.mipmaps > 1)
+            {
+                ImageMipmaps(&mipmapped);
+                ImageMipmaps(&faces);
+            }
         #endif
 
             // NOTE: Image formatting does not work with compressed textures

--- a/src/rtextures.c
+++ b/src/rtextures.c
@@ -4229,7 +4229,7 @@ TextureCubemap LoadTextureCubemap(Image image, int layout)
         if (cubemap.id != 0)
         {
             cubemap.format = faces.format;
-            cubemap.mipmaps = 1;
+            cubemap.mipmaps = faces.mipmaps;
         }
         else TRACELOG(LOG_WARNING, "IMAGE: Failed to load cubemap image");
 


### PR DESCRIPTION
_Another two patches for loading cubemaps with mipmaps. Hopefully the last ones 😅_

Two fixes in one PR for loading cubemaps with mipmaps:

 1. Previously we were always generating mipmaps if we could. This makes sense for cubemaps with _some_ mipmaps, but not all possible. If we didn't do it there, that cubemap would be incomplete when filtering with `GL_LINEAR_MIPMAP_LINEAR`/`RL_TEXTURE_FILTER_MIP_LINEAR` or `GL_NEAREST_MIPMAP_LINEAR`/`RL_TEXTURE_FILTER_NEAREST_MIP_LINEAR`, because those require all possible mipmaps to be available[^1]. For cubemaps with no mipmaps (just the base mipmap level), there is no need to generate any mipmaps (or use VRAM to store them), because the user wouldn't expect there to be any mipmaps in the first place. Thus, only build cubemap mipmaps when necessary.
 2. Previously, a cubemaps mipmap count would always be set to `1` (on the CPU), regardless of the actual number of mipmaps present on the GPU. This change neatly ties in with the first patch, because we can just use the number of mipmaps the image has, were we may or may not have generated them.

I tested that the `model_skybox` example still works, and obviously I tested it with my own IBL setup, where everything also works.

As last time, I structured the PR to be able to just be rebased onto master if you want all the different changes to reflect in the tree.

[^1]: This is not entirely true for "normal" OpenGL, but since there is no way to set `GL_TEXTURE_MAX_LEVEL` in plain raylib, I'd say it applies for us. See "The base and max levels must only specify mipmap levels that have been allocated [...]" [here](https://www.khronos.org/opengl/wiki/Texture#Mipmap_completeness)