### PR TITLE
[rcore] [web] Fix mouse position on resize callback

### DIFF
--- a/src/platforms/rcore_web.c
+++ b/src/platforms/rcore_web.c
@@ -162,13 +162,13 @@ bool WindowShouldClose(void)
     // REF: https://emscripten.org/docs/porting/asyncify.html
 
     // WindowShouldClose() is not called on a web-ready raylib application if using emscripten_set_main_loop()
-    // and encapsulating one frame execution on a UpdateDrawFrame() function, 
+    // and encapsulating one frame execution on a UpdateDrawFrame() function,
     // allowing the browser to manage execution asynchronously
 
     // Optionally we can manage the time we give-control-back-to-browser if required,
     // but it seems below line could generate stuttering on some browsers
     emscripten_sleep(12);
-    
+
     return false;
 }
 
@@ -1683,19 +1683,9 @@ static EM_BOOL EmscriptenResizeCallback(int eventType, const EmscriptenUiEvent *
     if (height < (int)CORE.Window.screenMin.height) height = CORE.Window.screenMin.height;
     else if ((height > (int)CORE.Window.screenMax.height) && (CORE.Window.screenMax.height > 0)) height = CORE.Window.screenMax.height;
 
-    emscripten_set_canvas_element_size(GetCanvasId(), width, height);
-
-    SetupViewport(width, height); // Reset viewport and projection matrix for new size
-
-    CORE.Window.currentFbo.width = width;
-    CORE.Window.currentFbo.height = height;
-    CORE.Window.resizedLastFrame = true;
-
     if (IsWindowFullscreen()) return 1;
 
-    // Set current screen size
-    CORE.Window.screen.width = width;
-    CORE.Window.screen.height = height;
+    glfwSetWindowSize(platform.handle, width, height);
 
     // NOTE: Postprocessing texture is not scaled to new size
 


### PR DESCRIPTION
Fix for this issue: https://github.com/raysan5/raylib/pull/4734#issuecomment-2622138249

<details><summary>Test case tested on shell.html and minshell.html on Chromium 130.0 and Firefox 131.0 on Linux Mint 22.0 with Emscripten 4.0.1:</summary><br>

``` c
#include "raylib.h"
int main(void) {
    InitWindow(800, 450, "test");
    SetTargetFPS(60);
    while (!WindowShouldClose()) {
        BeginDrawing();
        ClearBackground(RAYWHITE);

        if (IsKeyPressed(KEY_ONE)) { ToggleFullscreen(); }
        if (IsKeyPressed(KEY_TWO)) { ToggleBorderlessWindowed(); }

        if (IsKeyPressed(KEY_R)) { SetWindowState(FLAG_WINDOW_RESIZABLE); }

        const int mx = GetMouseX();
        const int my = GetMouseY();
        DrawText(TextFormat("Mouse Pos %i %i", mx, my), 20, 20, 20, BLACK);
        DrawCircle(mx, my, 5.0f, RED);

        EndDrawing();
    }
    CloseWindow();
    return 0;
}
```
</details>