### PR TITLE
Add Warning to direct users to appropriate WindowState / ConfigFlag function

### DIFF
--- a/src/platforms/rcore_desktop_glfw.c
+++ b/src/platforms/rcore_desktop_glfw.c
@@ -307,6 +307,8 @@ void RestoreWindow(void)
 // Set window configuration state using flags
 void SetWindowState(unsigned int flags)
 {
+    if (!CORE.Window.ready) TRACELOG(LOG_WARNING, "WINDOW: SetWindowState does nothing before window initialization, Use \"SetConfigFlags\" instead");
+
     // Check previous state and requested state to apply required changes
     // NOTE: In most cases the functions already change the flags internally
 

--- a/src/platforms/rcore_desktop_rgfw.c
+++ b/src/platforms/rcore_desktop_rgfw.c
@@ -350,6 +350,8 @@ void RestoreWindow(void)
 // Set window configuration state using flags
 void SetWindowState(unsigned int flags)
 {
+    if (!CORE.Window.ready) TRACELOG(LOG_WARNING, "WINDOW: SetWindowState does nothing before window initialization, Use \"SetConfigFlags\" instead");
+
     CORE.Window.flags |= flags;
 
     if (flags & FLAG_VSYNC_HINT)

--- a/src/platforms/rcore_desktop_sdl.c
+++ b/src/platforms/rcore_desktop_sdl.c
@@ -518,6 +518,8 @@ void RestoreWindow(void)
 // Set window configuration state using flags
 void SetWindowState(unsigned int flags)
 {
+    if (!CORE.Window.ready) TRACELOG(LOG_WARNING, "WINDOW: SetWindowState does nothing before window initialization, Use \"SetConfigFlags\" instead");
+
     CORE.Window.flags |= flags;
 
     if (flags & FLAG_VSYNC_HINT)

--- a/src/platforms/rcore_web.c
+++ b/src/platforms/rcore_web.c
@@ -364,6 +364,8 @@ void RestoreWindow(void)
 // Set window configuration state using flags
 void SetWindowState(unsigned int flags)
 {
+    if (!CORE.Window.ready) TRACELOG(LOG_WARNING, "WINDOW: SetWindowState does nothing before window initialization, Use \"SetConfigFlags\" instead");
+
     // Check previous state and requested state to apply required changes
     // NOTE: In most cases the functions already change the flags internally
 

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -1905,6 +1905,8 @@ void TakeScreenshot(const char *fileName)
 // To configure window states after creation, just use SetWindowState()
 void SetConfigFlags(unsigned int flags)
 {
+    if (CORE.Window.ready) TRACELOG(LOG_WARNING, "WINDOW: SetConfigFlags called after window initialization, Use \"SetWindowState\" to set flags instead");
+
     // Selected flags are set but not evaluated at this point,
     // flag evaluation happens at InitWindow() or SetWindowState()
     CORE.Window.flags |= flags;


### PR DESCRIPTION
When trying to check out the `FLAG_WINDOW_TRANSPARENT` I chose the wrong function (`SetWindowState`) and had a difficult time understanding why it was wrong and why I should use `SetConfigFlags` instead. I understand the distinction now, however I feel there should be some direction given to the user on why they aren't seeing their change, especially in the case where `SetWindowState` outputs that "_Framebuffer transparency can only be configured before window initialization_" but fails to mention _how_ it should be configured.

This PR simply adds a helpful TraceLog any time `SetWindowState` is called before `InitWindow`, or any time `SetConfigFlags` is called after `InitWindow`. In other words, it clearly communicates that the function call will not have the intended effect, and directs the user to the appropriate function (since the user's intent is clear)

I _do_ see that the documentation for SetConfigFlags mentions that it's only for before window initialization, however SetWindowState does not give the same documentation and so it will not be clear to a user why there is no effect by their call to SetWindowState before initialization without this TraceLog.