### PR TITLE
 Converting int to char

### DIFF
--- a/examples/core/core_2d_camera.c
+++ b/examples/core/core_2d_camera.c
@@ -44,7 +44,11 @@ int main(void)
 
         spacing += (int)buildings[i].width;
 
-        buildColors[i] = (Color){ GetRandomValue(200, 240), GetRandomValue(200, 240), GetRandomValue(200, 250), 255 };
+        buildColors[i] = (Color){
+            (unsigned char)GetRandomValue(200, 240),
+            (unsigned char)GetRandomValue(200, 240),
+            (unsigned char)GetRandomValue(200, 250),
+            255};
     }
 
     Camera2D camera = { 0 };


### PR DESCRIPTION
Fixes warning: narrowing conversion caused by trying to convert int to unsigned char