### PR TITLE
[rtext] Properly clean up the default font on unload

### DIFF
--- a/src/rtext.c
+++ b/src/rtext.c
@@ -331,6 +331,9 @@ extern void UnloadFontDefault(void)
     if (isGpuReady) UnloadTexture(defaultFont.texture);
     RL_FREE(defaultFont.glyphs);
     RL_FREE(defaultFont.recs);
+    defaultFont.glyphCount = 0;
+    defaultFont.glyphs = NULL;
+    defaultFont.recs = NULL;
 }
 #endif      // SUPPORT_DEFAULT_FONT
 


### PR DESCRIPTION
The default font is unloaded, but its fields are never set to null. This will cause problems if the window is opened again and something tries to reinitialize the default font. This PR resets the fields back to null on unload.