### PR TITLE
[rmodels] support CPU animation in OpenGL 1.1

### DIFF
--- a/src/rmodels.c
+++ b/src/rmodels.c
@@ -1423,9 +1423,17 @@ void DrawMesh(Mesh mesh, Material material, Matrix transform)
 
     rlEnableTexture(material.maps[MATERIAL_MAP_DIFFUSE].texture.id);
 
-    rlEnableStatePointer(GL_VERTEX_ARRAY, mesh.vertices);
+    if (mesh.animVertices)
+        rlEnableStatePointer(GL_VERTEX_ARRAY, mesh.animVertices);
+    else
+        rlEnableStatePointer(GL_VERTEX_ARRAY, mesh.vertices);
+
     rlEnableStatePointer(GL_TEXTURE_COORD_ARRAY, mesh.texcoords);
-    rlEnableStatePointer(GL_NORMAL_ARRAY, mesh.normals);
+    if (mesh.normals)
+        rlEnableStatePointer(GL_VERTEX_ARRAY, mesh.animNormalss);
+    else
+        rlEnableStatePointer(GL_NORMAL_ARRAY, mesh.normals);
+
     rlEnableStatePointer(GL_COLOR_ARRAY, mesh.colors);
 
     rlPushMatrix();


### PR DESCRIPTION
Currently when drawing meshes with GL 1.1 only the static vertex and normal buffers are used, this means that CPU animation can't work with GL 1.1.
This PR uses the animated vertex and normal buffers if they exist just like GL 2.2+ does, supporting animated models in GL1.1.
It's not going to be fast since it's all done CPU side, but that should be up to the user, not raylib.