### PR TITLE
[build] [Makefile]: Undefine _GNU_SOURCE for rglfw.c

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -742,7 +742,7 @@ rcore.o : rcore.c raylib.h rlgl.h utils.h raymath.h rcamera.h rgestures.h
 
 # Compile rglfw module
 rglfw.o : rglfw.c
-	$(CC) $(GLFW_OSX) -c $< $(CFLAGS) $(INCLUDE_PATHS)
+	$(CC) $(GLFW_OSX) -c $< $(CFLAGS) $(INCLUDE_PATHS) -U_GNU_SOURCE
 
 # Compile shapes module
 rshapes.o : rshapes.c raylib.h rlgl.h


### PR DESCRIPTION
Currently, a warning about _GNU_SOURCE being redefined is emitted when compiling rglfw.c

```c
In file included from rglfw.c:99:
external/glfw/src/posix_poll.c:27:9: warning: "_GNU_SOURCE" redefined
   27 | #define _GNU_SOURCE
      |         ^~~~~~~~~~~
<command-line>: note: this is the location of the previous definition
```

This can be avoided by not defining _GNU_SOURCE on the command line for this file.

Defining feature test macros in source code is not really good practice so this should probably reviewed in glfw itself, at least to maybe check
 #ifdef _GNU_SOURCE first. But for now this change will suffice.

Fixes #4725