### PR TITLE
[utils] fix const warning with SaveFileText callback

### DIFF
--- a/parser/output/raylib_api.json
+++ b/parser/output/raylib_api.json
@@ -3139,7 +3139,7 @@
           "name": "fileName"
         },
         {
-          "type": "char *",
+          "type": "const char *",
           "name": "text"
         }
       ]

--- a/parser/output/raylib_api.lua
+++ b/parser/output/raylib_api.lua
@@ -3108,7 +3108,7 @@ return {
       returnType = "bool",
       params = {
         {type = "const char *", name = "fileName"},
-        {type = "char *", name = "text"}
+        {type = "const char *", name = "text"}
       }
     },
     {

--- a/parser/output/raylib_api.txt
+++ b/parser/output/raylib_api.txt
@@ -985,7 +985,7 @@ Callback 005: SaveFileTextCallback() (2 input parameters)
   Return type: bool
   Description: FileIO: Save text data
   Param[1]: fileName (type: const char *)
-  Param[2]: text (type: char *)
+  Param[2]: text (type: const char *)
 Callback 006: AudioCallback() (2 input parameters)
   Name: AudioCallback
   Return type: void

--- a/parser/output/raylib_api.xml
+++ b/parser/output/raylib_api.xml
@@ -672,7 +672,7 @@
         </Callback>
         <Callback name="SaveFileTextCallback" retType="bool" paramCount="2" desc="FileIO: Save text data">
             <Param type="const char *" name="fileName" desc="" />
-            <Param type="char *" name="text" desc="" />
+            <Param type="const char *" name="text" desc="" />
         </Callback>
         <Callback name="AudioCallback" retType="void" paramCount="2" desc="">
             <Param type="void *" name="bufferData" desc="" />

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -954,7 +954,7 @@ typedef void (*TraceLogCallback)(int logLevel, const char *text, va_list args); 
 typedef unsigned char *(*LoadFileDataCallback)(const char *fileName, int *dataSize);    // FileIO: Load binary data
 typedef bool (*SaveFileDataCallback)(const char *fileName, void *data, int dataSize);   // FileIO: Save binary data
 typedef char *(*LoadFileTextCallback)(const char *fileName);            // FileIO: Load text data
-typedef bool (*SaveFileTextCallback)(const char *fileName, char *text); // FileIO: Save text data
+typedef bool (*SaveFileTextCallback)(const char *fileName, const char *text); // FileIO: Save text data
 
 //------------------------------------------------------------------------------------
 // Global Variables Definition


### PR DESCRIPTION
The SaveFileTextCallback does not take it's second argument as a const char*, this is not the same as the argument the caller passes in in SaveFileText function, this generates a warning in gcc.
```utils.c
../external/raylib-master/src/utils.c: In function 'SaveFileText':
../external/raylib-master/src/utils.c:416:43: warning: passing argument 2 of 'saveFileText' discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
  416 |             return saveFileText(fileName, text);
      |                                           ^~~~
../external/raylib-master/src/utils.c:416:43: note: expected 'char *' but argument is of type 'const char *'
```

This PR changes the callback signature to match. This should not change binary compatibility since const is not used at runtime. The argument should be const as the callback can not modify the text it is supposed to save.