### PR TITLE
[examples] Update `shapes_bouncing_ball` with gravity

### DIFF
--- a/examples/shapes/shapes_bouncing_ball.c
+++ b/examples/shapes/shapes_bouncing_ball.c
@@ -35,6 +35,7 @@ int main(void)
     int ballRadius = 20;
     float gravity = 0.2f;
 
+    bool useGravity = true;
     bool pause = 0;
     int framesCounter = 0;
 
@@ -46,18 +47,19 @@ int main(void)
     {
         // Update
         //-----------------------------------------------------
+        if (IsKeyPressed(KEY_G)) useGravity = !useGravity;
         if (IsKeyPressed(KEY_SPACE)) pause = !pause;
-
+        
         if (!pause)
         {
             ballPosition.x += ballSpeed.x;
             ballPosition.y += ballSpeed.y;
 
-            ballSpeed.y += gravity;
+            if (useGravity) ballSpeed.y += gravity;
             
             // Check walls collision for bouncing
             if ((ballPosition.x >= (GetScreenWidth() - ballRadius)) || (ballPosition.x <= ballRadius)) ballSpeed.x *= -1.0f;
-            if ((ballPosition.y >= (GetScreenHeight() - ballRadius))) ballSpeed.y *= -0.95f;
+            if ((ballPosition.y >= (GetScreenHeight() - ballRadius)) || (ballPosition.y <= ballRadius)) ballSpeed.y *= -0.95f;
         }
         else framesCounter++;
         //-----------------------------------------------------
@@ -70,12 +72,15 @@ int main(void)
 
             DrawCircleV(ballPosition, (float)ballRadius, MAROON);
             DrawText("PRESS SPACE to PAUSE BALL MOVEMENT", 10, GetScreenHeight() - 25, 20, LIGHTGRAY);
+            
+            if (useGravity) DrawText("GRAVITY: ON (Press G to disable)", 10, GetScreenHeight() - 50, 20, DARKGREEN);
+            else DrawText("GRAVITY: OFF (Press G to enable)", 10, GetScreenHeight() - 50, 20, RED);
 
             // On pause, we draw a blinking message
             if (pause && ((framesCounter/30)%2)) DrawText("PAUSED", 350, 200, 30, GRAY);
 
             DrawFPS(10, 10);
-
+            
         EndDrawing();
         //-----------------------------------------------------
     }

--- a/examples/shapes/shapes_bouncing_ball.c
+++ b/examples/shapes/shapes_bouncing_ball.c
@@ -4,8 +4,10 @@
 *
 *   Example complexity rating: [★☆☆☆] 1/4
 *
-*   Example originally created with raylib 2.5, last time updated with raylib 2.5
+*   Example originally created with raylib 2.5, last time updated with raylib 5.6
 *
+*   Example contributed by Jopestpe (@jopestpe)
+* 
 *   Example licensed under an unmodified zlib/libpng license, which is an OSI-certified,
 *   BSD-like license that allows static linking with closed source software
 *
@@ -31,6 +33,7 @@ int main(void)
     Vector2 ballPosition = { GetScreenWidth()/2.0f, GetScreenHeight()/2.0f };
     Vector2 ballSpeed = { 5.0f, 4.0f };
     int ballRadius = 20;
+    float gravity = 0.2f;
 
     bool pause = 0;
     int framesCounter = 0;
@@ -50,9 +53,11 @@ int main(void)
             ballPosition.x += ballSpeed.x;
             ballPosition.y += ballSpeed.y;
 
+            ballSpeed.y += gravity;
+            
             // Check walls collision for bouncing
             if ((ballPosition.x >= (GetScreenWidth() - ballRadius)) || (ballPosition.x <= ballRadius)) ballSpeed.x *= -1.0f;
-            if ((ballPosition.y >= (GetScreenHeight() - ballRadius)) || (ballPosition.y <= ballRadius)) ballSpeed.y *= -1.0f;
+            if ((ballPosition.y >= (GetScreenHeight() - ballRadius))) ballSpeed.y *= -0.95f;
         }
         else framesCounter++;
         //-----------------------------------------------------


### PR DESCRIPTION
Adds a new example based on the classic bouncing ball, modified to include gravity and floor damping. 

Added for: #5209

Tested on Desktop (Linux).

<img width="800" height="450" alt="screenshot" src="https://github.com/user-attachments/assets/fd53a2c9-d67d-4b1f-ad69-d799bf8fcd2c" />
