### PR TITLE
Use lowercase "message" to remove warning spam when building

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ include(CMakeOptions.txt)
 
 if (UNIX AND NOT APPLE AND NOT "${PLATFORM}" MATCHES "DRM" AND NOT "${PLATFORM}" MATCHES "Web")
   if (NOT GLFW_BUILD_WAYLAND AND NOT GLFW_BUILD_X11)
-    MESSAGE(FATAL_ERROR "Cannot disable both Wayland and X11")
+    message(FATAL_ERROR "Cannot disable both Wayland and X11")
   endif()
 endif()
 
@@ -51,7 +51,7 @@ if(NOT TARGET uninstall AND PROJECT_IS_TOP_LEVEL)
 endif()
 
 if (${BUILD_EXAMPLES})
-  MESSAGE(STATUS "Building examples is enabled")
+  message(STATUS "Building examples is enabled")
   add_subdirectory(examples)
 endif()
 


### PR DESCRIPTION
CMake is adding this in my terminal output when I build: "It is recommended to use lowercase CMake commands"
Making "MESSAGE" lowercase will help remove just a little bit more warning spam that we don't need so we can see actual warnings.

(Also it's messing with my OCD...)