### PR TITLE
[rcore] Some adjustments for `FilePathList`

### DIFF
--- a/src/rcore.c
+++ b/src/rcore.c
@@ -3681,7 +3681,6 @@ void SetupFramebuffer(int width, int height)
 static void ScanDirectoryFiles(const char *basePath, FilePathList *files, const char *filter)
 {
     static char path[MAX_FILEPATH_LENGTH] = { 0 };
-    memset(path, 0, MAX_FILEPATH_LENGTH);
 
     struct dirent *dp = NULL;
     DIR *dir = opendir(basePath);

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -3738,7 +3738,6 @@ static void ScanDirectoryFiles(const char *basePath, FilePathList *files, const 
 static void ScanDirectoryFilesRecursively(const char *basePath, FilePathList *files, const char *filter)
 {
     char path[MAX_FILEPATH_LENGTH] = { 0 };
-    memset(path, 0, MAX_FILEPATH_LENGTH);
 
     struct dirent *dp = NULL;
     DIR *dir = opendir(basePath);

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -2314,9 +2314,12 @@ FilePathList LoadDirectoryFilesEx(const char *basePath, const char *filter, bool
 // WARNING: files.count is not reseted to 0 after unloading
 void UnloadDirectoryFiles(FilePathList files)
 {
-    for (unsigned int i = 0; i < files.capacity; i++) RL_FREE(files.paths[i]);
+    if (files.paths != NULL)
+    {
+        for (unsigned int i = 0; i < files.capacity; i++) RL_FREE(files.paths[i]);
 
-    RL_FREE(files.paths);
+        RL_FREE(files.paths);
+    }
 }
 
 // Create directories (including full path requested), returns 0 on success


### PR DESCRIPTION
I'm just proposing a few adjustments to `LoadDirectoryFiles` and `UnloadDirectoryFiles`.

Originally, I only intended to add a null check for `file.paths` in `UnloadDirectoryFiles`.

But I also took the opportunity to remove a redundant call to `memset(path, 0, size);` in the `ScanDirectoryFiles` and `ScanDirectoryFilesRecursively` functions, since the array is already zero-initialized on the stack:

```c
    static char path[MAX_FILEPATH_LENGTH] = { 0 };
    memset(path, 0, MAX_FILEPATH_LENGTH);  //< redundant
```