### PR TITLE
Use logarithmic zoom scaling in 2d camera examples

### DIFF
--- a/examples/core/core_2d_camera.c
+++ b/examples/core/core_2d_camera.c
@@ -14,6 +14,7 @@
 ********************************************************************************************/
 
 #include "raylib.h"
+#include <math.h>
 
 #define MAX_BUILDINGS   100
 
@@ -81,7 +82,8 @@ int main(void)
         else if (camera.rotation < -40) camera.rotation = -40;
 
         // Camera zoom controls
-        camera.zoom += ((float)GetMouseWheelMove()*0.05f);
+        // Uses log scaling to provide consistent zoom speed
+        camera.zoom = expf(logf(camera.zoom) + ((float)GetMouseWheelMove()*0.05f));
 
         if (camera.zoom > 3.0f) camera.zoom = 3.0f;
         else if (camera.zoom < 0.1f) camera.zoom = 0.1f;

--- a/examples/core/core_2d_camera_mouse_zoom.c
+++ b/examples/core/core_2d_camera_mouse_zoom.c
@@ -73,9 +73,9 @@ int main ()
                 camera.target = mouseWorldPos;
 
                 // Zoom increment
-                float scaleFactor = 1.0f + (0.25f*fabsf(wheel));
-                if (wheel < 0) scaleFactor = 1.0f/scaleFactor;
-                camera.zoom = Clamp(camera.zoom*scaleFactor, 0.125f, 64.0f);
+                // Uses log scaling to provide consistent zoom speed
+                float scale = 0.2f*wheel;
+                camera.zoom = Clamp(expf(logf(camera.zoom)+scale), 0.125f, 64.0f);
             }
         }
         else
@@ -96,10 +96,10 @@ int main ()
             if (IsMouseButtonDown(MOUSE_BUTTON_RIGHT))
             {
                 // Zoom increment
+                // Uses log scaling to provide consistent zoom speed
                 float deltaX = GetMouseDelta().x;
-                float scaleFactor = 1.0f + (0.01f*fabsf(deltaX));
-                if (deltaX < 0) scaleFactor = 1.0f/scaleFactor;
-                camera.zoom = Clamp(camera.zoom*scaleFactor, 0.125f, 64.0f);
+                float scale = 0.005f*deltaX;
+                camera.zoom = Clamp(expf(logf(camera.zoom)+scale), 0.125f, 64.0f);
             }
         }
         //----------------------------------------------------------------------------------


### PR DESCRIPTION
This makes zoom level consistent across different scales, making the examples more visually appealing and showcasing how to achieve it.