### PR TITLE
[rcore] Proposal: Review and extend raylib's random generation utilities

### DIFF
--- a/examples/audio/audio_module_playing.c
+++ b/examples/audio/audio_module_playing.c
@@ -50,11 +50,11 @@ int main(void)
     for (int i = MAX_CIRCLES - 1; i >= 0; i--)
     {
         circles[i].alpha = 0.0f;
-        circles[i].radius = (float)GetRandomValue(10, 40);
-        circles[i].position.x = (float)GetRandomValue((int)circles[i].radius, (int)(screenWidth - circles[i].radius));
-        circles[i].position.y = (float)GetRandomValue((int)circles[i].radius, (int)(screenHeight - circles[i].radius));
-        circles[i].speed = (float)GetRandomValue(1, 100)/2000.0f;
-        circles[i].color = colors[GetRandomValue(0, 13)];
+        circles[i].radius = (float)GetRandomRangeInt(10, 40);
+        circles[i].position.x = (float)GetRandomRangeInt((int)circles[i].radius, (int)(screenWidth - circles[i].radius));
+        circles[i].position.y = (float)GetRandomRangeInt((int)circles[i].radius, (int)(screenHeight - circles[i].radius));
+        circles[i].speed = (float)GetRandomRangeInt(1, 100)/2000.0f;
+        circles[i].color = colors[GetRandomRangeInt(0, 13)];
     }
 
     Music music = LoadMusicStream("resources/mini1111.xm");
@@ -112,11 +112,11 @@ int main(void)
             if (circles[i].alpha <= 0.0f)
             {
                 circles[i].alpha = 0.0f;
-                circles[i].radius = (float)GetRandomValue(10, 40);
-                circles[i].position.x = (float)GetRandomValue((int)circles[i].radius, (int)(screenWidth - circles[i].radius));
-                circles[i].position.y = (float)GetRandomValue((int)circles[i].radius, (int)(screenHeight - circles[i].radius));
-                circles[i].color = colors[GetRandomValue(0, 13)];
-                circles[i].speed = (float)GetRandomValue(1, 100)/2000.0f;
+                circles[i].radius = (float)GetRandomRangeInt(10, 40);
+                circles[i].position.x = (float)GetRandomRangeInt((int)circles[i].radius, (int)(screenWidth - circles[i].radius));
+                circles[i].position.y = (float)GetRandomRangeInt((int)circles[i].radius, (int)(screenHeight - circles[i].radius));
+                circles[i].color = colors[GetRandomRangeInt(0, 13)];
+                circles[i].speed = (float)GetRandomRangeInt(1, 100)/2000.0f;
             }
         }
         //----------------------------------------------------------------------------------

--- a/examples/core/core_2d_camera.c
+++ b/examples/core/core_2d_camera.c
@@ -38,17 +38,17 @@ int main(void)
 
     for (int i = 0; i < MAX_BUILDINGS; i++)
     {
-        buildings[i].width = (float)GetRandomValue(50, 200);
-        buildings[i].height = (float)GetRandomValue(100, 800);
+        buildings[i].width = (float)GetRandomRangeInt(50, 200);
+        buildings[i].height = (float)GetRandomRangeInt(100, 800);
         buildings[i].y = screenHeight - 130.0f - buildings[i].height;
         buildings[i].x = -6000.0f + spacing;
 
         spacing += (int)buildings[i].width;
 
         buildColors[i] = (Color){
-            (unsigned char)GetRandomValue(200, 240),
-            (unsigned char)GetRandomValue(200, 240),
-            (unsigned char)GetRandomValue(200, 250),
+            (unsigned char)GetRandomRangeInt(200, 240),
+            (unsigned char)GetRandomRangeInt(200, 240),
+            (unsigned char)GetRandomRangeInt(200, 250),
             255};
     }
 

