### PR TITLE
[rlgl] Preserve current mode and textureId when switching mode or texture

### DIFF
--- a/src/rlgl.h
+++ b/src/rlgl.h
@@ -1473,7 +1473,10 @@ void rlBegin(int mode)
             if (!rlCheckRenderBatchLimit(RLGL.currentBatch->draws[RLGL.currentBatch->drawCounter - 1].vertexAlignment))
             {
                 RLGL.State.vertexCounter += RLGL.currentBatch->draws[RLGL.currentBatch->drawCounter - 1].vertexAlignment;
+
+                int currentTextureId = RLGL.currentBatch->draws[RLGL.currentBatch->drawCounter - 1].textureId;
                 RLGL.currentBatch->drawCounter++;
+                RLGL.currentBatch->draws[RLGL.currentBatch->drawCounter - 1].textureId = currentTextureId;
             }
         }
 
@@ -1481,7 +1484,6 @@ void rlBegin(int mode)
 
         RLGL.currentBatch->draws[RLGL.currentBatch->drawCounter - 1].mode = mode;
         RLGL.currentBatch->draws[RLGL.currentBatch->drawCounter - 1].vertexCount = 0;
-        RLGL.currentBatch->draws[RLGL.currentBatch->drawCounter - 1].textureId = RLGL.State.defaultTextureId;
     }
 }
 
@@ -1670,7 +1672,9 @@ void rlSetTexture(unsigned int id)
                 {
                     RLGL.State.vertexCounter += RLGL.currentBatch->draws[RLGL.currentBatch->drawCounter - 1].vertexAlignment;
 
+                    int currentMode = RLGL.currentBatch->draws[RLGL.currentBatch->drawCounter - 1].mode;
                     RLGL.currentBatch->drawCounter++;
+                    RLGL.currentBatch->draws[RLGL.currentBatch->drawCounter - 1].mode = currentMode;
                 }
             }
 

