### PR TITLE
C++20 formatters

### DIFF
--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1713,4 +1713,54 @@ RLAPI void DetachAudioMixedProcessor(AudioCallback processor); // Detach audio s
 }
 #endif
 
+#if __cplusplus >= 202002L && !defined(RAYLIB_DISABLE_CPP_FORMATTERS)
+
+// Optional C++20 formatters
+//-------------------------------------------------------------------------------
+
+#include <format>
+
+template <>
+struct std::formatter<Vector4> : std::formatter<std::string> {
+    auto format(Vector4 v, std::format_context& ctx) const {
+        auto fmt = std::format("{{{}, {}, {}, {}}}", v.x, v.y, v.z, v.w);
+        return std::formatter<std::string>::format(fmt, ctx);
+    }
+};
+
+template <>
+struct std::formatter<Vector3> : std::formatter<std::string> {
+    auto format(Vector3 v, std::format_context& ctx) const {
+        auto fmt = std::format("{{{}, {}, {}}}", v.x, v.y, v.z);
+        return std::formatter<std::string>::format(fmt, ctx);
+    }
+};
+
+template <>
+struct std::formatter<Vector2> : std::formatter<std::string> {
+    auto format(Vector2 v, std::format_context& ctx) const {
+        auto fmt = std::format("{{{}, {}}}", v.x, v.y);
+        return std::formatter<std::string>::format(fmt, ctx);
+    }
+};
+
+template <>
+struct std::formatter<Rectangle> : std::formatter<std::string> {
+    auto format(Rectangle rec, std::format_context& ctx) const {
+        auto fmt = std::format("{{{}, {}, {}, {}}}", rec.x, rec.y, rec.width, rec.height);
+        return std::formatter<std::string>::format(fmt, ctx);
+    }
+};
+
+template <>
+struct std::formatter<Color> : std::formatter<std::string> {
+    auto format(Color color, std::format_context& ctx) const {
+        auto fmt = std::format("{{{}, {}, {}}}", color.r, color.g, color.b);
+        return std::formatter<std::string>::format(fmt, ctx);
+    }
+};
+
+//-------------------------------------------------------------------------------
+#endif // C++20 formatters
+
 #endif // RAYLIB_H


### PR DESCRIPTION
I know this is mainly a C library, however I think that being able to format some of the raylib types via `std::println` and `std::format` makes for a more seemless C++ debugging experience, and therefore warrants an exception.

I think this will be a great feature for C++ users, in addition to the overloaded math operators in `raymath.h`. 