### PR TITLE
[build] Add ARM64 support to Linux builds

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -22,22 +22,28 @@ jobs:
   build:
     permissions:
       contents: write  # for actions/upload-release-asset to upload release asset
-    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       max-parallel: 1
       matrix:
-        bits: [32, 64]
         include:
         - bits: 32
           ARCH: "i386"
           ARCH_NAME: "i386"
           COMPILER_PATH: "/user/bin"
+          runner: "ubuntu-latest"
         - bits: 64
           ARCH: "x86_64"
           ARCH_NAME: "amd64"
           COMPILER_PATH: "/user/bin"
+          runner: "ubuntu-latest"
+        - bits: 64
+          ARCH: "aarch64"
+          ARCH_NAME: "arm64"
+          COMPILER_PATH: "/user/bin"
+          runner: "ubuntu-24.04-arm"
           
+    runs-on: ${{ matrix.runner }}
     env:
       RELEASE_NAME: raylib-dev_linux_${{ matrix.ARCH_NAME }}
     
@@ -66,7 +72,7 @@ jobs:
         # ${{ matrix.ARCH }}-linux-gnu-gcc -v
       
     # TODO: Support 32bit (i386) static/shared library building
-    - name: Build Library
+    - name: Build Library (32-bit)
       run: |
         cd src
         make PLATFORM=PLATFORM_DESKTOP CC=gcc RAYLIB_LIBTYPE=STATIC RAYLIB_RELEASE_PATH="../build/${{ env.RELEASE_NAME }}/lib" CUSTOM_CFLAGS="-m32" -B
@@ -74,13 +80,21 @@ jobs:
         cd ..
       if: matrix.bits == 32
 
-    - name: Build Library
+    - name: Build Library (64-bit x86)
       run: |
         cd src
         make PLATFORM=PLATFORM_DESKTOP CC=gcc RAYLIB_LIBTYPE=STATIC RAYLIB_RELEASE_PATH="../build/${{ env.RELEASE_NAME }}/lib" -B
         make PLATFORM=PLATFORM_DESKTOP CC=gcc RAYLIB_LIBTYPE=SHARED RAYLIB_RELEASE_PATH="../build/${{ env.RELEASE_NAME }}/lib" -B
         cd ..
-      if: matrix.bits == 64
+      if: matrix.bits == 64 && matrix.ARCH == 'x86_64'
+    
+    - name: Build Library (64-bit ARM)
+      run: |
+        cd src
+        make PLATFORM=PLATFORM_DESKTOP CC=gcc RAYLIB_LIBTYPE=STATIC RAYLIB_RELEASE_PATH="../build/${{ env.RELEASE_NAME }}/lib" -B
+        make PLATFORM=PLATFORM_DESKTOP CC=gcc RAYLIB_LIBTYPE=SHARED RAYLIB_RELEASE_PATH="../build/${{ env.RELEASE_NAME }}/lib" -B
+        cd ..
+      if: matrix.bits == 64 && matrix.ARCH == 'aarch64'
     
     - name: Generate Artifacts
       run: |


### PR DESCRIPTION
- Add ubuntu-24.04-arm runner for native ARM64 compilation
- Support building both static and shared libraries for ARM64
- Maintain backwards compatibility with existing x86/x64 builds
- Addresses issue #5051 for ARM64 pre-compiled binaries

Expected output: raylib-X.X-linux_arm64.tar.gz in releases