### PR TITLE
Only create uninstall target when raylib is top level

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,8 +46,9 @@ endif()
 # Main sources directory (the second parameter sets the output directory name to raylib)
 add_subdirectory(src raylib)
 
-# Uninstall target
-if(NOT TARGET uninstall)
+# Uninstall target, only create when building raylib by itself
+# Avoid conflicting target names when using raylib with other libraries
+if(NOT TARGET uninstall AND PROJECT_IS_TOP_LEVEL)
   configure_file(
     "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Uninstall.cmake"
     "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"


### PR DESCRIPTION
When building `raylib` with other libraries using CMake's `FetchContent`, the `uninstall` target might clash between these libraries. User might encounter error similar to the following (the other library here is [Eigen](https://gitlab.com/libeigen/eigen))
```
CMake Error at build/_deps/eigen3-src/CMakeLists.txt:648 (add_custom_target):
  add_custom_target cannot create target "uninstall" because another target
  with the same name already exists.  The existing target is a custom target
  created in source directory "/build/_deps/raylib-src".  See documentation for 
  policy CMP0002 for more details.
```
The solution to this is fairly straight-forward: only add the custom target if we are building `raylib` by itself. We can achieve this by using `PROJECT_IS_TOP_LEVEL` built-in variable introduced in CMake 3.21 (current CMake version in `raylib` is 3.25)