### PR TITLE
Add Color to DrawGrid

### DIFF
--- a/examples/audio/audio_sound_positioning.c
+++ b/examples/audio/audio_sound_positioning.c
@@ -77,7 +77,7 @@ int main(void)
             ClearBackground(RAYWHITE);
 
             BeginMode3D(camera);
-                DrawGrid(10, 2);
+                DrawGrid(10, 2, GRAY);
                 DrawSphere(spherePos, 0.5f, RED);
             EndMode3D();
 

--- a/examples/core/core_2d_camera_mouse_zoom.c
+++ b/examples/core/core_2d_camera_mouse_zoom.c
@@ -116,7 +116,7 @@ int main ()
                 rlPushMatrix();
                     rlTranslatef(0, 25*50, 0);
                     rlRotatef(90, 1, 0, 0);
-                    DrawGrid(100, 50);
+                    DrawGrid(100, 50, GRAY);
                 rlPopMatrix();
 
                 // Draw a reference circle

--- a/examples/core/core_3d_camera_free.c
+++ b/examples/core/core_3d_camera_free.c
@@ -63,7 +63,7 @@ int main(void)
                 DrawCube(cubePosition, 2.0f, 2.0f, 2.0f, RED);
                 DrawCubeWires(cubePosition, 2.0f, 2.0f, 2.0f, MAROON);
 
-                DrawGrid(10, 1.0f);
+                DrawGrid(10, 1.0f, GRAY);
 
             EndMode3D();
 

--- a/examples/core/core_3d_camera_mode.c
+++ b/examples/core/core_3d_camera_mode.c
@@ -59,7 +59,7 @@ int main(void)
                 DrawCube(cubePosition, 2.0f, 2.0f, 2.0f, RED);
                 DrawCubeWires(cubePosition, 2.0f, 2.0f, 2.0f, MAROON);
 
-                DrawGrid(10, 1.0f);
+                DrawGrid(10, 1.0f, GRAY);
 
             EndMode3D();
 

--- a/examples/core/core_3d_picking.c
+++ b/examples/core/core_3d_picking.c
@@ -95,7 +95,7 @@ int main(void)
                 }
 
                 DrawRay(ray, MAROON);
-                DrawGrid(10, 1.0f);
+                DrawGrid(10, 1.0f, GRAY);
 
             EndMode3D();
 

--- a/examples/core/core_vr_simulator.c
+++ b/examples/core/core_vr_simulator.c
@@ -122,7 +122,7 @@ int main(void)
 
                     DrawCube(cubePosition, 2.0f, 2.0f, 2.0f, RED);
                     DrawCubeWires(cubePosition, 2.0f, 2.0f, 2.0f, MAROON);
-                    DrawGrid(40, 1.0f);
+                    DrawGrid(40, 1.0f, GRAY);
 
                 EndMode3D();
             EndVrStereoMode();

--- a/examples/core/core_world_screen.c
+++ b/examples/core/core_world_screen.c
@@ -65,7 +65,7 @@ int main(void)
                 DrawCube(cubePosition, 2.0f, 2.0f, 2.0f, RED);
                 DrawCubeWires(cubePosition, 2.0f, 2.0f, 2.0f, MAROON);
 
-                DrawGrid(10, 1.0f);
+                DrawGrid(10, 1.0f, GRAY);
 
             EndMode3D();
 

--- a/examples/models/models_animation.c
+++ b/examples/models/models_animation.c
@@ -89,7 +89,7 @@ int main(void)
                     DrawCube(anims[0].framePoses[animFrameCounter][i].translation, 0.2f, 0.2f, 0.2f, RED);
                 }
 
-                DrawGrid(10, 1.0f);         // Draw a grid
+                DrawGrid(10, 1.0f, GRAY);         // Draw a grid
 
             EndMode3D();
 

