### PR TITLE
[rtext] BMFont loading, support RGB and RGBA image formats 

### DIFF
--- a/src/rtext.c
+++ b/src/rtext.c
@@ -2227,26 +2227,34 @@ static Font LoadBMFont(const char *fileName)
     {
         imFonts[i] = LoadImage(TextFormat("%s/%s", GetDirectoryPath(fileName), imFileName[i]));
 
-        if (imFonts[i].format == PIXELFORMAT_UNCOMPRESSED_GRAYSCALE)
-        {
-            // Convert image to GRAYSCALE + ALPHA, using the mask as the alpha channel
-            Image imFontAlpha = {
-                .data = RL_CALLOC(imFonts[i].width*imFonts[i].height, 2),
-                .width = imFonts[i].width,
-                .height = imFonts[i].height,
-                .mipmaps = 1,
-                .format = PIXELFORMAT_UNCOMPRESSED_GRAY_ALPHA
-            };
-
-            for (int p = 0, pi = 0; p < (imFonts[i].width*imFonts[i].height*2); p += 2, pi++)
-            {
-                ((unsigned char *)(imFontAlpha.data))[p] = 0xff;
-                ((unsigned char *)(imFontAlpha.data))[p + 1] = ((unsigned char *)imFonts[i].data)[pi];
-            }
-
-            UnloadImage(imFonts[i]);
-            imFonts[i] = imFontAlpha;
-        }
+        PixelFormat format = imFonts[i].format;
+		if (format != PIXELFORMAT_UNCOMPRESSED_GRAYSCALE && format != PIXELFORMAT_UNCOMPRESSED_R8G8B8A8 && format != PIXELFORMAT_UNCOMPRESSED_R8G8B8)
+			continue;
+		
+		// Convert image to GRAYSCALE + ALPHA, using the mask as the alpha channel
+		Image imFontAlpha = {
+			.data = RL_CALLOC(imFonts[i].width*imFonts[i].height, 2),
+			.width = imFonts[i].width,
+			.height = imFonts[i].height,
+			.mipmaps = 1,
+			.format = PIXELFORMAT_UNCOMPRESSED_GRAY_ALPHA
+		};
+		
+		int stride = 1;
+		if (format == PIXELFORMAT_UNCOMPRESSED_R8G8B8){
+			stride = 3;
+		}else if (format == PIXELFORMAT_UNCOMPRESSED_R8G8B8A8){
+			stride = 4;
+		}
+		
+		for (int p = 0, pi = 0; p < (imFonts[i].width*imFonts[i].height*2); p += 2, pi++)
+		{
+			((unsigned char *)(imFontAlpha.data))[p] = 0xff;
+			((unsigned char *)(imFontAlpha.data))[p + 1] = ((unsigned char *)imFonts[i].data)[pi * stride];
+		}
+		
+		UnloadImage(imFonts[i]);
+        imFonts[i] = imFontAlpha;
     }
 
     Image fullFont = imFonts[0];

--- a/src/rtext.c
+++ b/src/rtext.c
@@ -2229,7 +2229,7 @@ static Font LoadBMFont(const char *fileName)
 
         PixelFormat format = imFonts[i].format;
         if (format != PIXELFORMAT_UNCOMPRESSED_GRAYSCALE && format != PIXELFORMAT_UNCOMPRESSED_R8G8B8A8 && format != PIXELFORMAT_UNCOMPRESSED_R8G8B8){
-            TRACELOG(LOG_WARNING, "FONT: [%s] Page number %i used an unsupported pixel format", i, fileName);
+            TRACELOG(LOG_WARNING, "FONT: [%s] Page number %i used an unsupported pixel format", fileName, i);
             continue;
         }
         

