### PR TITLE
[rgl] Add Support for Integer Attributes in GPU via glVertexAttribIPointer

### DIFF
--- a/src/rlgl.h
+++ b/src/rlgl.h
@@ -743,6 +743,7 @@ RLAPI void rlUpdateVertexBufferElements(unsigned int id, const void *data, int d
 RLAPI void rlUnloadVertexArray(unsigned int vaoId);     // Unload vertex array (vao)
 RLAPI void rlUnloadVertexBuffer(unsigned int vboId);    // Unload vertex buffer object
 RLAPI void rlSetVertexAttribute(unsigned int index, int compSize, int type, bool normalized, int stride, int offset); // Set vertex attribute data configuration
+RLAPI void rlSetVertexAttributeI(unsigned int index, int compSize, int type, int stride, int offset);
 RLAPI void rlSetVertexAttributeDivisor(unsigned int index, int divisor); // Set vertex attribute data divisor
 RLAPI void rlSetVertexAttributeDefault(int locIndex, const void *value, int attribType, int count); // Set vertex attribute default value, when attribute to provided
 RLAPI void rlDrawVertexArray(int offset, int count);    // Draw vertex array (currently active vao)
@@ -4038,6 +4039,15 @@ void rlSetVertexAttribute(unsigned int index, int compSize, int type, bool norma
 
     size_t offsetNative = offset;
     glVertexAttribPointer(index, compSize, type, normalized, stride, (void *)offsetNative);
+#endif
+}
+
+void rlSetVertexAttributeI(unsigned int index, int compSize, int type, int stride, int offset)
+{
+#if defined(GRAPHICS_API_OPENGL_33) || defined(GRAPHICS_API_OPENGL_ES2)
+
+    size_t offsetNative = offset;
+    glVertexAttribIPointer(index, compSize, type, stride, (void *)offsetNative);
 #endif
 }
 

--- a/src/rlgl.h
+++ b/src/rlgl.h
@@ -4045,6 +4045,8 @@ void rlSetVertexAttribute(unsigned int index, int compSize, int type, bool norma
 void rlSetVertexAttributeI(unsigned int index, int compSize, int type, int stride, int offset)
 {
 #if defined(GRAPHICS_API_OPENGL_33) || defined(GRAPHICS_API_OPENGL_ES2)
+    // NOTE: Data type could be: GL_BYTE, GL_UNSIGNED_BYTE, GL_SHORT, GL_UNSIGNED_SHORT, GL_INT, GL_UNSIGNED_INT
+
 
     size_t offsetNative = offset;
     glVertexAttribIPointer(index, compSize, type, stride, (void *)offsetNative);


### PR DESCRIPTION
Hello!

I've added a small but useful function that allows sending an int to the GPU instead of a float by using glVertexAttribIPointer instead of glVertexAttribPointer.

This is particularly helpful for cases involving bit-packing, as OpenGL automatically converts integers to floats unless explicitly handled with glVertexAttribIPointer. This change ensures that integer data remains intact without unintended conversions.