--- a/examples/models/models_billboard.c
+++ b/examples/models/models_billboard.c
@@ -82,7 +82,7 @@ int main(void)
 
             BeginMode3D(camera);
 
-                DrawGrid(10, 1.0f);        // Draw a grid
+                DrawGrid(10, 1.0f, GRAY);        // Draw a grid
 
                 // Draw order matters!
                 if (distanceStatic > distanceRotating)

--- a/examples/models/models_bone_socket.c
+++ b/examples/models/models_bone_socket.c
@@ -153,7 +153,7 @@ int main(void)
                     DrawMesh(equipModel[i].meshes[0], equipModel[i].materials[1], matrixTransform);
                 }
 
-                DrawGrid(10, 1.0f);
+                DrawGrid(10, 1.0f, GRAY);
             EndMode3D();
 
             DrawText("Use the T/G to switch animation", 10, 10, 20, GRAY);

--- a/examples/models/models_box_collisions.c
+++ b/examples/models/models_box_collisions.c
@@ -107,7 +107,7 @@ int main(void)
                 // Draw player
                 DrawCubeV(playerPosition, playerSize, playerColor);
 
-                DrawGrid(10, 1.0f);        // Draw a grid
+                DrawGrid(10, 1.0f, GRAY);        // Draw a grid
 
             EndMode3D();
 

--- a/examples/models/models_draw_cube_texture.c
+++ b/examples/models/models_draw_cube_texture.c
@@ -72,7 +72,7 @@ int main(void)
                 DrawCubeTextureRec(texture, (Rectangle){ 0.0f, texture.height/2.0f, texture.width/2.0f, texture.height/2.0f },
                     (Vector3){ 2.0f, 1.0f, 0.0f }, 2.0f, 2.0f, 2.0f, WHITE);
 
-                DrawGrid(10, 1.0f);        // Draw a grid
+                DrawGrid(10, 1.0f, GRAY);        // Draw a grid
 
             EndMode3D();
 

--- a/examples/models/models_geometric_shapes.c
+++ b/examples/models/models_geometric_shapes.c
@@ -71,7 +71,7 @@ int main(void)
                 DrawCapsule     ((Vector3){-3.0f, 1.5f, -4.0f}, (Vector3){-4.0f, -1.0f, -4.0f}, 1.2f, 8, 8, VIOLET);
                 DrawCapsuleWires((Vector3){-3.0f, 1.5f, -4.0f}, (Vector3){-4.0f, -1.0f, -4.0f}, 1.2f, 8, 8, PURPLE);
 
-                DrawGrid(10, 1.0f);        // Draw a grid
+                DrawGrid(10, 1.0f, GRAY);        // Draw a grid
 
             EndMode3D();
 

--- a/examples/models/models_gpu_skinning.c
+++ b/examples/models/models_gpu_skinning.c
@@ -98,7 +98,7 @@ int main(void)
                 // Draw character mesh, pose calculation is done in shader (GPU skinning)
                 DrawMesh(characterModel.meshes[0], characterModel.materials[1], characterModel.transform);
 
-                DrawGrid(10, 1.0f);
+                DrawGrid(10, 1.0f, GRAY);
 
             EndMode3D();
 

--- a/examples/models/models_heightmap.c
+++ b/examples/models/models_heightmap.c
@@ -67,7 +67,7 @@ int main(void)
 
                 DrawModel(model, mapPosition, 1.0f, RED);
 
-                DrawGrid(20, 1.0f);
+                DrawGrid(20, 1.0f, GRAY);
 
             EndMode3D();
 

--- a/examples/models/models_loading.c
+++ b/examples/models/models_loading.c
@@ -126,7 +126,7 @@ int main(void)
 
                 DrawModel(model, position, 1.0f, WHITE);        // Draw 3d model with texture
 
-                DrawGrid(20, 10.0f);         // Draw a grid
+                DrawGrid(20, 10.0f, GRAY);         // Draw a grid
 
                 if (selected) DrawBoundingBox(bounds, GREEN);   // Draw selection box
 

