### PR TITLE
[rtextures] Fix ImageColorReplace() alpha issue replacement #5009

### DIFF
--- a/src/rtextures.c
+++ b/src/rtextures.c
@@ -2921,13 +2921,27 @@ void ImageColorReplace(Image *image, Color color, Color replace)
         }
     }
 
-    int format = image->format;
+    const int format = image->format;
     RL_FREE(image->data);
 
     image->data = pixels;
     image->format = PIXELFORMAT_UNCOMPRESSED_R8G8B8A8;
 
-    ImageFormat(image, format);
+    const bool formatHasNoAlpha = (format == PIXELFORMAT_UNCOMPRESSED_R8G8B8) ||
+                        (format == PIXELFORMAT_UNCOMPRESSED_R5G6B5) ||
+                        (format == PIXELFORMAT_UNCOMPRESSED_GRAYSCALE) ||
+                        (format == PIXELFORMAT_UNCOMPRESSED_R32G32B32) ||
+                        (format == PIXELFORMAT_UNCOMPRESSED_R16G16B16) ||
+                        (format == PIXELFORMAT_COMPRESSED_DXT1_RGB) ||
+                        (format == PIXELFORMAT_COMPRESSED_ETC1_RGB) ||
+                        (format == PIXELFORMAT_COMPRESSED_ETC2_RGB) ||
+                        (format == PIXELFORMAT_COMPRESSED_PVRT_RGB);
+
+    // Only convert back to original format if it supported alpha
+    if (!formatHasNoAlpha)
+    {
+        ImageFormat(image, format);
+    }
 }
 #endif      // SUPPORT_IMAGE_MANIPULATION
 


### PR DESCRIPTION
### Summary

Fix a bug in `ImageColorReplace()` where replacing a color in an image with RGB format would drop the alpha values from the replacement color.

### Problem

Currently, `ImageColorReplace()` always calls `ImageFormat(image, format)` at the end, even if the input image was in RGB format. This causes the newly replaced alpha values to be discarded, since the image is converted back to a format that does not support alpha (`R8G8B8`).

This issue was reported [on Github](https://github.com/raysan5/raylib/issues/5009), and can be reproduced with:

```c
// A pixel originally (0, 0, 0, 255) in RGB image
ImageColorReplace(img, (Color){ 0, 0, 0, 255 }, (Color){ 0, 0, 0, 0 });
// The pixel's alpha stays 255 instead of becoming 0
```

### Solution

Only convert the image back to the original format if it supports an alpha channel.
This avoids losing alpha data introduced during the replacement.

```c
if (!formatHasNoAlpha) ImageFormat(image, format);
```

### Platforms tested

- Windows11
-  Tested with a 16x16 PNG image using `PIXELFORMAT_UNCOMPRESSED_R8G8B8` format: <img width="16" height="16" alt="test-alpha" src="https://private-user-images.githubusercontent.com/34615798/459013761-d1cc9646-9f68-4cb9-9193-821e687a1275.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NTI2MTUwNjIsIm5iZiI6MTc1MjYxNDc2MiwicGF0aCI6Ii8zNDYxNTc5OC80NTkwMTM3NjEtZDFjYzk2NDYtOWY2OC00Y2I5LTkxOTMtODIxZTY4N2ExMjc1LnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNTA3MTUlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjUwNzE1VDIxMjYwMlomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTYyNDAwYTc0NTQzNTdmZjkyOWNkMDhmODIxMWJmZDBjZWNhZmNjODMzYjM3YzZiMzQ0ZjMxMTFhNjQ3ZDBiOTMmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.CtnFJO9aHn0R67yvnxr6ZjvIJ_Xxa5P5gXPT_OWgES8" />


Let me know if you'd prefer a helper function like FormatHasAlpha() to be added.