### PR TITLE
[zig] Fix zig examples for wasm

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -606,6 +606,7 @@ fn addExamples(
                     emccOutputDirExampleWithFile,
                     "-sFULL-ES3=1",
                     "-sUSE_GLFW=3",
+                    "-fsanitize=address",
                     "-sSTACK_OVERFLOW_CHECK=1",
                     "-sEXPORTED_RUNTIME_METHODS=['requestFullscreen']",
                     "-sASYNCIFY",


### PR DESCRIPTION
This is to avoid issues like:

`zig build -Dtarget=wasm32-emscripten shaders_julia_set`
```
wasm-ld: error: ./.zig-cache/o/0065c975c3f510f2f1172863c35c7e75/libshaders_julia_set.a(.zig-cache/o/b1603d96a02a9f3e8ae33663be1ac2aa/shaders_julia_set.o): undefined symbol: __ubsan_handle_out_of_bounds
wasm-ld: error: ./.zig-cache/o/0065c975c3f510f2f1172863c35c7e75/libshaders_julia_set.a(.zig-cache/o/b1603d96a02a9f3e8ae33663be1ac2aa/shaders_julia_set.o): undefined symbol: __ubsan_handle_pointer_overflow
```