### PR TITLE
[rlgl] Proposed fix for default near/far clipping range

### DIFF
--- a/src/rlgl.h
+++ b/src/rlgl.h
@@ -56,8 +56,8 @@
 *
 *       #define RL_MAX_MATRIX_STACK_SIZE             32    // Maximum size of internal Matrix stack
 *       #define RL_MAX_SHADER_LOCATIONS              32    // Maximum number of shader locations supported
-*       #define RL_CULL_DISTANCE_NEAR             0.05     // Default projection matrix near cull distance
-*       #define RL_CULL_DISTANCE_FAR            4000.0     // Default projection matrix far cull distance
+*       #define RL_CULL_DISTANCE_NEAR              0.05    // Default projection matrix near cull distance
+*       #define RL_CULL_DISTANCE_FAR             4000.0    // Default projection matrix far cull distance
 *
 *       When loading a shader, the following vertex attributes and uniform
 *       location names are tried to be set automatically:
@@ -237,7 +237,7 @@
     #define RL_CULL_DISTANCE_NEAR                 0.05      // Default near cull distance
 #endif
 #ifndef RL_CULL_DISTANCE_FAR
-    #define RL_CULL_DISTANCE_FAR                4000.0     // Default far cull distance
+    #define RL_CULL_DISTANCE_FAR                4000.0      // Default far cull distance
 #endif
 
 // Texture parameters (equivalent to OpenGL defines)

--- a/src/rlgl.h
+++ b/src/rlgl.h
@@ -56,8 +56,8 @@
 *
 *       #define RL_MAX_MATRIX_STACK_SIZE             32    // Maximum size of internal Matrix stack
 *       #define RL_MAX_SHADER_LOCATIONS              32    // Maximum number of shader locations supported
-*       #define RL_CULL_DISTANCE_NEAR             0.001    // Default projection matrix near cull distance
-*       #define RL_CULL_DISTANCE_FAR            10000.0    // Default projection matrix far cull distance
+*       #define RL_CULL_DISTANCE_NEAR             0.05     // Default projection matrix near cull distance
+*       #define RL_CULL_DISTANCE_FAR            4000.0     // Default projection matrix far cull distance
 *
 *       When loading a shader, the following vertex attributes and uniform
 *       location names are tried to be set automatically:
@@ -234,10 +234,10 @@
 
 // Projection matrix culling
 #ifndef RL_CULL_DISTANCE_NEAR
-    #define RL_CULL_DISTANCE_NEAR                0.001      // Default near cull distance
+    #define RL_CULL_DISTANCE_NEAR                 0.05      // Default near cull distance
 #endif
 #ifndef RL_CULL_DISTANCE_FAR
-    #define RL_CULL_DISTANCE_FAR               10000.0      // Default far cull distance
+    #define RL_CULL_DISTANCE_FAR                4000.0     // Default far cull distance
 #endif
 
 // Texture parameters (equivalent to OpenGL defines)


### PR DESCRIPTION
I've noticed the default near and far clipping planes were recently changed, and I'd like to suggest a fix

The current range `[0.001, 10000.0]` feels excessive and hard to justify

The near plane is too close, which can cause depth buffer precision issues and visual artifacts, while a far value of `10000.0` seems unnecessarily high for a default here

If the intent was to increase the far plane, a more reasonable default would be `[0.05, 4000.0]`, offering a better balance between depth precision and visible range

For special cases, `rlSetClipPlanes` already exists to override these defaults anyway

___

Here is a visual example using shadow mapping, where the scene depth (from the camera's point of view) was projected with a near/far range of `[0.001, 10000.0]`:

https://github.com/user-attachments/assets/1633d1d6-1e55-417f-b608-d25a2196bd18

And here is an example with `[0.05, 4000.0]`:

https://github.com/user-attachments/assets/a21d169f-0855-434c-b8ef-83c9b8e704ee

