### PR TITLE
[examples] automatically rebuild raylib

### DIFF
--- a/examples/build.zig.zon
+++ b/examples/build.zig.zon
@@ -1,0 +1,10 @@
+.{
+    .name = .raylib_examples,
+    .version = "0.0.0",
+    .fingerprint = 0x3570d11b06c2907a, // Changing this has security and trust implications.
+    .minimum_zig_version = "0.14.0",
+    .dependencies = .{
+        .raylib = .{ .path = ".." },
+    },
+    .paths = .{"."},
+}


### PR DESCRIPTION
Hooked up raylib as a library in the examples build so that if a change is made in raylib then running `zig build` in the examples directory will automatically rebuild raylib.

The main pieces to this are the build.zig.zon file which allows the examples build to see the parent raylib directory.  Then we can add raylib as a typical dependency and grab the "raylib" artifact to link to. We also no longer need to add include paths since raylib's build.zig installs them for us.