### PR TITLE
[rlgl] introduced rlStartBatch

### DIFF
--- a/examples/models/models_draw_cube_texture.c
+++ b/examples/models/models_draw_cube_texture.c
@@ -103,8 +103,6 @@ void DrawCubeTexture(Texture2D texture, Vector3 position, float width, float hei
     float y = position.y;
     float z = position.z;
 
-    // Set desired texture to be enabled while drawing following vertex data
-    rlSetTexture(texture.id);
 
     // Vertex data transformation can be defined with the commented lines,
     // but in this example we calculate the transformed vertex data directly when calling rlVertex3f()
@@ -114,7 +112,8 @@ void DrawCubeTexture(Texture2D texture, Vector3 position, float width, float hei
         //rlRotatef(45, 0, 1, 0);
         //rlScalef(2.0f, 2.0f, 2.0f);
 
-        rlBegin(RL_QUADS);
+        // Set desired texture to be enabled while drawing following vertex data
+        rlStartBatch(RL_QUADS, texture.id);
             rlColor4ub(color.r, color.g, color.b, color.a);
             // Front Face
             rlNormal3f(0.0f, 0.0f, 1.0f);       // Normal Pointing Towards Viewer
@@ -155,7 +154,7 @@ void DrawCubeTexture(Texture2D texture, Vector3 position, float width, float hei
         rlEnd();
     //rlPopMatrix();
 
-    rlSetTexture(0);
+    rlEndBatch();
 }
 
 // Draw cube with texture piece applied to all faces
@@ -168,11 +167,9 @@ void DrawCubeTextureRec(Texture2D texture, Rectangle source, Vector3 position, f
     float texHeight = (float)texture.height;
 
     // Set desired texture to be enabled while drawing following vertex data
-    rlSetTexture(texture.id);
-
-    // We calculate the normalized texture coordinates for the desired texture-source-rectangle
-    // It means converting from (tex.width, tex.height) coordinates to [0.0f, 1.0f] equivalent 
-    rlBegin(RL_QUADS);
+    rlStartBatch(RL_QUADS, texture.id);
+        // We calculate the normalized texture coordinates for the desired texture-source-rectangle
+        // It means converting from (tex.width, tex.height) coordinates to [0.0f, 1.0f] equivalent
         rlColor4ub(color.r, color.g, color.b, color.a);
 
         // Front face
@@ -243,5 +240,5 @@ void DrawCubeTextureRec(Texture2D texture, Rectangle source, Vector3 position, f
 
     rlEnd();
 
-    rlSetTexture(0);
+    rlEndBatch();
 }

--- a/examples/models/models_rlgl_solar_system.c
+++ b/examples/models/models_rlgl_solar_system.c
@@ -142,7 +142,7 @@ void DrawSphereBasic(Color color)
     // buffer to store all required vertex, batch is reseted if required
     rlCheckRenderBatchLimit((rings + 2)*slices*6);
 
-    rlBegin(RL_TRIANGLES);
+    rlStartBatch(RL_TRIANGLES, rlGetTextureIdDefault());
         rlColor4ub(color.r, color.g, color.b, color.a);
 
         for (int i = 0; i < (rings + 2); i++)

--- a/examples/others/rlgl_standalone.c
+++ b/examples/others/rlgl_standalone.c
@@ -281,7 +281,7 @@ static void KeyCallback(GLFWwindow *window, int key, int scancode, int action, i
 // Draw rectangle using rlgl OpenGL 1.1 style coding (translated to OpenGL 3.3 internally)
 static void DrawRectangleV(Vector2 position, Vector2 size, Color color)
 {
-    rlBegin(RL_TRIANGLES);
+    rlStartBatch(RL_TRIANGLES, rlGetTextureIdDefault());
         rlColor4ub(color.r, color.g, color.b, color.a);
 
         rlVertex2f(position.x, position.y);
@@ -299,7 +299,7 @@ static void DrawGrid(int slices, float spacing)
 {
     int halfSlices = slices / 2;
 
-    rlBegin(RL_LINES);
+    rlStartBatch(RL_LINES, rlGetTextureIdDefault());
         for (int i = -halfSlices; i <= halfSlices; i++)
         {
             if (i == 0)
@@ -341,7 +341,7 @@ static void DrawCube(Vector3 position, float width, float height, float length, 
         //rlScalef(2.0f, 2.0f, 2.0f);
         //rlRotatef(45, 0, 1, 0);
 
-        rlBegin(RL_TRIANGLES);
+        rlStartBatch(RL_TRIANGLES, rlGetTextureIdDefault());
             rlColor4ub(color.r, color.g, color.b, color.a);
 
             // Front Face -----------------------------------------------------
@@ -413,7 +413,7 @@ static void DrawCubeWires(Vector3 position, float width, float height, float len
         rlTranslatef(position.x, position.y, position.z);
         //rlRotatef(45, 0, 1, 0);
 
-        rlBegin(RL_LINES);
+        rlStartBatch(RL_LINES, rlGetTextureIdDefault());
             rlColor4ub(color.r, color.g, color.b, color.a);
 
             // Front Face -----------------------------------------------------

--- a/examples/shapes/shapes_rectangle_advanced.c
+++ b/examples/shapes/shapes_rectangle_advanced.c
@@ -143,10 +143,10 @@ static void DrawRectangleRoundedGradientH(Rectangle rec, float roundnessLeft, fl
     const float angles[4] = { 180.0f, 270.0f, 0.0f, 90.0f };
 
 #if defined(SUPPORT_QUADS_DRAW_MODE)
-    rlSetTexture(GetShapesTexture().id);
+    Texture texShapes = GetShapesTexture();
     Rectangle shapeRect = GetShapesTextureRectangle();
 
-    rlBegin(RL_QUADS);
+    rlStartBatch(RL_QUADS, texShapes.id);
         // Draw all the 4 corners: [1] Upper Left Corner, [3] Upper Right Corner, [5] Lower Right Corner, [7] Lower Left Corner
         for (int k = 0; k < 4; ++k)
         {
@@ -262,7 +262,7 @@ static void DrawRectangleRoundedGradientH(Rectangle rec, float roundnessLeft, fl
         rlVertex2f(point[9].x, point[9].y);
 
     rlEnd();
-    rlSetTexture(0);
+    rlEndBatch();
 #else
 
     // Here we use the 'Diagram' to guide ourselves to which point receives what color.
@@ -270,7 +270,7 @@ static void DrawRectangleRoundedGradientH(Rectangle rec, float roundnessLeft, fl
     // will naturally come from OpenGL interpolation.
     // But this time instead of Quad, we think in triangles.
 
-    rlBegin(RL_TRIANGLES);
+    rlStartBatch(RL_TRIANGLES, rlGetTextureIdDefault());
         // Draw all of the 4 corners: [1] Upper Left Corner, [3] Upper Right Corner, [5] Lower Right Corner, [7] Lower Left Corner
         for (int k = 0; k < 4; ++k)
         {

--- a/examples/text/text_draw_3d.c
+++ b/examples/text/text_draw_3d.c
@@ -488,12 +488,11 @@ static void DrawTextCodepoint3D(Font font, int codepoint, Vector3 position, floa
         if (SHOW_LETTER_BOUNDRY) DrawCubeWiresV((Vector3){ position.x + width/2, position.y, position.z + height/2}, (Vector3){ width, LETTER_BOUNDRY_SIZE, height }, LETTER_BOUNDRY_COLOR);
 
         rlCheckRenderBatchLimit(4 + 4*backface);
-        rlSetTexture(font.texture.id);
 
         rlPushMatrix();
             rlTranslatef(position.x, position.y, position.z);
 
-            rlBegin(RL_QUADS);
+            rlStartBatch(RL_QUADS, font.texture.id);
                 rlColor4ub(tint.r, tint.g, tint.b, tint.a);
 
                 // Front Face
@@ -515,7 +514,7 @@ static void DrawTextCodepoint3D(Font font, int codepoint, Vector3 position, floa
             rlEnd();
         rlPopMatrix();
 
-        rlSetTexture(0);
+        rlEndBatch();
     }
 }
 

--- a/examples/textures/textures_polygon.c
+++ b/examples/textures/textures_polygon.c
@@ -115,10 +115,8 @@ int main(void)
 // without crossing perimeter, points must be in anticlockwise order
 void DrawTexturePoly(Texture2D texture, Vector2 center, Vector2 *points, Vector2 *texcoords, int pointCount, Color tint)
 {
-    rlBegin(RL_TRIANGLES);
+    rlStartBatch(RL_TRIANGLES, texture.id);
     
-    rlSetTexture(texture.id);
-
         rlColor4ub(tint.r, tint.g, tint.b, tint.a);
 
         for (int i = 0; i < pointCount - 1; i++)
@@ -134,5 +132,5 @@ void DrawTexturePoly(Texture2D texture, Vector2 center, Vector2 *points, Vector2
         }
     rlEnd();
 
-    rlSetTexture(0);
+    rlEndBatch();
 }

--- a/examples/textures/textures_textured_curve.c
+++ b/examples/textures/textures_textured_curve.c
@@ -208,8 +208,7 @@ static void DrawTexturedCurve(void)
         Vector2 currentNegNormal = Vector2Add(current, Vector2Scale(normal, -curveWidth));
 
         // Draw the segment as a quad
-        rlSetTexture(texRoad.id);
-        rlBegin(RL_QUADS);
+        rlStartBatch(RL_QUADS, texRoad.id);
             rlColor4ub(255,255,255,255);
             rlNormal3f(0.0f, 0.0f, 1.0f);
 

--- a/src/rmodels.c
+++ b/src/rmodels.c
@@ -175,7 +175,7 @@ static void ProcessMaterialsOBJ(Material *rayMaterials, tinyobj_material_t *mate
 // Draw a line in 3D world space
 void DrawLine3D(Vector3 startPos, Vector3 endPos, Color color)
 {
-    rlBegin(RL_LINES);
+    rlStartBatch(RL_LINES, rlGetTextureIdDefault());
         rlColor4ub(color.r, color.g, color.b, color.a);
         rlVertex3f(startPos.x, startPos.y, startPos.z);
         rlVertex3f(endPos.x, endPos.y, endPos.z);
@@ -188,7 +188,7 @@ void DrawPoint3D(Vector3 position, Color color)
 {
     rlPushMatrix();
         rlTranslatef(position.x, position.y, position.z);
-        rlBegin(RL_LINES);
+        rlStartBatch(RL_LINES, rlGetTextureIdDefault());
             rlColor4ub(color.r, color.g, color.b, color.a);
             rlVertex3f(0.0f, 0.0f, 0.0f);
             rlVertex3f(0.0f, 0.0f, 0.1f);
@@ -203,7 +203,7 @@ void DrawCircle3D(Vector3 center, float radius, Vector3 rotationAxis, float rota
         rlTranslatef(center.x, center.y, center.z);
         rlRotatef(rotationAngle, rotationAxis.x, rotationAxis.y, rotationAxis.z);
 
-        rlBegin(RL_LINES);
+        rlStartBatch(RL_LINES, rlGetTextureIdDefault());
             for (int i = 0; i < 360; i += 10)
             {
                 rlColor4ub(color.r, color.g, color.b, color.a);
@@ -218,7 +218,7 @@ void DrawCircle3D(Vector3 center, float radius, Vector3 rotationAxis, float rota
 // Draw a color-filled triangle (vertex in counter-clockwise order!)
 void DrawTriangle3D(Vector3 v1, Vector3 v2, Vector3 v3, Color color)
 {
-    rlBegin(RL_TRIANGLES);
+    rlStartBatch(RL_TRIANGLES, rlGetTextureIdDefault());
         rlColor4ub(color.r, color.g, color.b, color.a);
         rlVertex3f(v1.x, v1.y, v1.z);
         rlVertex3f(v2.x, v2.y, v2.z);
@@ -231,7 +231,7 @@ void DrawTriangleStrip3D(const Vector3 *points, int pointCount, Color color)
 {
     if (pointCount < 3) return; // Security check
 
-    rlBegin(RL_TRIANGLES);
+    rlStartBatch(RL_TRIANGLES, rlGetTextureIdDefault());
         rlColor4ub(color.r, color.g, color.b, color.a);
 
         for (int i = 2; i < pointCount; i++)
@@ -266,7 +266,7 @@ void DrawCube(Vector3 position, float width, float height, float length, Color c
         //rlRotatef(45, 0, 1, 0);
         //rlScalef(1.0f, 1.0f, 1.0f);   // NOTE: Vertices are directly scaled on definition
 
-        rlBegin(RL_TRIANGLES);
+        rlStartBatch(RL_TRIANGLES, rlGetTextureIdDefault());
             rlColor4ub(color.r, color.g, color.b, color.a);
 
             // Front face
@@ -348,7 +348,7 @@ void DrawCubeWires(Vector3 position, float width, float height, float length, Co
     rlPushMatrix();
         rlTranslatef(position.x, position.y, position.z);
 
-        rlBegin(RL_LINES);
+        rlStartBatch(RL_LINES, rlGetTextureIdDefault());
             rlColor4ub(color.r, color.g, color.b, color.a);
 
             // Front face
@@ -435,7 +435,7 @@ void DrawSphereEx(Vector3 centerPos, float radius, int rings, int slices, Color 
         rlTranslatef(centerPos.x, centerPos.y, centerPos.z);
         rlScalef(radius, radius, radius);
 
-        rlBegin(RL_TRIANGLES);
+        rlStart(RL_TRIANGLES, rlGetTextureIdDefault());
             rlColor4ub(color.r, color.g, color.b, color.a);
 
             for (int i = 0; i < (rings + 2); i++)
@@ -472,7 +472,7 @@ void DrawSphereEx(Vector3 centerPos, float radius, int rings, int slices, Color 
         rlTranslatef(centerPos.x, centerPos.y, centerPos.z);
         rlScalef(radius, radius, radius);
 
-        rlBegin(RL_TRIANGLES);
+        rlStartBatch(RL_TRIANGLES, rlGetTextureIdDefault());
             rlColor4ub(color.r, color.g, color.b, color.a);
 
             float ringangle = DEG2RAD*(180.0f/(rings + 1)); // Angle between latitudinal parallels
@@ -520,7 +520,7 @@ void DrawSphereWires(Vector3 centerPos, float radius, int rings, int slices, Col
         rlTranslatef(centerPos.x, centerPos.y, centerPos.z);
         rlScalef(radius, radius, radius);
 
-        rlBegin(RL_LINES);
+        rlStartBatch(RL_LINES, rlGetTextureIdDefault());
             rlColor4ub(color.r, color.g, color.b, color.a);
 
             for (int i = 0; i < (rings + 2); i++)
@@ -564,7 +564,7 @@ void DrawCylinder(Vector3 position, float radiusTop, float radiusBottom, float h
     rlPushMatrix();
         rlTranslatef(position.x, position.y, position.z);
 
-        rlBegin(RL_TRIANGLES);
+        rlStartBatch(RL_TRIANGLES, rlGetTextureIdDefault());
             rlColor4ub(color.r, color.g, color.b, color.a);
 
             if (radiusTop > 0)
@@ -627,7 +627,7 @@ void DrawCylinderEx(Vector3 startPos, Vector3 endPos, float startRadius, float e
 
     float baseAngle = (2.0f*PI)/sides;
 
-    rlBegin(RL_TRIANGLES);
+    rlStartBatch(RL_TRIANGLES, rlGetTextureIdDefault());
         rlColor4ub(color.r, color.g, color.b, color.a);
 
         for (int i = 0; i < sides; i++)
@@ -682,7 +682,7 @@ void DrawCylinderWires(Vector3 position, float radiusTop, float radiusBottom, fl
     rlPushMatrix();
         rlTranslatef(position.x, position.y, position.z);
 
-        rlBegin(RL_LINES);
+        rlStartBatch(RL_LINES, rlGetTextureIdDefault());
             rlColor4ub(color.r, color.g, color.b, color.a);
 
             for (int i = 0; i < sides; i++)
@@ -718,7 +718,7 @@ void DrawCylinderWiresEx(Vector3 startPos, Vector3 endPos, float startRadius, fl
 
     float baseAngle = (2.0f*PI)/sides;
 
-    rlBegin(RL_LINES);
+    rlStartBatch(RL_LINES, rlGetTextureIdDefault());
         rlColor4ub(color.r, color.g, color.b, color.a);
 
         for (int i = 0; i < sides; i++)
@@ -769,7 +769,7 @@ void DrawCapsule(Vector3 startPos, Vector3 endPos, float radius, int slices, int
     float baseSliceAngle = (2.0f*PI)/slices;
     float baseRingAngle  = PI*0.5f/rings;
 
-    rlBegin(RL_TRIANGLES);
+    rlStartBatch(RL_TRIANGLES, rlGetTextureIdDefault());
         rlColor4ub(color.r, color.g, color.b, color.a);
 
         // render both caps
@@ -912,7 +912,7 @@ void DrawCapsuleWires(Vector3 startPos, Vector3 endPos, float radius, int slices
     float baseSliceAngle = (2.0f*PI)/slices;
     float baseRingAngle  = PI*0.5f/rings;
 
-    rlBegin(RL_LINES);
+    rlStartBatch(RL_LINES, rlGetTextureIdDefault());
         rlColor4ub(color.r, color.g, color.b, color.a);
 
         // render both caps
@@ -1035,7 +1035,7 @@ void DrawPlane(Vector3 centerPos, Vector2 size, Color color)
         rlTranslatef(centerPos.x, centerPos.y, centerPos.z);
         rlScalef(size.x, 1.0f, size.y);
 
-        rlBegin(RL_QUADS);
+        rlStartBatch(RL_QUADS, rlGetTextureIdDefault());
             rlColor4ub(color.r, color.g, color.b, color.a);
             rlNormal3f(0.0f, 1.0f, 0.0f);
 
@@ -1052,7 +1052,7 @@ void DrawRay(Ray ray, Color color)
 {
     float scale = 10000;
 
-    rlBegin(RL_LINES);
+    rlStartBatch(RL_LINES, rlGetTextureIdDefault());
         rlColor4ub(color.r, color.g, color.b, color.a);
         rlColor4ub(color.r, color.g, color.b, color.a);
 
@@ -1066,7 +1066,7 @@ void DrawGrid(int slices, float spacing)
 {
     int halfSlices = slices/2;
 
-    rlBegin(RL_LINES);
+    rlStartBatch(RL_LINES, rlGetTextureIdDefault());
         for (int i = -halfSlices; i <= halfSlices; i++)
         {
             if (i == 0)
@@ -3874,8 +3874,7 @@ void DrawBillboardPro(Camera camera, Texture2D texture, Rectangle source, Vector
     texcoords[2] = (Vector2){ (float)(source.x + source.width)/texture.width, (float)source.y/texture.height };
     texcoords[3] = (Vector2){ (float)source.x/texture.width, (float)source.y/texture.height };
 
-    rlSetTexture(texture.id);
-    rlBegin(RL_QUADS);
+    rlStartBatch(RL_QUADS, texture.id);
 
         rlColor4ub(tint.r, tint.g, tint.b, tint.a);
         for (int i = 0; i < 4; i++)
@@ -3885,7 +3884,7 @@ void DrawBillboardPro(Camera camera, Texture2D texture, Rectangle source, Vector
         }
 
     rlEnd();
-    rlSetTexture(0);
+    rlEndBatch();
 }
 
 // Draw a bounding box with wires

--- a/src/rshapes.c
+++ b/src/rshapes.c
@@ -133,10 +133,9 @@ void DrawPixel(int posX, int posY, Color color)
 void DrawPixelV(Vector2 position, Color color)
 {
 #if defined(SUPPORT_QUADS_DRAW_MODE)
-    rlSetTexture(GetShapesTexture().id);
     Rectangle shapeRect = GetShapesTextureRectangle();
 
-    rlBegin(RL_QUADS);
+    rlStartBatch(RL_QUADS, GetShapesTexture().id);
 
         rlNormal3f(0.0f, 0.0f, 1.0f);
         rlColor4ub(color.r, color.g, color.b, color.a);
@@ -155,9 +154,9 @@ void DrawPixelV(Vector2 position, Color color)
 
     rlEnd();
 
-    rlSetTexture(0);
+    rlEndBatch();
 #else
-    rlBegin(RL_TRIANGLES);
+    rlStart(RL_TRIANGLES, rlGetTextureIdDefault());
 
         rlColor4ub(color.r, color.g, color.b, color.a);
 
@@ -176,7 +175,7 @@ void DrawPixelV(Vector2 position, Color color)
 // Draw a line (using gl lines)
 void DrawLine(int startPosX, int startPosY, int endPosX, int endPosY, Color color)
 {
-    rlBegin(RL_LINES);
+    rlStartBatch(RL_LINES, rlGetTextureIdDefault());
         rlColor4ub(color.r, color.g, color.b, color.a);
         rlVertex2f((float)startPosX, (float)startPosY);
         rlVertex2f((float)endPosX, (float)endPosY);
@@ -186,7 +185,7 @@ void DrawLine(int startPosX, int startPosY, int endPosX, int endPosY, Color colo
 // Draw a line (using gl lines)
 void DrawLineV(Vector2 startPos, Vector2 endPos, Color color)
 {
-    rlBegin(RL_LINES);
+    rlStartBatch(RL_LINES, rlGetTextureIdDefault());
         rlColor4ub(color.r, color.g, color.b, color.a);
         rlVertex2f(startPos.x, startPos.y);
         rlVertex2f(endPos.x, endPos.y);
@@ -198,7 +197,7 @@ void DrawLineStrip(const Vector2 *points, int pointCount, Color color)
 {
     if (pointCount < 2) return; // Security check
 
-    rlBegin(RL_LINES);
+    rlStartBatch(RL_LINES, rlGetTextureIdDefault());
         rlColor4ub(color.r, color.g, color.b, color.a);
 
         for (int i = 0; i < pointCount - 1; i++)
@@ -312,10 +311,9 @@ void DrawCircleSector(Vector2 center, float radius, float startAngle, float endA
     float angle = startAngle;
 
 #if defined(SUPPORT_QUADS_DRAW_MODE)
-    rlSetTexture(GetShapesTexture().id);
     Rectangle shapeRect = GetShapesTextureRectangle();
 
-    rlBegin(RL_QUADS);
+    rlStartBatch(RL_QUADS, GetShapesTexture().id);
 
         // NOTE: Every QUAD actually represents two segments
         for (int i = 0; i < segments/2; i++)
@@ -357,9 +355,9 @@ void DrawCircleSector(Vector2 center, float radius, float startAngle, float endA
 
     rlEnd();
 
-    rlSetTexture(0);
+    rlEndBatch();
 #else
-    rlBegin(RL_TRIANGLES);
+    rlStart(RL_TRIANGLES, rlGetTextureIdDefault());
         for (int i = 0; i < segments; i++)
         {
             rlColor4ub(color.r, color.g, color.b, color.a);
@@ -404,7 +402,7 @@ void DrawCircleSectorLines(Vector2 center, float radius, float startAngle, float
     float angle = startAngle;
     bool showCapLines = true;
 
-    rlBegin(RL_LINES);
+    rlStartBatch(RL_LINES, rlGetTextureIdDefault());
         if (showCapLines)
         {
             rlColor4ub(color.r, color.g, color.b, color.a);
@@ -434,7 +432,7 @@ void DrawCircleSectorLines(Vector2 center, float radius, float startAngle, float
 // Draw a gradient-filled circle
 void DrawCircleGradient(int centerX, int centerY, float radius, Color inner, Color outer)
 {
-    rlBegin(RL_TRIANGLES);
+    rlStartBatch(RL_TRIANGLES, rlGetTextureIdDefault());
         for (int i = 0; i < 360; i += 10)
         {
             rlColor4ub(inner.r, inner.g, inner.b, inner.a);
@@ -456,7 +454,7 @@ void DrawCircleLines(int centerX, int centerY, float radius, Color color)
 // Draw circle outline (Vector version)
 void DrawCircleLinesV(Vector2 center, float radius, Color color)
 {
-    rlBegin(RL_LINES);
+    rlStartBatch(RL_LINES, rlGetTextureIdDefault());
         rlColor4ub(color.r, color.g, color.b, color.a);
 
         // NOTE: Circle outline is drawn pixel by pixel every degree (0 to 360)
@@ -471,7 +469,7 @@ void DrawCircleLinesV(Vector2 center, float radius, Color color)
 // Draw ellipse
 void DrawEllipse(int centerX, int centerY, float radiusH, float radiusV, Color color)
 {
-    rlBegin(RL_TRIANGLES);
+    rlStartBatch(RL_TRIANGLES, rlGetTextureIdDefault());
         for (int i = 0; i < 360; i += 10)
         {
             rlColor4ub(color.r, color.g, color.b, color.a);
@@ -485,7 +483,7 @@ void DrawEllipse(int centerX, int centerY, float radiusH, float radiusV, Color c
 // Draw ellipse outline
 void DrawEllipseLines(int centerX, int centerY, float radiusH, float radiusV, Color color)
 {
-    rlBegin(RL_LINES);
+    rlStartBatch(RL_LINES, rlGetTextureIdDefault());
         for (int i = 0; i < 360; i += 10)
         {
             rlColor4ub(color.r, color.g, color.b, color.a);
@@ -541,10 +539,9 @@ void DrawRing(Vector2 center, float innerRadius, float outerRadius, float startA
     float angle = startAngle;
 
 #if defined(SUPPORT_QUADS_DRAW_MODE)
-    rlSetTexture(GetShapesTexture().id);
     Rectangle shapeRect = GetShapesTextureRectangle();
 
-    rlBegin(RL_QUADS);
+    rlStartBatch(RL_QUADS, GetShapesTexture().id);
         for (int i = 0; i < segments; i++)
         {
             rlColor4ub(color.r, color.g, color.b, color.a);
@@ -565,9 +562,9 @@ void DrawRing(Vector2 center, float innerRadius, float outerRadius, float startA
         }
     rlEnd();
 
-    rlSetTexture(0);
+    rlEndBatch();
 #else
-    rlBegin(RL_TRIANGLES);
+    rlStart(RL_TRIANGLES, rlGetTextureIdDefault());
         for (int i = 0; i < segments; i++)
         {
             rlColor4ub(color.r, color.g, color.b, color.a);
@@ -631,7 +628,7 @@ void DrawRingLines(Vector2 center, float innerRadius, float outerRadius, float s
     float angle = startAngle;
     bool showCapLines = true;
 
-    rlBegin(RL_LINES);
+    rlStartBatch(RL_LINES, rlGetTextureIdDefault());
         if (showCapLines)
         {
             rlColor4ub(color.r, color.g, color.b, color.a);
@@ -721,10 +718,9 @@ void DrawRectanglePro(Rectangle rec, Vector2 origin, float rotation, Color color
     }
 
 #if defined(SUPPORT_QUADS_DRAW_MODE)
-    rlSetTexture(GetShapesTexture().id);
     Rectangle shapeRect = GetShapesTextureRectangle();
 
-    rlBegin(RL_QUADS);
+    rlStartBatch(RL_QUADS, GetShapesTexture().id);
 
         rlNormal3f(0.0f, 0.0f, 1.0f);
         rlColor4ub(color.r, color.g, color.b, color.a);
@@ -743,9 +739,9 @@ void DrawRectanglePro(Rectangle rec, Vector2 origin, float rotation, Color color
 
     rlEnd();
 
-    rlSetTexture(0);
+    rlEndBatch();
 #else
-    rlBegin(RL_TRIANGLES);
+    rlStart(RL_TRIANGLES, rlGetTextureIdDefault());
 
         rlColor4ub(color.r, color.g, color.b, color.a);
 
@@ -776,10 +772,9 @@ void DrawRectangleGradientH(int posX, int posY, int width, int height, Color lef
 // Draw a gradient-filled rectangle
 void DrawRectangleGradientEx(Rectangle rec, Color topLeft, Color bottomLeft, Color topRight, Color bottomRight)
 {
-    rlSetTexture(GetShapesTexture().id);
     Rectangle shapeRect = GetShapesTextureRectangle();
 
-    rlBegin(RL_QUADS);
+    rlStartBatch(RL_QUADS, GetShapesTexture().id);
         rlNormal3f(0.0f, 0.0f, 1.0f);
 
         // NOTE: Default raylib font character 95 is a white square
@@ -800,7 +795,7 @@ void DrawRectangleGradientEx(Rectangle rec, Color topLeft, Color bottomLeft, Col
         rlVertex2f(rec.x + rec.width, rec.y);
     rlEnd();
 
-    rlSetTexture(0);
+    rlEndBatch();
 }
 
 // Draw rectangle outline
@@ -813,7 +808,7 @@ void DrawRectangleLines(int posX, int posY, int width, int height, Color color)
     float xOffset = 0.5f/mat.m0;
     float yOffset = 0.5f/mat.m5;
 
-    rlBegin(RL_LINES);
+    rlStartBatch(RL_LINES, rlGetTextureIdDefault());
         rlColor4ub(color.r, color.g, color.b, color.a);
         rlVertex2f((float)posX + xOffset, (float)posY + yOffset);
         rlVertex2f((float)posX + (float)width - xOffset, (float)posY + yOffset);
@@ -836,7 +831,7 @@ void DrawRectangleLines(int posX, int posY, int width, int height, Color color)
     DrawRectangle(posX, posY + height - 1, width, 1, color);
     DrawRectangle(posX, posY + 1, 1, height - 2, color);
 #else
-    rlBegin(RL_LINES);
+    rlStart(RL_LINES, rlGetTextureIdDefault());
         rlColor4ub(color.r, color.g, color.b, color.a);
         rlVertex2f((float)posX, (float)posY);
         rlVertex2f((float)posX + (float)width, (float)posY + 1);
@@ -941,10 +936,9 @@ void DrawRectangleRounded(Rectangle rec, float roundness, int segments, Color co
     const float angles[4] = { 180.0f, 270.0f, 0.0f, 90.0f };
 
 #if defined(SUPPORT_QUADS_DRAW_MODE)
-    rlSetTexture(GetShapesTexture().id);
     Rectangle shapeRect = GetShapesTextureRectangle();
 
-    rlBegin(RL_QUADS);
+    rlStartBatch(RL_QUADS, GetShapesTexture().id);
         // Draw all the 4 corners: [1] Upper Left Corner, [3] Upper Right Corner, [5] Lower Right Corner, [7] Lower Left Corner
         for (int k = 0; k < 4; ++k) // Hope the compiler is smart enough to unroll this loop
         {
@@ -1044,9 +1038,9 @@ void DrawRectangleRounded(Rectangle rec, float roundness, int segments, Color co
         rlVertex2f(point[9].x, point[9].y);
 
     rlEnd();
-    rlSetTexture(0);
+    rlEndBatch();
 #else
-    rlBegin(RL_TRIANGLES);
+    rlStart(RL_TRIANGLES, rlGetTextureIdDefault());
 
         // Draw all of the 4 corners: [1] Upper Left Corner, [3] Upper Right Corner, [5] Lower Right Corner, [7] Lower Left Corner
         for (int k = 0; k < 4; ++k) // Hope the compiler is smart enough to unroll this loop
@@ -1195,10 +1189,9 @@ void DrawRectangleRoundedLinesEx(Rectangle rec, float roundness, int segments, f
     if (lineThick > 1)
     {
 #if defined(SUPPORT_QUADS_DRAW_MODE)
-        rlSetTexture(GetShapesTexture().id);
         Rectangle shapeRect = GetShapesTextureRectangle();
 
-        rlBegin(RL_QUADS);
+        rlStartBatch(RL_QUADS, GetShapesTexture().id);
 
             // Draw all the 4 corners first: Upper Left Corner, Upper Right Corner, Lower Right Corner, Lower Left Corner
             for (int k = 0; k < 4; ++k) // Hope the compiler is smart enough to unroll this loop
@@ -1270,9 +1263,9 @@ void DrawRectangleRoundedLinesEx(Rectangle rec, float roundness, int segments, f
             rlVertex2f(point[14].x, point[14].y);
 
         rlEnd();
-        rlSetTexture(0);
+        rlEndBatch();
 #else
-        rlBegin(RL_TRIANGLES);
+        rlStart(RL_TRIANGLES, rlGetTextureIdDefault());
 
             // Draw all of the 4 corners first: Upper Left Corner, Upper Right Corner, Lower Right Corner, Lower Left Corner
             for (int k = 0; k < 4; ++k) // Hope the compiler is smart enough to unroll this loop
@@ -1337,7 +1330,7 @@ void DrawRectangleRoundedLinesEx(Rectangle rec, float roundness, int segments, f
     else
     {
         // Use LINES to draw the outline
-        rlBegin(RL_LINES);
+        rlStartBatch(RL_LINES, rlGetTextureIdDefault());
 
             // Draw all the 4 corners first: Upper Left Corner, Upper Right Corner, Lower Right Corner, Lower Left Corner
             for (int k = 0; k < 4; ++k) // Hope the compiler is smart enough to unroll this loop
@@ -1371,10 +1364,9 @@ void DrawRectangleRoundedLinesEx(Rectangle rec, float roundness, int segments, f
 void DrawTriangle(Vector2 v1, Vector2 v2, Vector2 v3, Color color)
 {
 #if defined(SUPPORT_QUADS_DRAW_MODE)
-    rlSetTexture(GetShapesTexture().id);
     Rectangle shapeRect = GetShapesTextureRectangle();
 
-    rlBegin(RL_QUADS);
+    rlStartBatch(RL_QUADS, GetShapesTexture().id);
         rlColor4ub(color.r, color.g, color.b, color.a);
 
         rlTexCoord2f(shapeRect.x/texShapes.width, shapeRect.y/texShapes.height);
@@ -1390,9 +1382,9 @@ void DrawTriangle(Vector2 v1, Vector2 v2, Vector2 v3, Color color)
         rlVertex2f(v3.x, v3.y);
     rlEnd();
 
-    rlSetTexture(0);
+    rlEndBatch();
 #else
-    rlBegin(RL_TRIANGLES);
+    rlStart(RL_TRIANGLES, rlGetTextureIdDefault());
         rlColor4ub(color.r, color.g, color.b, color.a);
         rlVertex2f(v1.x, v1.y);
         rlVertex2f(v2.x, v2.y);
@@ -1405,7 +1397,7 @@ void DrawTriangle(Vector2 v1, Vector2 v2, Vector2 v3, Color color)
 // NOTE: Vertex must be provided in counter-clockwise order
 void DrawTriangleLines(Vector2 v1, Vector2 v2, Vector2 v3, Color color)
 {
-    rlBegin(RL_LINES);
+    rlStartBatch(RL_LINES, rlGetTextureIdDefault());
         rlColor4ub(color.r, color.g, color.b, color.a);
         rlVertex2f(v1.x, v1.y);
         rlVertex2f(v2.x, v2.y);
@@ -1425,10 +1417,9 @@ void DrawTriangleFan(const Vector2 *points, int pointCount, Color color)
 {
     if (pointCount >= 3)
     {
-        rlSetTexture(GetShapesTexture().id);
         Rectangle shapeRect = GetShapesTextureRectangle();
 
-        rlBegin(RL_QUADS);
+        rlStartBatch(RL_QUADS, GetShapesTexture().id);
             rlColor4ub(color.r, color.g, color.b, color.a);
 
             for (int i = 1; i < pointCount - 1; i++)
@@ -1446,7 +1437,7 @@ void DrawTriangleFan(const Vector2 *points, int pointCount, Color color)
                 rlVertex2f(points[i + 1].x, points[i + 1].y);
             }
         rlEnd();
-        rlSetTexture(0);
+        rlEndBatch();
     }
 }
 
@@ -1456,7 +1447,7 @@ void DrawTriangleStrip(const Vector2 *points, int pointCount, Color color)
 {
     if (pointCount >= 3)
     {
-        rlBegin(RL_TRIANGLES);
+        rlStartBatch(RL_TRIANGLES, rlGetTextureIdDefault());
             rlColor4ub(color.r, color.g, color.b, color.a);
 
             for (int i = 2; i < pointCount; i++)
@@ -1486,10 +1477,9 @@ void DrawPoly(Vector2 center, int sides, float radius, float rotation, Color col
     float angleStep = 360.0f/(float)sides*DEG2RAD;
 
 #if defined(SUPPORT_QUADS_DRAW_MODE)
-    rlSetTexture(GetShapesTexture().id);
     Rectangle shapeRect = GetShapesTextureRectangle();
 
-    rlBegin(RL_QUADS);
+    rlStartBatch(RL_QUADS, GetShapesTexture().id);
         for (int i = 0; i < sides; i++)
         {
             rlColor4ub(color.r, color.g, color.b, color.a);
@@ -1510,9 +1500,9 @@ void DrawPoly(Vector2 center, int sides, float radius, float rotation, Color col
             centralAngle = nextAngle;
         }
     rlEnd();
-    rlSetTexture(0);
+    rlEndBatch();
 #else
-    rlBegin(RL_TRIANGLES);
+    rlStart(RL_TRIANGLES, rlGetTextureIdDefault());
         for (int i = 0; i < sides; i++)
         {
             rlColor4ub(color.r, color.g, color.b, color.a);
@@ -1534,7 +1524,7 @@ void DrawPolyLines(Vector2 center, int sides, float radius, float rotation, Colo
     float centralAngle = rotation*DEG2RAD;
     float angleStep = 360.0f/(float)sides*DEG2RAD;
 
-    rlBegin(RL_LINES);
+    rlStartBatch(RL_LINES, rlGetTextureIdDefault());
         for (int i = 0; i < sides; i++)
         {
             rlColor4ub(color.r, color.g, color.b, color.a);
@@ -1555,10 +1545,9 @@ void DrawPolyLinesEx(Vector2 center, int sides, float radius, float rotation, fl
     float innerRadius = radius - (lineThick*cosf(DEG2RAD*exteriorAngle/2.0f));
 
 #if defined(SUPPORT_QUADS_DRAW_MODE)
-    rlSetTexture(GetShapesTexture().id);
     Rectangle shapeRect = GetShapesTextureRectangle();
 
-    rlBegin(RL_QUADS);
+    rlStartBatch(RL_QUADS, GetShapesTexture().id);
         for (int i = 0; i < sides; i++)
         {
             rlColor4ub(color.r, color.g, color.b, color.a);
@@ -1579,9 +1568,9 @@ void DrawPolyLinesEx(Vector2 center, int sides, float radius, float rotation, fl
             centralAngle = nextAngle;
         }
     rlEnd();
-    rlSetTexture(0);
+    rlEndBatch();
 #else
-    rlBegin(RL_TRIANGLES);
+    rlStart(RL_TRIANGLES, rlGetTextureIdDefault());
         for (int i = 0; i < sides; i++)
         {
             rlColor4ub(color.r, color.g, color.b, color.a);

--- a/src/rtextures.c
+++ b/src/rtextures.c
@@ -4546,8 +4546,7 @@ void DrawTexturePro(Texture2D texture, Rectangle source, Rectangle dest, Vector2
             bottomRight.y = y + (dx + dest.width)*sinRotation + (dy + dest.height)*cosRotation;
         }
 
-        rlSetTexture(texture.id);
-        rlBegin(RL_QUADS);
+        rlStartBatch(RL_QUADS, texture.id);
 
             rlColor4ub(tint.r, tint.g, tint.b, tint.a);
             rlNormal3f(0.0f, 0.0f, 1.0f);                          // Normal vector pointing towards viewer
@@ -4573,7 +4572,7 @@ void DrawTexturePro(Texture2D texture, Rectangle source, Rectangle dest, Vector2
             rlVertex2f(topRight.x, topRight.y);
 
         rlEnd();
-        rlSetTexture(0);
+        rlEndBatch();
 
         // NOTE: Vertex position can be transformed using matrices
         // but the process is way more costly than just calculating
@@ -4581,13 +4580,12 @@ void DrawTexturePro(Texture2D texture, Rectangle source, Rectangle dest, Vector2
         // I leave here the old implementation for educational purposes,
         // just in case someone wants to do some performance test
         /*
-        rlSetTexture(texture.id);
         rlPushMatrix();
             rlTranslatef(dest.x, dest.y, 0.0f);
             if (rotation != 0.0f) rlRotatef(rotation, 0.0f, 0.0f, 1.0f);
             rlTranslatef(-origin.x, -origin.y, 0.0f);
 
-            rlBegin(RL_QUADS);
+            rlStart(RL_QUADS, texture.id);
                 rlColor4ub(tint.r, tint.g, tint.b, tint.a);
                 rlNormal3f(0.0f, 0.0f, 1.0f);                          // Normal vector pointing towards viewer
 
@@ -4612,7 +4610,7 @@ void DrawTexturePro(Texture2D texture, Rectangle source, Rectangle dest, Vector2
                 rlVertex2f(dest.width, 0.0f);
             rlEnd();
         rlPopMatrix();
-        rlSetTexture(0);
+        rlEndBatch();
         */
     }
 }
@@ -4676,14 +4674,12 @@ void DrawTextureNPatch(Texture2D texture, NPatchInfo nPatchInfo, Rectangle dest,
         coordD.x = (nPatchInfo.source.x + nPatchInfo.source.width)/width;
         coordD.y = (nPatchInfo.source.y + nPatchInfo.source.height)/height;
 
-        rlSetTexture(texture.id);
-
         rlPushMatrix();
             rlTranslatef(dest.x, dest.y, 0.0f);
             rlRotatef(rotation, 0.0f, 0.0f, 1.0f);
             rlTranslatef(-origin.x, -origin.y, 0.0f);
 
-            rlBegin(RL_QUADS);
+            rlStartBatch(RL_QUADS, texture.id);
                 rlColor4ub(tint.r, tint.g, tint.b, tint.a);
                 rlNormal3f(0.0f, 0.0f, 1.0f);               // Normal vector pointing towards viewer
 
@@ -4810,7 +4806,7 @@ void DrawTextureNPatch(Texture2D texture, NPatchInfo nPatchInfo, Rectangle dest,
             rlEnd();
         rlPopMatrix();
 
-        rlSetTexture(0);
+        rlEndBatch();
     }
 }
 


### PR DESCRIPTION
I was thinking about #4878 , in the solution I had to call `rlSetTexture` before _every_ `rlBegin`, therefore I though that they should merge into one call and avoid problems in the future, so I created `rlStartBatch`.  
I think that if I use `rlBegin` I would forget `rlSetTexture`, that's why I created `rlStartBatch`, so I don't forget to set both _mode_ and _textureId_.  
`rlEndBatch` only exists because sometimes there are calls to `rlSetTexture(0)` (maybe merge with `rlEnd()`?).  
   
I tested bunnymark in RenderDoc, it looks fine (60 fps with max objects).  
  
So, two options  
1. PR #4878 , and tell users to **always** call `rlSetTexture/rlBegin` together
2. this PR, tell users to call `rlStartBatch` and maybe deprecate `rlSetTexture/rlBegin` in the future...  
