### PR TITLE
Update Camera3D.fovy description in raylib.h

### DIFF
--- a/src/raylib.h
+++ b/src/raylib.h
@@ -327,7 +327,7 @@ typedef struct Camera3D {
     Vector3 position;       // Camera position
     Vector3 target;         // Camera target it looks-at
     Vector3 up;             // Camera up vector (rotation over its axis)
-    float fovy;             // Camera field-of-view aperture in Y (degrees) in perspective, used as near plane width in orthographic
+    float fovy;             // Camera field-of-view aperture in Y (degrees) in perspective, used as near plane height in world units in orthographic
     int projection;         // Camera projection: CAMERA_PERSPECTIVE or CAMERA_ORTHOGRAPHIC
 } Camera3D;
 


### PR DESCRIPTION
Previously stated it was the near plane width in orthographic, in actuality it's the height. The wording has been fixed, with added clarity that it's in world units so no conversion is needed.