--- a/examples/core/core_3d_camera_first_person.c
+++ b/examples/core/core_3d_camera_first_person.c
@@ -47,9 +47,9 @@ int main(void)
 
     for (int i = 0; i < MAX_COLUMNS; i++)
     {
-        heights[i] = (float)GetRandomValue(1, 12);
-        positions[i] = (Vector3){ (float)GetRandomValue(-15, 15), heights[i]/2.0f, (float)GetRandomValue(-15, 15) };
-        colors[i] = (Color){ GetRandomValue(20, 255), GetRandomValue(10, 55), 30, 255 };
+        heights[i] = (float)GetRandomRangeInt(1, 12);
+        positions[i] = (Vector3){ (float)GetRandomRangeInt(-15, 15), heights[i]/2.0f, (float)GetRandomRangeInt(-15, 15) };
+        colors[i] = (Color){ GetRandomRangeInt(20, 255), GetRandomRangeInt(10, 55), 30, 255 };
     }
 
     DisableCursor();                    // Limit cursor to relative movement inside the window

--- a/examples/core/core_random_sequence.c
+++ b/examples/core/core_random_sequence.c
@@ -119,9 +119,9 @@ int main(void)
 static Color GenerateRandomColor()
 {
     Color color = { 
-        GetRandomValue(0, 255), 
-        GetRandomValue(0, 255),
-        GetRandomValue(0, 255),
+        GetRandomRangeInt(0, 255), 
+        GetRandomRangeInt(0, 255),
+        GetRandomRangeInt(0, 255),
         255
     };
 

--- a/examples/core/core_random_values.c
+++ b/examples/core/core_random_values.c
@@ -29,7 +29,7 @@ int main(void)
 
     // SetRandomSeed(0xaabbccff);   // Set a custom random seed if desired, by default: "time(NULL)"
 
-    int randValue = GetRandomValue(-8, 5);   // Get a random integer number between -8 and 5 (both included)
+    int randValue = GetRandomRangeInt(-8, 5);   // Get a random integer number between -8 and 5 (both included)
     
     unsigned int framesCounter = 0; // Variable used to count frames
     
@@ -46,7 +46,7 @@ int main(void)
         // Every two seconds (120 frames) a new random value is generated
         if (((framesCounter/120)%2) == 1)
         {
-            randValue = GetRandomValue(-8, 5);
+            randValue = GetRandomRangeInt(-8, 5);
             framesCounter = 0;
         }
         //----------------------------------------------------------------------------------

--- a/examples/core/core_storage_values.c
+++ b/examples/core/core_storage_values.c
@@ -55,8 +55,8 @@ int main(void)
         //----------------------------------------------------------------------------------
         if (IsKeyPressed(KEY_R))
         {
-            score = GetRandomValue(1000, 2000);
-            hiscore = GetRandomValue(2000, 4000);
+            score = GetRandomRangeInt(1000, 2000);
+            hiscore = GetRandomRangeInt(2000, 4000);
         }
 
         if (IsKeyPressed(KEY_ENTER))

--- a/examples/core/core_window_letterbox.c
+++ b/examples/core/core_window_letterbox.c
@@ -43,7 +43,7 @@ int main(void)
     SetTextureFilter(target.texture, TEXTURE_FILTER_BILINEAR);  // Texture scale filter to use
 
     Color colors[10] = { 0 };
-    for (int i = 0; i < 10; i++) colors[i] = (Color){ GetRandomValue(100, 250), GetRandomValue(50, 150), GetRandomValue(10, 100), 255 };
+    for (int i = 0; i < 10; i++) colors[i] = (Color){ GetRandomRangeInt(100, 250), GetRandomRangeInt(50, 150), GetRandomRangeInt(10, 100), 255 };
 
     SetTargetFPS(60);                   // Set our game to run at 60 frames-per-second
     //--------------------------------------------------------------------------------------
@@ -59,7 +59,7 @@ int main(void)
         if (IsKeyPressed(KEY_SPACE))
         {
             // Recalculate random colors for the bars
-            for (int i = 0; i < 10; i++) colors[i] = (Color){ GetRandomValue(100, 250), GetRandomValue(50, 150), GetRandomValue(10, 100), 255 };
+            for (int i = 0; i < 10; i++) colors[i] = (Color){ GetRandomRangeInt(100, 250), GetRandomRangeInt(50, 150), GetRandomRangeInt(10, 100), 255 };
         }
 
         // Update virtual mouse (clamped mouse value behind game screen)

--- a/examples/others/raylib_opengl_interop.c
+++ b/examples/others/raylib_opengl_interop.c
@@ -84,12 +84,12 @@ int main(void)
 
     for (int i = 0; i < MAX_PARTICLES; i++)
     {
-        particles[i].x = (float)GetRandomValue(20, screenWidth - 20);
-        particles[i].y = (float)GetRandomValue(50, screenHeight - 20);
+        particles[i].x = (float)GetRandomRangeInt(20, screenWidth - 20);
+        particles[i].y = (float)GetRandomRangeInt(50, screenHeight - 20);
         
         // Give each particle a slightly different period. But don't spread it to much. 
         // This way the particles line up every so often and you get a glimps of what is going on.
-        particles[i].period = (float)GetRandomValue(10, 30)/10.0f;
+        particles[i].period = (float)GetRandomRangeInt(10, 30)/10.0f;
     }
 
     // Create a plain OpenGL vertex buffer with the data and an vertex array object 

--- a/examples/shaders/shaders_mesh_instancing.c
+++ b/examples/shaders/shaders_mesh_instancing.c
@@ -60,9 +60,9 @@ int main(void)
     // Translate and rotate cubes randomly
     for (int i = 0; i < MAX_INSTANCES; i++)
     {
-        Matrix translation = MatrixTranslate((float)GetRandomValue(-50, 50), (float)GetRandomValue(-50, 50), (float)GetRandomValue(-50, 50));
-        Vector3 axis = Vector3Normalize((Vector3){ (float)GetRandomValue(0, 360), (float)GetRandomValue(0, 360), (float)GetRandomValue(0, 360) });
-        float angle = (float)GetRandomValue(0, 180)*DEG2RAD;
+        Matrix translation = MatrixTranslate((float)GetRandomRangeInt(-50, 50), (float)GetRandomRangeInt(-50, 50), (float)GetRandomRangeInt(-50, 50));
+        Vector3 axis = Vector3Normalize((Vector3){ (float)GetRandomRangeInt(0, 360), (float)GetRandomRangeInt(0, 360), (float)GetRandomRangeInt(0, 360) });
+        float angle = (float)GetRandomRangeInt(0, 180)*DEG2RAD;
         Matrix rotation = MatrixRotate(axis, angle);
         
         transforms[i] = MatrixMultiply(rotation, translation);

--- a/examples/shaders/shaders_spotlight.c
+++ b/examples/shaders/shaders_spotlight.c
@@ -124,14 +124,14 @@ int main(void)
     // and initialize the shader locations
     for (int i = 0; i < MAX_SPOTS; i++)
     {
-        spots[i].position.x = (float)GetRandomValue(64, screenWidth - 64);
-        spots[i].position.y = (float)GetRandomValue(64, screenHeight - 64);
+        spots[i].position.x = (float)GetRandomRangeInt(64, screenWidth - 64);
+        spots[i].position.y = (float)GetRandomRangeInt(64, screenHeight - 64);
         spots[i].speed = (Vector2){ 0, 0 };
 
         while ((fabs(spots[i].speed.x) + fabs(spots[i].speed.y)) < 2)
         {
-            spots[i].speed.x = GetRandomValue(-400, 40) / 10.0f;
-            spots[i].speed.y = GetRandomValue(-400, 40) / 10.0f;
+            spots[i].speed.x = GetRandomRangeInt(-400, 40) / 10.0f;
+            spots[i].speed.y = GetRandomRangeInt(-400, 40) / 10.0f;
         }
 
         spots[i].inner = 28.0f * (i + 1);
@@ -235,8 +235,8 @@ static void ResetStar(Star *s)
 
     do
     {
-        s->speed.x = (float)GetRandomValue(-1000, 1000)/100.0f;
-        s->speed.y = (float)GetRandomValue(-1000, 1000)/100.0f;
+        s->speed.x = (float)GetRandomRangeInt(-1000, 1000)/100.0f;
+        s->speed.y = (float)GetRandomRangeInt(-1000, 1000)/100.0f;
 
     } while (!(fabs(s->speed.x) + (fabs(s->speed.y) > 1)));
 

--- a/examples/shapes/shapes_top_down_lights.c
+++ b/examples/shapes/shapes_top_down_lights.c
@@ -204,7 +204,7 @@ void SetupBoxes(Rectangle *boxes, int *count)
 
     for (int i = 5; i < MAX_BOXES; i++)
     {
-        boxes[i] = (Rectangle){(float)GetRandomValue(0,GetScreenWidth()), (float)GetRandomValue(0,GetScreenHeight()), (float)GetRandomValue(10,100), (float)GetRandomValue(10,100) };
+        boxes[i] = (Rectangle){(float)GetRandomRangeInt(0,GetScreenWidth()), (float)GetRandomRangeInt(0,GetScreenHeight()), (float)GetRandomRangeInt(10,100), (float)GetRandomRangeInt(10,100) };
     }
 
     *count = MAX_BOXES;

--- a/examples/text/text_draw_3d.c
+++ b/examples/text/text_draw_3d.c
@@ -232,7 +232,7 @@ int main(void)
                 for (int i = 0; i < TEXT_MAX_LAYERS; ++i)
                 {
                     multi[i] = GenerateRandomColor(0.5f, 0.8f);
-                    multi[i].a = GetRandomValue(0, 255);
+                    multi[i].a = GetRandomRangeInt(0, 255);
                 }
             }
         }
@@ -688,7 +688,7 @@ static Vector3 MeasureTextWave3D(Font font, const char* text, float fontSize, fl
 static Color GenerateRandomColor(float s, float v)
 {
     const float Phi = 0.618033988749895f; // Golden ratio conjugate
-    float h = (float)GetRandomValue(0, 360);
+    float h = (float)GetRandomRangeInt(0, 360);
     h = fmodf((h + h*Phi), 360.0f);
     return ColorFromHSV(h, s, v);
 }

--- a/examples/text/text_unicode.c
+++ b/examples/text/text_unicode.c
@@ -313,18 +313,18 @@ int main(void)
 static void RandomizeEmoji(void)
 {
     hovered = selected = -1;
-    int start = GetRandomValue(45, 360);
+    int start = GetRandomRangeInt(45, 360);
 
     for (int i = 0; i < SIZEOF(emoji); ++i)
     {
         // 0-179 emoji codepoints (from emoji char array) each 4bytes + null char
-        emoji[i].index = GetRandomValue(0, 179)*5;
+        emoji[i].index = GetRandomRangeInt(0, 179)*5;
 
         // Generate a random color for this emoji
         emoji[i].color = Fade(ColorFromHSV((float)((start*(i + 1))%360), 0.6f, 0.85f), 0.8f);
 
         // Set a random message for this emoji
-        emoji[i].message = GetRandomValue(0, SIZEOF(messages) - 1);
+        emoji[i].message = GetRandomRangeInt(0, SIZEOF(messages) - 1);
     }
 }
 

--- a/examples/textures/textures_bunnymark.c
+++ b/examples/textures/textures_bunnymark.c
@@ -64,11 +64,11 @@ int main(void)
                 if (bunniesCount < MAX_BUNNIES)
                 {
                     bunnies[bunniesCount].position = GetMousePosition();
-                    bunnies[bunniesCount].speed.x = (float)GetRandomValue(-250, 250)/60.0f;
-                    bunnies[bunniesCount].speed.y = (float)GetRandomValue(-250, 250)/60.0f;
-                    bunnies[bunniesCount].color = (Color){ GetRandomValue(50, 240),
-                                                       GetRandomValue(80, 240),
-                                                       GetRandomValue(100, 240), 255 };
+                    bunnies[bunniesCount].speed.x = (float)GetRandomRangeInt(-250, 250)/60.0f;
+                    bunnies[bunniesCount].speed.y = (float)GetRandomRangeInt(-250, 250)/60.0f;
+                    bunnies[bunniesCount].color = (Color){ GetRandomRangeInt(50, 240),
+                                                       GetRandomRangeInt(80, 240),
+                                                       GetRandomRangeInt(100, 240), 255 };
                     bunniesCount++;
                 }
             }

--- a/examples/textures/textures_fog_of_war.c
+++ b/examples/textures/textures_fog_of_war.c
@@ -53,7 +53,7 @@ int main(void)
 
     // Load map tiles (generating 2 random tile ids for testing)
     // NOTE: Map tile ids should be probably loaded from an external map file
-    for (unsigned int i = 0; i < map.tilesY*map.tilesX; i++) map.tileIds[i] = GetRandomValue(0, 1);
+    for (unsigned int i = 0; i < map.tilesY*map.tilesX; i++) map.tileIds[i] = GetRandomRangeInt(0, 1);
 
     // Player position on the screen (pixel coordinates, not tile coordinates)
     Vector2 playerPosition = { 180, 130 };

--- a/examples/textures/textures_particles_blending.c
+++ b/examples/textures/textures_particles_blending.c
@@ -46,10 +46,10 @@ int main(void)
     for (int i = 0; i < MAX_PARTICLES; i++)
     {
         mouseTail[i].position = (Vector2){ 0, 0 };
-        mouseTail[i].color = (Color){ GetRandomValue(0, 255), GetRandomValue(0, 255), GetRandomValue(0, 255), 255 };
+        mouseTail[i].color = (Color){ GetRandomRangeInt(0, 255), GetRandomRangeInt(0, 255), GetRandomRangeInt(0, 255), 255 };
         mouseTail[i].alpha = 1.0f;
-        mouseTail[i].size = (float)GetRandomValue(1, 30)/20.0f;
-        mouseTail[i].rotation = (float)GetRandomValue(0, 360);
+        mouseTail[i].size = (float)GetRandomRangeInt(1, 30)/20.0f;
+        mouseTail[i].rotation = (float)GetRandomRangeInt(0, 360);
         mouseTail[i].active = false;
     }
 

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1091,7 +1091,9 @@ RLAPI void WaitTime(double seconds);                              // Wait for so
 
 // Random values generation functions
 RLAPI void SetRandomSeed(unsigned int seed);                      // Set the seed for the random number generator
-RLAPI int GetRandomValue(int min, int max);                       // Get a random value between min and max (both included)
+RLAPI float GetRandomFloat(void);                                 // Get a random float between zero and one included
+RLAPI float GetRandomRangeFloat(float min, float max);            // Get a random float between min and max included
+RLAPI int GetRandomRangeInt(int min, int max);                    // Get a random integer between min and max included
 RLAPI int *LoadRandomSequence(unsigned int count, int min, int max); // Load random values sequence, no values repeated
 RLAPI void UnloadRandomSequence(int *sequence);                   // Unload random values sequence
 

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -1793,8 +1793,46 @@ void SetRandomSeed(unsigned int seed)
 #endif
 }
 
