### PR TITLE
[rModels] Don't Double Upload Meshes in LoadObj, 

### DIFF
--- a/src/rmodels.c
+++ b/src/rmodels.c
@@ -4501,8 +4501,6 @@ static Model LoadOBJ(const char *fileName)
     tinyobj_shapes_free(objShapes, objShapeCount);
     tinyobj_materials_free(objMaterials, objMaterialCount);
 
-    for (int i = 0; i < model.meshCount; i++) UploadMesh(model.meshes + i, true);
-
     // Restore current working directory
     if (CHDIR(currentDir) != 0)
     {


### PR DESCRIPTION
Both LoadObj and LoadModel try to upload the meshes for an obj file. This causes a warning when reading OBJ files.
None of the other interchange format readers try to upload meshes, they rely on LoadModel to do that.
This PR removes the UploadMesh calls from LoadObj so that it works like the other functions and removes the warning.