### PR TITLE
Add early return when angles are equal in DrawCircleSector and DrawCircleSectorLine functions.

### DIFF
--- a/src/rshapes.c
+++ b/src/rshapes.c
@@ -285,6 +285,7 @@ void DrawCircleV(Vector2 center, float radius, Color color)
 // Draw a piece of a circle
 void DrawCircleSector(Vector2 center, float radius, float startAngle, float endAngle, int segments, Color color)
 {
+    if (startAngle == endAngle) return;
     if (radius <= 0.0f) radius = 0.1f;  // Avoid div by zero
 
     // Function expects (endAngle > startAngle)
@@ -376,6 +377,7 @@ void DrawCircleSector(Vector2 center, float radius, float startAngle, float endA
 // Draw a piece of a circle outlines
 void DrawCircleSectorLines(Vector2 center, float radius, float startAngle, float endAngle, int segments, Color color)
 {
+    if (startAngle == endAngle) return;
     if (radius <= 0.0f) radius = 0.1f;  // Avoid div by zero issue
 
     // Function expects (endAngle > startAngle)


### PR DESCRIPTION
This change adds early return to circle sector drawing functions `DrawCircleSector` and `DrawCircleSectorLines`
when startAngle equals endAngle, matching the existing behavior in `DrawRing` and 
`DrawRingLines` functions.

Benefits:
- Prevents unnecessary calculations when there's nothing to draw
- Avoids potential division by zero when angles are equal and segments=0
- Makes behavior consistent with the ring drawing functions

I've tested these changes on a Mac (no access to a Windows machine at the moment) and they don't break the build.
(In particular, `shapes_draw_circle_sector` example works the same way as before).

Suggestion - perhaps comparing the difference to `EPSILON` defined in `raylib.h` is a better approach for all this functions.