### PR TITLE
Update comments

### DIFF
--- a/parser/output/raylib_api.json
+++ b/parser/output/raylib_api.json
@@ -2300,7 +2300,7 @@
     },
     {
       "name": "GamepadAxis",
-      "description": "Gamepad axis",
+      "description": "Gamepad axes",
       "values": [
         {
           "name": "GAMEPAD_AXIS_LEFT_X",
@@ -5017,7 +5017,7 @@
     },
     {
       "name": "GetGamepadAxisCount",
-      "description": "Get gamepad axis count for a gamepad",
+      "description": "Get axis count for a gamepad",
       "returnType": "int",
       "params": [
         {
@@ -5028,7 +5028,7 @@
     },
     {
       "name": "GetGamepadAxisMovement",
-      "description": "Get axis movement value for a gamepad axis",
+      "description": "Get movement value for a gamepad axis",
       "returnType": "float",
       "params": [
         {

--- a/parser/output/raylib_api.lua
+++ b/parser/output/raylib_api.lua
@@ -2300,7 +2300,7 @@ return {
     },
     {
       name = "GamepadAxis",
-      description = "Gamepad axis",
+      description = "Gamepad axes",
       values = {
         {
           name = "GAMEPAD_AXIS_LEFT_X",
@@ -4426,7 +4426,7 @@ return {
     },
     {
       name = "GetGamepadAxisCount",
-      description = "Get gamepad axis count for a gamepad",
+      description = "Get axis count for a gamepad",
       returnType = "int",
       params = {
         {type = "int", name = "gamepad"}
@@ -4434,7 +4434,7 @@ return {
     },
     {
       name = "GetGamepadAxisMovement",
-      description = "Get axis movement value for a gamepad axis",
+      description = "Get movement value for a gamepad axis",
       returnType = "float",
       params = {
         {type = "int", name = "gamepad"},

--- a/parser/output/raylib_api.txt
+++ b/parser/output/raylib_api.txt
@@ -774,7 +774,7 @@ Enum 06: GamepadButton (18 values)
   Value[GAMEPAD_BUTTON_RIGHT_THUMB]: 17
 Enum 07: GamepadAxis (6 values)
   Name: GamepadAxis
-  Description: Gamepad axis
+  Description: Gamepad axes
   Value[GAMEPAD_AXIS_LEFT_X]: 0
   Value[GAMEPAD_AXIS_LEFT_Y]: 1
   Value[GAMEPAD_AXIS_RIGHT_X]: 2
@@ -1943,12 +1943,12 @@ Function 176: GetGamepadButtonPressed() (0 input parameters)
 Function 177: GetGamepadAxisCount() (1 input parameters)
   Name: GetGamepadAxisCount
   Return type: int
-  Description: Get gamepad axis count for a gamepad
+  Description: Get axis count for a gamepad
   Param[1]: gamepad (type: int)
 Function 178: GetGamepadAxisMovement() (2 input parameters)
   Name: GetGamepadAxisMovement
   Return type: float
-  Description: Get axis movement value for a gamepad axis
+  Description: Get movement value for a gamepad axis
   Param[1]: gamepad (type: int)
   Param[2]: axis (type: int)
 Function 179: SetGamepadMappings() (1 input parameters)

--- a/parser/output/raylib_api.xml
+++ b/parser/output/raylib_api.xml
@@ -486,7 +486,7 @@
             <Value name="GAMEPAD_BUTTON_LEFT_THUMB" integer="16" desc="Gamepad joystick pressed button left" />
             <Value name="GAMEPAD_BUTTON_RIGHT_THUMB" integer="17" desc="Gamepad joystick pressed button right" />
         </Enum>
-        <Enum name="GamepadAxis" valueCount="6" desc="Gamepad axis">
+        <Enum name="GamepadAxis" valueCount="6" desc="Gamepad axes">
             <Value name="GAMEPAD_AXIS_LEFT_X" integer="0" desc="Gamepad left stick X axis" />
             <Value name="GAMEPAD_AXIS_LEFT_Y" integer="1" desc="Gamepad left stick Y axis" />
             <Value name="GAMEPAD_AXIS_RIGHT_X" integer="2" desc="Gamepad right stick X axis" />
@@ -1216,10 +1216,10 @@
         </Function>
         <Function name="GetGamepadButtonPressed" retType="int" paramCount="0" desc="Get the last gamepad button pressed">
         </Function>
-        <Function name="GetGamepadAxisCount" retType="int" paramCount="1" desc="Get gamepad axis count for a gamepad">
+        <Function name="GetGamepadAxisCount" retType="int" paramCount="1" desc="Get axis count for a gamepad">
             <Param type="int" name="gamepad" desc="" />
         </Function>
-        <Function name="GetGamepadAxisMovement" retType="float" paramCount="2" desc="Get axis movement value for a gamepad axis">
+        <Function name="GetGamepadAxisMovement" retType="float" paramCount="2" desc="Get movement value for a gamepad axis">
             <Param type="int" name="gamepad" desc="" />
             <Param type="int" name="axis" desc="" />
         </Function>

--- a/src/platforms/rcore_desktop_glfw.c
+++ b/src/platforms/rcore_desktop_glfw.c
@@ -1,6 +1,6 @@
 /**********************************************************************************************
 *
-*   rcore_desktop - Functions to manage window, graphics device and inputs
+*   rcore_desktop_glfw - Functions to manage window, graphics device and inputs
 *
 *   PLATFORM: DESKTOP: GLFW
 *       - Windows (Win32, Win64)
@@ -1238,7 +1238,7 @@ void PollInputEvents(void)
                 }
             }
 
-            // Get current axis state
+            // Get current state of axes
             const float *axes = state.axes;
 
             for (int k = 0; (axes != NULL) && (k < GLFW_GAMEPAD_AXIS_LAST + 1); k++)
@@ -1246,7 +1246,7 @@ void PollInputEvents(void)
                 CORE.Input.Gamepad.axisState[i][k] = axes[k];
             }
 
-            // Register buttons for 2nd triggers (because GLFW doesn't count these as buttons but rather axis)
+            // Register buttons for 2nd triggers (because GLFW doesn't count these as buttons but rather as axes)
             if (CORE.Input.Gamepad.axisState[i][GAMEPAD_AXIS_LEFT_TRIGGER] > 0.1f)
             {
                 CORE.Input.Gamepad.currentButtonState[i][GAMEPAD_BUTTON_LEFT_TRIGGER_2] = 1;

--- a/src/platforms/rcore_desktop_sdl.c
+++ b/src/platforms/rcore_desktop_sdl.c
@@ -1825,7 +1825,7 @@ void PollInputEvents(void)
                     {
                         if (platform.gamepadId[i] == event.jaxis.which)
                         {
-                            // SDL axis value range is -32768 to 32767, we normalize it to RayLib's -1.0 to 1.0f range
+                            // SDL axis value range is -32768 to 32767, we normalize it to raylib's -1.0 to 1.0f range
                             float value = event.jaxis.value/(float)32767;
                             CORE.Input.Gamepad.axisState[i][axis] = value;
 

--- a/src/platforms/rcore_drm.c
+++ b/src/platforms/rcore_drm.c
@@ -124,7 +124,7 @@ typedef struct {
 
     // Gamepad data
     int gamepadStreamFd[MAX_GAMEPADS];  // Gamepad device file descriptor
-    int gamepadAbsAxisRange[MAX_GAMEPADS][MAX_GAMEPAD_AXES][2]; // [0] = min, [1] = range value of the axis
+    int gamepadAbsAxisRange[MAX_GAMEPADS][MAX_GAMEPAD_AXES][2]; // [0] = min, [1] = range value of the axes
     int gamepadAbsAxisMap[MAX_GAMEPADS][ABS_CNT]; // Maps the axes gamepads from the evdev api to a sequential one
     int gamepadCount;                   // The number of gamepads registered
 } PlatformData;
@@ -1460,7 +1460,7 @@ static void ConfigureEvdevDevice(char *device)
         // matter if we support them
         else if (hasAbsXY && TEST_BIT(keyBits, BTN_MOUSE)) isMouse = true;
 
-        // If any of the common joystick axis is present, we assume it's a gamepad
+        // If any of the common joystick axes are present, we assume it's a gamepad
         else
         {
             for (int axis = (hasAbsXY? ABS_Z : ABS_X); axis < ABS_PRESSURE; axis++)
@@ -1546,7 +1546,7 @@ static void ConfigureEvdevDevice(char *device)
         if (absAxisCount > 0)
         {
             // TODO / NOTE
-            // So gamepad axis (as in the actual linux joydev.c) are just simply enumerated
+            // So gamepad axes (as in the actual linux joydev.c) are just simply enumerated
             // and (at least for some input drivers like xpat) it's convention to use
             // ABS_X, ABX_Y for one joystick ABS_RX, ABS_RY for the other and the Z axes for the
             // shoulder buttons

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -743,7 +743,7 @@ typedef enum {
     GAMEPAD_BUTTON_RIGHT_THUMB          // Gamepad joystick pressed button right
 } GamepadButton;
 
-// Gamepad axis
+// Gamepad axes
 typedef enum {
     GAMEPAD_AXIS_LEFT_X        = 0,     // Gamepad left stick X axis
     GAMEPAD_AXIS_LEFT_Y        = 1,     // Gamepad left stick Y axis
@@ -1192,8 +1192,8 @@ RLAPI bool IsGamepadButtonDown(int gamepad, int button);      // Check if a game
 RLAPI bool IsGamepadButtonReleased(int gamepad, int button);  // Check if a gamepad button has been released once
 RLAPI bool IsGamepadButtonUp(int gamepad, int button);        // Check if a gamepad button is NOT being pressed
 RLAPI int GetGamepadButtonPressed(void);                      // Get the last gamepad button pressed
-RLAPI int GetGamepadAxisCount(int gamepad);                   // Get gamepad axis count for a gamepad
-RLAPI float GetGamepadAxisMovement(int gamepad, int axis);    // Get axis movement value for a gamepad axis
+RLAPI int GetGamepadAxisCount(int gamepad);                   // Get axis count for a gamepad
+RLAPI float GetGamepadAxisMovement(int gamepad, int axis);    // Get movement value for a gamepad axis
 RLAPI int SetGamepadMappings(const char *mappings);           // Set internal gamepad mappings (SDL_GameControllerDB)
 RLAPI void SetGamepadVibration(int gamepad, float leftMotor, float rightMotor, float duration); // Set gamepad vibration for both motors (duration in seconds)
 

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -235,10 +235,10 @@ __declspec(dllimport) unsigned int __stdcall timeEndPeriod(unsigned int uPeriod)
     #define MAX_GAMEPADS                   4        // Maximum number of gamepads supported
 #endif
 #ifndef MAX_GAMEPAD_NAME_LENGTH
-    #define MAX_GAMEPAD_NAME_LENGTH      128        // Maximum number of characters of gamepad name (byte size)
+    #define MAX_GAMEPAD_NAME_LENGTH      128        // Maximum number of characters in a gamepad name (byte size)
 #endif
 #ifndef MAX_GAMEPAD_AXES
-    #define MAX_GAMEPAD_AXES               8        // Maximum number of axis supported (per gamepad)
+    #define MAX_GAMEPAD_AXES               8        // Maximum number of axes supported (per gamepad)
 #endif
 #ifndef MAX_GAMEPAD_BUTTONS
     #define MAX_GAMEPAD_BUTTONS           32        // Maximum number of buttons supported (per gamepad)
@@ -354,7 +354,7 @@ typedef struct CoreData {
         } Touch;
         struct {
             int lastButtonPressed;          // Register last gamepad button pressed
-            int axisCount[MAX_GAMEPADS];    // Register number of available gamepad axis
+            int axisCount[MAX_GAMEPADS];    // Register number of available gamepad axes
             bool ready[MAX_GAMEPADS];       // Flag to know if gamepad is ready
             char name[MAX_GAMEPADS][MAX_GAMEPAD_NAME_LENGTH];               // Gamepad name holder
             char currentButtonState[MAX_GAMEPADS][MAX_GAMEPAD_BUTTONS];     // Current gamepad buttons state


### PR DESCRIPTION
This mostly replaces "axis" with "axes" where it makes sense.

There is still the ``GamepadAxis`` enum, which should be renamed to ``GamepadAxes``, but this is better left for another PR because it is not a comment.