### PR TITLE
[rcore] [GLFW] [SDL] Add `GetGamepadGUID()

### DIFF
--- a/src/platforms/rcore_android.c
+++ b/src/platforms/rcore_android.c
@@ -624,6 +624,13 @@ int SetGamepadMappings(const char *mappings)
     return 0;
 }
 
+// Get gamepad GUID
+const char *GetGamepadGUID(int gamepad)
+{
+    TRACELOG(LOG_WARNING, "GetGamepadGUID() not implemented on target platform");
+    return "";
+}
+
 // Set gamepad vibration
 void SetGamepadVibration(int gamepad, float leftMotor, float rightMotor, float duration)
 {

--- a/src/platforms/rcore_desktop_glfw.c
+++ b/src/platforms/rcore_desktop_glfw.c
@@ -1084,6 +1084,12 @@ int SetGamepadMappings(const char *mappings)
     return glfwUpdateGamepadMappings(mappings);
 }
 
+// Get gamepad GUID
+const char *GetGamepadGUID(int gamepad)
+{
+    return glfwGetJoystickGUID(gamepad);
+}
+
 // Set gamepad vibration
 void SetGamepadVibration(int gamepad, float leftMotor, float rightMotor, float duration)
 {

--- a/src/platforms/rcore_desktop_rgfw.c
+++ b/src/platforms/rcore_desktop_rgfw.c
@@ -789,6 +789,13 @@ int SetGamepadMappings(const char *mappings)
     return 0;
 }
 
+// Get gamepad GUID
+const char *GetGamepadGUID(int gamepad)
+{
+    TRACELOG(LOG_WARNING, "GetGamepadGUID() not implemented on target platform");
+    return "";
+}
+
 // Set gamepad vibration
 void SetGamepadVibration(int gamepad, float leftMotor, float rightMotor, float duration)
 {

--- a/src/platforms/rcore_desktop_sdl.c
+++ b/src/platforms/rcore_desktop_sdl.c
@@ -1245,7 +1245,7 @@ const char *GetGamepadGUID(int gamepad)
 {
     static char buffer[MAX_JOYSTICKGUID_BUFFER_LENGTH] = { 0 };
 
-    SDL_JoystickGUID joystickGUID = SDL_JoystickGetGUID(SDL_GameControllerGetJoystick(platform.gamepad[0]));
+    SDL_JoystickGUID joystickGUID = SDL_JoystickGetGUID(SDL_GameControllerGetJoystick(platform.gamepad[gamepad]));
 
     SDL_JoystickGetGUIDString(joystickGUID, buffer, MAX_JOYSTICKGUID_BUFFER_LENGTH -1);
 

--- a/src/platforms/rcore_desktop_sdl.c
+++ b/src/platforms/rcore_desktop_sdl.c
@@ -68,6 +68,10 @@
     #define MAX_CLIPBOARD_BUFFER_LENGTH 1024 // Size of the clipboard buffer used on GetClipboardText()
 #endif
 
+#ifndef MAX_JOYSTICKGUID_BUFFER_LENGTH
+    #define MAX_JOYSTICKGUID_BUFFER_LENGTH 64 // Size of the joystick GUID buffer used on GetGamepadGUID(), must be at least 33 bytes
+#endif
+
 #if ((defined(SDL_MAJOR_VERSION) && (SDL_MAJOR_VERSION == 3)) && (defined(SDL_MINOR_VERSION) && (SDL_MINOR_VERSION >= 1)))
     #ifndef PLATFORM_DESKTOP_SDL3
         #define PLATFORM_DESKTOP_SDL3
@@ -1239,8 +1243,13 @@ int SetGamepadMappings(const char *mappings)
 // Get gamepad GUID
 const char *GetGamepadGUID(int gamepad)
 {
-    TRACELOG(LOG_WARNING, "GetGamepadGUID() not implemented on target platform");
-    return "";
+    static char buffer[MAX_JOYSTICKGUID_BUFFER_LENGTH] = { 0 };
+
+    SDL_JoystickGUID joystickGUID = SDL_JoystickGetGUID(SDL_GameControllerGetJoystick(platform.gamepad[0]));
+
+    SDL_JoystickGetGUIDString(joystickGUID, buffer, MAX_JOYSTICKGUID_BUFFER_LENGTH -1);
+
+    return buffer;
 }
 
 // Set gamepad vibration

--- a/src/platforms/rcore_desktop_sdl.c
+++ b/src/platforms/rcore_desktop_sdl.c
@@ -1236,6 +1236,13 @@ int SetGamepadMappings(const char *mappings)
     return SDL_GameControllerAddMapping(mappings);
 }
 
+// Get gamepad GUID
+const char *GetGamepadGUID(int gamepad)
+{
+    TRACELOG(LOG_WARNING, "GetGamepadGUID() not implemented on target platform");
+    return "";
+}
+
 // Set gamepad vibration
 void SetGamepadVibration(int gamepad, float leftMotor, float rightMotor, float duration)
 {

--- a/src/platforms/rcore_drm.c
+++ b/src/platforms/rcore_drm.c
@@ -619,6 +619,13 @@ int SetGamepadMappings(const char *mappings)
     return 0;
 }
 
+// Get gamepad GUID
+const char *GetGamepadGUID(int gamepad)
+{
+    TRACELOG(LOG_WARNING, "GetGamepadGUID() not implemented on target platform");
+    return "";
+}
+
 // Set gamepad vibration
 void SetGamepadVibration(int gamepad, float leftMotor, float rightMotor, float duration)
 {

--- a/src/platforms/rcore_template.c
+++ b/src/platforms/rcore_template.c
@@ -381,6 +381,13 @@ int SetGamepadMappings(const char *mappings)
     return 0;
 }
 
+// Get gamepad GUID
+const char *GetGamepadGUID(int gamepad)
+{
+    TRACELOG(LOG_WARNING, "GetGamepadGUID() not implemented on target platform");
+    return "";
+}
+
 // Set gamepad vibration
 void SetGamepadVibration(int gamepad, float leftMotor, float rightMotor, float duration)
 {

--- a/src/platforms/rcore_web.c
+++ b/src/platforms/rcore_web.c
@@ -162,13 +162,13 @@ bool WindowShouldClose(void)
     // REF: https://emscripten.org/docs/porting/asyncify.html
 
     // WindowShouldClose() is not called on a web-ready raylib application if using emscripten_set_main_loop()
-    // and encapsulating one frame execution on a UpdateDrawFrame() function, 
+    // and encapsulating one frame execution on a UpdateDrawFrame() function,
     // allowing the browser to manage execution asynchronously
 
     // Optionally we can manage the time we give-control-back-to-browser if required,
     // but it seems below line could generate stuttering on some browsers
     emscripten_sleep(12);
-    
+
     return false;
 }
 
@@ -912,6 +912,13 @@ int SetGamepadMappings(const char *mappings)
     TRACELOG(LOG_INFO, "SetGamepadMappings not implemented in rcore_web.c");
 
     return 0;
+}
+
+// Get gamepad GUID
+const char *GetGamepadGUID(int gamepad)
+{
+    TRACELOG(LOG_WARNING, "GetGamepadGUID() not implemented on target platform");
+    return "";
 }
 
 // Set gamepad vibration

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1195,6 +1195,7 @@ RLAPI int GetGamepadButtonPressed(void);                      // Get the last ga
 RLAPI int GetGamepadAxisCount(int gamepad);                   // Get gamepad axis count for a gamepad
 RLAPI float GetGamepadAxisMovement(int gamepad, int axis);    // Get axis movement value for a gamepad axis
 RLAPI int SetGamepadMappings(const char *mappings);           // Set internal gamepad mappings (SDL_GameControllerDB)
+RLAPI const char *GetGamepadGUID(int gamepad);                // Get gamepad GUID
 RLAPI void SetGamepadVibration(int gamepad, float leftMotor, float rightMotor, float duration); // Set gamepad vibration for both motors (duration in seconds)
 
 // Input-related functions: mouse


### PR DESCRIPTION
Ref: #3651

I know that adding new functions should be avoided to keep the library lean, but, in my opinion, this one is necessary.

Currently gamepads are identified by device index (which is just the connected order), joystick id (which is generic/incremental for internal use only) and name (which is not unique and repeatable between controllers).

GUIDs, which are missing, are what actually identify controller for the user-side and the reference to link it to the correct mappings globally. Since controller mappings are outside the library responsability, it's up to the user to provide the necessary mappings, and the user can't do that without checking/confirming the GUID. Without this information, a controller may fail silently due to differences in GUID (e.g.: different firmware versions, etc) and there's no way for the user to learn that (which, incidentally, is one of the issues happening on #3651).

<details><summary>This PR was tested with Linux Mint 22.0 for `PLATFORM_DESKTOP_GLFW` and `PLATFORM_DESKTOP_SDL` with `SDL2` (2.30.11) with the following test case:</summary><br>

``` c
#include "raylib.h"
int main(void) {
    InitWindow(800, 450, "test");
    SetTargetFPS(60);

    while (!WindowShouldClose()) {
        TraceLog(LOG_INFO, "");

        int joy1 = IsGamepadAvailable(0);
        TraceLog(LOG_INFO, "joy1:%i", joy1);
        if (joy1) {
            TraceLog(LOG_INFO, "name:%s", GetGamepadName(0));
            TraceLog(LOG_INFO, "guid:%s", GetGamepadGUID(0));
        }

        BeginDrawing();
        ClearBackground(RAYWHITE);
        EndDrawing();
    }
    CloseWindow();
    return 0;
}
```
</details>