### PR TITLE
[rtextures] Add missing increments of k in `LoadImageDataNormalized()`

### DIFF
--- a/src/rtextures.c
+++ b/src/rtextures.c
@@ -5512,6 +5512,7 @@ static Vector4 *LoadImageDataNormalized(Image image)
                     pixels[i].z = 0.0f;
                     pixels[i].w = 1.0f;
 
+                    k += 1;
                 } break;
                 case PIXELFORMAT_UNCOMPRESSED_R32G32B32:
                 {
@@ -5537,6 +5538,8 @@ static Vector4 *LoadImageDataNormalized(Image image)
                     pixels[i].y = 0.0f;
                     pixels[i].z = 0.0f;
                     pixels[i].w = 1.0f;
+
+                    k += 1;
                 } break;
                 case PIXELFORMAT_UNCOMPRESSED_R16G16B16:
                 {


### PR DESCRIPTION
Fixes: https://github.com/raysan5/raylib/issues/4737

I tested the changes with a small program: https://gist.github.com/henrikglass/1c6a0b35703836a60bd3c44b88f9e7eb