-// Get a random value between min and max included
-int GetRandomValue(int min, int max)
+// Get a random float between zero and one included
+float GetRandomFloat(void)
+{
+    float value = 0.0f;
+
+#if defined(SUPPORT_RPRAND_GENERATOR)
+    value = rprand_get_float();
+#else
+    // rand() returns a value in the range [0, RAND_MAX], convert to [0.0, 1.0]
+    value = (float)rand() / (float)RAND_MAX;
+#endif
+
+    return value;
+}
+
+// Get a random float between min and max included
+float GetRandomRangeFloat(float min, float max)
+{
+    float value = 0.0f;
+
+    if (min > max)
+    {
+        float tmp = max;
+        max = min;
+        min = tmp;
+    }
+
+#if defined(SUPPORT_RPRAND_GENERATOR)
+    value = rprand_get_range_float(min, max);
+#else
+    // rand() returns a value in the range [0, RAND_MAX], convert to [0.0, 1.0]
+    float normalized = (float)rand() / (float)RAND_MAX;
+    value = min + normalized * (max - min);
+#endif
+
+    return value;
+}
+
+// Get a random integer between min and max included
+int GetRandomRangeInt(int min, int max)
 {
     int value = 0;
 
@@ -1806,7 +1844,7 @@ int GetRandomValue(int min, int max)
     }
 
 #if defined(SUPPORT_RPRAND_GENERATOR)
