### PR TITLE
fix: buffer overflow in jar_mod.h memcopy

### DIFF
--- a/src/external/jar_mod.h
+++ b/src/external/jar_mod.h
@@ -1130,7 +1130,7 @@ static bool jar_mod_load( jar_mod_context_t * modctx, void * mod_data, int mod_d
     {
         if( modctx )
         {
-            memcopy(&(modctx->song.title),modmemory,1084);
+            memcopy(&(modctx->song), modmemory, 1084);
 
             i = 0;
             modctx->number_of_channels = 0;


### PR DESCRIPTION
Fixed a buffer overflow warning in `jar_mod.h` where 1084 bytes were being copied into a 20-byte buffer, causing a `-Wstringop-overflow` compiler warning.

<img width="1016" height="675" alt="image" src="https://github.com/user-attachments/assets/c703b7d9-d387-475c-b7af-e8f2ee80d633" />

## Problem:

The `memcopy` call on line 1133 was incorrectly targeting `&(modctx->song.title)` (a 20-byte field) instead of the entire module structure when loading MOD file data:

## Solution:

Changed the destination address to point to the beginning of the entire song structure instead of just the title field.

The module structure has a total size of 1085 bytes:
`title[20]` = 20 bytes
`samples[31]` = 930 bytes (31 × 30 bytes each)
`length` = 1 byte
`protracker` = 1 byte
`patterntable[128]` = 128 bytes
`signature[4]` = 4 bytes
`speed` = 1 byte

## Testing:

1. Compiles without buffer overflow warnings
2. Preserves existing functionality for MOD file loading
3. No changes to public API or behavior

## Future improvements that I noticed which are outside the scope of this PR - if anyone cares to check them out:

* writing style doesnt match Raylib's overall code style: `if( modctx )`, `memcopy(&(modctx->song.title),modmemory,1084);`, etc...
* `1084` is a magic number and could (should) be a constant. What other magic numbers might be lying around?