### PR TITLE
cmake: replace custom variable with built-in one

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,14 +23,6 @@ cmake_policy(SET CMP0063 NEW)
 # Anywhere you see include(...) you can check <root>/cmake for that file
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
-# RAYLIB_IS_MAIN determines whether the project is being used from root
-# or if it is added as a dependency (through add_subdirectory for example).
-if ("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
-  set(RAYLIB_IS_MAIN TRUE)
-else()
-  set(RAYLIB_IS_MAIN FALSE)
-endif()
-
 # Sets compiler flags and language standard
 include(CompilerFlags)
 

--- a/CMakeOptions.txt
+++ b/CMakeOptions.txt
@@ -11,7 +11,7 @@ enum_option(PLATFORM "Desktop;Web;Android;Raspberry Pi;DRM;SDL" "Platform to bui
 enum_option(OPENGL_VERSION "OFF;4.3;3.3;2.1;1.1;ES 2.0;ES 3.0" "Force a specific OpenGL Version?")
 
 # Configuration options
-option(BUILD_EXAMPLES "Build the examples." ${RAYLIB_IS_MAIN})
+option(BUILD_EXAMPLES "Build the examples." ${PROJECT_IS_TOP_LEVEL})
 option(CUSTOMIZE_BUILD "Show options for customizing your Raylib library build." OFF)
 option(ENABLE_ASAN "Enable AddressSanitizer (ASAN) for debugging (degrades performance)" OFF)
 option(ENABLE_UBSAN "Enable UndefinedBehaviorSanitizer (UBSan) for debugging" OFF)

--- a/projects/CMake/CMakeLists.txt
+++ b/projects/CMake/CMakeLists.txt
@@ -18,7 +18,6 @@ if (NOT raylib_FOUND) # If there's none, fetch and build raylib
   if (NOT raylib_POPULATED) # Have we downloaded raylib yet?
     set(FETCHCONTENT_QUIET NO)
     FetchContent_MakeAvailable(raylib)
-    set(BUILD_EXAMPLES OFF CACHE BOOL "" FORCE) # don't build the supplied examples
   endif()
 endif()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,7 +8,7 @@ include(JoinPaths)
 
 # Sets build type if not set by now
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
-    if(RAYLIB_IS_MAIN)
+    if(PROJECT_IS_TOP_LEVEL)
         set(default_build_type Debug)
     else()
         message(WARNING "Default build type is not set (CMAKE_BUILD_TYPE)")


### PR DESCRIPTION
Byproduct of #4913

Since the current version of CMake in `raylib` is 3.25, we can replace the custom `RAYLIB_IS_MAIN` with `PROJECT_IS_TOP_LEVEL` (available since 3.21).