### PR TITLE
[rtext] Update font load message

### DIFF
--- a/src/rtext.c
+++ b/src/rtext.c
@@ -391,7 +391,7 @@ Font LoadFont(const char *fileName)
         else
         {
             SetTextureFilter(font.texture, TEXTURE_FILTER_POINT);    // By default, we set point filter (the best performance)
-            TRACELOG(LOG_INFO, "FONT: Data loaded successfully (%i pixel size | %i glyphs)", FONT_TTF_DEFAULT_SIZE, FONT_TTF_DEFAULT_NUMCHARS);
+            TRACELOG(LOG_INFO, "FONT: Data loaded successfully (%i pixel size | %i glyphs)", font.baseSize, font.glyphCount);
         }
     }
 


### PR DESCRIPTION
When loading a font with the LoadFont function in rtext.c, you get an info message on success that displays the pixel size and number of glyphs it has. But for some reason it doesn't use the actual font size and glyphs, it uses the constants `FONT_TTF_DEFAULT_SIZE` and `FONT_TTF_DEFAULT_NUMCHARS`. It's not a big deal but I spent like 10 minutes looking through the load font funcions to try and see why it "wasn't loading all the glyphs" (it was, it was the info message that was wrong).