--- a/src/rmodels.c
+++ b/src/rmodels.c
@@ -175,6 +175,7 @@ static void ProcessMaterialsOBJ(Material *rayMaterials, tinyobj_material_t *mate
 // Draw a line in 3D world space
 void DrawLine3D(Vector3 startPos, Vector3 endPos, Color color)
 {
+    rlSetTexture(rlGetTextureIdDefault());
     rlBegin(RL_LINES);
         rlColor4ub(color.r, color.g, color.b, color.a);
         rlVertex3f(startPos.x, startPos.y, startPos.z);
@@ -186,6 +187,7 @@ void DrawLine3D(Vector3 startPos, Vector3 endPos, Color color)
 // WARNING: OpenGL ES 2.0 does not support point mode drawing
 void DrawPoint3D(Vector3 position, Color color)
 {
+    rlSetTexture(rlGetTextureIdDefault());
     rlPushMatrix();
         rlTranslatef(position.x, position.y, position.z);
         rlBegin(RL_LINES);
@@ -199,6 +201,7 @@ void DrawPoint3D(Vector3 position, Color color)
 // Draw a circle in 3D world space
 void DrawCircle3D(Vector3 center, float radius, Vector3 rotationAxis, float rotationAngle, Color color)
 {
+    rlSetTexture(rlGetTextureIdDefault());
     rlPushMatrix();
         rlTranslatef(center.x, center.y, center.z);
         rlRotatef(rotationAngle, rotationAxis.x, rotationAxis.y, rotationAxis.z);
@@ -218,6 +221,7 @@ void DrawCircle3D(Vector3 center, float radius, Vector3 rotationAxis, float rota
 // Draw a color-filled triangle (vertex in counter-clockwise order!)
 void DrawTriangle3D(Vector3 v1, Vector3 v2, Vector3 v3, Color color)
 {
+    rlSetTexture(rlGetTextureIdDefault());
     rlBegin(RL_TRIANGLES);
         rlColor4ub(color.r, color.g, color.b, color.a);
         rlVertex3f(v1.x, v1.y, v1.z);
@@ -231,6 +235,7 @@ void DrawTriangleStrip3D(const Vector3 *points, int pointCount, Color color)
 {
     if (pointCount < 3) return; // Security check
 
+    rlSetTexture(rlGetTextureIdDefault());
     rlBegin(RL_TRIANGLES);
         rlColor4ub(color.r, color.g, color.b, color.a);
 
@@ -266,6 +271,7 @@ void DrawCube(Vector3 position, float width, float height, float length, Color c
         //rlRotatef(45, 0, 1, 0);
         //rlScalef(1.0f, 1.0f, 1.0f);   // NOTE: Vertices are directly scaled on definition
 
+        rlSetTexture(rlGetTextureIdDefault());
         rlBegin(RL_TRIANGLES);
             rlColor4ub(color.r, color.g, color.b, color.a);
 
@@ -345,6 +351,7 @@ void DrawCubeWires(Vector3 position, float width, float height, float length, Co
     float y = 0.0f;
     float z = 0.0f;
 
+    rlSetTexture(rlGetTextureIdDefault());
     rlPushMatrix();
         rlTranslatef(position.x, position.y, position.z);
 
@@ -435,6 +442,7 @@ void DrawSphereEx(Vector3 centerPos, float radius, int rings, int slices, Color 
         rlTranslatef(centerPos.x, centerPos.y, centerPos.z);
         rlScalef(radius, radius, radius);
 
+        rlSetTexture(rlGetTextureIdDefault());
         rlBegin(RL_TRIANGLES);
             rlColor4ub(color.r, color.g, color.b, color.a);
 
@@ -472,6 +480,7 @@ void DrawSphereEx(Vector3 centerPos, float radius, int rings, int slices, Color 
         rlTranslatef(centerPos.x, centerPos.y, centerPos.z);
         rlScalef(radius, radius, radius);
 
+        rlSetTexture(rlGetTextureIdDefault());
         rlBegin(RL_TRIANGLES);
             rlColor4ub(color.r, color.g, color.b, color.a);
 
@@ -520,6 +529,7 @@ void DrawSphereWires(Vector3 centerPos, float radius, int rings, int slices, Col
         rlTranslatef(centerPos.x, centerPos.y, centerPos.z);
         rlScalef(radius, radius, radius);
 
+        rlSetTexture(rlGetTextureIdDefault());
         rlBegin(RL_LINES);
             rlColor4ub(color.r, color.g, color.b, color.a);
 
@@ -561,6 +571,7 @@ void DrawCylinder(Vector3 position, float radiusTop, float radiusBottom, float h
 
     const float angleStep = 360.0f/sides;
 
+    rlSetTexture(rlGetTextureIdDefault());
     rlPushMatrix();
         rlTranslatef(position.x, position.y, position.z);
 
@@ -627,6 +638,7 @@ void DrawCylinderEx(Vector3 startPos, Vector3 endPos, float startRadius, float e
 
     float baseAngle = (2.0f*PI)/sides;
 
+    rlSetTexture(rlGetTextureIdDefault());
     rlBegin(RL_TRIANGLES);
         rlColor4ub(color.r, color.g, color.b, color.a);
 
@@ -679,6 +691,7 @@ void DrawCylinderWires(Vector3 position, float radiusTop, float radiusBottom, fl
 
     const float angleStep = 360.0f/sides;
 
+    rlSetTexture(rlGetTextureIdDefault());
     rlPushMatrix();
         rlTranslatef(position.x, position.y, position.z);
 
@@ -718,6 +731,7 @@ void DrawCylinderWiresEx(Vector3 startPos, Vector3 endPos, float startRadius, fl
 
     float baseAngle = (2.0f*PI)/sides;
 
+    rlSetTexture(rlGetTextureIdDefault());
     rlBegin(RL_LINES);
         rlColor4ub(color.r, color.g, color.b, color.a);
 
@@ -769,6 +783,7 @@ void DrawCapsule(Vector3 startPos, Vector3 endPos, float radius, int slices, int
     float baseSliceAngle = (2.0f*PI)/slices;
     float baseRingAngle  = PI*0.5f/rings;
 
+    rlSetTexture(rlGetTextureIdDefault());
     rlBegin(RL_TRIANGLES);
         rlColor4ub(color.r, color.g, color.b, color.a);
 
@@ -912,6 +927,7 @@ void DrawCapsuleWires(Vector3 startPos, Vector3 endPos, float radius, int slices
     float baseSliceAngle = (2.0f*PI)/slices;
     float baseRingAngle  = PI*0.5f/rings;
 
+    rlSetTexture(rlGetTextureIdDefault());
     rlBegin(RL_LINES);
         rlColor4ub(color.r, color.g, color.b, color.a);
 
@@ -1031,6 +1047,7 @@ void DrawCapsuleWires(Vector3 startPos, Vector3 endPos, float radius, int slices
 void DrawPlane(Vector3 centerPos, Vector2 size, Color color)
 {
     // NOTE: Plane is always created on XZ ground
+    rlSetTexture(rlGetTextureIdDefault());
     rlPushMatrix();
         rlTranslatef(centerPos.x, centerPos.y, centerPos.z);
         rlScalef(size.x, 1.0f, size.y);
@@ -1052,6 +1069,7 @@ void DrawRay(Ray ray, Color color)
 {
     float scale = 10000;
 
+    rlSetTexture(rlGetTextureIdDefault());
     rlBegin(RL_LINES);
         rlColor4ub(color.r, color.g, color.b, color.a);
         rlColor4ub(color.r, color.g, color.b, color.a);
@@ -1066,6 +1084,7 @@ void DrawGrid(int slices, float spacing)
 {
     int halfSlices = slices/2;
 
+    rlSetTexture(rlGetTextureIdDefault());
     rlBegin(RL_LINES);
         for (int i = -halfSlices; i <= halfSlices; i++)
         {

--- a/src/rshapes.c
+++ b/src/rshapes.c
@@ -157,6 +157,7 @@ void DrawPixelV(Vector2 position, Color color)
 
     rlSetTexture(0);
 #else
+    rlSetTexture(rlGetTextureIdDefault());
     rlBegin(RL_TRIANGLES);
 
         rlColor4ub(color.r, color.g, color.b, color.a);
@@ -176,6 +177,7 @@ void DrawPixelV(Vector2 position, Color color)
 // Draw a line (using gl lines)
 void DrawLine(int startPosX, int startPosY, int endPosX, int endPosY, Color color)
 {
+    rlSetTexture(rlGetTextureIdDefault());
     rlBegin(RL_LINES);
         rlColor4ub(color.r, color.g, color.b, color.a);
         rlVertex2f((float)startPosX, (float)startPosY);
@@ -186,6 +188,7 @@ void DrawLine(int startPosX, int startPosY, int endPosX, int endPosY, Color colo
 // Draw a line (using gl lines)
 void DrawLineV(Vector2 startPos, Vector2 endPos, Color color)
 {
+    rlSetTexture(rlGetTextureIdDefault());
     rlBegin(RL_LINES);
         rlColor4ub(color.r, color.g, color.b, color.a);
         rlVertex2f(startPos.x, startPos.y);
@@ -198,6 +201,7 @@ void DrawLineStrip(const Vector2 *points, int pointCount, Color color)
 {
     if (pointCount < 2) return; // Security check
 
+    rlSetTexture(rlGetTextureIdDefault());
     rlBegin(RL_LINES);
         rlColor4ub(color.r, color.g, color.b, color.a);
 
@@ -359,6 +363,7 @@ void DrawCircleSector(Vector2 center, float radius, float startAngle, float endA
 
     rlSetTexture(0);
 #else
+    rlSetTexture(rlGetTextureIdDefault());
     rlBegin(RL_TRIANGLES);
         for (int i = 0; i < segments; i++)
         {
@@ -404,6 +409,7 @@ void DrawCircleSectorLines(Vector2 center, float radius, float startAngle, float
     float angle = startAngle;
     bool showCapLines = true;
 
+    rlSetTexture(rlGetTextureIdDefault());
     rlBegin(RL_LINES);
         if (showCapLines)
         {
@@ -434,6 +440,7 @@ void DrawCircleSectorLines(Vector2 center, float radius, float startAngle, float
 // Draw a gradient-filled circle
 void DrawCircleGradient(int centerX, int centerY, float radius, Color inner, Color outer)
 {
+    rlSetTexture(rlGetTextureIdDefault());
     rlBegin(RL_TRIANGLES);
         for (int i = 0; i < 360; i += 10)
         {
@@ -456,6 +463,7 @@ void DrawCircleLines(int centerX, int centerY, float radius, Color color)
 // Draw circle outline (Vector version)
 void DrawCircleLinesV(Vector2 center, float radius, Color color)
 {
+    rlSetTexture(rlGetTextureIdDefault());
     rlBegin(RL_LINES);
         rlColor4ub(color.r, color.g, color.b, color.a);
 
@@ -471,6 +479,7 @@ void DrawCircleLinesV(Vector2 center, float radius, Color color)
 // Draw ellipse
 void DrawEllipse(int centerX, int centerY, float radiusH, float radiusV, Color color)
 {
+    rlSetTexture(rlGetTextureIdDefault());
     rlBegin(RL_TRIANGLES);
         for (int i = 0; i < 360; i += 10)
         {
@@ -485,6 +494,7 @@ void DrawEllipse(int centerX, int centerY, float radiusH, float radiusV, Color c
 // Draw ellipse outline
 void DrawEllipseLines(int centerX, int centerY, float radiusH, float radiusV, Color color)
 {
+    rlSetTexture(rlGetTextureIdDefault());
     rlBegin(RL_LINES);
         for (int i = 0; i < 360; i += 10)
         {
@@ -567,6 +577,7 @@ void DrawRing(Vector2 center, float innerRadius, float outerRadius, float startA
 
     rlSetTexture(0);
 #else
+    rlSetTexture(rlGetTextureIdDefault());
     rlBegin(RL_TRIANGLES);
         for (int i = 0; i < segments; i++)
         {
@@ -631,6 +642,7 @@ void DrawRingLines(Vector2 center, float innerRadius, float outerRadius, float s
     float angle = startAngle;
     bool showCapLines = true;
 
+    rlSetTexture(rlGetTextureIdDefault());
     rlBegin(RL_LINES);
         if (showCapLines)
         {
@@ -745,6 +757,7 @@ void DrawRectanglePro(Rectangle rec, Vector2 origin, float rotation, Color color
 
     rlSetTexture(0);
 #else
+    rlSetTexture(rlGetTextureIdDefault());
     rlBegin(RL_TRIANGLES);
 
         rlColor4ub(color.r, color.g, color.b, color.a);
@@ -813,6 +826,7 @@ void DrawRectangleLines(int posX, int posY, int width, int height, Color color)
     float xOffset = 0.5f/mat.m0;
     float yOffset = 0.5f/mat.m5;
 
+    rlSetTexture(rlGetTextureIdDefault());
     rlBegin(RL_LINES);
         rlColor4ub(color.r, color.g, color.b, color.a);
         rlVertex2f((float)posX + xOffset, (float)posY + yOffset);
@@ -836,6 +850,7 @@ void DrawRectangleLines(int posX, int posY, int width, int height, Color color)
     DrawRectangle(posX, posY + height - 1, width, 1, color);
     DrawRectangle(posX, posY + 1, 1, height - 2, color);
 #else
+    rlSetTexture(rlGetTextureIdDefault());
     rlBegin(RL_LINES);
         rlColor4ub(color.r, color.g, color.b, color.a);
         rlVertex2f((float)posX, (float)posY);
@@ -1046,6 +1061,7 @@ void DrawRectangleRounded(Rectangle rec, float roundness, int segments, Color co
     rlEnd();
     rlSetTexture(0);
 #else
+    rlSetTexture(rlGetTextureIdDefault());
     rlBegin(RL_TRIANGLES);
 
         // Draw all of the 4 corners: [1] Upper Left Corner, [3] Upper Right Corner, [5] Lower Right Corner, [7] Lower Left Corner
@@ -1272,6 +1288,7 @@ void DrawRectangleRoundedLinesEx(Rectangle rec, float roundness, int segments, f
         rlEnd();
         rlSetTexture(0);
 #else
+        rlSetTexture(rlGetTextureIdDefault());
         rlBegin(RL_TRIANGLES);
 
             // Draw all of the 4 corners first: Upper Left Corner, Upper Right Corner, Lower Right Corner, Lower Left Corner
@@ -1337,6 +1354,7 @@ void DrawRectangleRoundedLinesEx(Rectangle rec, float roundness, int segments, f
     else
     {
         // Use LINES to draw the outline
+        rlSetTexture(rlGetTextureIdDefault());
         rlBegin(RL_LINES);
 
             // Draw all the 4 corners first: Upper Left Corner, Upper Right Corner, Lower Right Corner, Lower Left Corner
@@ -1392,6 +1410,7 @@ void DrawTriangle(Vector2 v1, Vector2 v2, Vector2 v3, Color color)
 
     rlSetTexture(0);
 #else
+    rlSetTexture(rlGetTextureIdDefault());
     rlBegin(RL_TRIANGLES);
         rlColor4ub(color.r, color.g, color.b, color.a);
         rlVertex2f(v1.x, v1.y);
@@ -1405,6 +1424,7 @@ void DrawTriangle(Vector2 v1, Vector2 v2, Vector2 v3, Color color)
 // NOTE: Vertex must be provided in counter-clockwise order
 void DrawTriangleLines(Vector2 v1, Vector2 v2, Vector2 v3, Color color)
 {
+    rlSetTexture(rlGetTextureIdDefault());
     rlBegin(RL_LINES);
         rlColor4ub(color.r, color.g, color.b, color.a);
         rlVertex2f(v1.x, v1.y);
@@ -1456,6 +1476,7 @@ void DrawTriangleStrip(const Vector2 *points, int pointCount, Color color)
 {
     if (pointCount >= 3)
     {
+        rlSetTexture(rlGetTextureIdDefault());
         rlBegin(RL_TRIANGLES);
             rlColor4ub(color.r, color.g, color.b, color.a);
 
@@ -1512,6 +1533,7 @@ void DrawPoly(Vector2 center, int sides, float radius, float rotation, Color col
     rlEnd();
     rlSetTexture(0);
 #else
+    rlSetTexture(rlGetTextureIdDefault());
     rlBegin(RL_TRIANGLES);
         for (int i = 0; i < sides; i++)
         {
@@ -1534,6 +1556,7 @@ void DrawPolyLines(Vector2 center, int sides, float radius, float rotation, Colo
     float centralAngle = rotation*DEG2RAD;
     float angleStep = 360.0f/(float)sides*DEG2RAD;
 
+    rlSetTexture(rlGetTextureIdDefault());
     rlBegin(RL_LINES);
         for (int i = 0; i < sides; i++)
         {
@@ -1581,6 +1604,7 @@ void DrawPolyLinesEx(Vector2 center, int sides, float radius, float rotation, fl
     rlEnd();
     rlSetTexture(0);
 #else
+    rlSetTexture(rlGetTextureIdDefault());
     rlBegin(RL_TRIANGLES);
         for (int i = 0; i < sides; i++)
         {


### PR DESCRIPTION
Related to #4874 , #4347 , #4364 
I tested both `textures_polygon` and `textures_bunnymark`, they both work. I tested some others too, didn't see any problem, but feel free to comment.