### PR TITLE
Image draw line ex fix

### DIFF
--- a/src/rtextures.c
+++ b/src/rtextures.c
@@ -3565,34 +3565,39 @@ void ImageDrawLineEx(Image *dst, Vector2 start, Vector2 end, int thick, Color co
     int dx = x2 - x1;
     int dy = y2 - y1;
 
-    // Draw the main line between (x1, y1) and (x2, y2)
-    ImageDrawLine(dst, x1, y1, x2, y2, color);
-
     // Determine if the line is more horizontal or vertical
     if ((dx != 0) && (abs(dy/dx) < 1))
     {
         // Line is more horizontal
-        // Calculate half the width of the line
-        int wy = (thick - 1)*(int)sqrtf((float)(dx*dx + dy*dy))/(2*abs(dx));
+        int wy = thick - 1;
 
-        // Draw additional lines above and below the main line
-        for (int i = 1; i <= wy; i++)
+        //Draw the main line and lower half
+        for (int i = 0; i <= ((wy+1)/2); i++)
+        {
+            ImageDrawLine(dst, x1, y1 + i, x2, y2 + i, color); // Draw below the main line
+        }
+
+        //Draw the upper half
+        for (int i = 1; i <= (wy/2); i++)
         {
             ImageDrawLine(dst, x1, y1 - i, x2, y2 - i, color); // Draw above the main line
-            ImageDrawLine(dst, x1, y1 + i, x2, y2 + i, color); // Draw below the main line
         }
     }
     else if (dy != 0)
     {
         // Line is more vertical or perfectly horizontal
-        // Calculate half the width of the line
-        int wx = (thick - 1)*(int)sqrtf((float)(dx*dx + dy*dy))/(2*abs(dy));
+        int wx = thick - 1;
 
-        // Draw additional lines to the left and right of the main line
-        for (int i = 1; i <= wx; i++)
+        //Draw the main line and right half
+        for (int i = 0; i <= ((wx+1)/2); i++)
+        {
+            ImageDrawLine(dst, x1 + i, y1, x2 + i, y2, color); // Draw right of the main line
+        }
+
+        //Draw the the left half
+        for (int i = 1; i <= (wx/2); i++)
         {
             ImageDrawLine(dst, x1 - i, y1, x2 - i, y2, color); // Draw left of the main line
-            ImageDrawLine(dst, x1 + i, y1, x2 + i, y2, color); // Draw right of the main line
         }
     }
 }

