### PR TITLE
use RL_MALLOC in stb_truetype

### DIFF
--- a/src/rtext.c
+++ b/src/rtext.c
@@ -93,6 +93,9 @@
         #pragma GCC diagnostic ignored "-Wunused-function"
     #endif
 
+    #define STBTT_malloc(x,u) ((void)(u),RL_MALLOC(x))
+    #define STBTT_free(x,u) ((void)(u),RL_FREE(x))
+
     #define STBTT_STATIC
     #define STB_TRUETYPE_IMPLEMENTATION
     #include "external/stb_truetype.h"      // Required for: ttf font data reading


### PR DESCRIPTION
Some allocations that were made by STBTT_malloc are being deallocated with RL_FREE in LoadFontFromMemory. This is an issue if user defines custom RL allocation functions because he is asked to deallocate something he never allocated.