### PR TITLE
[rcore] Check if mode is valid on `GetMonitorRefreshRate` to avoid Segfault when removing Monitor

### DIFF
--- a/src/platforms/rcore_desktop_glfw.c
+++ b/src/platforms/rcore_desktop_glfw.c
@@ -959,8 +959,11 @@ int GetMonitorRefreshRate(int monitor)
 
     if ((monitor >= 0) && (monitor < monitorCount))
     {
-        const GLFWvidmode *vidmode = glfwGetVideoMode(monitors[monitor]);
-        refresh = vidmode->refreshRate;
+        const GLFWvidmode *mode = glfwGetVideoMode(monitors[monitor]);
+
+        if (mode) refresh = mode->refreshRate;
+        else TRACELOG(LOG_WARNING, "GLFW: Failed to find video mode for selected monitor");
+
     }
     else TRACELOG(LOG_WARNING, "GLFW: Failed to find selected monitor");
 


### PR DESCRIPTION
This PR is to fix the issue when removing a Monitor while getting information about it.
The issue was confirmed on Linux and Windows.

<img width="728" height="800" alt="image" src="https://github.com/user-attachments/assets/e8d457b1-1573-4a75-89d3-2ea3fa4371cd" />

<img width="822" height="424" alt="image" src="https://github.com/user-attachments/assets/5e24c108-e213-4312-a367-bf54a6430c44" />

Renamed `vidmode` to `mode` to match with methods like `GetMonitorHeight` and `GetMonitorWidth`.
