### PR TITLE
[rtext] Don't call TextLength in DrawTextEx and MeasureTextEx

### DIFF
--- a/src/rtext.c
+++ b/src/rtext.c
@@ -1153,18 +1153,18 @@ void DrawTextEx(Font font, const char *text, Vector2 position, float fontSize, f
 {
     if (font.texture.id == 0) font = GetFontDefault();  // Security check in case of not valid font
 
-    int size = TextLength(text);    // Total size in bytes of the text, scanned by codepoints in loop
-
     float textOffsetY = 0;          // Offset between lines (on linebreak '\n')
     float textOffsetX = 0.0f;       // Offset X to next character to draw
 
     float scaleFactor = fontSize/font.baseSize;         // Character quad scaling factor
 
-    for (int i = 0; i < size;)
+    int codepointByteCount = 0;
+    int codepoint = 0;
+
+    for (; *text != '\0'; text += codepointByteCount)
     {
         // Get next codepoint from byte string and glyph index in font
-        int codepointByteCount = 0;
-        int codepoint = GetCodepointNext(&text[i], &codepointByteCount);
+        codepoint = GetCodepointNext(text, &codepointByteCount);
         int index = GetGlyphIndex(font, codepoint);
 
         if (codepoint == '\n')
@@ -1183,8 +1183,6 @@ void DrawTextEx(Font font, const char *text, Vector2 position, float fontSize, f
             if (font.glyphs[index].advanceX == 0) textOffsetX += ((float)font.recs[index].width*scaleFactor + spacing);
             else textOffsetX += ((float)font.glyphs[index].advanceX*scaleFactor + spacing);
         }
-
-        i += codepointByteCount;   // Move text bytes counter to next codepoint
     }
 }
 
@@ -1289,7 +1287,6 @@ Vector2 MeasureTextEx(Font font, const char *text, float fontSize, float spacing
     if ((isGpuReady && (font.texture.id == 0)) ||
         (text == NULL) || (text[0] == '\0')) return textSize; // Security check
 
-    int size = TextLength(text);    // Get size in bytes of text
     int tempByteCounter = 0;        // Used to count longer text line num chars
     int byteCounter = 0;
 
@@ -1299,18 +1296,16 @@ Vector2 MeasureTextEx(Font font, const char *text, float fontSize, float spacing
     float textHeight = fontSize;
     float scaleFactor = fontSize/(float)font.baseSize;
 
+    int codepointByteCount = 0;
     int letter = 0;                 // Current character
     int index = 0;                  // Index position in sprite font
 
-    for (int i = 0; i < size;)
+    for (; *text != '\0'; text += codepointByteCount)
     {
         byteCounter++;
 
-        int codepointByteCount = 0;
-        letter = GetCodepointNext(&text[i], &codepointByteCount);
+        letter = GetCodepointNext(text, &codepointByteCount);
         index = GetGlyphIndex(font, letter);
-
-        i += codepointByteCount;
 
         if (letter != '\n')
         {


### PR DESCRIPTION
Currently, DrawTextEx and MeasureTextEx call TextLength first to scan for the null terminator, before beginning a loop on all of the codepoints. Instead, check for the null terminator during the loop.