### PR TITLE
[examples] Fix textures polygon drawing example for opengl 1.1

### DIFF
--- a/examples/textures/textures_polygon_drawing.c
+++ b/examples/textures/textures_polygon_drawing.c
@@ -115,9 +115,9 @@ int main(void)
 // without crossing perimeter, points must be in anticlockwise order
 void DrawTexturePoly(Texture2D texture, Vector2 center, Vector2 *points, Vector2 *texcoords, int pointCount, Color tint)
 {
+    rlSetTexture(texture.id);
     rlBegin(RL_TRIANGLES);
 
-    rlSetTexture(texture.id);
 
         rlColor4ub(tint.r, tint.g, tint.b, tint.a);
 


### PR DESCRIPTION
Issue was only happening on Opengl 1.1

Before reorder:

<img width="932" height="609" alt="image" src="https://github.com/user-attachments/assets/da314b9c-56c1-4082-9ef3-656cfe5350fe" />

After reorder:

<img width="932" height="609" alt="image" src="https://github.com/user-attachments/assets/85b4180b-cd40-46a4-a6dc-9d2184084684" />
