### PR TITLE
[rtext] Fix `stb_truetype` composite glyph scaling logic

### DIFF
--- a/src/external/stb_truetype.h
+++ b/src/external/stb_truetype.h
@@ -1863,11 +1863,11 @@ static int stbtt__GetGlyphShapeTT(const stbtt_fontinfo *info, int glyph_index, s
                stbtt_vertex* v = &comp_verts[i];
                stbtt_vertex_type x,y;
                x=v->x; y=v->y;
-               v->x = (stbtt_vertex_type)(m * (mtx[0]*x + mtx[2]*y + mtx[4]));
-               v->y = (stbtt_vertex_type)(n * (mtx[1]*x + mtx[3]*y + mtx[5]));
+               v->x = (stbtt_vertex_type)(mtx[0]*x + mtx[2]*y + mtx[4]*m);
+               v->y = (stbtt_vertex_type)(mtx[1]*x + mtx[3]*y + mtx[5]*n);
                x=v->cx; y=v->cy;
-               v->cx = (stbtt_vertex_type)(m * (mtx[0]*x + mtx[2]*y + mtx[4]));
-               v->cy = (stbtt_vertex_type)(n * (mtx[1]*x + mtx[3]*y + mtx[5]));
+               v->cx = (stbtt_vertex_type)(mtx[0]*x + mtx[2]*y + mtx[4]*m);
+               v->cy = (stbtt_vertex_type)(mtx[1]*x + mtx[3]*y + mtx[5]*n);
             }
             // Append vertices.
             tmp = (stbtt_vertex*)STBTT_malloc((num_vertices+comp_num_verts)*sizeof(stbtt_vertex), info->userdata);


### PR DESCRIPTION
The logic for handling composite glyph scaling doesn't match the truetype specs, hence the results are different when a glyph in a ttf file defines composite glyh scales. I couldn't really find a ttf font with a glyph that has this exact issue, but the specs allows both uniform and non-uniform scaling for composite glyphs.

Part of the spec i am referring to
![image](https://github.com/user-attachments/assets/e183bfa0-529b-4f47-85a5-20995dbaadeb)

Synthetic tests (intentionally add scale to glyph component, spec allows it)
Left is FontForger, Right is raylib
![image](https://github.com/user-attachments/assets/db449590-f6a3-4793-bfca-e79bb715c698)

With this fix applied
![image](https://github.com/user-attachments/assets/fb672b71-60a2-41e4-b046-6c8f449cc7bb)

