### PR TITLE
[raudio] AddAudioStreamProcessor: enable closures and similar user context use cases by providing a "context pointer"

### DIFF
--- a/projects/Notepad++/raylib_npp_parser/raylib_to_parse.h
+++ b/projects/Notepad++/raylib_npp_parser/raylib_to_parse.h
@@ -737,6 +737,11 @@ RLAPI void SetAudioStreamCallback(AudioStream stream, AudioCallback callback); /
 RLAPI void AttachAudioStreamProcessor(AudioStream stream, AudioCallback processor); // Attach audio stream processor to stream, receives the samples as 'float'
 RLAPI void DetachAudioStreamProcessor(AudioStream stream, AudioCallback processor); // Detach audio stream processor from stream
 
+RLAPI void AttachAudioStreamProcessorWithUserData(void* user_data, AudioStream stream, AudioCallbackWithUserData processor); // Attach audio stream processor to stream, receives the samples as 'float'
+RLAPI void DetachAudioStreamProcessorWithUserData(AudioStream stream, AudioCallbackWithUserData processor); // Detach audio stream processor from stream
+
 RLAPI void AttachAudioMixedProcessor(AudioCallback processor); // Attach audio stream processor to the entire audio pipeline, receives the samples as 'float'
 RLAPI void DetachAudioMixedProcessor(AudioCallback processor); // Detach audio stream processor from the entire audio pipeline
 
+RLAPI void AttachAudioMixedProcessorWithUserData(void* user_data, AudioCallbackWithUserData processor); // Attach audio stream processor to the entire audio pipeline, receives the samples as 'float'
+RLAPI void DetachAudioMixedProcessorWithUserData(AudioCallbackWithUserData processor); // Detach audio stream processor from the entire audio pipeline

--- a/src/raudio.c
+++ b/src/raudio.c
@@ -2236,7 +2236,7 @@ void AttachAudioStreamProcessor(AudioStream stream, AudioCallback process)
 
     rAudioProcessor *processor = (rAudioProcessor *)RL_CALLOC(1, sizeof(rAudioProcessor));
     processor->process = process;
- processor->process_with_user_data = NULL;
+    processor->process_with_user_data = NULL;
     processor->user_data = NULL;
 
     rAudioProcessor *last = stream.buffer->processor;
@@ -2341,7 +2341,7 @@ void AttachAudioMixedProcessor(AudioCallback process)
 
     rAudioProcessor *processor = (rAudioProcessor *)RL_CALLOC(1, sizeof(rAudioProcessor));
     processor->process = process;
-        processor->process_with_user_data = NULL;
+    processor->process_with_user_data = NULL;
     processor->user_data = NULL;
 
     rAudioProcessor *last = AUDIO.mixedProcessor;

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1623,6 +1623,7 @@ RLAPI RayCollision GetRayCollisionQuad(Ray ray, Vector3 p1, Vector3 p2, Vector3 
 // Audio Loading and Playing Functions (Module: audio)
 //------------------------------------------------------------------------------------
 typedef void (*AudioCallback)(void *bufferData, unsigned int frames);
+typedef void (*AudioCallbackWithUserData)(void* user_data, void *bufferData, unsigned int frames);
 
 // Audio device management functions
 RLAPI void InitAudioDevice(void);                                     // Initialize audio device and context
@@ -1698,10 +1699,13 @@ RLAPI void SetAudioStreamCallback(AudioStream stream, AudioCallback callback); /
 
 RLAPI void AttachAudioStreamProcessor(AudioStream stream, AudioCallback processor); // Attach audio stream processor to stream, receives the samples as 'float'
 RLAPI void DetachAudioStreamProcessor(AudioStream stream, AudioCallback processor); // Detach audio stream processor from stream
+RLAPI void AttachAudioStreamProcessorWithUserData(void* user_data, AudioStream stream, AudioCallbackWithUserData processor); // Attach audio stream processor to stream, receives the samples as 'float'
+RLAPI void DetachAudioStreamProcessorWithUserData(AudioStream stream, AudioCallbackWithUserData processor); // Detach audio stream processor from stream
 
 RLAPI void AttachAudioMixedProcessor(AudioCallback processor); // Attach audio stream processor to the entire audio pipeline, receives the samples as 'float'
 RLAPI void DetachAudioMixedProcessor(AudioCallback processor); // Detach audio stream processor from the entire audio pipeline
-
+RLAPI void AttachAudioMixedProcessorWithUserData(void* user_data, AudioCallbackWithUserData processor); // Attach audio stream processor to the entire audio pipeline, receives the samples as 'float'
+RLAPI void DetachAudioMixedProcessorWithUserData(AudioCallbackWithUserData processor); // Detach audio stream processor from the entire audio pipeline
 #if defined(__cplusplus)
 }
 #endif


### PR DESCRIPTION
I played with your wonderful library after I listened to a recent podcast with an interview with you :-).

I encountered a problem while trying to attach a callback in rust as audio stream processor. While it was possible to add it via free functions I had some problems when trying to attach a closure.

It would be much easier when the audio stream processor callback signature would include a context pointer (`void* user_data`) like in other APIs like pthread. With such a context pointer a context data structure can easily be attached to a callback. This helps disambiguating the callbacks from each other.
 
I tried to propose a non-breaking extension to allow in addition to the existing callbacks to include a new callback with a context pointer.

I would be happy to discuss this proposal - and hopefully to find a solution to my problem.