### PR TITLE
Expose `android_fopen()` and associated `fopen` macro for Android platform builds

### DIFF
--- a/src/raylib.h
+++ b/src/raylib.h
@@ -87,6 +87,10 @@
 
 #include <stdarg.h>     // Required for: va_list - Only used by TraceLogCallback
 
+#if defined(PLATFORM_ANDROID)
+    #include <stdio.h>  // Required for: FILE    - Only used by android_fopen
+#endif
+
 #define RAYLIB_VERSION_MAJOR 5
 #define RAYLIB_VERSION_MINOR 6
 #define RAYLIB_VERSION_PATCH 0
@@ -1124,6 +1128,12 @@ RLAPI bool ExportDataAsCode(const unsigned char *data, int dataSize, const char 
 RLAPI char *LoadFileText(const char *fileName);                   // Load text data from file (read), returns a '\0' terminated string
 RLAPI void UnloadFileText(char *text);                            // Unload file text data allocated by LoadFileText()
 RLAPI bool SaveFileText(const char *fileName, const char *text);  // Save text data to file (write), string must be '\0' terminated, returns true on success
+#if defined(PLATFORM_ANDROID)
+    RLAPI FILE *android_fopen(const char *filename, const char *mode); // Open an asset file
+    #if !defined(fopen)
+        #define fopen(name, mode) android_fopen(name, mode)
+    #endif
+#endif
 //------------------------------------------------------------------
 
 // File system functions


### PR DESCRIPTION
In RayGui (non-standalone mode), the `GuiLoadStyle()` function uses `fopen()` to load style files. However, on Android, standard `fopen()` cannot access asset files within the APK directly. As a result, RayGui could not load styles from assets on Android.

This PR exposes the `android_fopen()` function declaration for Android builds so it can be used where needed (e.g., in RayGui). It also defines a macro to redirect `fopen` to `android_fopen` when `PLATFORM_ANDROID` is defined.

Currently, `android_fopen()` is defined in `utils.h`, which has a very generic name. This can conflict with other files named `utils.h` in user projects. Because it’s not declared in any Raylib header, developers are forced to manually patch Raylib headers to use `android_fopen` (which breaks portability and automation). A more specific name like `rutils.h` could also help in the future.

Note:
- The macro-based redirection of `fopen` may cause issues if users rely on `fopen()` for accessing non-asset or external storage files on Android. If needed, I can adjust the PR to make this redirection opt-in.