### PR TITLE
Update raudio.c

### DIFF
--- a/src/raudio.c
+++ b/src/raudio.c
@@ -81,7 +81,7 @@
     #include "utils.h"          // Required for: fopen() Android mapping
 #endif
 
-#if defined(SUPPORT_MODULE_RAUDIO)
+#if defined(SUPPORT_MODULE_RAUDIO) || defined(RAUDIO_STANDALONE)
 
 #if defined(_WIN32)
 // To avoid conflicting windows.h symbols with raylib, some flags are defined


### PR DESCRIPTION
Allow for raudio to be used as a standalone module.  Including it here, because this fix was original done in the main raudio repo, but during an update to raudio to bring it up to date to the version that is being used here, that fix was regressed back.

Putting this PR here in hoping that the fix would be more persistent and filter to the raudio specific repo as well.  If accepted here, I'll remove the original PR from raudio's repo.