### PR TITLE
[raudio] Fixed memory leak on early-return of WaveFormat func

### DIFF
--- a/src/raudio.c
+++ b/src/raudio.c
@@ -1240,6 +1240,7 @@ void WaveFormat(Wave *wave, int sampleRate, int sampleSize, int channels)
     frameCount = (ma_uint32)ma_convert_frames(data, frameCount, formatOut, channels, sampleRate, wave->data, frameCountIn, formatIn, wave->channels, wave->sampleRate);
     if (frameCount == 0)
     {
+        RL_FREE(wave->data);
         TRACELOG(LOG_WARNING, "WAVE: Failed format conversion");
         return;
     }


### PR DESCRIPTION
In the case of a failure within miniaudio on the function: `ma_convert_frames`, the dynamic memory allocated for the `data` variable will leak on the early return.