### PR TITLE
Prevent immediate window restore from minimize in core_window_flags

### DIFF
--- a/examples/core/core_window_flags.c
+++ b/examples/core/core_window_flags.c
@@ -97,7 +97,10 @@ int main(void)
         if (IsWindowState(FLAG_WINDOW_MINIMIZED))
         {
             framesCounter++;
-            if (framesCounter >= 240) RestoreWindow(); // Restore window after 3 seconds
+            if (framesCounter >= 240) {
+                RestoreWindow(); // Restore window after 3 seconds
+                framesCounter = 0;
+            }
         }
 
         if (IsKeyPressed(KEY_M))
@@ -165,7 +168,7 @@ int main(void)
         if (IsWindowState(FLAG_WINDOW_HIDDEN)) DrawText("[H] FLAG_WINDOW_HIDDEN: on", 10, 140, 10, LIME);
         else DrawText("[H] FLAG_WINDOW_HIDDEN: off", 10, 140, 10, MAROON);
         if (IsWindowState(FLAG_WINDOW_MINIMIZED)) DrawText("[N] FLAG_WINDOW_MINIMIZED: on", 10, 160, 10, LIME);
-        else DrawText("[N] FLAG_WINDOW_MINIMIZED: off", 10, 160, 10, MAROON);
+        else DrawText("[N] FLAG_WINDOW_MINIMIZED: off (restores after 3 seconds)", 10, 160, 10, MAROON);
         if (IsWindowState(FLAG_WINDOW_MAXIMIZED)) DrawText("[M] FLAG_WINDOW_MAXIMIZED: on", 10, 180, 10, LIME);
         else DrawText("[M] FLAG_WINDOW_MAXIMIZED: off", 10, 180, 10, MAROON);
         if (IsWindowState(FLAG_WINDOW_UNFOCUSED)) DrawText("[G] FLAG_WINDOW_UNFOCUSED: on", 10, 200, 10, LIME);


### PR DESCRIPTION
The core_window_flags example automatically restores the window from being minimized after 3 seconds. However, it only resets the frameCounter if the window is minimized through the app from inputting KEY_N.  This means if you miminize the window by other means (like pressing the minimize button) then the example will immediately restore the window because the frame counter wasn't reset. I've fixed this by setting the frameCounter back to 0 once it's expired. I also added a note in the UI that the example automatically restores the window so it's not a surprise.