### PR TITLE
[examples] Reorganize some conditions to fix overlap bugs

### DIFF
--- a/examples/shapes/shapes_splines_drawing.c
+++ b/examples/shapes/shapes_splines_drawing.c
@@ -158,6 +158,9 @@ int main(void)
         else if (IsKeyPressed(KEY_TWO)) splineTypeActive = 1;
         else if (IsKeyPressed(KEY_THREE)) splineTypeActive = 2;
         else if (IsKeyPressed(KEY_FOUR)) splineTypeActive = 3;
+
+        // Clear selection when changing to a spline without control points
+        if (IsKeyPressed(KEY_ONE) || IsKeyPressed(KEY_TWO) || IsKeyPressed(KEY_THREE)) selectedControlPoint = NULL;
         //----------------------------------------------------------------------------------
 
         // Draw

--- a/examples/shapes/shapes_splines_drawing.c
+++ b/examples/shapes/shapes_splines_drawing.c
@@ -101,15 +101,18 @@ int main(void)
         }
 
         // Spline point focus and selection logic
-        for (int i = 0; i < pointCount; i++)
+        if ((selectedPoint == -1) && ((splineTypeActive != SPLINE_BEZIER) || (selectedControlPoint == NULL)))
         {
-            if (CheckCollisionPointCircle(GetMousePosition(), points[i], 8.0f))
+            focusedPoint = -1;
+            for (int i = 0; i < pointCount; i++)
             {
-                focusedPoint = i;
-                if (IsMouseButtonDown(MOUSE_LEFT_BUTTON)) selectedPoint = i; 
-                break;
+                if (CheckCollisionPointCircle(GetMousePosition(), points[i], 8.0f))
+                {
+                    focusedPoint = i;
+                    break;
+                }
             }
-            else focusedPoint = -1;
+            if (IsMouseButtonPressed(MOUSE_LEFT_BUTTON)) selectedPoint = focusedPoint;
         }
         
         // Spline point movement logic
@@ -123,21 +126,23 @@ int main(void)
         if ((splineTypeActive == SPLINE_BEZIER) && (focusedPoint == -1))
         {
             // Spline control point focus and selection logic
-            for (int i = 0; i < pointCount - 1; i++)
+            if (selectedControlPoint == NULL)
             {
-                if (CheckCollisionPointCircle(GetMousePosition(), control[i].start, 6.0f))
+                focusedControlPoint = NULL;
+                for (int i = 0; i < pointCount - 1; i++)
                 {
-                    focusedControlPoint = &control[i].start;
-                    if (IsMouseButtonDown(MOUSE_LEFT_BUTTON)) selectedControlPoint = &control[i].start; 
-                    break;
+                    if (CheckCollisionPointCircle(GetMousePosition(), control[i].start, 6.0f))
+                    {
+                        focusedControlPoint = &control[i].start;
+                        break;
+                    }
+                    else if (CheckCollisionPointCircle(GetMousePosition(), control[i].end, 6.0f))
+                    {
+                        focusedControlPoint = &control[i].end;
+                        break;
+                    }
                 }
-                else if (CheckCollisionPointCircle(GetMousePosition(), control[i].end, 6.0f))
-                {
-                    focusedControlPoint = &control[i].end;
-                    if (IsMouseButtonDown(MOUSE_LEFT_BUTTON)) selectedControlPoint = &control[i].end; 
-                    break;
-                }
-                else focusedControlPoint = NULL;
+                if (IsMouseButtonPressed(MOUSE_LEFT_BUTTON)) selectedControlPoint = focusedControlPoint;
             }
             
             // Spline control point movement logic
@@ -249,7 +254,7 @@ int main(void)
             }
 
             // Check all possible UI states that require controls lock
-            if (splineTypeEditMode) GuiLock();
+            if (splineTypeEditMode || (selectedPoint != -1) || (selectedControlPoint != NULL)) GuiLock();
             
             // Draw spline config
             GuiLabel((Rectangle){ 12, 62, 140, 24 }, TextFormat("Spline thickness: %i", (int)splineThickness));
@@ -257,10 +262,12 @@ int main(void)
 
             GuiCheckBox((Rectangle){ 12, 110, 20, 20 }, "Show point helpers", &splineHelpersActive);
 
-            GuiUnlock();
+            if (splineTypeEditMode) GuiUnlock();
 
             GuiLabel((Rectangle){ 12, 10, 140, 24 }, "Spline type:");
             if (GuiDropdownBox((Rectangle){ 12, 8 + 24, 140, 28 }, "LINEAR;BSPLINE;CATMULLROM;BEZIER", &splineTypeActive, splineTypeEditMode)) splineTypeEditMode = !splineTypeEditMode;
+            
+            GuiUnlock();
 
         EndDrawing();
         //----------------------------------------------------------------------------------


### PR DESCRIPTION
Move some if statements to surround for loops instead of being inside them, and add additional conditions for ensuring selection is inactive before looking for a point to focus.

Related to #4828 