### PR TITLE
[rtext] Add GetDefaultFontSpacing()

### DIFF
--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1485,6 +1485,7 @@ RLAPI void DrawTextCodepoint(Font font, int codepoint, Vector2 position, float f
 RLAPI void DrawTextCodepoints(Font font, const int *codepoints, int codepointCount, Vector2 position, float fontSize, float spacing, Color tint); // Draw multiple character (codepoint)
 
 // Text font info functions
+RLAPI float GetDefaultFontSpacing(int fontSize);                                            // Get the text spacing of the default font (only used in DrawText)
 RLAPI void SetTextLineSpacing(int spacing);                                                 // Set vertical line spacing when drawing with line-breaks
 RLAPI int MeasureText(const char *text, int fontSize);                                      // Measure string width for default font
 RLAPI Vector2 MeasureTextEx(Font font, const char *text, float fontSize, float spacing);    // Measure string size for Font

--- a/src/rtext.c
+++ b/src/rtext.c
@@ -1192,11 +1192,9 @@ void DrawText(const char *text, int posX, int posY, int fontSize, Color color)
     {
         Vector2 position = { (float)posX, (float)posY };
 
-        int defaultFontSize = 10;   // Default Font chars height in pixel
-        if (fontSize < defaultFontSize) fontSize = defaultFontSize;
-        int spacing = fontSize/defaultFontSize;
+        float spacing = GetDefaultFontSpacing(fontSize);
 
-        DrawTextEx(GetFontDefault(), text, position, (float)fontSize, (float)spacing, color);
+        DrawTextEx(GetFontDefault(), text, position, (float)fontSize, spacing, color);
     }
 }
 
@@ -1308,6 +1306,16 @@ void DrawTextCodepoints(Font font, const int *codepoints, int codepointCount, Ve
             else textOffsetX += ((float)font.glyphs[index].advanceX*scaleFactor + spacing);
         }
     }
+}
+
+// Get the text spacing of the default font (only used in DrawText)
+RLAPI float GetDefaultFontSpacing(int fontSize)
+{
+    int defaultFontSize = 10;   // Default Font chars height in pixel
+    if (fontSize < defaultFontSize) fontSize = defaultFontSize;
+    int spacing = fontSize/defaultFontSize;
+
+    return (float)spacing;
 }
 
 // Set vertical line spacing when drawing with line-breaks


### PR DESCRIPTION
Hi, I was trying to draw text in the center of screen, so I need to measure text size. But `MeasureTextEx()` needs text spacing, and there's no way to get the spacing `DrawText()` use except reading the code. This PR just adds a function for this kind of situation. Since it's a rare situation, it's totally fine to close this as not planned. Just open here in case of this situation not considered.

About the new function name, I don't know how to suit Raylib, maybe `GetDrawTextSpacing()` is better?