### PR TITLE
RGFW backend: add missing Right Control key

### DIFF
--- a/src/platforms/rcore_desktop_rgfw.c
+++ b/src/platforms/rcore_desktop_rgfw.c
@@ -175,6 +175,7 @@ static const unsigned short keyMappingRGFW[] = {
     [RGFW_superL] = KEY_LEFT_SUPER,
     #ifndef RGFW_MACOS
     [RGFW_shiftR] = KEY_RIGHT_SHIFT,
+    [RGFW_controlR] = KEY_RIGHT_CONTROL,
     [RGFW_altR] = KEY_RIGHT_ALT,
     #endif
     [RGFW_space] = KEY_SPACE,


### PR DESCRIPTION
The title says it all.

Note: tested only on Linux.