### PR TITLE
build.zig: run zig fmt

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -192,7 +192,6 @@ fn compileRaylib(b: *std.Build, target: std.Build.ResolvedTarget, optimize: std.
             setDesktopPlatform(raylib, options.platform);
         },
         .linux => {
-
             if (options.platform == .drm) {
                 if (options.opengl_version == .auto) {
                     raylib.linkSystemLibrary("GLESv2");
@@ -209,34 +208,32 @@ fn compileRaylib(b: *std.Build, target: std.Build.ResolvedTarget, optimize: std.
             } else if (target.result.abi == .android) {
 
                 //these are the only tag options per https://developer.android.com/ndk/guides/other_build_systems
-                const hostTuple = switch(builtin.target.os.tag) {
-                    .linux =>   "linux-x86_64",
+                const hostTuple = switch (builtin.target.os.tag) {
+                    .linux => "linux-x86_64",
                     .windows => "windows-x86_64",
-                    .macos =>   "darwin-x86_64",
-                    else => {
-                        @panic("unsupported host OS");
-                    }
+                    .macos => "darwin-x86_64",
+                    else => @panic("unsupported host OS"),
                 };
 
                 const androidTriple = try target.result.linuxTriple(b.allocator);
                 const androidNdkPathString: []const u8 = options.android_ndk;
-                if(androidNdkPathString.len < 1) @panic("no ndk path provided and ANDROID_NDK_HOME is not set");
+                if (androidNdkPathString.len < 1) @panic("no ndk path provided and ANDROID_NDK_HOME is not set");
                 const androidApiLevel: []const u8 = options.android_api_version;
 
-                const androidSysroot = try std.fs.path.join(b.allocator, &.{androidNdkPathString,  "/toolchains/llvm/prebuilt/", hostTuple, "/sysroot"});
-                const androidLibPath = try std.fs.path.join(b.allocator, &.{androidSysroot, "/usr/lib/", androidTriple});
-                const androidApiSpecificPath =  try std.fs.path.join(b.allocator, &.{androidLibPath, androidApiLevel});
-                const androidIncludePath = try std.fs.path.join(b.allocator, &.{androidSysroot, "/usr/include"});
-                const androidArchIncludePath = try std.fs.path.join(b.allocator, &.{androidIncludePath, androidTriple});
-                const androidAsmPath = try std.fs.path.join(b.allocator, &.{androidIncludePath, "/asm-generic"});
-                const androidGluePath = try std.fs.path.join(b.allocator, &.{androidNdkPathString, "/sources/android/native_app_glue/"});
+                const androidSysroot = try std.fs.path.join(b.allocator, &.{ androidNdkPathString, "/toolchains/llvm/prebuilt/", hostTuple, "/sysroot" });
+                const androidLibPath = try std.fs.path.join(b.allocator, &.{ androidSysroot, "/usr/lib/", androidTriple });
+                const androidApiSpecificPath = try std.fs.path.join(b.allocator, &.{ androidLibPath, androidApiLevel });
+                const androidIncludePath = try std.fs.path.join(b.allocator, &.{ androidSysroot, "/usr/include" });
+                const androidArchIncludePath = try std.fs.path.join(b.allocator, &.{ androidIncludePath, androidTriple });
+                const androidAsmPath = try std.fs.path.join(b.allocator, &.{ androidIncludePath, "/asm-generic" });
+                const androidGluePath = try std.fs.path.join(b.allocator, &.{ androidNdkPathString, "/sources/android/native_app_glue/" });
 
-                raylib.addLibraryPath(.{ .cwd_relative =  androidLibPath});
+                raylib.addLibraryPath(.{ .cwd_relative = androidLibPath });
                 raylib.root_module.addLibraryPath(.{ .cwd_relative = androidApiSpecificPath });
                 raylib.addSystemIncludePath(.{ .cwd_relative = androidIncludePath });
-                raylib.addSystemIncludePath(.{ .cwd_relative = androidArchIncludePath});
-                raylib.addSystemIncludePath( .{ .cwd_relative = androidAsmPath});
-                raylib.addSystemIncludePath(.{ .cwd_relative = androidGluePath});
+                raylib.addSystemIncludePath(.{ .cwd_relative = androidArchIncludePath });
+                raylib.addSystemIncludePath(.{ .cwd_relative = androidAsmPath });
+                raylib.addSystemIncludePath(.{ .cwd_relative = androidGluePath });
 
                 var libcData = std.ArrayList(u8).init(b.allocator);
                 const writer = libcData.writer();
@@ -442,7 +439,7 @@ pub const PlatformBackend = enum {
     rgfw,
     sdl,
     drm,
-    android
+    android,
 };
 
 pub fn build(b: *std.Build) !void {


### PR DESCRIPTION
Formats `build.zig` with `zig fmt build.zig`.  It was formatted before but fell out with the recent changes to add android.