### PR TITLE
Change `RGFW_window_eventWait` timeout to -1 to fix `EnableEventWaiting`

### DIFF
--- a/src/platforms/rcore_desktop_rgfw.c
+++ b/src/platforms/rcore_desktop_rgfw.c
@@ -989,7 +989,7 @@ void PollInputEvents(void)
 
     if ((CORE.Window.eventWaiting) || (IsWindowState(FLAG_WINDOW_MINIMIZED) && !IsWindowState(FLAG_WINDOW_ALWAYS_RUN)))
     {
-        RGFW_window_eventWait(platform.window, 0); // Wait for input events: keyboard/mouse/window events (callbacks) -> Update keys state
+        RGFW_window_eventWait(platform.window, -1); // Wait for input events: keyboard/mouse/window events (callbacks) -> Update keys state
         CORE.Time.previous = GetTime();
     }
 


### PR DESCRIPTION
there is a mistake in rcore_desktop_rgfw line 992
currently it looks like this:
```c
if ((CORE.Window.eventWaiting) || (IsWindowState(FLAG_WINDOW_MINIMIZED) && !IsWindowState(FLAG_WINDOW_ALWAYS_RUN)))
{
    RGFW_window_eventWait(platform.window, 0); // Wait for input events: keyboard/mouse/window events (callbacks) -> Update keys state
    CORE.Time.previous = GetTime();
}
```

with `RGFW_window_eventWait` set to 0 timeout. this makes `EnableEventWaiting();` not work, since the timeout is always 0. setting it to -1 makes it work correctly.