### PR TITLE
small build.zig fix

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -238,7 +238,7 @@ fn compileRaylib(b: *std.Build, target: std.Build.ResolvedTarget, optimize: std.
                 raylib.addSystemIncludePath( .{ .cwd_relative = androidAsmPath});
                 raylib.addSystemIncludePath(.{ .cwd_relative = androidGluePath});
 
-                var libcData = std.ArrayList(u8).init(b.allocator).writer();
+                var libcData = std.ArrayList(u8).init(b.allocator);
                 const writer = libcData.writer();
                 try (std.zig.LibCInstallation{
                     .include_dir = androidIncludePath,


### PR DESCRIPTION
Fixes an issue (that I created, sorry) with the generated `android-libc.txt` file when using raylib as a dependency in another zig project. Tested on Linux and Windows.