### PR TITLE
Rename GamepadAxis enum to GamepadAxes (breaking change)

### DIFF
--- a/parser/output/raylib_api.json
+++ b/parser/output/raylib_api.json
@@ -2299,7 +2299,7 @@
       ]
     },
     {
-      "name": "GamepadAxis",
+      "name": "GamepadAxes",
       "description": "Gamepad axes",
       "values": [
         {

--- a/parser/output/raylib_api.lua
+++ b/parser/output/raylib_api.lua
@@ -2299,7 +2299,7 @@ return {
       }
     },
     {
-      name = "GamepadAxis",
+      name = "GamepadAxes",
       description = "Gamepad axes",
       values = {
         {

--- a/parser/output/raylib_api.txt
+++ b/parser/output/raylib_api.txt
@@ -772,8 +772,8 @@ Enum 06: GamepadButton (18 values)
   Value[GAMEPAD_BUTTON_MIDDLE_RIGHT]: 15
   Value[GAMEPAD_BUTTON_LEFT_THUMB]: 16
   Value[GAMEPAD_BUTTON_RIGHT_THUMB]: 17
-Enum 07: GamepadAxis (6 values)
-  Name: GamepadAxis
+Enum 07: GamepadAxes (6 values)
+  Name: GamepadAxes
   Description: Gamepad axes
   Value[GAMEPAD_AXIS_LEFT_X]: 0
   Value[GAMEPAD_AXIS_LEFT_Y]: 1

--- a/parser/output/raylib_api.xml
+++ b/parser/output/raylib_api.xml
@@ -486,7 +486,7 @@
             <Value name="GAMEPAD_BUTTON_LEFT_THUMB" integer="16" desc="Gamepad joystick pressed button left" />
             <Value name="GAMEPAD_BUTTON_RIGHT_THUMB" integer="17" desc="Gamepad joystick pressed button right" />
         </Enum>
-        <Enum name="GamepadAxis" valueCount="6" desc="Gamepad axes">
+        <Enum name="GamepadAxes" valueCount="6" desc="Gamepad axes">
             <Value name="GAMEPAD_AXIS_LEFT_X" integer="0" desc="Gamepad left stick X axis" />
             <Value name="GAMEPAD_AXIS_LEFT_Y" integer="1" desc="Gamepad left stick Y axis" />
             <Value name="GAMEPAD_AXIS_RIGHT_X" integer="2" desc="Gamepad right stick X axis" />

--- a/src/platforms/rcore_drm.c
+++ b/src/platforms/rcore_drm.c
@@ -1551,7 +1551,7 @@ static void ConfigureEvdevDevice(char *device)
             // ABS_X, ABX_Y for one joystick ABS_RX, ABS_RY for the other and the Z axes for the
             // shoulder buttons
             // If these are now enumerated you get LJOY_X, LJOY_Y, LEFT_SHOULDERB, RJOY_X, ...
-            // That means they don't match the GamepadAxis enum
+            // That means they don't match the GamepadAxes enum
             // This could be fixed
             int axisIndex = 0;
             for (int axis = ABS_X; axis < ABS_PRESSURE; axis++)

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -751,7 +751,7 @@ typedef enum {
     GAMEPAD_AXIS_RIGHT_Y       = 3,     // Gamepad right stick Y axis
     GAMEPAD_AXIS_LEFT_TRIGGER  = 4,     // Gamepad back trigger left, pressure level: [1..-1]
     GAMEPAD_AXIS_RIGHT_TRIGGER = 5      // Gamepad back trigger right, pressure level: [1..-1]
-} GamepadAxis;
+} GamepadAxes;
 
 // Material map index
 typedef enum {


### PR DESCRIPTION
A follow-up to the likes of 341bfb2 and 3418172.

This is a breaking change.