### PR TITLE
[rcore][web] Work around to fix mouse positioning on scaled window

### DIFF
--- a/src/platforms/rcore_web.c
+++ b/src/platforms/rcore_web.c
@@ -1824,6 +1824,8 @@ static EM_BOOL EmscriptenResizeCallback(int eventType, const EmscriptenUiEvent *
     CORE.Window.screen.width = width;
     CORE.Window.screen.height = height;
 
+    glfwSetWindowSize(platform.handle, CORE.Window.screen.width, CORE.Window.screen.height);
+
     // NOTE: Postprocessing texture is not scaled to new size
 
     return 0;


### PR DESCRIPTION
Suggestion is to `glfwSetWindowSize` when triggered `EmscriptenResizeCallback`.
 
Tested on example `core_window_letterbox`

Issue:
<img width="1701" height="1155" alt="image" src="https://github.com/user-attachments/assets/096a2aca-245b-4e21-9099-c29584a71d27" />

Result:
<img width="2135" height="1219" alt="image" src="https://github.com/user-attachments/assets/4d80100f-2b58-4db2-9d20-67598f6d4b14" />
