### PR TITLE
Improve description of RestoreWindow

### DIFF
--- a/parser/output/raylib_api.json
+++ b/parser/output/raylib_api.json
@@ -3280,7 +3280,7 @@
     },
     {
       "name": "RestoreWindow",
-      "description": "Set window state: not minimized/maximized",
+      "description": "Restore window from being minimized/maximized",
       "returnType": "void"
     },
     {

--- a/parser/output/raylib_api.lua
+++ b/parser/output/raylib_api.lua
@@ -3223,7 +3223,7 @@ return {
     },
     {
       name = "RestoreWindow",
-      description = "Set window state: not minimized/maximized",
+      description = "Restore window from being minimized/maximized",
       returnType = "void"
     },
     {

--- a/parser/output/raylib_api.txt
+++ b/parser/output/raylib_api.txt
@@ -1085,7 +1085,7 @@ Function 017: MinimizeWindow() (0 input parameters)
 Function 018: RestoreWindow() (0 input parameters)
   Name: RestoreWindow
   Return type: void
-  Description: Set window state: not minimized/maximized
+  Description: Restore window from being minimized/maximized
   No input parameters
 Function 019: SetWindowIcon() (1 input parameters)
   Name: SetWindowIcon

--- a/parser/output/raylib_api.xml
+++ b/parser/output/raylib_api.xml
@@ -720,7 +720,7 @@
         </Function>
         <Function name="MinimizeWindow" retType="void" paramCount="0" desc="Set window state: minimized, if resizable">
         </Function>
-        <Function name="RestoreWindow" retType="void" paramCount="0" desc="Set window state: not minimized/maximized">
+        <Function name="RestoreWindow" retType="void" paramCount="0" desc="Restore window from being minimized/maximized">
         </Function>
         <Function name="SetWindowIcon" retType="void" paramCount="1" desc="Set icon for window (single image, RGBA 32bit)">
             <Param type="Image" name="image" desc="" />

--- a/projects/Notepad++/raylib_npp_parser/raylib_npp.xml
+++ b/projects/Notepad++/raylib_npp_parser/raylib_npp.xml
@@ -65,7 +65,7 @@
             <Overload retVal="void" descr="Set window state: minimized, if resizable"></Overload>
         </KeyWord>
         <KeyWord name="RestoreWindow" func="yes">
-            <Overload retVal="void" descr="Set window state: not minimized/maximized"></Overload>
+            <Overload retVal="void" descr="Restore window from being minimized/maximized"></Overload>
         </KeyWord>
         <KeyWord name="SetWindowIcon" func="yes">
             <Overload retVal="void" descr="Set icon for window (single image, RGBA 32bit)">

--- a/projects/Notepad++/raylib_npp_parser/raylib_to_parse.h
+++ b/projects/Notepad++/raylib_npp_parser/raylib_to_parse.h
@@ -20,7 +20,7 @@ RLAPI void ToggleFullscreen(void);                                // Toggle wind
 RLAPI void ToggleBorderlessWindowed(void);                        // Toggle window state: borderless windowed, resizes window to match monitor resolution
 RLAPI void MaximizeWindow(void);                                  // Set window state: maximized, if resizable
 RLAPI void MinimizeWindow(void);                                  // Set window state: minimized, if resizable
-RLAPI void RestoreWindow(void);                                   // Set window state: not minimized/maximized
+RLAPI void RestoreWindow(void);                                   // Restore window from being minimized/maximized
 RLAPI void SetWindowIcon(Image image);                            // Set icon for window (single image, RGBA 32bit)
 RLAPI void SetWindowIcons(Image *images, int count);              // Set icon for window (multiple images, RGBA 32bit)
 RLAPI void SetWindowTitle(const char *title);                     // Set title for window

--- a/src/platforms/rcore_android.c
+++ b/src/platforms/rcore_android.c
@@ -337,7 +337,7 @@ void MinimizeWindow(void)
     TRACELOG(LOG_WARNING, "MinimizeWindow() not available on target platform");
 }
 
-// Set window state: not minimized/maximized
+// Restore window from being minimized/maximized
 void RestoreWindow(void)
 {
     TRACELOG(LOG_WARNING, "RestoreWindow() not available on target platform");

--- a/src/platforms/rcore_desktop_glfw.c
+++ b/src/platforms/rcore_desktop_glfw.c
@@ -292,7 +292,7 @@ void MinimizeWindow(void)
     glfwIconifyWindow(platform.handle);
 }
 
-// Set window state: not minimized/maximized
+// Restore window from being minimized/maximized
 void RestoreWindow(void)
 {
     if (glfwGetWindowAttrib(platform.handle, GLFW_RESIZABLE) == GLFW_TRUE)

--- a/src/platforms/rcore_desktop_rgfw.c
+++ b/src/platforms/rcore_desktop_rgfw.c
@@ -339,7 +339,7 @@ void MinimizeWindow(void)
     RGFW_window_minimize(platform.window);
 }
 
-// Set window state: not minimized/maximized
+// Restore window from being minimized/maximized
 void RestoreWindow(void)
 {
     if (!(CORE.Window.flags & FLAG_WINDOW_UNFOCUSED)) RGFW_window_focus(platform.window);

--- a/src/platforms/rcore_desktop_sdl.c
+++ b/src/platforms/rcore_desktop_sdl.c
@@ -508,7 +508,7 @@ void MinimizeWindow(void)
     if ((CORE.Window.flags & FLAG_WINDOW_MINIMIZED) == 0) CORE.Window.flags |= FLAG_WINDOW_MINIMIZED;
 }
 
-// Set window state: not minimized/maximized
+// Restore window from being minimized/maximized
 void RestoreWindow(void)
 {
     SDL_RestoreWindow(platform.window);

--- a/src/platforms/rcore_drm.c
+++ b/src/platforms/rcore_drm.c
@@ -277,7 +277,7 @@ void MinimizeWindow(void)
     TRACELOG(LOG_WARNING, "MinimizeWindow() not available on target platform");
 }
 
-// Set window state: not minimized/maximized
+// Restore window from being minimized/maximized
 void RestoreWindow(void)
 {
     TRACELOG(LOG_WARNING, "RestoreWindow() not available on target platform");

--- a/src/platforms/rcore_template.c
+++ b/src/platforms/rcore_template.c
@@ -114,7 +114,7 @@ void MinimizeWindow(void)
     TRACELOG(LOG_WARNING, "MinimizeWindow() not available on target platform");
 }
 
-// Set window state: not minimized/maximized
+// Restore window from being minimized/maximized
 void RestoreWindow(void)
 {
     TRACELOG(LOG_WARNING, "RestoreWindow() not available on target platform");

--- a/src/platforms/rcore_web.c
+++ b/src/platforms/rcore_web.c
@@ -350,7 +350,7 @@ void MinimizeWindow(void)
     TRACELOG(LOG_WARNING, "MinimizeWindow() not available on target platform");
 }
 
-// Set window state: not minimized/maximized
+// Restore window from being minimized/maximized
 void RestoreWindow(void)
 {
     if ((glfwGetWindowAttrib(platform.handle, GLFW_RESIZABLE) == GLFW_TRUE) && (CORE.Window.flags & FLAG_WINDOW_MAXIMIZED))

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -987,7 +987,7 @@ RLAPI void ToggleFullscreen(void);                                // Toggle wind
 RLAPI void ToggleBorderlessWindowed(void);                        // Toggle window state: borderless windowed, resizes window to match monitor resolution
 RLAPI void MaximizeWindow(void);                                  // Set window state: maximized, if resizable
 RLAPI void MinimizeWindow(void);                                  // Set window state: minimized, if resizable
-RLAPI void RestoreWindow(void);                                   // Set window state: not minimized/maximized
+RLAPI void RestoreWindow(void);                                   // Restore window from being minimized/maximized
 RLAPI void SetWindowIcon(Image image);                            // Set icon for window (single image, RGBA 32bit)
 RLAPI void SetWindowIcons(Image *images, int count);              // Set icon for window (multiple images, RGBA 32bit)
 RLAPI void SetWindowTitle(const char *title);                     // Set title for window


### PR DESCRIPTION
Restore window currently says it sets the window state to:

   "not minimized/maximized"

However, if a window is maximized and then minimized, it's typical that it would restore back to being maximized, which is what seems to happen from my testing. I've reworded the description to better reflect this behavior.