### PR TITLE
[rcore] fix crash in InitWindow, due to unchecked result of InitPlatform

### DIFF
--- a/src/rcore.c
+++ b/src/rcore.c
@@ -685,7 +685,7 @@ void InitWindow(int width, int height, const char *title)
 
     if (result != 0)
     {
-        TRACELOG(LOG_ERROR, "SYSTEM: Failed to initialize Platform");
+        TRACELOG(LOG_WARNING, "SYSTEM: Failed to initialize Platform");
         return;
     }
     //--------------------------------------------------------------

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -681,7 +681,10 @@ void InitWindow(int width, int height, const char *title)
 
     // Initialize platform
     //--------------------------------------------------------------
-    InitPlatform();
+    if(InitPlatform() != 0) {
+        TRACELOG(LOG_ERROR, "SYSTEM: Failed to initialize Platform");
+        return;
+    }
     //--------------------------------------------------------------
 
     // Initialize rlgl default data (buffers and shaders)

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -681,7 +681,10 @@ void InitWindow(int width, int height, const char *title)
 
     // Initialize platform
     //--------------------------------------------------------------
-    if(InitPlatform() != 0) {
+    int result = InitPlatform();
+
+    if (result != 0)
+    {
         TRACELOG(LOG_ERROR, "SYSTEM: Failed to initialize Platform");
         return;
     }


### PR DESCRIPTION
Check the result of InitPlatform(), if it isn't 0, report the Error and return. This prevent crashes and allows for gracefully aborting or recovering by checking IsWindowReady().

I decided to use `LOG_ERROR` here, because this is a fatal error in most cases, and it will cause a crash when ignored. However, I'm not so sure about `SYSTEM` prefix. There was no good choice for it. It must be very generic because InitPlatform() can fail in multiple cases.

Tested on native x86_64 Linux, and on x86_64 MacOS 13.6.9 running in VM. With GLFW in both cases.

Partially-fixes: https://github.com/raysan5/raylib/issues/4801