### PR TITLE
[rcore] Fixing base64 decoding error when input string is bad

### DIFF
--- a/src/rcore.c
+++ b/src/rcore.c
@@ -2671,13 +2671,24 @@ unsigned char *DecodeDataBase64(const char *text, int *outputSize)
     for (int i = 0; i < dataSize;)
     {
         // Every 4 sixtets must generate 3 octets
+        if (i + 2 >= dataSize)
+        {
+            TRACELOG(LOG_WARNING, "BASE64 decoding error: Input data size is not valid");
+            break;
+        }
+
         unsigned int sixtetA = base64DecodeTable[(unsigned char)text[i]];
         unsigned int sixtetB = base64DecodeTable[(unsigned char)text[i + 1]];
-        unsigned int sixtetC = ((unsigned char)text[i + 2] != '=')? base64DecodeTable[(unsigned char)text[i + 2]] : 0;
-        unsigned int sixtetD = ((unsigned char)text[i + 3] != '=')? base64DecodeTable[(unsigned char)text[i + 3]] : 0;
+        unsigned int sixtetC = (i + 2 < dataSize && (unsigned char)text[i + 2] != '=')? base64DecodeTable[(unsigned char)text[i + 2]] : 0;
+        unsigned int sixtetD = (i + 3 < dataSize && (unsigned char)text[i + 3] != '=')? base64DecodeTable[(unsigned char)text[i + 3]] : 0;
 
         unsigned int octetPack = (sixtetA << 18) | (sixtetB << 12)  | (sixtetC << 6) | sixtetD;
 
+        if (outputCount + 3 > maxOutputSize)
+        {
+            TRACELOG(LOG_WARNING, "BASE64 decoding: Output data size is too small");
+            break;
+        }
         decodedData[outputCount + 0] = (octetPack >> 16) & 0xff;
         decodedData[outputCount + 1] = (octetPack >> 8) & 0xff;
         decodedData[outputCount + 2] = octetPack & 0xff;


### PR DESCRIPTION
The following code would crash the previous version when calling MemFree:

	// 53 * A
	const char maliciousBase64Input[] = "AAAAAAAAAAAAAAAAAAAAAAAA"
		"AAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
	int decodedSize = 0;
	unsigned char *decodedData = DecodeDataBase64(
		maliciousBase64Input, &decodedSize);
	if (decodedData) {
		MemFree(decodedData);
	}

The reason is a lack of array bound checks in the decoding loop, which corrupted here the heap (though this is platform dependent).

Adding the bound checks here prevents the memory corruption.

Tested with encoding random data of sizes 0-1023 and comparing it with the decoded result.

Note 1: It would be great if the functions like DecodeDataBase64 or DecompressData had "Try..." functions that return 0 or 1 depending on success. I understand that passing pointers is somewhat awkward for less advanced users, but this function already accepts a pointer anyway. My data comes from user inputs, so I have to run some checks on it and it would be a bit easier if there were "Try..." functions in case decoding fails. I currently can't tell if the decoding was successful or not.

Alternatively: In case errors are encountered, the function could also free the memory and return 0. I think this would be better than returning a data block that is containing corrupted data.

Note 2: I created a test file to first verify the crash before fixing and verifying that the code still works as expected. Would it make sense to add a test folder to raylib that contains small test programs that test certain aspects of the rcore library functions? In that case, I would have a first test for that 😅