### PR TITLE
Specified the pixel sequence order in the code comment

### DIFF
--- a/src/rtextures.c
+++ b/src/rtextures.c
@@ -2943,7 +2943,7 @@ void ImageColorReplace(Image *image, Color color, Color replace)
 }
 #endif      // SUPPORT_IMAGE_MANIPULATION
 
-// Load color data from image as a Color array (RGBA - 32bit)
+// Load color data from image as a Color array (RGBA - 32bit) with row-major order
 // NOTE: Memory allocated should be freed using UnloadImageColors();
 Color *LoadImageColors(Image image)
 {


### PR DESCRIPTION
Problem: When using the function `Color *LoadImageColors(Image image)`, I did not know what was the pixel order (left-to-right, top-to-bottom, etc.).

Solution: I read through the source code and identified it was row-major (left-to-right, top-to-bottom). I added this information to the comment of the function for future users.

No logic code was modified, so no need for tests, ports, or examples.