### PR TITLE
[raudio] Initialize sound alias properties as if it was a new sound

### DIFF
--- a/src/raudio.c
+++ b/src/raudio.c
@@ -982,8 +982,12 @@ Sound LoadSoundAlias(Sound source)
         }
 
         audioBuffer->sizeInFrames = source.stream.buffer->sizeInFrames;
-        audioBuffer->volume = source.stream.buffer->volume;
         audioBuffer->data = source.stream.buffer->data;
+
+        // initalize the buffer as if it was new
+        audioBuffer->volume = 1.0f;
+        audioBuffer->pitch = 1.0f;
+        audioBuffer->pan = 0.5f;
 
         sound.frameCount = source.frameCount;
         sound.stream.sampleRate = AUDIO.System.device.sampleRate;


### PR DESCRIPTION
The sound alias would copy the volume from the source sound, this made the new sound be in a different state than it would be if it was loaded as a copy.
This PR forces sound alias to the same state as a new sound for consistency.