### PR TITLE
[rshapes] Add GetOverlappingRectangle()

### DIFF
--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1318,6 +1318,7 @@ RLAPI bool CheckCollisionPointLine(Vector2 point, Vector2 p1, Vector2 p2, int th
 RLAPI bool CheckCollisionPointPoly(Vector2 point, const Vector2 *points, int pointCount);                // Check if point is within a polygon described by array of vertices
 RLAPI bool CheckCollisionLines(Vector2 startPos1, Vector2 endPos1, Vector2 startPos2, Vector2 endPos2, Vector2 *collisionPoint); // Check the collision between two lines defined by two points each, returns collision point by reference
 RLAPI Rectangle GetCollisionRec(Rectangle rec1, Rectangle rec2);                                         // Get collision rectangle for two rectangles collision
+RLAPI Rectangle GetRectangleOverlap(Rectangle a, Rectangle b);                                           // Get smallest rectangle entirely overlapping both rectangles
 
 //------------------------------------------------------------------------------------
 // Texture Loading and Drawing Functions (Module: textures)

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1318,7 +1318,7 @@ RLAPI bool CheckCollisionPointLine(Vector2 point, Vector2 p1, Vector2 p2, int th
 RLAPI bool CheckCollisionPointPoly(Vector2 point, const Vector2 *points, int pointCount);                // Check if point is within a polygon described by array of vertices
 RLAPI bool CheckCollisionLines(Vector2 startPos1, Vector2 endPos1, Vector2 startPos2, Vector2 endPos2, Vector2 *collisionPoint); // Check the collision between two lines defined by two points each, returns collision point by reference
 RLAPI Rectangle GetCollisionRec(Rectangle rec1, Rectangle rec2);                                         // Get collision rectangle for two rectangles collision
-RLAPI Rectangle GetRectangleOverlap(Rectangle a, Rectangle b);                                           // Get smallest rectangle entirely overlapping both rectangles
+RLAPI Rectangle GetOverlappingRectangle(Rectangle a, Rectangle b);  
 
 //------------------------------------------------------------------------------------
 // Texture Loading and Drawing Functions (Module: textures)

--- a/src/rshapes.c
+++ b/src/rshapes.c
@@ -2406,7 +2406,7 @@ Rectangle GetCollisionRec(Rectangle rec1, Rectangle rec2)
 }
 
 // Get smallest rectangle entirely overlapping both rectangles
-Rectangle GetRectangleOverlap(Rectangle a, Rectangle b) {
+Rectangle GetOverlappingRectangle(Rectangle a, Rectangle b) {
 	
 	Rectangle overlap;
 	Rectangle left, right, top, bottom;

--- a/src/rshapes.c
+++ b/src/rshapes.c
@@ -2405,6 +2405,36 @@ Rectangle GetCollisionRec(Rectangle rec1, Rectangle rec2)
     return overlap;
 }
 
+// Get smallest rectangle entirely overlapping both rectangles
+Rectangle GetRectangleOverlap(Rectangle a, Rectangle b) {
+	
+	Rectangle overlap;
+	Rectangle left, right, top, bottom;
+	
+	if (a.x == b.x) {
+		left   = (a.width == fmin(a.width, b.width)) ? a : b;
+		right  = (a.width == fmax(a.width, b.width)) ? a : b;
+	} else {
+		left   = (a.x < b.x) ? a : b;
+		right  = (a.x > b.x) ? a : b;
+	}
+	
+	if (a.y == b.y) {
+		top    = (a.height == fmin(a.height, b.height)) ? a : b;
+		bottom = (a.height == fmax(a.height, b.height)) ? a : b;
+	} else {
+		top    = (a.y < b.y) ? a : b;
+		bottom = (a.y > b.y) ? a : b;
+	}
+	
+	overlap.x      = fmin(a.x, b.x);
+	overlap.y      = fmin(a.y, b.y);
+	overlap.width  = fmax(left.width + (right.x -  (left.x + left.width) + right.width),   left.width);
+	overlap.height = fmax(top.height + (bottom.y - (top.y  + top.height) + bottom.height), top.height);
+	
+	return overlap;
+}
+
 //----------------------------------------------------------------------------------
 // Module specific Functions Definition
 //----------------------------------------------------------------------------------


### PR DESCRIPTION
This function gets two rectangles as parameters and returns the smallest rectangle possible overlapping both.

Examples / Test cases:

![image](https://github.com/user-attachments/assets/8e8c26b9-ade8-459b-acfc-2be622e93224)

![image](https://github.com/user-attachments/assets/2ed27251-041d-42d8-89fe-e41b8057a34b)
