### PR TITLE
[rmodels] Improve default normal and tangent values (UploadMesh)

### DIFF
--- a/src/rmodels.c
+++ b/src/rmodels.c
@@ -1307,7 +1307,7 @@ void UploadMesh(Mesh *mesh, bool dynamic)
     {
         // Default vertex attribute: normal
         // WARNING: Default value provided to shader if location available
-        float value[3] = { 1.0f, 1.0f, 1.0f };
+        float value[3] = { 0.0f, 0.0f, 1.0f };
         rlSetVertexAttributeDefault(RL_DEFAULT_SHADER_ATTRIB_LOCATION_NORMAL, value, SHADER_ATTRIB_VEC3, 3);
         rlDisableVertexAttribute(RL_DEFAULT_SHADER_ATTRIB_LOCATION_NORMAL);
     }
@@ -1339,7 +1339,7 @@ void UploadMesh(Mesh *mesh, bool dynamic)
     {
         // Default vertex attribute: tangent
         // WARNING: Default value provided to shader if location available
-        float value[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
+        float value[4] = { 1.0f, 0.0f, 0.0f, 1.0f };
         rlSetVertexAttributeDefault(RL_DEFAULT_SHADER_ATTRIB_LOCATION_TANGENT, value, SHADER_ATTRIB_VEC4, 4);
         rlDisableVertexAttribute(RL_DEFAULT_SHADER_ATTRIB_LOCATION_TANGENT);
     }


### PR DESCRIPTION
### Description: 
This PR updates the default normal and tangent values used when a mesh lacks corresponding buffers.  

#### Changes:
- **Default normal:** Changed from `(1, 1, 1)` to **`(0, 0, 1)`** to ensure a properly normalized default normal, aligned with the standard convention of pointing out of the surface.  
- **Default tangent:** Changed from `(0, 0, 0, 0)` to **`(1, 0, 0, 1)`** to provide a valid and reliable fallback for constructing the bitangent in shaders.  

#### Benefits:
- Avoids potential problems when calculating the bitangent from a tangent that has a zero value.
- You can achieve **optional normal mapping** without requiring extra checks/shaders or conditional branches in shaders.