### PR TITLE
[rcore] Use snprintf to prevent buffer overflow in path construction

### DIFF
--- a/src/rcore.c
+++ b/src/rcore.c
@@ -3688,12 +3688,16 @@ static void ScanDirectoryFiles(const char *basePath, FilePathList *files, const 
                 (strcmp(dp->d_name, "..") != 0))
             {
             #if defined(_WIN32)
-                sprintf(path, "%s\\%s", basePath, dp->d_name);
+                int realPathLength = snprintf(path, sizeof(path) - 1, "%s\\%s", basePath, dp->d_name);
             #else
-                sprintf(path, "%s/%s", basePath, dp->d_name);
+                int realPathLength = snprintf(path, sizeof(path) - 1, "%s/%s", basePath, dp->d_name);
             #endif
 
-                if (filter != NULL)
+                if (realPathLength < 0 || realPathLength >= sizeof(path))
+                {
+                    TRACELOG(LOG_WARNING, "FILEIO: Path longer than %d characters (%s...)", MAX_FILEPATH_LENGTH, basePath);
+                }
+                else if (filter != NULL)
                 {
                     if (IsPathFile(path))
                     {
@@ -3742,12 +3746,16 @@ static void ScanDirectoryFilesRecursively(const char *basePath, FilePathList *fi
             {
                 // Construct new path from our base path
             #if defined(_WIN32)
-                sprintf(path, "%s\\%s", basePath, dp->d_name);
+                int realPathLength = snprintf(path, sizeof(path) - 1, "%s\\%s", basePath, dp->d_name);
             #else
-                sprintf(path, "%s/%s", basePath, dp->d_name);
+                int realPathLength = snprintf(path, sizeof(path) - 1, "%s/%s", basePath, dp->d_name);
             #endif
 
-                if (IsPathFile(path))
+                if (realPathLength < 0 || realPathLength >= sizeof(path))
+                {
+                    TRACELOG(LOG_WARNING, "FILEIO: Path longer than %d characters (%s...)", MAX_FILEPATH_LENGTH, basePath);
+                }
+                else if (IsPathFile(path))
                 {
                     if (filter != NULL)
                     {


### PR DESCRIPTION
In some cases, specific user configurations may allow for file/directory paths that exceed the set path limit. In such cases the current implementation of `ScanDirectoryFiles` would cause a buffer overflow.

This change makes sure that the path string does not exceed the buffer size, failing gracefully with the following warning.
```
WARNING: FILEIO: Path longer than 4096 characters ([very long path]...)
WARNING: FILEIO: Read files count do not match capacity allocated
```