### PR TITLE
[examples] Corrected typo in core_input_mouse

### DIFF
--- a/examples/core/core_input_mouse.c
+++ b/examples/core/core_input_mouse.c
@@ -72,7 +72,7 @@ int main(void)
             DrawText("move ball with mouse and click mouse button to change color", 10, 10, 20, DARKGRAY);
             DrawText("Press 'H' to toggle cursor visibility", 10, 30, 20, DARKGRAY);
 
-            if (!IsCursorHidden()) DrawText("CURSOR HIDDEN", 20, 60, 20, RED);
+            if (IsCursorHidden()) DrawText("CURSOR HIDDEN", 20, 60, 20, RED);
             else DrawText("CURSOR VISIBLE", 20, 60, 20, LIME);
 
         EndDrawing();


### PR DESCRIPTION
I noticed while porting the example to Odin that the boolean check of whether the mouse is visible is actually the opposite of what it should be.