### PR TITLE
[rcore] Support window flags with initialization issues

### DIFF
--- a/src/platforms/rcore_desktop_glfw.c
+++ b/src/platforms/rcore_desktop_glfw.c
@@ -1351,6 +1351,8 @@ int InitPlatform(void)
     // additionally auto iconify restores the hardware resolution of the monitor if the window that loses focus is a fullscreen window
     glfwWindowHint(GLFW_AUTO_ICONIFY, 0);
 
+    // Keep flags to restore after initialization (for flags not supported on initialization)  
+    unsigned int originalCoreWindowFlags = CORE.Window.flags;
     // Check window creation flags
     if ((CORE.Window.flags & FLAG_FULLSCREEN_MODE) > 0) CORE.Window.fullscreen = true;
 
@@ -1709,7 +1711,10 @@ int InitPlatform(void)
     char *glfwPlatform = "";
     switch (glfwGetPlatform())
     {
-        case GLFW_PLATFORM_WIN32: glfwPlatform = "Win32"; break;
+        case GLFW_PLATFORM_WIN32: 
+            glfwPlatform = "Win32";
+            SetWindowState(originalCoreWindowFlags);
+            break;
         case GLFW_PLATFORM_COCOA: glfwPlatform = "Cocoa"; break;
         case GLFW_PLATFORM_WAYLAND: glfwPlatform = "Wayland"; break;
         case GLFW_PLATFORM_X11: glfwPlatform = "X11"; break;


### PR DESCRIPTION
This may not be the correct approach, however this appears to work. The idea is that before modifying `CORE.Window.flags` when first creating the window we keep a copy of the flags in order to call `SetWindowState` after initialization has completed, which should behave as if `MaximizeWindow` or `MinimizeWindow`, or conceptually any other flag modifying function were called after `InitWindow`.

This pull request only performs this for the windows platform, modify as needed in the switch statement at the end for others.