### PR TITLE
build.zig: fix building raylib for emscripten

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -504,7 +504,7 @@ fn addExamples(
     raylib: *std.Build.Step.Compile,
 ) !*std.Build.Step {
     if (target.result.os.tag == .emscripten) {
-        @panic("Emscripten building via Zig unsupported");
+        return &b.addFail("Emscripten building via Zig unsupported").step;
     }
 
     const all = b.step(module, "All " ++ module ++ " examples");


### PR DESCRIPTION
build.zig doesn't support the examples for the emscripten OS but it does support the raylib library. However, the examples panic if emscripten is configured which prevents it from building the library. I've replaced this panic with a fail step to fix this.