### PR TITLE
Update build.zig.zon to use the new zig v0.14 version

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,9 @@
 .{
-    .name = "raylib",
+    .name = .raylib,
     .version = "5.5.0",
-    .minimum_zig_version = "0.13.0",
+    .minimum_zig_version = "0.14.0",
+
+    .fingerprint = 0x13035e5cb8bc1ac2,
 
     .dependencies = .{
         .xcode_frameworks = .{


### PR DESCRIPTION
The new zig version changed the `build.zig.zon` file. Not updating to the new standard causes the projects to automatically re-fetch the package on every build (resulting in 10-15 second build times).

I have updated the `build.zig.zon` to use zig v0.14.0 and the appropriate [fingerprint](https://ziglang.org/download/0.14.0/release-notes.html#New-Package-Hash-Format). 

