### PR TITLE
[rcore][SDL2] First touch position is overwritten with mouse pos

### DIFF
--- a/src/platforms/rcore_desktop_sdl.c
+++ b/src/platforms/rcore_desktop_sdl.c
@@ -1363,7 +1363,10 @@ void PollInputEvents(void)
     for (int i = 0; i < MAX_TOUCH_POINTS; i++) CORE.Input.Touch.previousTouchState[i] = CORE.Input.Touch.currentTouchState[i];
 
     // Map touch position to mouse position for convenience
-    CORE.Input.Touch.position[0] = CORE.Input.Mouse.currentPosition;
+    if (CORE.Input.Touch.pointCount == 0)
+    {
+        CORE.Input.Touch.position[0] = CORE.Input.Mouse.currentPosition;
+    }
 
     int touchAction = -1;       // 0-TOUCH_ACTION_UP, 1-TOUCH_ACTION_DOWN, 2-TOUCH_ACTION_MOVE
     bool realTouch = false;     // Flag to differentiate real touch gestures from mouse ones


### PR DESCRIPTION
I believe it makes sense to only do this when there are no known touch points. I am not even sure if this should be done at all.

See https://github.com/raysan5/raylib/issues/4872 for more information on the bug this attempts to fix.