### PR TITLE
[rcore] add `SetEventWaitingTimeout()`

### DIFF
--- a/src/platforms/rcore_desktop_glfw.c
+++ b/src/platforms/rcore_desktop_glfw.c
@@ -1268,7 +1268,15 @@ void PollInputEvents(void)
 
     if ((CORE.Window.eventWaiting) || (IsWindowState(FLAG_WINDOW_MINIMIZED) && !IsWindowState(FLAG_WINDOW_ALWAYS_RUN)))
     {
-        glfwWaitEvents();     // Wait for in input events before continue (drawing is paused)
+        if ((CORE.Window.eventWaiting) && (CORE.Window.eventWaitingTimeout > 0))
+        {
+            // Wait for timeout or input events before continue (drawing is paused)
+            glfwWaitEventsTimeout(CORE.Window.eventWaitingTimeout);
+        }
+        else {
+            glfwWaitEvents();   // Wait for input events before continue (drawing is paused)
+        }
+
         CORE.Time.previous = GetTime();
     }
     else glfwPollEvents();      // Poll input events: keyboard/mouse/window events (callbacks) -> Update keys state

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1019,6 +1019,7 @@ RLAPI const char *GetClipboardText(void);                         // Get clipboa
 RLAPI Image GetClipboardImage(void);                              // Get clipboard image content
 RLAPI void EnableEventWaiting(void);                              // Enable waiting for events on EndDrawing(), no automatic event polling
 RLAPI void DisableEventWaiting(void);                             // Disable waiting for events on EndDrawing(), automatic events polling
+RLAPI void SetEventWaitingTimeout(double seconds);                // Set timeout to wait for events [>0.0f], if waiting for events is enabled
 
 // Cursor-related functions
 RLAPI void ShowCursor(void);                                      // Shows cursor

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -290,6 +290,7 @@ typedef struct CoreData {
         bool shouldClose;                   // Check if window set for closing
         bool resizedLastFrame;              // Check if window has been resized last frame
         bool eventWaiting;                  // Wait for events before ending frame
+        double eventWaitingTimeout;         // If waiting for events, wait with this timeout (0 means wait forever)
         bool usingFbo;                      // Using FBO (RenderTexture) for rendering instead of default framebuffer
 
         Point position;                     // Window position (required on fullscreen toggle)
@@ -860,6 +861,13 @@ void EnableEventWaiting(void)
 void DisableEventWaiting(void)
 {
     CORE.Window.eventWaiting = false;
+}
+
+// Set timeout to wait for events [>0.0f], if waiting for events is enabled
+void SetEventWaitingTimeout(double seconds)
+{
+    if (seconds <= 0) CORE.Window.eventWaitingTimeout = 0;
+    else CORE.Window.eventWaitingTimeout = seconds;
 }
 
 // Check if cursor is not visible


### PR DESCRIPTION
Proof of concept for the ability to wait for input events with a timeout.  This is a request from people using [dvui](https://github.com/david-vanderson/dvui) with raylib for variable framerate applications.

Is this something raylib would like?

If so I will work on adding the capability to the other platforms.  Any advice about the API or code is appreciated.

Should the function log something or error if the value is <= 0?  Is there an example this should be added to?