--- a/src/rtext.c
+++ b/src/rtext.c
@@ -2258,12 +2258,12 @@ static Font LoadBMFont(const char *fileName)
         
         for (int p = 0, pi = 0; p < (imFonts[i].width * imFonts[i].height * 2); p += 2, pi++)
         {
-            ((unsigned char *)(imFontAlpha.data))[p] = 0xff;
-            ((unsigned char *)(imFontAlpha.data))[p + 1] = ((unsigned char *)imFonts[i].data)[pi * stride];
+            ((unsigned char *)(imFont.data))[p] = 0xff;
+            ((unsigned char *)(imFont.data))[p + 1] = ((unsigned char *)imFonts[i].data)[pi * stride];
         }
         
         UnloadImage(imFonts[i]);
-        imFonts[i] = imFontAlpha;
+        imFonts[i] = imFont;
     }
 
     Image fullFont = imFonts[0];

--- a/src/rtext.c
+++ b/src/rtext.c
@@ -2228,32 +2228,32 @@ static Font LoadBMFont(const char *fileName)
         imFonts[i] = LoadImage(TextFormat("%s/%s", GetDirectoryPath(fileName), imFileName[i]));
 
         PixelFormat format = imFonts[i].format;
-		if (format != PIXELFORMAT_UNCOMPRESSED_GRAYSCALE && format != PIXELFORMAT_UNCOMPRESSED_R8G8B8A8 && format != PIXELFORMAT_UNCOMPRESSED_R8G8B8)
-			continue;
-		
-		// Convert image to GRAYSCALE + ALPHA, using the mask as the alpha channel
-		Image imFontAlpha = {
-			.data = RL_CALLOC(imFonts[i].width*imFonts[i].height, 2),
-			.width = imFonts[i].width,
-			.height = imFonts[i].height,
-			.mipmaps = 1,
-			.format = PIXELFORMAT_UNCOMPRESSED_GRAY_ALPHA
-		};
-		
-		int stride = 1;
-		if (format == PIXELFORMAT_UNCOMPRESSED_R8G8B8){
-			stride = 3;
-		}else if (format == PIXELFORMAT_UNCOMPRESSED_R8G8B8A8){
-			stride = 4;
-		}
-		
-		for (int p = 0, pi = 0; p < (imFonts[i].width*imFonts[i].height*2); p += 2, pi++)
-		{
-			((unsigned char *)(imFontAlpha.data))[p] = 0xff;
-			((unsigned char *)(imFontAlpha.data))[p + 1] = ((unsigned char *)imFonts[i].data)[pi * stride];
-		}
-		
-		UnloadImage(imFonts[i]);
+        if (format != PIXELFORMAT_UNCOMPRESSED_GRAYSCALE && format != PIXELFORMAT_UNCOMPRESSED_R8G8B8A8 && format != PIXELFORMAT_UNCOMPRESSED_R8G8B8)
+            continue;
+        
+        // Convert image to GRAYSCALE + ALPHA, using the mask as the alpha channel
+        Image imFontAlpha = {
+            .data = RL_CALLOC(imFonts[i].width*imFonts[i].height, 2),
+            .width = imFonts[i].width,
+            .height = imFonts[i].height,
+            .mipmaps = 1,
+            .format = PIXELFORMAT_UNCOMPRESSED_GRAY_ALPHA
+        };
+        
+        int stride = 1;
+        if (format == PIXELFORMAT_UNCOMPRESSED_R8G8B8){
+            stride = 3;
+        }else if (format == PIXELFORMAT_UNCOMPRESSED_R8G8B8A8){
+            stride = 4;
+        }
+        
+        for (int p = 0, pi = 0; p < (imFonts[i].width*imFonts[i].height*2); p += 2, pi++)
+        {
+            ((unsigned char *)(imFontAlpha.data))[p] = 0xff;
+            ((unsigned char *)(imFontAlpha.data))[p + 1] = ((unsigned char *)imFonts[i].data)[pi * stride];
+        }
+        
+        UnloadImage(imFonts[i]);
         imFonts[i] = imFontAlpha;
     }
 

