### PR TITLE
Uncomment SetTargetFPS in core_window_flags

### DIFF
--- a/examples/core/core_window_flags.c
+++ b/examples/core/core_window_flags.c
@@ -52,7 +52,7 @@ int main(void)
 
     int framesCounter = 0;
 
-    //SetTargetFPS(60);               // Set our game to run at 60 frames-per-second
+    SetTargetFPS(60);               // Set our game to run at 60 frames-per-second
     //----------------------------------------------------------
 
     // Main game loop
@@ -163,7 +163,7 @@ int main(void)
         if (IsWindowState(FLAG_WINDOW_UNDECORATED)) DrawText("[D] FLAG_WINDOW_UNDECORATED: on", 10, 120, 10, LIME);
         else DrawText("[D] FLAG_WINDOW_UNDECORATED: off", 10, 120, 10, MAROON);
         if (IsWindowState(FLAG_WINDOW_HIDDEN)) DrawText("[H] FLAG_WINDOW_HIDDEN: on", 10, 140, 10, LIME);
-        else DrawText("[H] FLAG_WINDOW_HIDDEN: off", 10, 140, 10, MAROON);
+        else DrawText("[H] FLAG_WINDOW_HIDDEN: off (hides for 3 seconds)", 10, 140, 10, MAROON);
         if (IsWindowState(FLAG_WINDOW_MINIMIZED)) DrawText("[N] FLAG_WINDOW_MINIMIZED: on", 10, 160, 10, LIME);
         else DrawText("[N] FLAG_WINDOW_MINIMIZED: off", 10, 160, 10, MAROON);
         if (IsWindowState(FLAG_WINDOW_MAXIMIZED)) DrawText("[M] FLAG_WINDOW_MAXIMIZED: on", 10, 180, 10, LIME);


### PR DESCRIPTION
I think this line was accidently commented out in this commit:

3d1ae3500c731aa37d8f887cd165db480c4890eb

The FPS limit is needed to get the desired wait time for the "hide window" test, which uses the frame counter to hide the window for 3 seconds. On my machine without this limit it runs at over 1000 FPS and it appears like the hide window state is broken.

I also added some text that tells the user that it only hides the window for 3 seconds so they're not surprised when the window automatically reappears.