### PR TITLE
Clamp camera pitch

### DIFF
--- a/examples/core/core_3d_fps_controller.c
+++ b/examples/core/core_3d_fps_controller.c
@@ -261,7 +261,9 @@ static void UpdateCameraAngle(Camera *camera)
     Vector3 right = Vector3Normalize(Vector3CrossProduct(yaw, up));
 
     // Rotate view vector around right axis
-    Vector3 pitch = Vector3RotateByAxisAngle(yaw, right, -lookRotation.y - lean.y);
+    float pitchAngle = -player.body.lookRotation.y - player.lean.y;
+    pitchAngle = Clamp(pitchAngle, -PI / 2 + 0.0001f, PI / 2 - 0.0001f); // Clamp angle so it doesn't go past straight up or straight down
+    Vector3 pitch = Vector3RotateByAxisAngle(yaw, right, pitchAngle);
 
     // Head animation
     // Rotate up direction around forward axis


### PR DESCRIPTION
If you look straight down (or up I think) the camera yaw flips 180 degrees. This fixes that