### PR TITLE
[rlgl] Added rlWriteTexturePixels to support work with externally allocated buffers

### DIFF
--- a/src/rlgl.h
+++ b/src/rlgl.h
@@ -760,6 +760,7 @@ RLAPI const char *rlGetPixelFormatName(unsigned int format);              // Get
 RLAPI void rlUnloadTexture(unsigned int id);                              // Unload texture from GPU memory
 RLAPI void rlGenTextureMipmaps(unsigned int id, int width, int height, int format, int *mipmaps); // Generate mipmap data for selected texture
 RLAPI void *rlReadTexturePixels(unsigned int id, int width, int height, int format); // Read texture pixel data
+RLAPI void rlWriteTexturePixels(unsigned int id, int width, int height, int format, void *pixels); // Write texture pixel data to a buffer (rlReadTexturePixels without malloc)
 RLAPI unsigned char *rlReadScreenPixels(int width, int height);           // Read screen pixel data (color buffer)
 
 // Framebuffer management (fbo)
@@ -3671,6 +3672,38 @@ void *rlReadTexturePixels(unsigned int id, int width, int height, int format)
 #endif
 
     return pixels;
+}
+//rlReadTexturePixels implementation without malloc
+void rlWriteTexturePixels(unsigned int id, int width, int height, int format, void *pixels)
+{
+    if(pixels == NULL){
+        TRACELOG(RL_LOG_WARNING, "TEXTURE: [ID %i] Attempt to write texture data to a null pointer", id, format);
+        return;
+    }
+#if defined(GRAPHICS_API_OPENGL_11) || defined(GRAPHICS_API_OPENGL_33)
+    glBindTexture(GL_TEXTURE_2D, id);
+    glPixelStorei(GL_PACK_ALIGNMENT, 1);
+    unsigned int glInternalFormat, glFormat, glType;
+    rlGetGlTextureFormats(format, &glInternalFormat, &glFormat, &glType);
+    unsigned int size = rlGetPixelDataSize(width, height, format);
+    if ((glInternalFormat != 0) && (format < RL_PIXELFORMAT_COMPRESSED_DXT1_RGB))
+    {
+        glGetTexImage(GL_TEXTURE_2D, 0, glFormat, glType, pixels);
+    }
+    else TRACELOG(RL_LOG_WARNING, "TEXTURE: [ID %i] Data retrieval not suported for pixel format (%i)", id, format);
+
+    glBindTexture(GL_TEXTURE_2D, 0);
+#endif
+
+#if defined(GRAPHICS_API_OPENGL_ES2)
+    unsigned int fboId = rlLoadFramebuffer();
+    glBindFramebuffer(GL_FRAMEBUFFER, fboId);
+    glBindTexture(GL_TEXTURE_2D, 0);
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, id, 0);
+    glReadPixels(0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE, (unsigned char *)pixels);
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+    rlUnloadFramebuffer(fboId);
+#endif
 }
 
 // Read screen pixel data (color buffer)


### PR DESCRIPTION
Added rlWriteTexturePixels, whitch is rlReadTexturePixels implementation without internal memory allocations, to support dynamic conversion from the Texture to the Image, without a need for free() on previous memory buffer
