### PR TITLE
Adds more filters for conditional build of GetWindowHandle with GLFW

### DIFF
--- a/src/platforms/rcore_desktop_glfw.c
+++ b/src/platforms/rcore_desktop_glfw.c
@@ -75,13 +75,15 @@
     #include <sys/time.h>               // Required for: timespec, nanosleep(), select() - POSIX
 
     //#define GLFW_EXPOSE_NATIVE_WAYLAND
-    #define GLFW_EXPOSE_NATIVE_X11
-    #define Font X11Font                // Hack to fix 'Font' name collision
-                                        // The definition and references to the X11 Font type will be replaced by 'X11Font'
-                                        // Works as long as the current file consistently references any X11 Font as X11Font
-                                        // Since it is never referenced (as of writting), this does not pose an issue
-    #include "GLFW/glfw3native.h"       // Required for: glfwGetX11Window()
-    #undef Font                         // Revert hack and allow normal raylib Font usage
+    #ifdef _GLFW_X11
+        #define GLFW_EXPOSE_NATIVE_X11
+        #define Font X11Font                // Hack to fix 'Font' name collision
+                                            // The definition and references to the X11 Font type will be replaced by 'X11Font'
+                                            // Works as long as the current file consistently references any X11 Font as X11Font
+                                            // Since it is never referenced (as of writting), this does not pose an issue
+        #include "GLFW/glfw3native.h"       // Required for: glfwGetX11Window()
+        #undef Font                         // Revert hack and allow normal raylib Font usage
+    #endif
 #endif
 #if defined(__APPLE__)
     #include <unistd.h>                 // Required for: usleep()
@@ -710,7 +712,7 @@ void SetWindowFocused(void)
     glfwFocusWindow(platform.handle);
 }
 
-#if defined(__linux__)
+#if defined(__linux__) && defined(_GLFW_X11)
 // Local storage for the window handle returned by glfwGetX11Window
 // This is needed as X11 handles are integers and may not fit inside a pointer depending on platform
 // Storing the handle locally and returning a pointer in GetWindowHandle allows the code to work regardless of pointer width
@@ -723,7 +725,7 @@ void *GetWindowHandle(void)
     // NOTE: Returned handle is: void *HWND (windows.h)
     return glfwGetWin32Window(platform.handle);
 #endif
-#if defined(__linux__)
+#if defined(__linux__) && defined(_GLFW_X11)
     // Store the window handle localy and return a pointer to the variable instead
     // Reasoning detailed in the declaration of X11WindowHandle
     X11WindowHandle = glfwGetX11Window(platform.handle);


### PR DESCRIPTION
Fixes #5110

Adds more conditions for the macros for conditional compilation of X11 window handle getter.
Now allows code to be built exclusively for Wayland.