### PR TITLE
[rcore][drm] Replace DRM swap buffer implementation with asynchronous page-flipping and triple framebuffer caching

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -299,4 +299,9 @@
 //------------------------------------------------------------------------------------
 #define MAX_TRACELOG_MSG_LENGTH       256       // Max length of one trace-log message
 
+//DRM configuration
+#if defined(PLATFORM_DRM)
+//#define SUPPORT_DRM_CACHE 1 //enable triple buffered DRM caching
+#endif //PLATFORM_DRM
+
 #endif // CONFIG_H

--- a/src/platforms/rcore_drm.c
+++ b/src/platforms/rcore_drm.c
@@ -1308,12 +1308,12 @@ int InitPlatform(void)
 
 #if defined(SUPPORT_DRM_CACHE)
     if(InitSwapScreenBuffer() == 0) {
+#endif//SUPPORT_DRM_CACHE
         TRACELOG(LOG_INFO, "PLATFORM: DRM: Initialized successfully");
         return 0;
-    } else {
-#endif//SUPPORT_DRM_CACHE
-        TRACELOG(LOG_INFO, "PLATFORM: DRM: Initialized failed");
 #if defined(SUPPORT_DRM_CACHE)
+    } else {
+        TRACELOG(LOG_INFO, "PLATFORM: DRM: Initialized failed");
         return -1;
     }
 #endif //SUPPORT_DRM_CACHE


### PR DESCRIPTION
The original implementation created/destroyed framebuffers (FBs) per-frame, leading to kernel overhead and screen tearing. This commit replaces it with a different approach using:
- Asynchronous `drmModePageFlip()` with vblank sync
- Framebuffer caching to reduce repeated FB creation/removal operations
- Proper resource management through BO callbacks and buffer release synchronization
- Added error handling for busy displays, cache overflows, and flip failures
- Event-driven cleanup via page_flip_handler to prevent GPU/scanout conflicts

Would you please review this code?
In my case it works better, has less framedrop or tearing.
Tested it on a Raspberry Pi Zero 2W.

Maybe this implementation should be handled as a compiler option for the user. To select if he wants the minimal DRM or the page-flipping, cached DRM.

#### **Summary: Key Differences**

| **Aspect**               | Function (`SwapScreenBuffer - Original`)                     | Function (`SwapScreenBuffer new`)                              |
|--------------------------|---------------------------------------------------------------|-----------------------------------------------------------------|
| **Framebuffer Creation**  | Creates/removes an FB per frame (expensive).                 | Caches Fbs for reuse; minimizes kernel operations.               |
| **Flip Synchronization**  | No vblank sync: likely causes tearing.                       | Uses `drmModePageFlip()` with vblank sync to prevent tearing.    |
| **Error Handling**        | Minimal recovery (logs errors, continues).                    | Graceful error handling and tracking via counters/callbacks.     |
| **Resource Management**   | Frees buffers immediately; risks conflicts.                   | Properly releases BOs/Fbs only after flips complete.             |
| **Complexity/Overhead**   | Simple code but performs poorly at high frame rates.         | More complex but optimizes for performance      |

---