### PR TITLE
Guard against DEBUG Redefinition

### DIFF
--- a/src/external/jar_xm.h
+++ b/src/external/jar_xm.h
@@ -232,6 +232,13 @@ uint64_t jar_xm_get_remaining_samples(jar_xm_context_t* ctx);
 #include <limits.h>
 #include <string.h>
 
+#ifdef DEBUG
+    // Undefine DEBUG to avoid external redefinition warnings/conflicts
+    // This is probably a common definition for
+    // many external build systems' debug configurations
+    #undef DEBUG
+#endif
+
 #if JAR_XM_DEBUG            //JAR_XM_DEBUG defined as 0
 #include <stdio.h>
 #define DEBUG(fmt, ...) do {                                        \


### PR DESCRIPTION
I added an #undef DEBUG before the DEBUG(...) macro definition in jar_xm.h to prevent redefinition warnings and potential conflicts. This macro is commonly defined by external build systems for debug configurations, so undefining it here avoids collisions without disrupting other code.  

I also looked and jar_xm.h seems to only be included in raudio.c as an implementation detail, so I don't believe this should affect anything else(and if anything does include jar_xm.h directly, it was almost certainly getting redefined anyway)

This should help clean up some pesky warnings in debug builds so people can turn on -Werror to enforce clean builds, even if they define DEBUG elsewhere or pass -DDEBUG as a compiler option.