### PR TITLE
[zig] Update emsdk version for zig build to fix the issue with the EM_BOOL

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -12,8 +12,8 @@
             .lazy = true,
         },
         .emsdk = .{
-            .url = "git+https://github.com/emscripten-core/emsdk#3.1.50",
-            .hash = "N-V-__8AALRTBQDo_pUJ8IQ-XiIyYwDKQVwnr7-7o5kvPDGE",
+            .url = "git+https://github.com/emscripten-core/emsdk#4.0.9",
+            .hash = "N-V-__8AAJl1DwBezhYo_VE6f53mPVm00R-Fk28NPW7P14EQ",
             .lazy = true,
         },
     },
@@ -23,6 +23,6 @@
         "build.zig.zon",
         "src",
         "examples",
-	"LICENSE",
+        "LICENSE",
     },
 }


### PR DESCRIPTION
In `v3.1.62` of `Emscripten`, they changed their bool type from int to bool, so the size of the `EmscriptenTouch` Structs were different from the current major version of the `Emscripten`, It was provoking memory corruption, getting completely wrong values from `GetTouchPosition`.

My issue was with the TouchScreen but it solves as well any issue that the struct is created on `Emscripten` side.

Issue:
* `Emscripten` trying to create a struct size: 1552
* `C` receiving a struct size: 1696

![image](https://github.com/user-attachments/assets/9f321c6a-595b-412b-afaf-3484ba154e05)

Solved:
* `Emscripten` trying to create a struct size: 1552
* `C` receiving a struct size: 1552

![image](https://github.com/user-attachments/assets/263f164a-9532-4223-95fd-3c4486bec4dc)
