### PR TITLE
[rcore] Fix ScanDirectoryFilesRecursively

### DIFF
--- a/src/rcore.c
+++ b/src/rcore.c
@@ -3757,7 +3757,7 @@ static void ScanDirectoryFiles(const char *basePath, FilePathList *files, const 
 // Scan all files and directories recursively from a base path
 static void ScanDirectoryFilesRecursively(const char *basePath, FilePathList *files, const char *filter)
 {
-    static char path[MAX_FILEPATH_LENGTH] = { 0 };
+    char path[MAX_FILEPATH_LENGTH] = { 0 };
     memset(path, 0, MAX_FILEPATH_LENGTH);
 
     struct dirent *dp = NULL;


### PR DESCRIPTION
Fixes a regression since 5.5, where `ScanDirectoryFilesRecursively` no longer does the "recursively" part due to `path` being `static`.

The issue was once already fixed in https://github.com/raysan5/raylib/commit/5530a3ceb88962066affa5db8e13b00b64444b37 but recently made it back it in.