### PR TITLE
[rlgl] Fix Not default Draw Mode breaking when changing texture

### DIFF
--- a/src/rlgl.h
+++ b/src/rlgl.h
@@ -1676,13 +1676,13 @@ void rlSetTexture(unsigned int id)
                     RLGL.State.vertexCounter += RLGL.currentBatch->draws[RLGL.currentBatch->drawCounter - 1].vertexAlignment;
 
                     RLGL.currentBatch->drawCounter++;
+                    
+                    RLGL.currentBatch->draws[RLGL.currentBatch->drawCounter - 1].mode = RLGL.currentBatch->draws[RLGL.currentBatch->drawCounter - 2].mode;
                 }
             }
 
             if (RLGL.currentBatch->drawCounter >= RL_DEFAULT_BATCH_DRAWCALLS) rlDrawRenderBatch(RLGL.currentBatch);
-            if (RLGL.currentBatch->drawCounter > 1) {
-                RLGL.currentBatch->draws[RLGL.currentBatch->drawCounter - 1].mode = RLGL.currentBatch->draws[RLGL.currentBatch->drawCounter - 2].mode;
-            }
+
             RLGL.currentBatch->draws[RLGL.currentBatch->drawCounter - 1].textureId = id;
             RLGL.currentBatch->draws[RLGL.currentBatch->drawCounter - 1].vertexCount = 0;
         }

