### PR TITLE
[rlgl] Fix Not default Draw Mode breaking when changing texture

### DIFF
--- a/src/rlgl.h
+++ b/src/rlgl.h
@@ -1680,7 +1680,9 @@ void rlSetTexture(unsigned int id)
             }
 
             if (RLGL.currentBatch->drawCounter >= RL_DEFAULT_BATCH_DRAWCALLS) rlDrawRenderBatch(RLGL.currentBatch);
-
+            if (RLGL.currentBatch->drawCounter > 1) {
+                RLGL.currentBatch->draws[RLGL.currentBatch->drawCounter - 1].mode = RLGL.currentBatch->draws[RLGL.currentBatch->drawCounter - 2].mode;
+            }
             RLGL.currentBatch->draws[RLGL.currentBatch->drawCounter - 1].textureId = id;
             RLGL.currentBatch->draws[RLGL.currentBatch->drawCounter - 1].vertexCount = 0;
         }


### PR DESCRIPTION
This PR is to fix the `rlSetTexture` as when you have different textures it will not override the mode that is default to GL_QUAD.
The fix is to check if the `drawCounter` has more then 1 and copy the previous mode to the new Draw.

Fix for the issue: https://github.com/raysan5/raylib/issues/5142 

<img width="945" height="624" alt="image" src="https://github.com/user-attachments/assets/41490850-b5d5-4355-801d-1107a9bac2f1" />
