### PR TITLE
[rcore] Don't overwrite old gifs

### DIFF
--- a/src/rcore.c
+++ b/src/rcore.c
@@ -1012,7 +1012,14 @@ void EndDrawing(void)
 
                 Vector2 scale = GetWindowScaleDPI();
                 msf_gif_begin(&gifState, (int)((float)CORE.Window.render.width*scale.x), (int)((float)CORE.Window.render.height*scale.y));
-                screenshotCounter++;
+
+                for (int i = 0; i <= 999; i++)
+                {
+                    if (!FileExists(TextFormat("%s/screenrec%03i.gif", CORE.Storage.basePath, screenshotCounter)))
+                        break;
+
+                    screenshotCounter++;
+                }
 
                 TRACELOG(LOG_INFO, "SYSTEM: Start animated GIF recording: %s", TextFormat("screenrec%03i.gif", screenshotCounter));
             }


### PR DESCRIPTION
Having a gif recorder is a nice feature but when I try to record gifs in seperate sessions it overwrites by old gifs and this is a bit annoying so here is a small fix for that

So it makes

#### Session 1
screenrec0.gif
screenrec1.gif

#### Session 2
screenrec2.gif
screenrec3.gif