### PR TITLE
Update rcore_desktop_sdl.c

### DIFF
--- a/src/platforms/rcore_desktop_sdl.c
+++ b/src/platforms/rcore_desktop_sdl.c
@@ -1670,7 +1670,7 @@ void PollInputEvents(void)
             {
                 int jid = event.jdevice.which; // Joystick device index
 
-                if (!CORE.Input.Gamepad.ready[jid] && (jid < MAX_GAMEPADS))
+                if (CORE.Input.Gamepad.ready[jid] && (jid < MAX_GAMEPADS))
                 {
                     platform.gamepad[jid] = SDL_GameControllerOpen(jid);
                     platform.gamepadId[jid] = SDL_JoystickInstanceID(SDL_GameControllerGetJoystick(platform.gamepad[jid]));


### PR DESCRIPTION
raylib app crashing when started and a gamepad is already connected to the PC (even if the gamepad is not used in the app). I only tested this with a gamepad that has a layout which is not recognized. Using SDL3 as backend.