### PR TITLE
[examples] REVIEW: `core_3d_camera_free` uses `IsKeyPressed()` incorrectly

### DIFF
--- a/examples/core/core_3d_camera_free.c
+++ b/examples/core/core_3d_camera_free.c
@@ -49,7 +49,7 @@ int main(void)
         //----------------------------------------------------------------------------------
         UpdateCamera(&camera, CAMERA_FREE);
 
-        if (IsKeyPressed('Z')) camera.target = (Vector3){ 0.0f, 0.0f, 0.0f };
+        if (IsKeyPressed(KEY_Z)) camera.target = (Vector3){ 0.0f, 0.0f, 0.0f };
         //----------------------------------------------------------------------------------
 
         // Draw


### PR DESCRIPTION
Hello! I noticed core_3d_camera_free uses a char in place of the constants that it is supposed to be using. I don't see this repeated in other examples, so I think it would be better to replace it with the constant to prevent future confusion.