### PR TITLE
[examples] Potential for new example: `text_styled_texts`

### DIFF
--- a/examples/text/text_styled.c
+++ b/examples/text/text_styled.c
@@ -1,0 +1,70 @@
+/*******************************************************************************************
+*
+*   raylib [text] example - Text styled
+*
+*   Example complexity rating: [★☆☆☆] 1/4
+*
+*   Example originally created with raylib 5.5, last time updated with raylib 5.5
+*
+*   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
+*   BSD-like license that allows static linking with closed source software
+*
+*   Copyright (c) 2025 Wagner Barongello (@SultansOfCode)
+*
+********************************************************************************************/
+
+#include "raylib.h"
+
+//------------------------------------------------------------------------------------
+// Program main entry point
+//------------------------------------------------------------------------------------
+int main(void)
+{
+    // Initialization
+    //--------------------------------------------------------------------------------------
+    const int screenWidth = 800;
+    const int screenHeight = 450;
+
+    InitWindow(screenWidth, screenHeight, "raylib [text] example - text styled");
+
+    SetTargetFPS(60);               // Set our game to run at 60 frames-per-second
+
+    Color colors[3] = { RED, GREEN, BLUE };
+    int colorCount = sizeof(colors) / sizeof(Color);
+    //--------------------------------------------------------------------------------------
+
+    // Main game loop
+    while (!WindowShouldClose())    // Detect window close button or ESC key
+    {
+        // Update
+        //----------------------------------------------------------------------------------
+        // TODO: Update your variables here
+        //----------------------------------------------------------------------------------
+
+        // Draw
+        //----------------------------------------------------------------------------------
+        BeginDrawing();
+
+            ClearBackground(SKYBLUE);
+
+            DrawTextStyled("This changes the \0032foreground color", 200, 80, 20, colors, colorCount);
+
+            DrawTextStyled("This changes the \0030,2background color", 200, 120, 20, colors, colorCount);
+
+            DrawTextStyled("This changes the \0031,2foreground and background colors", 200, 160, 20, colors, colorCount);
+
+            DrawTextStyled("\0031,2This \015restores the colors to the default ones", 200, 200, 20, colors, colorCount);
+
+            DrawTextStyled("\0031,2This \022inverts\022 the colors", 200, 240, 20, colors, colorCount);
+
+        EndDrawing();
+        //----------------------------------------------------------------------------------
+    }
+
+    // De-Initialization
+    //--------------------------------------------------------------------------------------
+    CloseWindow();        // Close window and OpenGL context
+    //--------------------------------------------------------------------------------------
+
+    return 0;
+}

--- a/examples/text/text_styled.c
+++ b/examples/text/text_styled.c
@@ -49,13 +49,13 @@ int main(void)
 
             DrawTextStyled("This changes the \0032foreground color", 200, 80, 20, colors, colorCount);
 
-            DrawTextStyled("This changes the \0030,2background color", 200, 120, 20, colors, colorCount);
+            DrawTextStyled("This changes the \0042background color", 200, 120, 20, colors, colorCount);
 
-            DrawTextStyled("This changes the \0031,2foreground and background colors", 200, 160, 20, colors, colorCount);
+            DrawTextStyled("This changes the \0031\0042foreground and background colors", 200, 160, 20, colors, colorCount);
 
-            DrawTextStyled("\0031,2This \015restores the colors to the default ones", 200, 200, 20, colors, colorCount);
+            DrawTextStyled("\0031\0042This \015restores the colors to the default ones", 200, 200, 20, colors, colorCount);
 