--- a/src/rmodels.c
+++ b/src/rmodels.c
@@ -3939,8 +3939,13 @@ void DrawBillboardPro(Camera camera, Texture2D texture, Rectangle source, Vector
     texcoords[2] = (Vector2){ (float)(source.x + source.width)/texture.width, (float)source.y/texture.height };
     texcoords[3] = (Vector2){ (float)source.x/texture.width, (float)source.y/texture.height };
 
+#if defined(GRAPHICS_API_OPENGL_11)
     rlSetTexture(texture.id);
     rlBegin(RL_QUADS);
+#else
+    rlBegin(RL_QUADS);
+    rlSetTexture(texture.id);
+#endif
 
         rlColor4ub(tint.r, tint.g, tint.b, tint.a);
         for (int i = 0; i < 4; i++)

--- a/src/rshapes.c
+++ b/src/rshapes.c
@@ -132,10 +132,16 @@ void DrawPixel(int posX, int posY, Color color)
 void DrawPixelV(Vector2 position, Color color)
 {
 #if defined(SUPPORT_QUADS_DRAW_MODE)
+    #if defined(GRAPHICS_API_OPENGL_11)
     rlSetTexture(GetShapesTexture().id);
     Rectangle shapeRect = GetShapesTextureRectangle();
 
     rlBegin(RL_QUADS);
+    #else
+    rlBegin(RL_QUADS);
+    rlSetTexture(GetShapesTexture().id);
+    Rectangle shapeRect = GetShapesTextureRectangle();
+    #endif
 
         rlNormal3f(0.0f, 0.0f, 1.0f);
         rlColor4ub(color.r, color.g, color.b, color.a);
@@ -311,10 +317,16 @@ void DrawCircleSector(Vector2 center, float radius, float startAngle, float endA
     float angle = startAngle;
 
 #if defined(SUPPORT_QUADS_DRAW_MODE)
+    #if defined(GRAPHICS_API_OPENGL_11)
     rlSetTexture(GetShapesTexture().id);
     Rectangle shapeRect = GetShapesTextureRectangle();
 
     rlBegin(RL_QUADS);
+    #else
+    rlBegin(RL_QUADS);
+    rlSetTexture(GetShapesTexture().id);
+    Rectangle shapeRect = GetShapesTextureRectangle();
+    #endif
 
         // NOTE: Every QUAD actually represents two segments
         for (int i = 0; i < segments/2; i++)
@@ -552,10 +564,17 @@ void DrawRing(Vector2 center, float innerRadius, float outerRadius, float startA
     float angle = startAngle;
 
 #if defined(SUPPORT_QUADS_DRAW_MODE)
+    #if defined(GRAPHICS_API_OPENGL_11)
     rlSetTexture(GetShapesTexture().id);
     Rectangle shapeRect = GetShapesTextureRectangle();
 
     rlBegin(RL_QUADS);
+    #else
+    rlBegin(RL_QUADS);
+    rlSetTexture(GetShapesTexture().id);
+    Rectangle shapeRect = GetShapesTextureRectangle();
+    #endif
+
         for (int i = 0; i < segments; i++)
         {
             rlColor4ub(color.r, color.g, color.b, color.a);
@@ -732,10 +751,17 @@ void DrawRectanglePro(Rectangle rec, Vector2 origin, float rotation, Color color
     }
 
 #if defined(SUPPORT_QUADS_DRAW_MODE)
+    #if defined(GRAPHICS_API_OPENGL_11)
     rlSetTexture(GetShapesTexture().id);
     Rectangle shapeRect = GetShapesTextureRectangle();
 
     rlBegin(RL_QUADS);
+    #else
+    rlBegin(RL_QUADS);
+    rlSetTexture(GetShapesTexture().id);
+    Rectangle shapeRect = GetShapesTextureRectangle();
+    #endif
+
 
         rlNormal3f(0.0f, 0.0f, 1.0f);
         rlColor4ub(color.r, color.g, color.b, color.a);
@@ -787,10 +813,18 @@ void DrawRectangleGradientH(int posX, int posY, int width, int height, Color lef
 // Draw a gradient-filled rectangle
 void DrawRectangleGradientEx(Rectangle rec, Color topLeft, Color bottomLeft, Color bottomRight, Color topRight)
 {
+
+#if defined(GRAPHICS_API_OPENGL_11)
     rlSetTexture(GetShapesTexture().id);
     Rectangle shapeRect = GetShapesTextureRectangle();
 
     rlBegin(RL_QUADS);
+#else
+    rlBegin(RL_QUADS);
+    rlSetTexture(GetShapesTexture().id);
+    Rectangle shapeRect = GetShapesTextureRectangle();
+#endif
+
         rlNormal3f(0.0f, 0.0f, 1.0f);
 
         // NOTE: Default raylib font character 95 is a white square
@@ -952,10 +986,17 @@ void DrawRectangleRounded(Rectangle rec, float roundness, int segments, Color co
     const float angles[4] = { 180.0f, 270.0f, 0.0f, 90.0f };
 
 #if defined(SUPPORT_QUADS_DRAW_MODE)
+    #if defined(GRAPHICS_API_OPENGL_11)
     rlSetTexture(GetShapesTexture().id);
     Rectangle shapeRect = GetShapesTextureRectangle();
 
     rlBegin(RL_QUADS);
+    #else
+    rlBegin(RL_QUADS);
+    rlSetTexture(GetShapesTexture().id);
+    Rectangle shapeRect = GetShapesTextureRectangle();
+    #endif
+
         // Draw all the 4 corners: [1] Upper Left Corner, [3] Upper Right Corner, [5] Lower Right Corner, [7] Lower Left Corner
         for (int k = 0; k < 4; ++k) // Hope the compiler is smart enough to unroll this loop
         {
@@ -1206,10 +1247,17 @@ void DrawRectangleRoundedLinesEx(Rectangle rec, float roundness, int segments, f
     if (lineThick > 1)
     {
 #if defined(SUPPORT_QUADS_DRAW_MODE)
-        rlSetTexture(GetShapesTexture().id);
-        Rectangle shapeRect = GetShapesTextureRectangle();
+    #if defined(GRAPHICS_API_OPENGL_11)
+    rlSetTexture(GetShapesTexture().id);
+    Rectangle shapeRect = GetShapesTextureRectangle();
 
-        rlBegin(RL_QUADS);
+    rlBegin(RL_QUADS);
+    #else
+    rlBegin(RL_QUADS);
+    rlSetTexture(GetShapesTexture().id);
+    Rectangle shapeRect = GetShapesTextureRectangle();
+    #endif
+
 
             // Draw all the 4 corners first: Upper Left Corner, Upper Right Corner, Lower Right Corner, Lower Left Corner
             for (int k = 0; k < 4; ++k) // Hope the compiler is smart enough to unroll this loop
@@ -1382,10 +1430,17 @@ void DrawRectangleRoundedLinesEx(Rectangle rec, float roundness, int segments, f
 void DrawTriangle(Vector2 v1, Vector2 v2, Vector2 v3, Color color)
 {
 #if defined(SUPPORT_QUADS_DRAW_MODE)
+    #if defined(GRAPHICS_API_OPENGL_11)
     rlSetTexture(GetShapesTexture().id);
     Rectangle shapeRect = GetShapesTextureRectangle();
 
     rlBegin(RL_QUADS);
+    #else
+    rlBegin(RL_QUADS);
+    rlSetTexture(GetShapesTexture().id);
+    Rectangle shapeRect = GetShapesTextureRectangle();
+    #endif
+
         rlColor4ub(color.r, color.g, color.b, color.a);
 
         rlTexCoord2f(shapeRect.x/texShapes.width, shapeRect.y/texShapes.height);
@@ -1436,10 +1491,18 @@ void DrawTriangleFan(const Vector2 *points, int pointCount, Color color)
 {
     if (pointCount >= 3)
     {
-        rlSetTexture(GetShapesTexture().id);
-        Rectangle shapeRect = GetShapesTextureRectangle();
 
-        rlBegin(RL_QUADS);
+#if defined(GRAPHICS_API_OPENGL_11)
+    rlSetTexture(GetShapesTexture().id);
+    Rectangle shapeRect = GetShapesTextureRectangle();
+
+    rlBegin(RL_QUADS);
+#else
+    rlBegin(RL_QUADS);
+    rlSetTexture(GetShapesTexture().id);
+    Rectangle shapeRect = GetShapesTextureRectangle();
+#endif
+
             rlColor4ub(color.r, color.g, color.b, color.a);
 
             for (int i = 1; i < pointCount - 1; i++)
@@ -1497,10 +1560,17 @@ void DrawPoly(Vector2 center, int sides, float radius, float rotation, Color col
     float angleStep = 360.0f/(float)sides*DEG2RAD;
 
 #if defined(SUPPORT_QUADS_DRAW_MODE)
+    #if defined(GRAPHICS_API_OPENGL_11)
     rlSetTexture(GetShapesTexture().id);
     Rectangle shapeRect = GetShapesTextureRectangle();
 
     rlBegin(RL_QUADS);
+    #else
+    rlBegin(RL_QUADS);
+    rlSetTexture(GetShapesTexture().id);
+    Rectangle shapeRect = GetShapesTextureRectangle();
+    #endif
+
         for (int i = 0; i < sides; i++)
         {
             rlColor4ub(color.r, color.g, color.b, color.a);
@@ -1566,10 +1636,17 @@ void DrawPolyLinesEx(Vector2 center, int sides, float radius, float rotation, fl
     float innerRadius = radius - (lineThick*cosf(DEG2RAD*exteriorAngle/2.0f));
 
 #if defined(SUPPORT_QUADS_DRAW_MODE)
+    #if defined(GRAPHICS_API_OPENGL_11)
     rlSetTexture(GetShapesTexture().id);
     Rectangle shapeRect = GetShapesTextureRectangle();
 
     rlBegin(RL_QUADS);
+    #else
+    rlBegin(RL_QUADS);
+    rlSetTexture(GetShapesTexture().id);
+    Rectangle shapeRect = GetShapesTextureRectangle();
+    #endif
+
         for (int i = 0; i < sides; i++)
         {
             rlColor4ub(color.r, color.g, color.b, color.a);

--- a/src/rtextures.c
+++ b/src/rtextures.c
@@ -4568,8 +4568,13 @@ void DrawTexturePro(Texture2D texture, Rectangle source, Rectangle dest, Vector2
             bottomRight.y = y + (dx + dest.width)*sinRotation + (dy + dest.height)*cosRotation;
         }
 
+#if defined(GRAPHICS_API_OPENGL_11)
         rlSetTexture(texture.id);
         rlBegin(RL_QUADS);
+#else
+        rlBegin(RL_QUADS);
+        rlSetTexture(texture.id);
+#endif
 
             rlColor4ub(tint.r, tint.g, tint.b, tint.a);
             rlNormal3f(0.0f, 0.0f, 1.0f);                          // Normal vector pointing towards viewer
@@ -4603,13 +4608,18 @@ void DrawTexturePro(Texture2D texture, Rectangle source, Rectangle dest, Vector2
         // I leave here the old implementation for educational purposes,
         // just in case someone wants to do some performance test
         /*
-        rlSetTexture(texture.id);
         rlPushMatrix();
             rlTranslatef(dest.x, dest.y, 0.0f);
             if (rotation != 0.0f) rlRotatef(rotation, 0.0f, 0.0f, 1.0f);
             rlTranslatef(-origin.x, -origin.y, 0.0f);
 
+#if defined(GRAPHICS_API_OPENGL_11)
+            rlSetTexture(texture.id);
             rlBegin(RL_QUADS);
+#else
+            rlBegin(RL_QUADS);
+            rlSetTexture(texture.id);
+#endif
                 rlColor4ub(tint.r, tint.g, tint.b, tint.a);
                 rlNormal3f(0.0f, 0.0f, 1.0f);                          // Normal vector pointing towards viewer
 
@@ -4698,7 +4708,9 @@ void DrawTextureNPatch(Texture2D texture, NPatchInfo nPatchInfo, Rectangle dest,
         coordD.x = (nPatchInfo.source.x + nPatchInfo.source.width)/width;
         coordD.y = (nPatchInfo.source.y + nPatchInfo.source.height)/height;
 
-        rlSetTexture(texture.id);
+#if defined(GRAPHICS_API_OPENGL_11)
+            rlSetTexture(texture.id);
+#endif
 
         rlPushMatrix();
             rlTranslatef(dest.x, dest.y, 0.0f);
@@ -4706,6 +4718,9 @@ void DrawTextureNPatch(Texture2D texture, NPatchInfo nPatchInfo, Rectangle dest,
             rlTranslatef(-origin.x, -origin.y, 0.0f);
 
             rlBegin(RL_QUADS);
+#if !defined(GRAPHICS_API_OPENGL_11)
+            rlSetTexture(texture.id);
+#endif
                 rlColor4ub(tint.r, tint.g, tint.b, tint.a);
                 rlNormal3f(0.0f, 0.0f, 1.0f);               // Normal vector pointing towards viewer
 


### PR DESCRIPTION
This PR is to fix the `rlSetTexture` as when you have different textures it will not override the mode that is default to GL_QUAD.
The fix is to check if the `drawCounter` has more then 1 and copy the previous mode to the new Draw.
If the developer is drawing a mix of Modes The `rlSetTexture` need to be after `rlBegin`.

Fix for the issue: https://github.com/raysan5/raylib/issues/5142 

<img width="945" height="624" alt="image" src="https://github.com/user-attachments/assets/41490850-b5d5-4355-801d-1107a9bac2f1" />

## RenderDoc tests:

<img width="1916" height="1023" alt="image" src="https://github.com/user-attachments/assets/96d1875f-d03d-41ce-bc42-7ff08246b493" />

<img width="1912" height="1022" alt="Screenshot_20250919_095035" src="https://github.com/user-attachments/assets/ea860df4-7a2c-490f-ade4-1f2024c5cb5d" />

<img width="1917" height="1027" alt="Screenshot_20250919_101854" src="https://github.com/user-attachments/assets/132d275b-8054-44e7-b217-816c704d51b3" />

