### PR TITLE
Removed verbose logging on SDL3. 

### DIFF
--- a/src/platforms/rcore_desktop_sdl.c
+++ b/src/platforms/rcore_desktop_sdl.c
@@ -1104,8 +1104,7 @@ Vector2 GetWindowScaleDPI(void)
     TRACELOG(LOG_WARNING, "GetWindowScaleDPI() not implemented on target platform");
 #else
     scale.x = SDL_GetWindowDisplayScale(platform.window);
-    scale.y = scale.x;
-    TRACELOG(LOG_INFO, "WindowScaleDPI is %f", scale.x);
+    scale.y = scale.x;    
 #endif
 
     return scale;


### PR DESCRIPTION
Logs the property every time the property is read! It should be logged on the user side if needed.