### PR TITLE
[build][cmake] Set PLATFORM to Web by default when configuring web builds with emcmake

### DIFF
--- a/CMakeOptions.txt
+++ b/CMakeOptions.txt
@@ -2,6 +2,10 @@
 include(CMakeDependentOption)
 include(EnumOption)
 
+if(EMSCRIPTEN)
+    # When configuring web builds with "emcmake cmake -B build -S .", set PLATFORM to Web by default
+    SET(PLATFORM Web CACHE STRING "Platform to build for.")
+endif()
 enum_option(PLATFORM "Desktop;Web;Android;Raspberry Pi;DRM;SDL" "Platform to build for.")
 
 enum_option(OPENGL_VERSION "OFF;4.3;3.3;2.1;1.1;ES 2.0;ES 3.0" "Force a specific OpenGL Version?")


### PR DESCRIPTION
This PR improves the CMake web build by setting the `PLATFORM` to `Web` by default when configuring builds using `emcmake cmake`.
This solution is the same as 9821725c6bafeaf4153ab8604e692dfe13cbff09 wanted to achieve, but for it to work the value must be set before `enum_option(PLATFORM ...)` is called, that's why it didn't work before.

My only doubt is if it's best to just set the default value like I did, or if it makes sense to force PLATFORM to Web and only call `enum_option(PLATFORM ...)` in the `else()` branch, since Emscripten cannot build raylib with any other value of PLATFORM set.