-    value = rprand_get_value(min, max);
+    value = rprand_get_range_int(min, max);
 #else
     // WARNING: Ranges higher than RAND_MAX will return invalid results
     // More specifically, if (max - min) > INT_MAX there will be an overflow,
@@ -1814,7 +1852,7 @@ int GetRandomValue(int min, int max)
     // NOTE: Depending on the library it can be as low as 32767
     if ((unsigned int)(max - min) > (unsigned int)RAND_MAX)
     {
-        TRACELOG(LOG_WARNING, "Invalid GetRandomValue() arguments, range should not be higher than %i", RAND_MAX);
+        TRACELOG(LOG_WARNING, "Invalid GetRandomRangeInt() arguments, range should not be higher than %i", RAND_MAX);
     }
 
     value = (rand()%(abs(max - min) + 1) + min);

--- a/src/rtextures.c
+++ b/src/rtextures.c
@@ -980,14 +980,14 @@ Image GenImageChecked(int width, int height, int checksX, int checksY, Color col
 }
 
 // Generate image: white noise
-// NOTE: It requires GetRandomValue(), defined in [rcore]
+// NOTE: It requires GetRandomRangeInt(), defined in [rcore]
 Image GenImageWhiteNoise(int width, int height, float factor)
 {
     Color *pixels = (Color *)RL_MALLOC(width*height*sizeof(Color));
 
     for (int i = 0; i < width*height; i++)
     {
-        if (GetRandomValue(0, 99) < (int)(factor*100.0f)) pixels[i] = WHITE;
+        if (GetRandomRangeInt(0, 99) < (int)(factor*100.0f)) pixels[i] = WHITE;
         else pixels[i] = BLACK;
     }
 
@@ -1066,8 +1066,8 @@ Image GenImageCellular(int width, int height, int tileSize)
 
     for (int i = 0; i < seedCount; i++)
     {
-        int y = (i/seedsPerRow)*tileSize + GetRandomValue(0, tileSize - 1);
-        int x = (i%seedsPerRow)*tileSize + GetRandomValue(0, tileSize - 1);
+        int y = (i/seedsPerRow)*tileSize + GetRandomRangeInt(0, tileSize - 1);
+        int x = (i%seedsPerRow)*tileSize + GetRandomRangeInt(0, tileSize - 1);
         seeds[i] = (Vector2){ (float)x, (float)y };
     }
 


### PR DESCRIPTION
I'd just like to open a discussion about possible improvements to random number generation in raylib, which currently only provides the `GetRandomValue()` function

I've always found this limitation a bit unfortunate, especially considering that rprand is already available and could easily be adapted to efficiently generate floating-point numbers, as demonstrated here.

At the moment, generating a float between 0 and 1, which is a very common need, requires something like:
```c
float value = (float)GetRandomValue(0, 1000) / 1000.0f;
```

This involves integer modulo, floating-point division, a call to `abs`, subtraction, and two additions.

In contrast, we could introduce a `GetRandomFloat()` function that performs just a bit-shift, an OR operation, and a subtraction, resulting in better performance and accuracy.

This is just a suggestion, I don’t necessarily expect the PR to be accepted, but I’d be happy to start a conversation around this topic.