### PR TITLE
[rtext] fix: misuse of cast in GetCodepointCount

### DIFF
--- a/src/rtext.c
+++ b/src/rtext.c
@@ -1915,7 +1915,7 @@ void UnloadCodepoints(int *codepoints)
 int GetCodepointCount(const char *text)
 {
     unsigned int length = 0;
-    char *ptr = (char *)&text[0];
+    const char *ptr = text;
 
     while (*ptr != '\0')
     {


### PR DESCRIPTION
I was really wondering what is going on here :D I believe this code tried initially to out-cast 'const' specifier but this is not needed here at all. Currently, it just confuses whoever reads this so I changed it. The old code would also trigger -Wcast-qual warning on some compilers.

Tested on Linux with latest branch.