### PR TITLE
Fix GetCurrentMonitor comments.

### DIFF
--- a/src/platforms/rcore_android.c
+++ b/src/platforms/rcore_android.c
@@ -431,7 +431,7 @@ int GetMonitorCount(void)
     return 1;
 }
 
-// Get number of monitors
+// Get current monitor where window is placed
 int GetCurrentMonitor(void)
 {
     TRACELOG(LOG_WARNING, "GetCurrentMonitor() not implemented on target platform");

--- a/src/platforms/rcore_desktop_glfw.c
+++ b/src/platforms/rcore_desktop_glfw.c
@@ -736,7 +736,7 @@ int GetMonitorCount(void)
     return monitorCount;
 }
 
-// Get number of monitors
+// Get current monitor where window is placed
 int GetCurrentMonitor(void)
 {
     int index = 0;

--- a/src/platforms/rcore_desktop_rgfw.c
+++ b/src/platforms/rcore_desktop_rgfw.c
@@ -651,7 +651,7 @@ int GetMonitorCount(void)
     return count;
 }
 
-// Get number of monitors
+// Get current monitor where window is placed
 int GetCurrentMonitor(void)
 {
     RGFW_monitor *mons = RGFW_getMonitors();

--- a/src/platforms/rcore_desktop_sdl.c
+++ b/src/platforms/rcore_desktop_sdl.c
@@ -914,7 +914,7 @@ int GetMonitorCount(void)
     return monitorCount;
 }
 
-// Get number of monitors
+// Get current monitor where window is placed
 int GetCurrentMonitor(void)
 {
     int currentMonitor = 0;

--- a/src/platforms/rcore_drm.c
+++ b/src/platforms/rcore_drm.c
@@ -371,7 +371,7 @@ int GetMonitorCount(void)
     return 1;
 }
 
-// Get number of monitors
+// Get current monitor where window is placed
 int GetCurrentMonitor(void)
 {
     TRACELOG(LOG_WARNING, "GetCurrentMonitor() not implemented on target platform");

--- a/src/platforms/rcore_template.c
+++ b/src/platforms/rcore_template.c
@@ -208,7 +208,7 @@ int GetMonitorCount(void)
     return 1;
 }
 
-// Get number of monitors
+// Get current monitor where window is placed
 int GetCurrentMonitor(void)
 {
     TRACELOG(LOG_WARNING, "GetCurrentMonitor() not implemented on target platform");

--- a/src/platforms/rcore_web.c
+++ b/src/platforms/rcore_web.c
@@ -709,7 +709,7 @@ int GetMonitorCount(void)
     return 1;
 }
 
-// Get number of monitors
+// Get current monitor where window is placed
 int GetCurrentMonitor(void)
 {
     TRACELOG(LOG_WARNING, "GetCurrentMonitor() not implemented on target platform");


### PR DESCRIPTION
Hello, my editor was pulling the function description from the raylib source and the comment for GetCurrentMonitor was not accurate which was confusing. This is just a small fix to replace the comment with what is in raylib.h.