### PR TITLE
Allow passing options to raygui in build.zig

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -366,8 +366,8 @@ fn compileRaylib(b: *std.Build, target: std.Build.ResolvedTarget, optimize: std.
     return raylib;
 }
 
-pub fn addRaygui(b: *std.Build, raylib: *std.Build.Step.Compile, raygui_dep: *std.Build.Dependency) void {
-    const raylib_dep = b.dependencyFromBuildZig(@This(), .{});
+pub fn addRaygui(b: *std.Build, raylib: *std.Build.Step.Compile, raygui_dep: *std.Build.Dependency, options: Options) void {
+    const raylib_dep = b.dependencyFromBuildZig(@This(), options);
     var gen_step = b.addWriteFiles();
     raylib.step.dependOn(&gen_step.step);
 


### PR DESCRIPTION
This fixes build issues when building raygui on Linux systems without wayland, that are missing the `wayland-scanner` program. More details on the issue can be found at Not-Nik/raylib-zig#243.

A different solution to this problem could be requiring `raylib_dep` to be passed into `addRaygui` directly, but I don't see any semantic difference, as the dependency functions should reuse previously created `std.Build.Dependency` instances.