--- a/examples/models/models_loading_gltf.c
+++ b/examples/models/models_loading_gltf.c
@@ -80,7 +80,7 @@ int main(void)
 
             BeginMode3D(camera);
                 DrawModel(model, position, 1.0f, WHITE);    // Draw animated model
-                DrawGrid(10, 1.0f);
+                DrawGrid(10, 1.0f, GRAY);
             EndMode3D();
 
             DrawText("Use the LEFT/RIGHT mouse buttons to switch animation", 10, 10, 20, GRAY);

--- a/examples/models/models_loading_m3d.c
+++ b/examples/models/models_loading_m3d.c
@@ -147,7 +147,7 @@ int main(void)
                     }
                 }
 
-                DrawGrid(10, 1.0f);         // Draw a grid
+                DrawGrid(10, 1.0f, GRAY);         // Draw a grid
 
             EndMode3D();
 

--- a/examples/models/models_loading_vox.c
+++ b/examples/models/models_loading_vox.c
@@ -168,7 +168,7 @@ int main(void)
 		BeginMode3D(camera);
 
 		DrawModel(models[currentModel], modelpos, 1.0f, WHITE);
-		DrawGrid(10, 1.0);
+		DrawGrid(10, 1.0, GRAY);
 
 		// Draw spheres to show where the lights are
 		for (int i = 0; i < MAX_LIGHTS; i++)

--- a/examples/models/models_mesh_generation.c
+++ b/examples/models/models_mesh_generation.c
@@ -97,7 +97,7 @@ int main(void)
             BeginMode3D(camera);
 
                DrawModel(models[currentModel], position, 1.0f, WHITE);
-               DrawGrid(10, 1.0);
+               DrawGrid(10, 1.0, GRAY);
 
             EndMode3D();
 

--- a/examples/models/models_mesh_picking.c
+++ b/examples/models/models_mesh_picking.c
@@ -199,7 +199,7 @@ int main(void)
 
                 DrawRay(ray, MAROON);
 
-                DrawGrid(10, 10.0f);
+                DrawGrid(10, 10.0f, GRAY);
 
             EndMode3D();
 

--- a/examples/models/models_orthographic_projection.c
+++ b/examples/models/models_orthographic_projection.c
@@ -80,7 +80,7 @@ int main(void)
                 DrawCylinder((Vector3){1.0f, 0.0f, -4.0f}, 0.0f, 1.5f, 3.0f, 8, GOLD);
                 DrawCylinderWires((Vector3){1.0f, 0.0f, -4.0f}, 0.0f, 1.5f, 3.0f, 8, PINK);
 
-                DrawGrid(10, 1.0f);        // Draw a grid
+                DrawGrid(10, 1.0f, GRAY);        // Draw a grid
 
             EndMode3D();
 

--- a/examples/models/models_rlgl_solar_system.c
+++ b/examples/models/models_rlgl_solar_system.c
@@ -108,7 +108,7 @@ int main(void)
 
                 // Some reference elements (not affected by previous matrix transformations)
                 DrawCircle3D((Vector3){ 0.0f, 0.0f, 0.0f }, earthOrbitRadius, (Vector3){ 1, 0, 0 }, 90.0f, Fade(RED, 0.5f));
-                DrawGrid(20, 1.0f);
+                DrawGrid(20, 1.0f, GRAY);
 
             EndMode3D();
 

--- a/examples/models/models_skybox.c
+++ b/examples/models/models_skybox.c
@@ -157,7 +157,7 @@ int main(void)
                 rlEnableBackfaceCulling();
                 rlEnableDepthMask();
 
-                DrawGrid(10, 1.0f);
+                DrawGrid(10, 1.0f, GRAY);
 
             EndMode3D();
 

--- a/examples/models/models_waving_cubes.c
+++ b/examples/models/models_waving_cubes.c
@@ -69,7 +69,7 @@ int main()
 
             BeginMode3D(camera);
 
