### PR TITLE
[rlgl] Implementing `rlReloadVertexBuffer()` and `rlReloadVertexBufferElement()`

### DIFF
--- a/src/rlgl.h
+++ b/src/rlgl.h
@@ -738,6 +738,8 @@ RLAPI void rlSetTexture(unsigned int id);               // Set current texture f
 RLAPI unsigned int rlLoadVertexArray(void);             // Load vertex array (vao) if supported
 RLAPI unsigned int rlLoadVertexBuffer(const void *buffer, int size, bool dynamic); // Load a vertex buffer object
 RLAPI unsigned int rlLoadVertexBufferElement(const void *buffer, int size, bool dynamic); // Load vertex buffer elements object
+RLAPI void rlReloadVertexBuffer(unsigned int id, const void *buffer, int size, bool dynamic); // Reload an existing vertex buffer object
+RLAPI void rlReloadVertexBufferElement(unsigned int id, const void *buffer, int size, bool dynamic); // Reload an existing vertex buffer elements object
 RLAPI void rlUpdateVertexBuffer(unsigned int bufferId, const void *data, int dataSize, int offset); // Update vertex buffer object data on GPU buffer
 RLAPI void rlUpdateVertexBufferElements(unsigned int id, const void *data, int dataSize, int offset); // Update vertex buffer elements data on GPU buffer
 RLAPI void rlUnloadVertexArray(unsigned int vaoId);     // Unload vertex array (vao)
@@ -3857,6 +3859,24 @@ unsigned int rlLoadVertexBufferElement(const void *buffer, int size, bool dynami
 #endif
 
     return id;
+}
+
+// Reload an existing vertex buffer object
+void rlReloadVertexBuffer(unsigned int id, const void *buffer, int size, bool dynamic)
+{
+#if defined(GRAPHICS_API_OPENGL_33) || defined(GRAPHICS_API_OPENGL_ES2)
+    glBindBuffer(GL_ARRAY_BUFFER, id);
+    glBufferData(GL_ARRAY_BUFFER, size, buffer, dynamic? GL_DYNAMIC_DRAW : GL_STATIC_DRAW);
+#endif
+}
+
+// Reload an existing vertex buffer elements object
+void rlReloadVertexBufferElement(unsigned int id, const void *buffer, int size, bool dynamic)
+{
+#if defined(GRAPHICS_API_OPENGL_33) || defined(GRAPHICS_API_OPENGL_ES2)
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, id);
+    glBufferData(GL_ELEMENT_ARRAY_BUFFER, size, buffer, dynamic? GL_DYNAMIC_DRAW : GL_STATIC_DRAW);
+#endif
 }
 
 // Enable vertex buffer (VBO)


### PR DESCRIPTION
Currently, a VBO/EBO cannot be resized after being loaded with `rlLoadVertexBuffer()` or its element counterpart. Using `rlUpdateVertexBuffer()` only works if your new vertex data is as big or smaller than what was initially allocated; not if it is bigger. The buffer's _usage_ is also not modifiable this way.

At the moment, the raylib-only solution is to use `rlUnloadVertexBuffer` on the old buffer and load it anew with `rlLoadVertexBuffer()`, while also recreating any VAOs using these VBO/EBOs. Implementing a solution within your own code doesn't seem to be possible out of the box considering that the OpenGL functions it requires don't seem to be exposed by Raylib.

With these changes we get `rlReloadVertexBuffer()` and `rlReloadVertexBufferElement()`, which reload an existing vertex buffer without requiring new bindings. I believe this is a really simple addition that can be really helpful in cases when you may want to modify parts of an existing mesh without destroying and recreating it completely, or when you're handling vertex buffer objects on your own without using Raylib's structures directly.