--- a/src/rtext.c
+++ b/src/rtext.c
@@ -2228,8 +2228,10 @@ static Font LoadBMFont(const char *fileName)
         imFonts[i] = LoadImage(TextFormat("%s/%s", GetDirectoryPath(fileName), imFileName[i]));
 
         PixelFormat format = imFonts[i].format;
-        if (format != PIXELFORMAT_UNCOMPRESSED_GRAYSCALE && format != PIXELFORMAT_UNCOMPRESSED_R8G8B8A8 && format != PIXELFORMAT_UNCOMPRESSED_R8G8B8)
+        if (format != PIXELFORMAT_UNCOMPRESSED_GRAYSCALE && format != PIXELFORMAT_UNCOMPRESSED_R8G8B8A8 && format != PIXELFORMAT_UNCOMPRESSED_R8G8B8){
+            TRACELOG(LOG_WARNING, "FONT: [%s] Page number %i used an unsupported pixel format", i, fileName);
             continue;
+        }
         
         // Convert image to GRAYSCALE + ALPHA, using the mask as the alpha channel
         Image imFontAlpha = {

--- a/src/rtext.c
+++ b/src/rtext.c
@@ -2227,15 +2227,18 @@ static Font LoadBMFont(const char *fileName)
     {
         imFonts[i] = LoadImage(TextFormat("%s/%s", GetDirectoryPath(fileName), imFileName[i]));
 
-        PixelFormat format = imFonts[i].format;
-        if (format != PIXELFORMAT_UNCOMPRESSED_GRAYSCALE && format != PIXELFORMAT_UNCOMPRESSED_R8G8B8A8 && format != PIXELFORMAT_UNCOMPRESSED_R8G8B8){
+        int pageFormat = imFonts[i].format;
+        
+        if (pageFormat != PIXELFORMAT_UNCOMPRESSED_GRAYSCALE && pageFormat != PIXELFORMAT_UNCOMPRESSED_R8G8B8A8 && pageFormat != PIXELFORMAT_UNCOMPRESSED_R8G8B8)
+        {
             TRACELOG(LOG_WARNING, "FONT: [%s] Page number %i used an unsupported pixel format", fileName, i);
             continue;
         }
         
         // Convert image to GRAYSCALE + ALPHA, using the mask as the alpha channel
-        Image imFontAlpha = {
-            .data = RL_CALLOC(imFonts[i].width*imFonts[i].height, 2),
+        
+        Image imFont = {
+            .data = RL_CALLOC(imFonts[i].width * imFonts[i].height, 2),
             .width = imFonts[i].width,
             .height = imFonts[i].height,
             .mipmaps = 1,
@@ -2243,13 +2246,17 @@ static Font LoadBMFont(const char *fileName)
         };
         
         int stride = 1;
-        if (format == PIXELFORMAT_UNCOMPRESSED_R8G8B8){
+        
+        if (pageFormat == PIXELFORMAT_UNCOMPRESSED_R8G8B8)
+        {
             stride = 3;
-        }else if (format == PIXELFORMAT_UNCOMPRESSED_R8G8B8A8){
+        }
+        else if (pageFormat == PIXELFORMAT_UNCOMPRESSED_R8G8B8A8)
+        {
             stride = 4;
         }
         
-        for (int p = 0, pi = 0; p < (imFonts[i].width*imFonts[i].height*2); p += 2, pi++)
+        for (int p = 0, pi = 0; p < (imFonts[i].width * imFonts[i].height * 2); p += 2, pi++)
         {
             ((unsigned char *)(imFontAlpha.data))[p] = 0xff;
             ((unsigned char *)(imFontAlpha.data))[p + 1] = ((unsigned char *)imFonts[i].data)[pi * stride];


### PR DESCRIPTION
With this PR, if the BMFont file points to images that aren't grayscale, they will now load and be converted. This allows the images to be, for example, .qoi ones which are solely RGBA.

~~I'm curious if failing the format check should throw a log warning, let me know and I'll add that.~~ EDIT: Subsequently added a log warning.