-            DrawTextStyled("\0031,2This \022inverts\022 the colors", 200, 240, 20, colors, colorCount);
+            DrawTextStyled("\0031\0042This \022inverts\022 the colors", 200, 240, 20, colors, colorCount);
 
         EndDrawing();
         //----------------------------------------------------------------------------------

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1485,12 +1485,14 @@ RLAPI void DrawTextCodepoint(Font font, int codepoint, Vector2 position, float f
 RLAPI void DrawTextCodepoints(Font font, const int *codepoints, int codepointCount, Vector2 position, float fontSize, float spacing, Color tint); // Draw multiple character (codepoint)
 
 // Text font info functions
-RLAPI void SetTextLineSpacing(int spacing);                                                 // Set vertical line spacing when drawing with line-breaks
-RLAPI int MeasureText(const char *text, int fontSize);                                      // Measure string width for default font
-RLAPI Vector2 MeasureTextEx(Font font, const char *text, float fontSize, float spacing);    // Measure string size for Font
-RLAPI int GetGlyphIndex(Font font, int codepoint);                                          // Get glyph index position in font for a codepoint (unicode character), fallback to '?' if not found
-RLAPI GlyphInfo GetGlyphInfo(Font font, int codepoint);                                     // Get glyph font info data for a codepoint (unicode character), fallback to '?' if not found
-RLAPI Rectangle GetGlyphAtlasRec(Font font, int codepoint);                                 // Get glyph rectangle in font atlas for a codepoint (unicode character), fallback to '?' if not found
+RLAPI void SetTextLineSpacing(int spacing);                                                       // Set vertical line spacing when drawing with line-breaks
+RLAPI int MeasureText(const char *text, int fontSize);                                            // Measure string width for default font
+RLAPI Vector2 MeasureTextEx(Font font, const char *text, float fontSize, float spacing);          // Measure string size for Font
+RLAPI int MeasureTextStyled(const char *text, int fontSize);                                      // Measure styled string width for default font
+RLAPI Vector2 MeasureTextStyledEx(Font font, const char *text, float fontSize, float spacing);    // Measure styled string size for Font
+RLAPI int GetGlyphIndex(Font font, int codepoint);                                                // Get glyph index position in font for a codepoint (unicode character), fallback to '?' if not found
+RLAPI GlyphInfo GetGlyphInfo(Font font, int codepoint);                                           // Get glyph font info data for a codepoint (unicode character), fallback to '?' if not found
+RLAPI Rectangle GetGlyphAtlasRec(Font font, int codepoint);                                       // Get glyph rectangle in font atlas for a codepoint (unicode character), fallback to '?' if not found
 
 // Text codepoints management functions (unicode characters)
 RLAPI char *LoadUTF8(const int *codepoints, int length);                                    // Load UTF-8 text encoded from codepoints array

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1479,6 +1479,8 @@ RLAPI void DrawFPS(int posX, int posY);                                         
 RLAPI void DrawText(const char *text, int posX, int posY, int fontSize, Color color);       // Draw text (using default font)
 RLAPI void DrawTextEx(Font font, const char *text, Vector2 position, float fontSize, float spacing, Color tint); // Draw text using font and additional parameters
 RLAPI void DrawTextPro(Font font, const char *text, Vector2 position, Vector2 origin, float rotation, float fontSize, float spacing, Color tint); // Draw text using Font and pro parameters (rotation)
+RLAPI void DrawTextStyled(const char *text, int posX, int posY, int fontSize, const Color *colors, int colorCount); // Draw styled text (using default font)
+RLAPI void DrawTextStyledEx(Font font, const char *text, Vector2 position, float fontSize, float spacing, const Color *colors, int colorCount); // Draw styled text using font and additional parameters
 RLAPI void DrawTextCodepoint(Font font, int codepoint, Vector2 position, float fontSize, Color tint); // Draw one character (codepoint)
 RLAPI void DrawTextCodepoints(Font font, const int *codepoints, int codepointCount, Vector2 position, float fontSize, float spacing, Color tint); // Draw multiple character (codepoint)
 


### PR DESCRIPTION
Hello!

I have added the ability to customize text color and background color with special characters inside the text (pretty much like mIRC does)

You can use the functions `DrawTextStyled` and `DrawTextStyledEx` almost as you would use `DrawText` and `DrawTextEx` respectively

The changes are: instead of passing the Color, you will pass an array of Colors and the size of this array

Inside the text you can use `\003` to set the foreground color, `\004` to set the background color, `\015` to reset them to their default values (first color in array, if any, as foreground color [or black, if none], and transparent background) and `\022` to swap foreground and background colors

Also added `MeasureTextStyled` and `MeasureTextStyledEx` to correctly measure them as `MeasureText` and `MeasureTextEx` would for plain texts

If any adjustment is needed, either to the code or to the PR, please, let me know

Thank you