### PR TITLE
[CORE} Make GetRenderWidth/Height return the FBO size if one is active

### DIFF
--- a/src/rcore.c
+++ b/src/rcore.c
@@ -827,6 +827,8 @@ int GetScreenHeight(void)
 // Get current render width which is equal to screen width*dpi scale
 int GetRenderWidth(void)
 {
+    if (CORE.Window.usingFbo) return CORE.Window.currentFbo.width;
+
     int width = 0;
 #if defined(__APPLE__)
     Vector2 scale = GetWindowScaleDPI();
@@ -840,6 +842,8 @@ int GetRenderWidth(void)
 // Get current screen height which is equal to screen height*dpi scale
 int GetRenderHeight(void)
 {
+    if (CORE.Window.usingFbo) return CORE.Window.currentFbo.height;
+
     int height = 0;
 #if defined(__APPLE__)
     Vector2 scale = GetWindowScaleDPI();


### PR DESCRIPTION
This PR makes the GetRender size functions return the size of the active render target, if a render texture is active then the size of that texture will be returned. This gives users a consistent way to get the current target frame buffer size without having to know the current target. This makes creating reusable libraries much easier.