### PR TITLE
Add LICENSE to build.zig.zon

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -23,5 +23,6 @@
         "build.zig.zon",
         "src",
         "examples",
+	"LICENSE",
     },
 }


### PR DESCRIPTION
Zig users importing raylib need to have the license too.