### PR TITLE
[retextures] fix integer overflow in cast for `ImageBlurGaussian`

### DIFF
--- a/src/rtextures.c
+++ b/src/rtextures.c
@@ -2217,9 +2217,9 @@ void ImageBlurGaussian(Image *image, int blurSize)
         else if (pixelsCopy1[i].w <= 255.0f)
         {
             float alpha = (float)pixelsCopy1[i].w/255.0f;
-            pixels[i].r = (unsigned char)((float)pixelsCopy1[i].x/alpha);
-            pixels[i].g = (unsigned char)((float)pixelsCopy1[i].y/alpha);
-            pixels[i].b = (unsigned char)((float)pixelsCopy1[i].z/alpha);
+            pixels[i].r = (unsigned char)fminf((float)pixelsCopy1[i].x/alpha, 255.0);
+            pixels[i].g = (unsigned char)fminf((float)pixelsCopy1[i].y/alpha, 255.0);
+            pixels[i].b = (unsigned char)fminf((float)pixelsCopy1[i].z/alpha, 255.0);
             pixels[i].a = (unsigned char) pixelsCopy1[i].w;
         }
     }


### PR DESCRIPTION
I had a weird bug where `ImageBlurGaussian` with `blurSize=1` added weird discolored lines:
<div>
<img width="256" height="256" alt="lightblub-noblur" src="https://github.com/user-attachments/assets/710dcd9d-3032-4bd2-8d02-2457aa8b4883" />
<img width="256" height="256" alt="lightbulb-blur" src="https://github.com/user-attachments/assets/959147b8-e28c-4989-bb83-54fe46bc6cfb" />
</div>

The bug happens in the [final 'reverse premultiply' step](https://github.com/raysan5/raylib/blob/55a567471433dc60d92cb06f530d09ede97190c3/src/rtextures.c#L2219-L2222) where a rounding error can produce RGB color values that are >=256.0. When cast back to unsigned char for storage, this overflows to zero -- producing colors that are way off. This fix rounds these values down to 255 instead. 