### PR TITLE
Fixes GLFW failing when SetPropW fails silently

### DIFF
--- a/src/external/glfw/src/win32_init.c
+++ b/src/external/glfw/src/win32_init.c
@@ -498,18 +498,19 @@ void _glfwInputErrorWin32(int error, const char* description)
     WCHAR buffer[_GLFW_MESSAGE_SIZE] = L"";
     char message[_GLFW_MESSAGE_SIZE] = "";
 
+    DWORD lastError = GetLastError();
     FormatMessageW(FORMAT_MESSAGE_FROM_SYSTEM |
                        FORMAT_MESSAGE_IGNORE_INSERTS |
                        FORMAT_MESSAGE_MAX_WIDTH_MASK,
                    NULL,
-                   GetLastError() & 0xffff,
+                   lastError & 0xffff,
                    MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
                    buffer,
                    sizeof(buffer) / sizeof(WCHAR),
                    NULL);
     WideCharToMultiByte(CP_UTF8, 0, buffer, -1, message, sizeof(message), NULL, NULL);
 
-    _glfwInputError(error, "%s: %s", description, message);
+    _glfwInputError(error, "%s (0x%lx / %lu): %s", description, lastError, lastError, message);
 }
 
 // Updates key names according to the current keyboard layout

--- a/src/external/glfw/src/win32_window.c
+++ b/src/external/glfw/src/win32_window.c
@@ -551,8 +551,23 @@ static LRESULT CALLBACK windowProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM l
                     EnableNonClientDpiScaling(hWnd);
             }
         }
+        else
+        {
+            // HACK: SetPropW returns FALSE in some instances (GetLastError() = 0x8 Insufficient resources).
+            //       We already have the global list of windows, check against it. It's not many, and we are already
+            //       doing this in the (one of the callers) PollEvents below.
+            window = _glfw.windowListHead;
+            while (window)
+            {
+                if (window->win32.handle == hWnd) { break; }
+                window = window->next;
+            }
+        }
 
+        if (!window)
+        {
         return DefWindowProcW(hWnd, uMsg, wParam, lParam);
+    }
     }
 
     switch (uMsg)
@@ -1405,7 +1420,13 @@ static int createNativeWindow(_GLFWwindow* window,
         return GLFW_FALSE;
     }
 
-    SetPropW(window->win32.handle, L"GLFW", window);
+    if (!SetPropW(window->win32.handle, L"GLFW", window))
+    {
+        // In some cases, SetPropW returns FALSE: GetLastError() returns 0x8 (Insufficient resources).
+        // The message pump fails to work because windowProc cannot look up the GLFW property.
+        // Instead of failing the program completely by raising an error instead, windowProc looks up
+        // the global window list to find the hWnd under consideration.        
+    }
 
     if (IsWindows7OrGreater())
     {


### PR DESCRIPTION
**Issue**

In some cases, on Windows, `SetPropW`  returns `FALSE`.
raylib currently silently ignores the result.
This means that the message pump `windowProc` fails to work (does not receive keyboard events for example). Drawing is fine though as it's a different GLFW mechanism.

I had this failure frequently infrequently and it was frustrating to deal with (just have to rerun the program a few times and hope `SetPropW` doesn't return `FALSE`). So sending this fix in case others are facing the issue on Windows.

**Fix**

On Windows+GLFW, `windowProc` will fallback to looking up the GLFW window list (just like `PollEvents` does).
Also added the error code to `_glfwInputError` message to aid debugging in the future.

My suggestion is to get rid of `SetPropW`/`GetPropW` as it is a string-based Windows API (slow/fragile)- we already have the lightweight linked list, might as well just use it always - also it's usually just the one or two windows we deal with.

- [x] Read the [contributor guidelines](https://github.com/raysan5/raylib/blob/138010c1ebabe184097f3945534dfed1ca19e929/CONTRIBUTING.md)
- [x] Verified on Windows - message pump is stable with this fix (once I was able to repro this issue).
