### PR TITLE
fix(rcore): correctly scale content on macOS

### DIFF
--- a/src/platforms/rcore_desktop_glfw.c
+++ b/src/platforms/rcore_desktop_glfw.c
@@ -1428,10 +1428,18 @@ int InitPlatform(void)
     // was enabled by default. Disabling it gets back the old behavior. A
     // complete fix will require removing a lot of CORE.Window.render
     // manipulation code
-    glfwWindowHint(GLFW_SCALE_FRAMEBUFFER, GLFW_FALSE);
+    // NOTE: This currently doesn't work on macOS(see #5185), so we skip it there
+    // when FLAG_WINDOW_HIGHDPI is *unset*
+#if !defined(__APPLE__)
+        glfwWindowHint(GLFW_SCALE_FRAMEBUFFER, GLFW_FALSE);
+#endif
 
     if ((CORE.Window.flags & FLAG_WINDOW_HIGHDPI) > 0)
     {
+        // since we skipped it before, now make sure to set this on macOS
+#if defined(__APPLE__)
+        glfwWindowHint(GLFW_SCALE_FRAMEBUFFER, GLFW_FALSE);
+#endif
         // Resize window content area based on the monitor content scale
         // NOTE: This hint only has an effect on platforms where screen coordinates and pixels always map 1:1 such as Windows and X11
         // On platforms like macOS the resolution of the framebuffer is changed independently of the window size


### PR DESCRIPTION
Currently, scaling doesn't work correctly on macOS (see #5185).  This commit
works around this issue by disabling SCALE_FRAMEBUFFER on macOS when
`FLAG_WINDOW_HIGHDPI` is unset.

## Testing Steps

0. Buy a Mac and set up developer tools
1. `git clone git@github.com:vegerot/snek.git --recurse-submodules`
2. `zig build play`
3. Play around for a minute and have fun 🙂 

Everything should be working

4. `git switch -d HEAD~1`
5. `git submodule update --init`
6. `zig build play`

Expected: everything should work
Actual: Incorrect scaling