### PR TITLE
[rcore] Some adjustments for `FilePathList`

### DIFF
--- a/src/rcore.c
+++ b/src/rcore.c
@@ -2314,9 +2314,12 @@ FilePathList LoadDirectoryFilesEx(const char *basePath, const char *filter, bool
 // WARNING: files.count is not reseted to 0 after unloading
 void UnloadDirectoryFiles(FilePathList files)
 {
-    for (unsigned int i = 0; i < files.capacity; i++) RL_FREE(files.paths[i]);
+    if (files.paths != NULL)
+    {
+        for (unsigned int i = 0; i < files.capacity; i++) RL_FREE(files.paths[i]);
 
-    RL_FREE(files.paths);
+        RL_FREE(files.paths);
+    }
 }
 
 // Create directories (including full path requested), returns 0 on success

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -3741,7 +3741,7 @@ static void ScanDirectoryFiles(const char *basePath, FilePathList *files, const 
 // Scan all files and directories recursively from a base path
 static void ScanDirectoryFilesRecursively(const char *basePath, FilePathList *files, const char *filter)
 {
-    char path[MAX_FILEPATH_LENGTH] = { 0 };
+    static char path[MAX_FILEPATH_LENGTH] = { 0 };
     memset(path, 0, MAX_FILEPATH_LENGTH);
 
     struct dirent *dp = NULL;


### PR DESCRIPTION
This PR adds a null check for `files.paths` before calling `free()` in `UnloadDirectoryFiles`

While at it, I fixed an inconsistency in `ScanDirectoryFilesRecursively` by making `path` static, just like in `ScanDirectoryFiles`

Previously, both functions called `memset(path, 0, size)`, but only `ScanDirectoryFiles` had `path` declared as `static`
In the recursive version, `path` was reallocated on the stack and zero-initialized twice on each call

This change aligns the recursive version with the apparent original intent

___

Review of my previous PR: https://github.com/raysan5/raylib/pull/4921