--- a/src/rtextures.c
+++ b/src/rtextures.c
@@ -3569,15 +3569,17 @@ void ImageDrawLineEx(Image *dst, Vector2 start, Vector2 end, int thick, Color co
     if ((dx != 0) && (abs(dy/dx) < 1))
     {
         // Line is more horizontal
+
+        // How many additional lines to draw
         int wy = thick - 1;
 
-        //Draw the main line and lower half
+        // Draw the main line and lower half
         for (int i = 0; i <= ((wy+1)/2); i++)
         {
             ImageDrawLine(dst, x1, y1 + i, x2, y2 + i, color); // Draw below the main line
         }
 
-        //Draw the upper half
+        // Draw the upper half
         for (int i = 1; i <= (wy/2); i++)
         {
             ImageDrawLine(dst, x1, y1 - i, x2, y2 - i, color); // Draw above the main line
@@ -3586,6 +3588,8 @@ void ImageDrawLineEx(Image *dst, Vector2 start, Vector2 end, int thick, Color co
     else if (dy != 0)
     {
         // Line is more vertical or perfectly horizontal
+        
+        // How many additional lines to draw
         int wx = thick - 1;
 
         //Draw the main line and right half
@@ -3594,7 +3598,7 @@ void ImageDrawLineEx(Image *dst, Vector2 start, Vector2 end, int thick, Color co
             ImageDrawLine(dst, x1 + i, y1, x2 + i, y2, color); // Draw right of the main line
         }
 
-        //Draw the the left half
+        // Draw the left half
         for (int i = 1; i <= (wx/2); i++)
         {
             ImageDrawLine(dst, x1 - i, y1, x2 - i, y2, color); // Draw left of the main line


### PR DESCRIPTION
This PR is to address ImageDrawLineEx based on issue #5040. This PR attempts to fix the inability to draw lines with an even number of pixel thickness. Note another difference between ImageDrawLineEx and DrawLineEx seems to be that the former starts x and y at zero and the latter starts it at 1. So in the test images you can see that ImageDrawLineEx starts 1 pixel further down than DrawLineEx I tested the changes and got the following results(Test code below). 


Output from ImageDrawLineEx using current master branch of Raylib
<img width="50" height="50" alt="image" src="https://github.com/user-attachments/assets/deed1ba6-c5b9-463e-8dce-d67a57b30a83" />


Output from ImageDrawLineEx with the changes applied
<img width="50" height="50" alt="image" src="https://github.com/user-attachments/assets/6163d6d4-aae5-4497-ba89-0e8822506341" />



DrawLineEx screenshot
<img width="50" height="50" alt="image" src="https://github.com/user-attachments/assets/c8386fe1-b3c9-4aea-8bd1-a5f782ad0c90" />


```C
#include "raylib.h"

int main(void) {
  const int width = 50;
  const int height = 50;
  InitWindow(width, height, "line example");

  Image image = GenImageColor(width, height, WHITE);

  // Horizontal test
  ImageDrawLineEx(&image, (Vector2){0, 2}, (Vector2){23, 2}, 1, RED);
  ImageDrawLineEx(&image, (Vector2){0, 4}, (Vector2){23, 4}, 2, RED);
  ImageDrawLineEx(&image, (Vector2){0, 8}, (Vector2){23, 8}, 3, RED);
  ImageDrawLineEx(&image, (Vector2){0, 12}, (Vector2){23, 12}, 4, RED);
  ImageDrawLineEx(&image, (Vector2){0, 18}, (Vector2){23, 18}, 5, RED);

  // Vertical test
  ImageDrawLineEx(&image, (Vector2){25, 0}, (Vector2){25, 33}, 1, RED);
  ImageDrawLineEx(&image, (Vector2){27, 0}, (Vector2){27, 33}, 2, RED);
  ImageDrawLineEx(&image, (Vector2){31, 0}, (Vector2){31, 33}, 3, RED);
  ImageDrawLineEx(&image, (Vector2){35, 0}, (Vector2){35, 33}, 4, RED);
  ImageDrawLineEx(&image, (Vector2){41, 0}, (Vector2){41, 33}, 5, RED);
  
  // Diagonal Test
  ImageDrawLineEx(&image, (Vector2){0, 2+20}, (Vector2){23, 12+20}, 1, RED);
  ImageDrawLineEx(&image, (Vector2){0, 4+20}, (Vector2){23, 15+20}, 2, RED);
  ImageDrawLineEx(&image, (Vector2){0, 8+20}, (Vector2){23, 19+20}, 3, RED);
  ImageDrawLineEx(&image, (Vector2){0, 12+20}, (Vector2){23, 24+20}, 4, RED);
  ImageDrawLineEx(&image, (Vector2){0, 18+20}, (Vector2){23, 30+20}, 5, RED);

  ExportImage(image, "image.png");

  while (!WindowShouldClose()) {
    BeginDrawing();
    ClearBackground(WHITE);
      // Horizontal test
      DrawLineEx((Vector2){0, 2}, (Vector2){23, 2}, 1, RED);
      DrawLineEx((Vector2){0, 4}, (Vector2){23, 4}, 2, RED);
      DrawLineEx((Vector2){0, 8}, (Vector2){23, 8}, 3, RED);
      DrawLineEx((Vector2){0, 12}, (Vector2){23, 12}, 4, RED);
      DrawLineEx((Vector2){0, 18}, (Vector2){23, 18}, 5, RED);

      // Vertical test
      DrawLineEx((Vector2){25, 0}, (Vector2){25, 33}, 1, RED);
      DrawLineEx((Vector2){27, 0}, (Vector2){27, 33}, 2, RED);
      DrawLineEx((Vector2){31, 0}, (Vector2){31, 33}, 3, RED);
      DrawLineEx((Vector2){35, 0}, (Vector2){35, 33}, 4, RED);
      DrawLineEx((Vector2){41, 0}, (Vector2){41, 33}, 5, RED);

      // Diagonal Test
      DrawLineEx((Vector2){0, 2+20}, (Vector2){23, 12+20}, 1, RED);
      DrawLineEx((Vector2){0, 4+20}, (Vector2){23, 15+20}, 2, RED);
      DrawLineEx((Vector2){0, 8+20}, (Vector2){23, 19+20}, 3, RED);
      DrawLineEx((Vector2){0, 12+20}, (Vector2){23, 24+20}, 4, RED);
      DrawLineEx((Vector2){0, 18+20}, (Vector2){23, 30+20}, 5, RED);
    EndDrawing();
  }
  UnloadImage(image);
  CloseWindow();
  return 0;
}
```

In case the images are altered by github here are the original files:
[Archive.zip](https://github.com/user-attachments/files/21208994/Archive.zip)

