### PR TITLE
[examples] Increasing julia_set maxInterations glsl100 to 255

### DIFF
--- a/examples/shaders/resources/shaders/glsl120/julia_set.fs
+++ b/examples/shaders/resources/shaders/glsl120/julia_set.fs
@@ -1,6 +1,4 @@
-#version 100
-
-precision mediump float;
+#version 120
 
 // Input vertex attributes (from vertex shader)
 varying vec2 fragTexCoord;


### PR DESCRIPTION
Issue to solve:
<img width="826" height="512" alt="image" src="https://github.com/user-attachments/assets/a947fcb9-5eaf-48b6-9216-60cad8a69770" />

Solution suggested
Changes glsl100 version:
- set `maxIterations = 255;`
- `for` for to use `maxIteration`

Added glsl120 version. (tested setting the graphics to use gl_2_1)

Desktop and Web test:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/9b691cfa-add0-4faf-9b93-309e51dda2df" />

RPI 3 Desktop GLSL100
<img width="1632" height="1229" alt="image" src="https://github.com/user-attachments/assets/889453ef-81fb-47e0-83b3-3b40ebc08d93" />

RPI 3 DRM GLSL100
<img width="1632" height="1229" alt="image" src="https://github.com/user-attachments/assets/89da8c56-907e-4012-97ea-a98b96a1ade3" />