-                DrawGrid(10, 5.0f);
+                DrawGrid(10, 5.0f, GRAY);
 
                 for (int x = 0; x < numBlocks; x++)
                 {

--- a/examples/models/models_yaw_pitch_roll.c
+++ b/examples/models/models_yaw_pitch_roll.c
@@ -96,7 +96,7 @@ int main(void)
             BeginMode3D(camera);
 
                 DrawModel(model, (Vector3){ 0.0f, -8.0f, 0.0f }, 1.0f, WHITE);   // Draw 3d model with texture
-                DrawGrid(10, 10.0f);
+                DrawGrid(10, 10.0f, GRAY);
 
             EndMode3D();
 

--- a/examples/others/rlgl_standalone.c
+++ b/examples/others/rlgl_standalone.c
@@ -103,7 +103,7 @@ static void ErrorCallback(int error, const char *description);
 static void KeyCallback(GLFWwindow *window, int key, int scancode, int action, int mods);
 
 // Drawing functions (uses rlgl functionality)
-static void DrawGrid(int slices, float spacing);
+static void DrawGrid(int slices, float spacing, Color color);
 static void DrawCube(Vector3 position, float width, float height, float length, Color color);
 static void DrawCubeWires(Vector3 position, float width, float height, float length, Color color);
 static void DrawRectangleV(Vector2 position, Vector2 size, Color color);
@@ -213,7 +213,7 @@ int main(void)
 
             DrawCube(cubePosition, 2.0f, 2.0f, 2.0f, RED);
             DrawCubeWires(cubePosition, 2.0f, 2.0f, 2.0f, RAYWHITE);
-            DrawGrid(10, 1.0f);
+            DrawGrid(10, 1.0f, DARKGRAY);
 
             // Draw internal render batch buffers (3D data)
             rlDrawRenderBatchActive();
@@ -295,28 +295,15 @@ static void DrawRectangleV(Vector2 position, Vector2 size, Color color)
 }
 
 // Draw a grid centered at (0, 0, 0)
