### PR TITLE
[rTextures] Use the render size not the screen size for screenshots

### DIFF
--- a/src/rtextures.c
+++ b/src/rtextures.c
@@ -592,11 +592,10 @@ Image LoadImageFromTexture(Texture2D texture)
 // Load image from screen buffer and (screenshot)
 Image LoadImageFromScreen(void)
 {
-    Vector2 scale = GetWindowScaleDPI();
     Image image = { 0 };
 
-    image.width = (int)(GetScreenWidth()*scale.x);
-    image.height = (int)(GetScreenHeight()*scale.y);
+    image.width = (int)(GetRenderWidth());
+    image.height = (int)(GetRenderHeight());
     image.mipmaps = 1;
     image.format = PIXELFORMAT_UNCOMPRESSED_R8G8B8A8;
     image.data = rlReadScreenPixels(image.width, image.height);


### PR DESCRIPTION
The screenshot code is always applying the DPI scale to the image, even if the framebuffer was not created with that scale, thus if you have a DPI scale but are NOT doing DPI auto scaling and using the window at it's native resolution, the image will be too big.

The screenshot code should never use ScreenSize, it should use RenderSize, so that it gets the size of the framebuffer that it's saving. There should not be any need for High DPI logic here since this is just saving an existing framebuffer that has a fixed size.

This PR makes the change so that screenshots work in both modes on all platforms since it's just using the same size that the framebuffer was created with.