### PR TITLE
removed unneeded check for macro defined variable EPSILON

### DIFF
--- a/src/raymath.h
+++ b/src/raymath.h
@@ -1197,10 +1197,6 @@ RMAPI Vector3 Vector3ClampValue(Vector3 v, float min, float max)
 // Check whether two given vectors are almost equal
 RMAPI int Vector3Equals(Vector3 p, Vector3 q)
 {
-#if !defined(EPSILON)
-    #define EPSILON 0.000001f
-#endif
-
     int result = ((fabsf(p.x - q.x)) <= (EPSILON*fmaxf(1.0f, fmaxf(fabsf(p.x), fabsf(q.x))))) &&
                  ((fabsf(p.y - q.y)) <= (EPSILON*fmaxf(1.0f, fmaxf(fabsf(p.y), fabsf(q.y))))) &&
                  ((fabsf(p.z - q.z)) <= (EPSILON*fmaxf(1.0f, fmaxf(fabsf(p.z), fabsf(q.z)))));


### PR DESCRIPTION
the check already happens at the top of the file so this one is unneeded