### PR TITLE
[example] Fix pbr example shaders to use vec4 for vertexTangent

### DIFF
--- a/examples/shaders/resources/shaders/glsl100/pbr.vs
+++ b/examples/shaders/resources/shaders/glsl100/pbr.vs
@@ -4,7 +4,7 @@
 attribute vec3 vertexPosition;
 attribute vec2 vertexTexCoord;
 attribute vec3 vertexNormal;
-attribute vec3 vertexTangent;
+attribute vec4 vertexTangent;
 attribute vec4 vertexColor;
 
 // Input uniform values
@@ -52,7 +52,7 @@ mat3 transpose(mat3 m)
 void main()
 {
     // Compute binormal from vertex normal and tangent
-    vec3 vertexBinormal = cross(vertexNormal, vertexTangent);
+    vec3 vertexBinormal = cross(vertexNormal, vertexTangent.xyz) * vertexTangent.w;
 
     // Compute fragment normal based on normal transformations
     mat3 normalMatrix = transpose(inverse(mat3(matModel)));
@@ -62,7 +62,7 @@ void main()
 
     fragTexCoord = vertexTexCoord*2.0;
     fragNormal = normalize(normalMatrix*vertexNormal);
-    vec3 fragTangent = normalize(normalMatrix*vertexTangent);
+    vec3 fragTangent = normalize(normalMatrix*vertexTangent.xyz) * vertexTangent.w;
     fragTangent = normalize(fragTangent - dot(fragTangent, fragNormal)*fragNormal);
     vec3 fragBinormal = normalize(normalMatrix*vertexBinormal);
     fragBinormal = cross(fragNormal, fragTangent);

--- a/examples/shaders/resources/shaders/glsl100/pbr.vs
+++ b/examples/shaders/resources/shaders/glsl100/pbr.vs
@@ -62,7 +62,7 @@ void main()
 
     fragTexCoord = vertexTexCoord*2.0;
     fragNormal = normalize(normalMatrix*vertexNormal);
-    vec3 fragTangent = normalize(normalMatrix*vertexTangent.xyz) * vertexTangent.w;
+    vec3 fragTangent = normalize(normalMatrix*vertexTangent.xyz);
     fragTangent = normalize(fragTangent - dot(fragTangent, fragNormal)*fragNormal);
     vec3 fragBinormal = normalize(normalMatrix*vertexBinormal);
     fragBinormal = cross(fragNormal, fragTangent);

--- a/examples/shaders/resources/shaders/glsl120/pbr.vs
+++ b/examples/shaders/resources/shaders/glsl120/pbr.vs
@@ -4,7 +4,7 @@
 attribute vec3 vertexPosition;
 attribute vec2 vertexTexCoord;
 attribute vec3 vertexNormal;
-attribute vec3 vertexTangent;
+attribute vec4 vertexTangent;
 attribute vec4 vertexColor;
 
 // Input uniform values
@@ -52,7 +52,7 @@ mat3 transpose(mat3 m)
 void main()
 {
     // Compute binormal from vertex normal and tangent
-    vec3 vertexBinormal = cross(vertexNormal, vertexTangent);
+    vec3 vertexBinormal = cross(vertexNormal, vertexTangent.xyz) * vertexTangent.w;
 
     // Compute fragment normal based on normal transformations
     mat3 normalMatrix = transpose(inverse(mat3(matModel)));
@@ -62,7 +62,7 @@ void main()
 
     fragTexCoord = vertexTexCoord*2.0;
     fragNormal = normalize(normalMatrix*vertexNormal);
-    vec3 fragTangent = normalize(normalMatrix*vertexTangent);
+    vec3 fragTangent = normalize(normalMatrix*vertexTangent.xyz) * vertexTangent.w;
     fragTangent = normalize(fragTangent - dot(fragTangent, fragNormal)*fragNormal);
     vec3 fragBinormal = normalize(normalMatrix*vertexBinormal);
     fragBinormal = cross(fragNormal, fragTangent);

--- a/examples/shaders/resources/shaders/glsl120/pbr.vs
+++ b/examples/shaders/resources/shaders/glsl120/pbr.vs
@@ -62,7 +62,7 @@ void main()
 
     fragTexCoord = vertexTexCoord*2.0;
     fragNormal = normalize(normalMatrix*vertexNormal);
-    vec3 fragTangent = normalize(normalMatrix*vertexTangent.xyz) * vertexTangent.w;
+    vec3 fragTangent = normalize(normalMatrix*vertexTangent.xyz);
     fragTangent = normalize(fragTangent - dot(fragTangent, fragNormal)*fragNormal);
     vec3 fragBinormal = normalize(normalMatrix*vertexBinormal);
     fragBinormal = cross(fragNormal, fragTangent);

--- a/examples/shaders/resources/shaders/glsl330/pbr.vs
+++ b/examples/shaders/resources/shaders/glsl330/pbr.vs
@@ -36,7 +36,7 @@ void main()
 
     fragTexCoord = vertexTexCoord*2.0;
     fragNormal = normalize(normalMatrix*vertexNormal);
-    vec3 fragTangent = normalize(normalMatrix*vertexTangent.xyz) * vertexTangent.w;
+    vec3 fragTangent = normalize(normalMatrix*vertexTangent.xyz);
     fragTangent = normalize(fragTangent - dot(fragTangent, fragNormal)*fragNormal);
     vec3 fragBinormal = normalize(normalMatrix*vertexBinormal);
     fragBinormal = cross(fragNormal, fragTangent);

--- a/examples/shaders/resources/shaders/glsl330/pbr.vs
+++ b/examples/shaders/resources/shaders/glsl330/pbr.vs
@@ -4,7 +4,7 @@
 in vec3 vertexPosition;
 in vec2 vertexTexCoord;
 in vec3 vertexNormal;
-in vec3 vertexTangent;
+in vec4 vertexTangent;
 in vec4 vertexColor;
 
 // Input uniform values
@@ -26,7 +26,7 @@ const float normalOffset = 0.1;
 void main()
 {
     // Compute binormal from vertex normal and tangent
-    vec3 vertexBinormal = cross(vertexNormal, vertexTangent);
+    vec3 vertexBinormal = cross(vertexNormal, vertexTangent.xyz) * vertexTangent.w;
 
     // Compute fragment normal based on normal transformations
     mat3 normalMatrix = transpose(inverse(mat3(matModel)));
@@ -36,7 +36,7 @@ void main()
 
     fragTexCoord = vertexTexCoord*2.0;
     fragNormal = normalize(normalMatrix*vertexNormal);
-    vec3 fragTangent = normalize(normalMatrix*vertexTangent);
+    vec3 fragTangent = normalize(normalMatrix*vertexTangent.xyz) * vertexTangent.w;
     fragTangent = normalize(fragTangent - dot(fragTangent, fragNormal)*fragNormal);
     vec3 fragBinormal = normalize(normalMatrix*vertexBinormal);
     fragBinormal = cross(fragNormal, fragTangent);


### PR DESCRIPTION
The shaders are currently using a vec3 for vertexTangent despite Raylib uploading vec4's to them. I also multiplied the biNormal by the w component as this example loads .glb files which use the w component for the tangent basis sign.