### PR TITLE
[rmodels] Separate GLTF roughness and metallic channels on load

### DIFF
--- a/src/rmodels.c
+++ b/src/rmodels.c
@@ -5347,7 +5347,33 @@ static Model LoadGLTF(const char *fileName)
                     Image imMetallicRoughness = LoadImageFromCgltfImage(data->materials[i].pbr_metallic_roughness.metallic_roughness_texture.texture->image, texPath);
                     if (imMetallicRoughness.data != NULL)
                     {
-                        model.materials[j].maps[MATERIAL_MAP_ROUGHNESS].texture = LoadTextureFromImage(imMetallicRoughness);
+                        Image imMetallic, imRoughness;
+
+                        imMetallic.data = RL_MALLOC(imMetallicRoughness.width * imMetallicRoughness.height);
+                        imRoughness.data = RL_MALLOC(imMetallicRoughness.width * imMetallicRoughness.height);
+
+                        imMetallic.width = imRoughness.width = imMetallicRoughness.width;
+                        imMetallic.height = imRoughness.height = imMetallicRoughness.height;
+
+                        imMetallic.format = imRoughness.format = PIXELFORMAT_UNCOMPRESSED_GRAYSCALE;
+                        imMetallic.mipmaps = imRoughness.mipmaps = 1;
+
+                        for (int x = 0; x < imRoughness.width; x++) {
+                            for (int y = 0; y < imRoughness.height; y++) {
+                                Color color = GetImageColor(imMetallicRoughness, x, y);
+
+                                Color roughness = (Color) {color.g};
+                                Color metallic = (Color) {color.b};
+
+                                ((unsigned char *)imRoughness.data)[y*imRoughness.width + x] = color.g;
+                                ((unsigned char *)imMetallic.data)[y*imMetallic.width + x] = color.b;
+                            }
+                        }
+                        model.materials[j].maps[MATERIAL_MAP_ROUGHNESS].texture = LoadTextureFromImage(imRoughness);
+                        model.materials[j].maps[MATERIAL_MAP_METALNESS].texture = LoadTextureFromImage(imMetallic);
+
+                        UnloadImage(imRoughness);
+                        UnloadImage(imMetallic);
                         UnloadImage(imMetallicRoughness);
                     }
 


### PR DESCRIPTION
Create separate textures for roughness and metallic values when loading GLTF/GLB files. No one interjected, so I just did the implementation of my proposal.

This doesn't break any examples, because the only GLTF+PBR example we have, loads its own texture files manually. I did test this with my own setup, where this creates the same behaviour as if doing the separation in an image editing tool before running, and then loading the textures, after loading the image.

For more info see #4715