### PR TITLE
[rshapes] Changed startAngle and endAngle comparison to compare against FLT_EPSILON instead of 0 in DrawCircleSector, DrawCircleSectorLines, DrawRing, DrawRingLines functions

### DIFF
--- a/src/rshapes.c
+++ b/src/rshapes.c
@@ -285,7 +285,8 @@ void DrawCircleV(Vector2 center, float radius, Color color)
 // Draw a piece of a circle
 void DrawCircleSector(Vector2 center, float radius, float startAngle, float endAngle, int segments, Color color)
 {
-    if (startAngle == endAngle) return;
+    if (FLT_EPSILON < endAngle - startAngle && endAngle - startAngle < FLT_EPSILON) return;
+
     if (radius <= 0.0f) radius = 0.1f;  // Avoid div by zero
 
     // Function expects (endAngle > startAngle)
@@ -377,7 +378,8 @@ void DrawCircleSector(Vector2 center, float radius, float startAngle, float endA
 // Draw a piece of a circle outlines
 void DrawCircleSectorLines(Vector2 center, float radius, float startAngle, float endAngle, int segments, Color color)
 {
-    if (startAngle == endAngle) return;
+    if (FLT_EPSILON < endAngle - startAngle && endAngle - startAngle < FLT_EPSILON) return;
+
     if (radius <= 0.0f) radius = 0.1f;  // Avoid div by zero issue
 
     // Function expects (endAngle > startAngle)
@@ -498,7 +500,7 @@ void DrawEllipseLines(int centerX, int centerY, float radiusH, float radiusV, Co
 // Draw ring
 void DrawRing(Vector2 center, float innerRadius, float outerRadius, float startAngle, float endAngle, int segments, Color color)
 {
-    if (startAngle == endAngle) return;
+    if (FLT_EPSILON < endAngle - startAngle && endAngle - startAngle < FLT_EPSILON) return;
 
     // Function expects (outerRadius > innerRadius)
     if (outerRadius < innerRadius)
@@ -589,7 +591,7 @@ void DrawRing(Vector2 center, float innerRadius, float outerRadius, float startA
 // Draw ring outline
 void DrawRingLines(Vector2 center, float innerRadius, float outerRadius, float startAngle, float endAngle, int segments, Color color)
 {
-    if (startAngle == endAngle) return;
+    if (FLT_EPSILON < endAngle - startAngle && endAngle - startAngle < FLT_EPSILON) return;
 
     // Function expects (outerRadius > innerRadius)
     if (outerRadius < innerRadius)


### PR DESCRIPTION
This change adds early return condition in the following  drawing functions:
`DrawCircleSector`, `DrawCircleSectorLines`, `DrawRing`, `DrawRingLines`.

Instead of comparing for equality, the comparisons are done against `FLT_EPSILON`.
**(Perhaps for consistency, it should be done against `EPSILON` in `raymath.h`, however `raymath.h`
header is not imported in `rshapes.c` and other functions (the ones that check against collisions for example) compare against `FLT_EPSILON` as well)**

Benefits: Prevents problems related to to numerical stability. Comparing floating numbers is ill advice in general.

I've tested these changes on a Mac  and they don't break the build.
In addition, I didn't notice any changes in the behavior of the following examples:
`shapes_draw_ring`, `core_input_gestures_web`, `shapes_draw_circle_segment`, `raymath_vector_angle` that use the affected functions.
