### PR TITLE
[RCORE] Fix issue with screenshots on HIGHDPI displays 

### DIFF
--- a/src/rcore.c
+++ b/src/rcore.c
@@ -1879,7 +1879,10 @@ void TakeScreenshot(const char *fileName)
     // Security check to (partially) avoid malicious code
     if (strchr(fileName, '\'') != NULL) { TRACELOG(LOG_WARNING, "SYSTEM: Provided fileName could be potentially malicious, avoid [\'] character"); return; }
 
-    Vector2 scale = GetWindowScaleDPI();
+    // apply a scale if we are doing HIGHDPI auto-scaling
+    Vector2 scale = { 1,1 };
+    if (IsWindowState(FLAG_WINDOW_HIGHDPI)) scale = GetWindowScaleDPI();
+
     unsigned char *imgData = rlReadScreenPixels((int)((float)CORE.Window.render.width*scale.x), (int)((float)CORE.Window.render.height*scale.y));
     Image image = { imgData, (int)((float)CORE.Window.render.width*scale.x), (int)((float)CORE.Window.render.height*scale.y), 1, PIXELFORMAT_UNCOMPRESSED_R8G8B8A8 };
 


### PR DESCRIPTION
If you take a screenshot on a high DPI display and are using the native resolution (you do not set WINDOW_FLAG_HIGHDPI), then you will not get a good screenshot as it will be scaled incorrectly.

This PR Only scale the screenshot by the DPI scale if we are doing automatic High DPI scaling, otherwise the native resolution is correct.

Fixes #4882

A mac user should test this change, it may need to be stubbed out for APPLE platforms due to the way the mac handles it's high DPI stuff and it's buggy GL drivers.