### PR TITLE
[zig] Fix `compileRaylib` targeted to `emscripten`

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -386,6 +386,8 @@ fn compileRaylib(b: *std.Build, target: std.Build.ResolvedTarget, optimize: std.
             setDesktopPlatform(raylib, options.platform);
         },
         .emscripten => {
+            const activate_emsdk_step = emsdk.zemscripten.activateEmsdkStep(b);
+            raylib.step.dependOn(activate_emsdk_step);
             raylib.root_module.addCMacro("PLATFORM_WEB", "");
             if (options.opengl_version == .auto) {
                 raylib.root_module.addCMacro("GRAPHICS_API_OPENGL_ES3", "");


### PR DESCRIPTION
This PR is to `install` and `active` `emscripten` to compile Raylib and fix this issue: https://github.com/raylib-zig/raylib-zig/issues/283

Fix suggested by @HaxSam, tested and working as intended.