### PR TITLE
doc: audio stream processor, number of channels

### DIFF
--- a/parser/output/raylib_api.json
+++ b/parser/output/raylib_api.json
@@ -12119,7 +12119,7 @@
     },
     {
       "name": "AttachAudioStreamProcessor",
-      "description": "Attach audio stream processor to stream, receives the samples as 'float'",
+      "description": "Attach audio stream processor to stream, receives frames x 2 samples as 'float' (stereo)",
       "returnType": "void",
       "params": [
         {
@@ -12149,7 +12149,7 @@
     },
     {
       "name": "AttachAudioMixedProcessor",
-      "description": "Attach audio stream processor to the entire audio pipeline, receives the samples as 'float'",
+      "description": "Attach audio stream processor to the entire audio pipeline, receives frames x 2 samples as 'float' (stereo)",
       "returnType": "void",
       "params": [
         {

--- a/parser/output/raylib_api.lua
+++ b/parser/output/raylib_api.lua
@@ -8276,7 +8276,7 @@ return {
     },
     {
       name = "AttachAudioStreamProcessor",
-      description = "Attach audio stream processor to stream, receives the samples as 'float'",
+      description = "Attach audio stream processor to stream, receives frames x 2 samples as 'float' (stereo)",
       returnType = "void",
       params = {
         {type = "AudioStream", name = "stream"},
@@ -8294,7 +8294,7 @@ return {
     },
     {
       name = "AttachAudioMixedProcessor",
-      description = "Attach audio stream processor to the entire audio pipeline, receives the samples as 'float'",
+      description = "Attach audio stream processor to the entire audio pipeline, receives frames x 2 samples as 'float' (stereo)",
       returnType = "void",
       params = {
         {type = "AudioCallback", name = "processor"}

--- a/parser/output/raylib_api.txt
+++ b/parser/output/raylib_api.txt
@@ -4659,7 +4659,7 @@ Function 578: SetAudioStreamCallback() (2 input parameters)
 Function 579: AttachAudioStreamProcessor() (2 input parameters)
   Name: AttachAudioStreamProcessor
   Return type: void
-  Description: Attach audio stream processor to stream, receives the samples as 'float'
+  Description: Attach audio stream processor to stream, receives frames x 2 samples as 'float' (stereo)
   Param[1]: stream (type: AudioStream)
   Param[2]: processor (type: AudioCallback)
 Function 580: DetachAudioStreamProcessor() (2 input parameters)
@@ -4671,7 +4671,7 @@ Function 580: DetachAudioStreamProcessor() (2 input parameters)
 Function 581: AttachAudioMixedProcessor() (1 input parameters)
   Name: AttachAudioMixedProcessor
   Return type: void
-  Description: Attach audio stream processor to the entire audio pipeline, receives the samples as 'float'
+  Description: Attach audio stream processor to the entire audio pipeline, receives frames x 2 samples as 'float' (stereo)
   Param[1]: processor (type: AudioCallback)
 Function 582: DetachAudioMixedProcessor() (1 input parameters)
   Name: DetachAudioMixedProcessor

--- a/parser/output/raylib_api.xml
+++ b/parser/output/raylib_api.xml
@@ -3104,7 +3104,7 @@
             <Param type="AudioStream" name="stream" desc="" />
             <Param type="AudioCallback" name="callback" desc="" />
         </Function>
-        <Function name="AttachAudioStreamProcessor" retType="void" paramCount="2" desc="Attach audio stream processor to stream, receives the samples as 'float'">
+        <Function name="AttachAudioStreamProcessor" retType="void" paramCount="2" desc="Attach audio stream processor to stream, receives frames x 2 samples as 'float' (stereo)">
             <Param type="AudioStream" name="stream" desc="" />
             <Param type="AudioCallback" name="processor" desc="" />
         </Function>
@@ -3112,7 +3112,7 @@
             <Param type="AudioStream" name="stream" desc="" />
             <Param type="AudioCallback" name="processor" desc="" />
         </Function>
-        <Function name="AttachAudioMixedProcessor" retType="void" paramCount="1" desc="Attach audio stream processor to the entire audio pipeline, receives the samples as 'float'">
+        <Function name="AttachAudioMixedProcessor" retType="void" paramCount="1" desc="Attach audio stream processor to the entire audio pipeline, receives frames x 2 samples as 'float' (stereo)">
             <Param type="AudioCallback" name="processor" desc="" />
         </Function>
         <Function name="DetachAudioMixedProcessor" retType="void" paramCount="1" desc="Detach audio stream processor from the entire audio pipeline">

--- a/projects/Notepad++/raylib_npp_parser/raylib_npp.xml
+++ b/projects/Notepad++/raylib_npp_parser/raylib_npp.xml
@@ -3013,7 +3013,7 @@
                 <Param name="Vector2 size" />
                 <Param name="Vector2 origin" />
                 <Param name="float rotation" />
-                <Param name="ï¿½ï¿½_)% " />
+                <Param name="°ñ_)% " />
             </Overload>
         </KeyWord>
 

--- a/projects/Notepad++/raylib_npp_parser/raylib_npp.xml
+++ b/projects/Notepad++/raylib_npp_parser/raylib_npp.xml
@@ -3013,7 +3013,7 @@
                 <Param name="Vector2 size" />
                 <Param name="Vector2 origin" />
                 <Param name="float rotation" />
-                <Param name="°ñ_)% " />
+                <Param name="ï¿½ï¿½_)% " />
             </Overload>
         </KeyWord>
 
@@ -3634,7 +3634,7 @@
         </KeyWord>
 
         <KeyWord name="AttachAudioStreamProcessor" func="yes">
-            <Overload retVal="void" descr="Attach audio stream processor to stream, receives the samples as 'float'">
+            <Overload retVal="void" descr="Attach audio stream processor to stream, receives frames x 2 samples as 'float' (stereo)">
                 <Param name="AudioStream stream" />
                 <Param name="AudioCallback processor" />
             </Overload>
@@ -3647,7 +3647,7 @@
         </KeyWord>
 
         <KeyWord name="AttachAudioMixedProcessor" func="yes">
-            <Overload retVal="void" descr="Attach audio stream processor to the entire audio pipeline, receives the samples as 'float'">
+            <Overload retVal="void" descr="Attach audio stream processor to the entire audio pipeline, receives frames x 2 samples as 'float' (stereo)">
                 <Param name="AudioCallback processor" />
             </Overload>
         </KeyWord>

--- a/projects/Notepad++/raylib_npp_parser/raylib_to_parse.h
+++ b/projects/Notepad++/raylib_npp_parser/raylib_to_parse.h
@@ -734,9 +734,9 @@ RLAPI void SetAudioStreamPan(AudioStream stream, float pan);          // Set pan
 RLAPI void SetAudioStreamBufferSizeDefault(int size);                 // Default size for new audio streams
 RLAPI void SetAudioStreamCallback(AudioStream stream, AudioCallback callback); // Audio thread callback to request new data
 
-RLAPI void AttachAudioStreamProcessor(AudioStream stream, AudioCallback processor); // Attach audio stream processor to stream, receives the samples as 'float'
+RLAPI void AttachAudioStreamProcessor(AudioStream stream, AudioCallback processor); // Attach audio stream processor to stream, receives frames x 2 samples as 'float' (stereo)
 RLAPI void DetachAudioStreamProcessor(AudioStream stream, AudioCallback processor); // Detach audio stream processor from stream
 
-RLAPI void AttachAudioMixedProcessor(AudioCallback processor); // Attach audio stream processor to the entire audio pipeline, receives the samples as 'float'
+RLAPI void AttachAudioMixedProcessor(AudioCallback processor); // Attach audio stream processor to the entire audio pipeline, receives frames x 2 samples as 'float' (stereo)
 RLAPI void DetachAudioMixedProcessor(AudioCallback processor); // Detach audio stream processor from the entire audio pipeline
 

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1701,10 +1701,10 @@ RLAPI void SetAudioStreamPan(AudioStream stream, float pan);          // Set pan
 RLAPI void SetAudioStreamBufferSizeDefault(int size);                 // Default size for new audio streams
 RLAPI void SetAudioStreamCallback(AudioStream stream, AudioCallback callback); // Audio thread callback to request new data
 
-RLAPI void AttachAudioStreamProcessor(AudioStream stream, AudioCallback processor); // Attach audio stream processor to stream, receives the samples as 'float'
+RLAPI void AttachAudioStreamProcessor(AudioStream stream, AudioCallback processor); // Attach audio stream processor to stream, receives frames x 2 samples as 'float' (stereo)
 RLAPI void DetachAudioStreamProcessor(AudioStream stream, AudioCallback processor); // Detach audio stream processor from stream
 
-RLAPI void AttachAudioMixedProcessor(AudioCallback processor); // Attach audio stream processor to the entire audio pipeline, receives the samples as 'float'
+RLAPI void AttachAudioMixedProcessor(AudioCallback processor); // Attach audio stream processor to the entire audio pipeline, receives frames x 2 samples as 'float' (stereo)
 RLAPI void DetachAudioMixedProcessor(AudioCallback processor); // Detach audio stream processor from the entire audio pipeline
 
 #if defined(__cplusplus)


### PR DESCRIPTION
Thank you for your nice library.

I stumbled over the usage of audio processors. Initially I processed a mono-audio file and was surprised to receive stereo data. After analyzing the code I realized that it always provides two channels as float (see #4743). 

I added additional documentation. Could you have a critical look and help to clarify the usage?
Thank you
