### PR TITLE
Fix SDL3 compilation error with gcc

### DIFF
--- a/src/platforms/rcore_desktop_sdl.c
+++ b/src/platforms/rcore_desktop_sdl.c
@@ -1621,7 +1621,7 @@ void PollInputEvents(void)
                 {
                     // Add character (codepoint) to the queue
                     #if defined(PLATFORM_DESKTOP_SDL3)
-                    unsigned int textLen = strlen(event.text.text);
+                    size_t textLen = strlen(event.text.text);
                     unsigned int codepoint = (unsigned int)SDL_StepUTF8(&event.text.text, &textLen);
                     #else
                     int codepointSize = 0;


### PR DESCRIPTION
When compiling PLATFORM_DESKTOP_SDL using gcc, it results in an error: -Wincompatible-pointer-types. 
The fix from #5118 worked when using clang as it only gives a warning.