### PR TITLE
[Examples] Remove duplicate resource file

### DIFF
--- a/projects/VS2022/examples/models_loading_gltf.vcxproj
+++ b/projects/VS2022/examples/models_loading_gltf.vcxproj
@@ -556,9 +556,6 @@
     <ClCompile Include="..\..\..\examples\models\models_loading_gltf.c" />
   </ItemGroup>
   <ItemGroup>
-    <ResourceCompile Include="..\..\..\examples\examples.rc" />
-  </ItemGroup>
-  <ItemGroup>
     <ResourceCompile Include="..\..\..\src\raylib.rc" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
The gltf example had a duplicate res file in it's project and would not build, this PR removes the extra file from the build so there is not a duplicate icon resource.