### PR TITLE
Fix typo in mesh animNormals

### DIFF
--- a/src/rmodels.c
+++ b/src/rmodels.c
@@ -1433,7 +1433,7 @@ void DrawMesh(Mesh mesh, Material material, Matrix transform)
     else rlEnableStatePointer(GL_VERTEX_ARRAY, mesh.vertices);
 
     rlEnableStatePointer(GL_TEXTURE_COORD_ARRAY, mesh.texcoords);
-    if (mesh.normals) rlEnableStatePointer(GL_VERTEX_ARRAY, mesh.animNormalss);
+    if (mesh.normals) rlEnableStatePointer(GL_VERTEX_ARRAY, mesh.animNormals);
     else rlEnableStatePointer(GL_NORMAL_ARRAY, mesh.normals);
 
     rlEnableStatePointer(GL_COLOR_ARRAY, mesh.colors);


### PR DESCRIPTION
* `DrawMesh` incorrectly references `animNormalss` instead of `animNormals`, preventing an OpenGL 1.1 build.