### PR TITLE
[rcore] fix: TRACELOG upon successfully changing directory

### DIFF
--- a/src/rcore.c
+++ b/src/rcore.c
@@ -2354,6 +2354,7 @@ bool ChangeDirectory(const char *dir)
     bool result = CHDIR(dir);
 
     if (result != 0) TRACELOG(LOG_WARNING, "SYSTEM: Failed to change to directory: %s", dir);
+    else TRACELOG(LOG_INFO, "SYSTEM: Working Directory: %s", dir);
 
     return (result == 0);
 }


### PR DESCRIPTION
I find it quite confusing that `InitWindow()` logs CWD during initialization, but the actual `ChangeDirectory()` does not do this upon successfully changing directory. This patch adds one line with `TRACELOG()` for said condition. It uses the same message as the one from InitWindow. Tested on Linux by building and running some examples with Cmake.