### PR TITLE
Fix typo on config.h

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -189,7 +189,7 @@
 //------------------------------------------------------------------------------------
 // Module: rtextures - Configuration Flags
 //------------------------------------------------------------------------------------
-// Selecte desired fileformats to be supported for image data loading
+// Selected desired fileformats to be supported for image data loading
 #define SUPPORT_FILEFORMAT_PNG      1
 //#define SUPPORT_FILEFORMAT_BMP      1
 //#define SUPPORT_FILEFORMAT_TGA      1


### PR DESCRIPTION
Fixes a typo in config.h, from "Selecte" to "Selected", same expression as the comment on line 223.