-static void DrawGrid(int slices, float spacing)
+static void DrawGrid(int slices, float spacing, Color color)
 {
     int halfSlices = slices / 2;
 
     rlBegin(RL_LINES);
+        rlColor4ub(color.r, color.g, color.b, color.a);
+
         for (int i = -halfSlices; i <= halfSlices; i++)
         {
-            if (i == 0)
-            {
-                rlColor3f(0.5f, 0.5f, 0.5f);
-                rlColor3f(0.5f, 0.5f, 0.5f);
-                rlColor3f(0.5f, 0.5f, 0.5f);
-                rlColor3f(0.5f, 0.5f, 0.5f);
-            }
-            else
-            {
-                rlColor3f(0.75f, 0.75f, 0.75f);
-                rlColor3f(0.75f, 0.75f, 0.75f);
-                rlColor3f(0.75f, 0.75f, 0.75f);
-                rlColor3f(0.75f, 0.75f, 0.75f);
-            }
-
             rlVertex3f((float)i*spacing, 0.0f, (float)-halfSlices*spacing);
             rlVertex3f((float)i*spacing, 0.0f, (float)halfSlices*spacing);
 

--- a/examples/shaders/shaders_basic_lighting.c
+++ b/examples/shaders/shaders_basic_lighting.c
@@ -120,7 +120,7 @@ int main(void)
                     else DrawSphereWires(lights[i].position, 0.2f, 8, 8, ColorAlpha(lights[i].color, 0.3f));
                 }
 
-                DrawGrid(10, 1.0f);
+                DrawGrid(10, 1.0f, GRAY);
 
             EndMode3D();
 

--- a/examples/shaders/shaders_custom_uniform.c
+++ b/examples/shaders/shaders_custom_uniform.c
@@ -95,7 +95,7 @@ int main(void)
 
             BeginMode3D(camera);        // Begin 3d mode drawing
                 DrawModel(model, position, 0.5f, WHITE);   // Draw 3d model with texture
-                DrawGrid(10, 1.0f);     // Draw a grid
+                DrawGrid(10, 1.0f, GRAY); // Draw a grid
             EndMode3D();                // End 3d mode drawing, returns to orthographic 2d mode
 
             DrawText("TEXT DRAWN IN RENDER TEXTURE", 200, 10, 30, RED);

--- a/examples/shaders/shaders_hybrid_render.c
+++ b/examples/shaders/shaders_hybrid_render.c
@@ -125,7 +125,7 @@ int main(void)
                     DrawCubeV((Vector3){ 0.0f, 0.5f, 1.0f }, (Vector3){ 1.0f, 1.0f, 1.0f }, PURPLE);
                     DrawCubeWiresV((Vector3){ 0.0f, 0.5f, -1.0f }, (Vector3){ 1.0f, 1.0f, 1.0f }, DARKGREEN);
                     DrawCubeV((Vector3) { 0.0f, 0.5f, -1.0f }, (Vector3){ 1.0f, 1.0f, 1.0f }, YELLOW);
-                    DrawGrid(10, 1.0f);
+                    DrawGrid(10, 1.0f, GRAY);
                 EndShaderMode();
             EndMode3D();
         EndTextureMode();

--- a/examples/shaders/shaders_model_shader.c
+++ b/examples/shaders/shaders_model_shader.c
@@ -84,7 +84,7 @@ int main(void)
 
                 DrawModel(model, position, 0.2f, WHITE);   // Draw 3d model with texture
 
-                DrawGrid(10, 1.0f);     // Draw a grid
+                DrawGrid(10, 1.0f, GRAY);     // Draw a grid
 
             EndMode3D();
 

--- a/examples/shaders/shaders_postprocessing.c
+++ b/examples/shaders/shaders_postprocessing.c
@@ -138,7 +138,7 @@ int main(void)
 
             BeginMode3D(camera);        // Begin 3d mode drawing
                 DrawModel(model, position, 0.1f, WHITE);   // Draw 3d model with texture
-                DrawGrid(10, 1.0f);     // Draw a grid
+                DrawGrid(10, 1.0f, GRAY); // Draw a grid
             EndMode3D();                // End 3d mode drawing, returns to orthographic 2d mode
         EndTextureMode();               // End drawing to texture (now we have a texture available for next passes)
 

--- a/examples/shaders/shaders_simple_mask.c
+++ b/examples/shaders/shaders_simple_mask.c
@@ -121,7 +121,7 @@ int main(void)
                 DrawModel(model1, (Vector3){ 0.5f, 0.0f, 0.0f }, 1, WHITE);
                 DrawModelEx(model2, (Vector3){ -0.5f, 0.0f, 0.0f }, (Vector3){ 1.0f, 1.0f, 0.0f }, 50, (Vector3){ 1.0f, 1.0f, 1.0f }, WHITE);
                 DrawModel(model3,(Vector3){ 0.0f, 0.0f, -1.5f }, 1, WHITE);
-                DrawGrid(10, 1.0f);        // Draw a grid
+                DrawGrid(10, 1.0f, GRAY);        // Draw a grid
 
             EndMode3D();
 

--- a/examples/shaders/shaders_texture_tiling.c
+++ b/examples/shaders/shaders_texture_tiling.c
@@ -86,7 +86,7 @@ int main(void)
                     DrawModel(model, (Vector3){ 0.0f, 0.0f, 0.0f }, 2.0f, WHITE);
                 EndShaderMode();
 
-                DrawGrid(10, 1.0f);
+                DrawGrid(10, 1.0f, GRAY);
 
             EndMode3D();
 

--- a/examples/shaders/shaders_write_depth.c
+++ b/examples/shaders/shaders_write_depth.c
@@ -84,7 +84,7 @@ int main(void)
                     DrawCubeV((Vector3){ 0.0f, 0.5f, 1.0f }, (Vector3){ 1.0f, 1.0f, 1.0f }, PURPLE);
                     DrawCubeWiresV((Vector3){ 0.0f, 0.5f, -1.0f }, (Vector3){ 1.0f, 1.0f, 1.0f }, DARKGREEN);
                     DrawCubeV((Vector3) { 0.0f, 0.5f, -1.0f }, (Vector3){ 1.0f, 1.0f, 1.0f }, YELLOW);
-                    DrawGrid(10, 1.0f);
+                    DrawGrid(10, 1.0f, GRAY);
                 EndShaderMode();
             EndMode3D();
         EndTextureMode();

--- a/examples/text/text_draw_3d.c
+++ b/examples/text/text_draw_3d.c
@@ -285,7 +285,7 @@ int main(void)
                 DrawCubeV(cubePosition, cubeSize, dark);
                 DrawCubeWires(cubePosition, 2.1f, 2.1f, 2.1f, light);
 
-                DrawGrid(10, 2.0f);
+                DrawGrid(10, 2.0f, GRAY);
 
                 // Use a shader to handle the depth buffer issue with transparent textures
                 // NOTE: more info at https://bedroomcoders.co.uk/posts/198

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1551,7 +1551,7 @@ RLAPI void DrawCapsule(Vector3 startPos, Vector3 endPos, float radius, int slice
 RLAPI void DrawCapsuleWires(Vector3 startPos, Vector3 endPos, float radius, int slices, int rings, Color color); // Draw capsule wireframe with the center of its sphere caps at startPos and endPos
 RLAPI void DrawPlane(Vector3 centerPos, Vector2 size, Color color);                                      // Draw a plane XZ
 RLAPI void DrawRay(Ray ray, Color color);                                                                // Draw a ray line
-RLAPI void DrawGrid(int slices, float spacing);                                                          // Draw a grid (centered at (0, 0, 0))
+RLAPI void DrawGrid(int slices, float spacing, Color color);                                             // Draw a grid (centered at (0, 0, 0))
 
 //------------------------------------------------------------------------------------
 // Model 3d Loading and Drawing Functions (Module: models)

--- a/src/rmodels.c
+++ b/src/rmodels.c
@@ -1068,22 +1068,15 @@ void DrawRay(Ray ray, Color color)
 }
 
 // Draw a grid centered at (0, 0, 0)
-void DrawGrid(int slices, float spacing)
+void DrawGrid(int slices, float spacing, Color color)
 {
     int halfSlices = slices/2;
 
     rlBegin(RL_LINES);
+        rlColor4ub(color.r, color.g, color.b, color.a);
+
         for (int i = -halfSlices; i <= halfSlices; i++)
         {
-            if (i == 0)
-            {
-                rlColor3f(0.5f, 0.5f, 0.5f);
-            }
-            else
-            {
-                rlColor3f(0.75f, 0.75f, 0.75f);
-            }
-
             rlVertex3f((float)i*spacing, 0.0f, (float)-halfSlices*spacing);
             rlVertex3f((float)i*spacing, 0.0f, (float)halfSlices*spacing);
 


### PR DESCRIPTION
Being able to choose the grid color helps avoid this kind of case with the background color:
<img width="725" height="446" alt="" src="https://github.com/user-attachments/assets/00b4b134-5693-4929-9513-968d94a0a93c" />

We can use custom colors (Or change transparency):
<img width="643" height="403" alt="" src="https://github.com/user-attachments/assets/38cbedc0-4dae-4145-a063-eb71a45e13cd" />
<img width="596" height="349" alt="" src="https://github.com/user-attachments/assets/14100f18-1353-4a95-b8ae-1a0535ec3fd1" />

For the examples, I put GRAY because in most cases, RAYWHITE is used for the background