### PR TITLE
[rcore] add GetDisplayWidth() and GetDisplayHeight()

### DIFF
--- a/src/raylib.h
+++ b/src/raylib.h
@@ -999,6 +999,8 @@ RLAPI void SetWindowSize(int width, int height);                  // Set window 
 RLAPI void SetWindowOpacity(float opacity);                       // Set window opacity [0.0f..1.0f]
 RLAPI void SetWindowFocused(void);                                // Set window focused
 RLAPI void *GetWindowHandle(void);                                // Get native window handle
+RLAPI int GetDisplayWidth(void);                                  // Get display width
+RLAPI int GetDisplayHeight(void);                                 // Get display height
 RLAPI int GetScreenWidth(void);                                   // Get current screen width
 RLAPI int GetScreenHeight(void);                                  // Get current screen height
 RLAPI int GetRenderWidth(void);                                   // Get current render width (it considers HiDPI)

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -819,6 +819,18 @@ bool IsWindowState(unsigned int flag)
     return ((CORE.Window.flags & flag) > 0);
 }
 
+// Get display width
+int GetDisplayWidth(void)
+{
+    return CORE.Window.display.width;
+}
+
+// Get display height
+int GetDisplayHeight(void)
+{
+    return CORE.Window.display.height;
+}
+
 // Get current screen width
 int GetScreenWidth(void)
 {


### PR DESCRIPTION
As far as I know, the way you're supposed to find out how big you can make your window/get the display resolution is GetMonitorWidth(GetCurrentMonitor())
works great, so why even add this?
because that doesn't work on android
monitor stuff isn't implemented yet for android, and even if it was, thinking of monitors in android applications doesn't really feel right anyway
so I started thinking of the best way to expose ANativeWindow_getWidth() to the user in some way, since to me it seems like what you'd want for android
one option was to make GetMonitorWidth() on android a fake that always just returns ANativeWindow_getWidth(), but that didn't seem right
while looking for solutions I found a response to an issue by raysan which mentioned that InitWindow(0, 0) automatically creates a window with the display size as the window size
and turns out on android the display size is set with ANativeWindow_getWidth()/Height()
it's as far as I know the only way to access the value from within the library
so I thought: display size seems really useful and would solve my problem, why not expose it?
it even seems like an easier alternative than the working monitor based desktop solution

if there is a good reason display width and height currently aren't exposed, no problem, of course, I am really just looking for any way to expose ANativeWindow_getWidth(), and this seemed like one that would at the same time make the api easier for all other platforms as well