### PR TITLE
[rcore] fix: use `strstr()` instead of `TextFindIndex()` to decouple module from `rtext`

### DIFF
--- a/src/rcore.c
+++ b/src/rcore.c
@@ -3696,7 +3696,7 @@ static void ScanDirectoryFiles(const char *basePath, FilePathList *files, const 
                     }
                     else
                     {
-                        if (TextFindIndex(filter, DIRECTORY_FILTER_TAG) >= 0)
+                        if (strstr(filter, DIRECTORY_FILTER_TAG) != NULL)
                         {
                             strcpy(files->paths[files->count], path);
                             files->count++;
@@ -3762,7 +3762,7 @@ static void ScanDirectoryFilesRecursively(const char *basePath, FilePathList *fi
                 }
                 else
                 {
-                    if ((filter != NULL) && (TextFindIndex(filter, DIRECTORY_FILTER_TAG) >= 0))
+                    if ((filter != NULL) && (strstr(filter, DIRECTORY_FILTER_TAG) != NULL))
                     {
                         strcpy(files->paths[files->count], path);
                         files->count++;


### PR DESCRIPTION
this fixes issue addressed at #4758, but preserving functionality. 
in short, module `rcore` cannot be compiled independently from module `rtext` since it uses the function `TextFindIndex()`, implemented at `rtext`.