### PR TITLE
[rtextures] Fix `HalfToFloat()` and `FloatToHalf()` dereferencing issues with an union

### DIFF
--- a/src/rtextures.c
+++ b/src/rtextures.c
@@ -5396,7 +5396,6 @@ static float HalfToFloat(unsigned short x)
     float result = 0.0f;
 
     union floatUnsignedUnion uni;
-    uni.fm = 0.0f;
 
     const unsigned int e = (x & 0x7C00) >> 10; // Exponent
     const unsigned int m = (x & 0x03FF) << 13; // Mantissa

--- a/src/rtextures.c
+++ b/src/rtextures.c
@@ -5384,18 +5384,17 @@ int GetPixelDataSize(int width, int height, int format)
 //----------------------------------------------------------------------------------
 // Module specific Functions Definition
 //----------------------------------------------------------------------------------
-union floatUnsignedUnion {
-    float fm;
-    unsigned int ui;
-};
-
 // Convert half-float (stored as unsigned short) to float
 // REF: https://stackoverflow.com/questions/1659440/32-bit-to-16-bit-floating-point-conversion/60047308#60047308
 static float HalfToFloat(unsigned short x)
 {
     float result = 0.0f;
 
-    union floatUnsignedUnion uni;
+    union
+    {
+        float fm;
+        unsigned int ui;
+    } uni;
 
     const unsigned int e = (x & 0x7C00) >> 10; // Exponent
     const unsigned int m = (x & 0x03FF) << 13; // Mantissa
@@ -5413,7 +5412,11 @@ static unsigned short FloatToHalf(float x)
 {
     unsigned short result = 0;
 
-    union floatUnsignedUnion uni;
+    union
+    {
+        float fm;
+        unsigned int ui;
+    } uni;
     uni.fm = x;
 
     const unsigned int b = uni.ui + 0x00001000; // Round-to-nearest-even: add last bit after truncated mantissa

--- a/src/rtextures.c
+++ b/src/rtextures.c
@@ -5384,19 +5384,27 @@ int GetPixelDataSize(int width, int height, int format)
 //----------------------------------------------------------------------------------
 // Module specific Functions Definition
 //----------------------------------------------------------------------------------
+union floatUnsignedUnion {
+    float fm;
+    unsigned int ui;
+};
+
 // Convert half-float (stored as unsigned short) to float
 // REF: https://stackoverflow.com/questions/1659440/32-bit-to-16-bit-floating-point-conversion/60047308#60047308
 static float HalfToFloat(unsigned short x)
 {
     float result = 0.0f;
 
+    union floatUnsignedUnion uni;
+    uni.fm = 0.0f;
+
     const unsigned int e = (x & 0x7C00) >> 10; // Exponent
     const unsigned int m = (x & 0x03FF) << 13; // Mantissa
-    const float fm = (float)m;
-    const unsigned int v = (*(unsigned int *)&fm) >> 23; // Evil log2 bit hack to count leading zeros in denormalized format
-    const unsigned int r = (x & 0x8000) << 16 | (e != 0)*((e + 112) << 23 | m) | ((e == 0)&(m != 0))*((v - 37) << 23 | ((m << (150 - v)) & 0x007FE000)); // sign : normalized : denormalized
+    uni.fm = (float)m;
+    const unsigned int v = uni.ui >> 23; // Evil log2 bit hack to count leading zeros in denormalized format
+    uni.ui = (x & 0x8000) << 16 | (e != 0)*((e + 112) << 23 | m) | ((e == 0)&(m != 0))*((v - 37) << 23 | ((m << (150 - v)) & 0x007FE000)); // sign : normalized : denormalized
 
-    result = *(float *)&r;
+    result = uni.fm;
 
     return result;
 }
@@ -5406,7 +5414,10 @@ static unsigned short FloatToHalf(float x)
 {
     unsigned short result = 0;
 
-    const unsigned int b = (*(unsigned int *) & x) + 0x00001000; // Round-to-nearest-even: add last bit after truncated mantissa
+    union floatUnsignedUnion uni;
+    uni.fm = x;
+
+    const unsigned int b = uni.ui + 0x00001000; // Round-to-nearest-even: add last bit after truncated mantissa
     const unsigned int e = (b & 0x7F800000) >> 23; // Exponent
     const unsigned int m = b & 0x007FFFFF; // Mantissa; in line below: 0x007FF000 = 0x00800000-0x00001000 = decimal indicator flag - initial rounding
 


### PR DESCRIPTION
Attempts to fix #4728 using @Not-Nik suggestion (https://github.com/raysan5/raylib/issues/4728#issuecomment-2614469470) of using an `union`.

<details><summary>This change was tested with the following test on Linux Mint 22.0:</summary><br>

Both versions were tested side by side to confirm they would return the same results:

``` c
// NOTE: Compile this with -02.

#include <stdio.h>

// Snippet from 'rtextures.c' ------------------------------------------

    // Convert half-float (stored as unsigned short) to float
    // REF: https://stackoverflow.com/questions/1659440/32-bit-to-16-bit-floating-point-conversion/60047308#60047308
    static float aHalfToFloat(unsigned short x)
    {
        float result = 0.0f;

        const unsigned int e = (x & 0x7C00) >> 10; // Exponent
        const unsigned int m = (x & 0x03FF) << 13; // Mantissa
        const float fm = (float)m;
        const unsigned int v = (*(unsigned int *)&fm) >> 23; // Evil log2 bit hack to count leading zeros in denormalized format
        const unsigned int r = (x & 0x8000) << 16 | (e != 0)*((e + 112) << 23 | m) | ((e == 0)&(m != 0))*((v - 37) << 23 | ((m << (150 - v)) & 0x007FE000)); // sign : normalized : denormalized

        result = *(float *)&r;

        return result;
    }

    // Convert float to half-float (stored as unsigned short)
    static unsigned short aFloatToHalf(float x)
    {
        unsigned short result = 0;

        const unsigned int b = (*(unsigned int *) & x) + 0x00001000; // Round-to-nearest-even: add last bit after truncated mantissa
        const unsigned int e = (b & 0x7F800000) >> 23; // Exponent
        const unsigned int m = b & 0x007FFFFF; // Mantissa; in line below: 0x007FF000 = 0x00800000-0x00001000 = decimal indicator flag - initial rounding

        result = (b & 0x80000000) >> 16 | (e > 112)*((((e - 112) << 10) & 0x7C00) | m >> 13) | ((e < 113) & (e > 101))*((((0x007FF000 + m) >> (125 - e)) + 1) >> 1) | (e > 143)*0x7FFF; // sign : normalized : denormalized : saturate

        return result;
    }

// ---------------------------------------------------------------------

// This PR change on 'rtextures.c' -------------------------------------

    union floatUnsignedUnion {
        float fm;
        unsigned int ui;
    };

    // Convert half-float (stored as unsigned short) to float
    // REF: https://stackoverflow.com/questions/1659440/32-bit-to-16-bit-floating-point-conversion/60047308#60047308
    static float bHalfToFloat(unsigned short x)
    {
        float result = 0.0f;

        union floatUnsignedUnion uni;
        uni.fm = 0.0f;

        const unsigned int e = (x & 0x7C00) >> 10; // Exponent
        const unsigned int m = (x & 0x03FF) << 13; // Mantissa
        uni.fm = (float)m;
        const unsigned int v = uni.ui >> 23; // Evil log2 bit hack to count leading zeros in denormalized format
        uni.ui = (x & 0x8000) << 16 | (e != 0)*((e + 112) << 23 | m) | ((e == 0)&(m != 0))*((v - 37) << 23 | ((m << (150 - v)) & 0x007FE000)); // sign : normalized : denormalized

        result = uni.fm;

        return result;
    }

    // Convert float to half-float (stored as unsigned short)
    static unsigned short bFloatToHalf(float x)
    {
        unsigned short result = 0;

        union floatUnsignedUnion uni;
        uni.fm = x;

        const unsigned int b = uni.ui + 0x00001000; // Round-to-nearest-even: add last bit after truncated mantissa
        const unsigned int e = (b & 0x7F800000) >> 23; // Exponent
        const unsigned int m = b & 0x007FFFFF; // Mantissa; in line below: 0x007FF000 = 0x00800000-0x00001000 = decimal indicator flag - initial rounding

        result = (b & 0x80000000) >> 16 | (e > 112)*((((e - 112) << 10) & 0x7C00) | m >> 13) | ((e < 113) & (e > 101))*((((0x007FF000 + m) >> (125 - e)) + 1) >> 1) | (e > 143)*0x7FFF; // sign : normalized : denormalized : saturate

        return result;
    }

// ---------------------------------------------------------------------

int main(void) {

    float f;
    unsigned short us;

    printf("\ncurrent master branch:\n");

    f = 0.0f; us = aFloatToHalf(f); printf("aFloatToHalf(0.0f):%d\n", us);
    f = 100.0f; us = aFloatToHalf(f); printf("aFloatToHalf(100.0f):%d\n", us);
    f = 1000.0f; us = aFloatToHalf(f); printf("aFloatToHalf(1000.0f):%d\n", us);
    f = 10000.0f; us = aFloatToHalf(f); printf("aFloatToHalf(10000.0f):%d\n", us);

    us = 0; f = aHalfToFloat(us); printf("aHalfToFloat(0):%f\n", f);
    us = 22080; f = aHalfToFloat(us); printf("aHalfToFloat(22080):%f\n", f);
    us = 25552; f = aHalfToFloat(us); printf("aHalfToFloat(25552):%f\n", f);
    us = 28898; f = aHalfToFloat(us); printf("aHalfToFloat(28898):%f\n", f);

    printf("\nthis PR:\n");

    f = 0.0f; us = bFloatToHalf(f); printf("bFloatToHalf(0.0f):%d\n", us);
    f = 100.0f; us = bFloatToHalf(f); printf("bFloatToHalf(100.0f):%d\n", us);
    f = 1000.0f; us = bFloatToHalf(f); printf("bFloatToHalf(1000.0f):%d\n", us);
    f = 10000.0f; us = bFloatToHalf(f); printf("bFloatToHalf(10000.0f):%d\n", us);

    us = 0; f = bHalfToFloat(us); printf("bHalfToFloat(0):%f\n", f);
    us = 22080; f = bHalfToFloat(us); printf("bHalfToFloat(22080):%f\n", f);
    us = 25552; f = bHalfToFloat(us); printf("bHalfToFloat(25552):%f\n", f);
    us = 28898; f = bHalfToFloat(us); printf("bHalfToFloat(28898):%f\n", f);

    return 0;

}
```
Which produces the following results:

``` bash

current master branch:
aFloatToHalf(0.0f):0
aFloatToHalf(100.0f):22080
aFloatToHalf(1000.0f):25552
aFloatToHalf(10000.0f):28898
aHalfToFloat(0):0.000000
aHalfToFloat(22080):100.000000
aHalfToFloat(25552):1000.000000
aHalfToFloat(28898):10000.000000

this PR:
bFloatToHalf(0.0f):0
bFloatToHalf(100.0f):22080
bFloatToHalf(1000.0f):25552
bFloatToHalf(10000.0f):28898
bHalfToFloat(0):0.000000
bHalfToFloat(22080):100.000000
bHalfToFloat(25552):1000.000000
bHalfToFloat(28898):10000.000000
```
</details>

Note: @Not-Nik If you can, could you please review this? I don't want to accidentaly break 16-Bit HDR.