### PR TITLE
[raudio] Prevent UpdateMusicStream to run without music playing

### DIFF
--- a/src/raudio.c
+++ b/src/raudio.c
@@ -1871,6 +1871,7 @@ void SeekMusicStream(Music music, float position)
 void UpdateMusicStream(Music music)
 {
     if (music.stream.buffer == NULL) return;
+    if (!music.stream.buffer->playing) return;
 
     ma_mutex_lock(&AUDIO.System.lock);
 


### PR DESCRIPTION
Save some resource when no music playing by stopping the UpdateMusicStream to process without music.