### PR TITLE
include `raylib.h` and `rcore.c` in platform files

### DIFF
--- a/src/platforms/rcore_android.c
+++ b/src/platforms/rcore_android.c
@@ -46,6 +46,11 @@
 *
 **********************************************************************************************/
 
+#ifndef RAYLIB_H // this should never actually happen, it's only here for IDEs
+#include "../raylib.h"
+#include "../rcore.c"
+#endif
+
 #include <android_native_app_glue.h>    // Required for: android_app struct and activity management
 #include <android/window.h>             // Required for: AWINDOW_FLAG_FULLSCREEN definition and others
 //#include <android/sensor.h>           // Required for: Android sensors functions (accelerometer, gyroscope, light...)

--- a/src/platforms/rcore_desktop_glfw.c
+++ b/src/platforms/rcore_desktop_glfw.c
@@ -49,6 +49,11 @@
 *
 **********************************************************************************************/
 
+#ifndef RAYLIB_H // this should never actually happen, it's only here for IDEs
+    #include "../raylib.h"
+    #include "../rcore.c"
+#endif
+
 #define GLFW_INCLUDE_NONE       // Disable the standard OpenGL header inclusion on GLFW3
                                 // NOTE: Already provided by rlgl implementation (on glad.h)
 #include "GLFW/glfw3.h"         // GLFW3 library: Windows, OpenGL context and Input management

--- a/src/platforms/rcore_desktop_rgfw.c
+++ b/src/platforms/rcore_desktop_rgfw.c
@@ -48,9 +48,9 @@
 *
 **********************************************************************************************/
 
-#ifndef RAYLIB_H /* this should never actually happen, it's only here for IDEs */
-#include "raylib.h"
-#include "../rcore.c"
+#ifndef RAYLIB_H // this should never actually happen, it's only here for IDEs
+    #include "../raylib.h"
+    #include "../rcore.c"
 #endif
 
 #if defined(PLATFORM_WEB_RGFW)

--- a/src/platforms/rcore_desktop_sdl.c
+++ b/src/platforms/rcore_desktop_sdl.c
@@ -48,6 +48,11 @@
 *
 **********************************************************************************************/
 
+#ifndef RAYLIB_H // this should never actually happen, it's only here for IDEs
+    #include "../raylib.h"
+    #include "../rcore.c"
+#endif
+
 #ifdef USING_SDL3_PACKAGE
     #define USING_SDL3_PROJECT
 #endif

--- a/src/platforms/rcore_drm.c
+++ b/src/platforms/rcore_drm.c
@@ -48,6 +48,11 @@
 *
 **********************************************************************************************/
 
+#ifndef RAYLIB_H // this should never actually happen, it's only here for IDEs
+    #include "../raylib.h"
+    #include "../rcore.c"
+#endif
+
 #include <fcntl.h>          // POSIX file control definitions - open(), creat(), fcntl()
 #include <unistd.h>         // POSIX standard function definitions - read(), close(), STDIN_FILENO
 #include <termios.h>        // POSIX terminal control definitions - tcgetattr(), tcsetattr()

--- a/src/platforms/rcore_template.c
+++ b/src/platforms/rcore_template.c
@@ -47,6 +47,10 @@
 **********************************************************************************************/
 
 // TODO: Include the platform specific libraries
+#ifndef RAYLIB_H // this should never actually happen, it's only here for IDEs
+    #include "../raylib.h"
+    #include "../rcore.c"
+#endif
 
 //----------------------------------------------------------------------------------
 // Types and Structures Definition

--- a/src/platforms/rcore_web.c
+++ b/src/platforms/rcore_web.c
@@ -45,6 +45,11 @@
 *
 **********************************************************************************************/
 
+#ifndef RAYLIB_H // this should never actually happen, it's only here for IDEs
+    #include "../raylib.h"
+    #include "../rcore.c"
+#endif
+
 #define GLFW_INCLUDE_NONE       // Disable the standard OpenGL header inclusion on GLFW3
                                 // NOTE: Already provided by rlgl implementation (on glad.h)
 #include "GLFW/glfw3.h"         // GLFW3: Windows, OpenGL context and Input management


### PR DESCRIPTION
this has already been done in `rcore_desktop_rgfw.c`, but not perfectly as the comments state, its there for LSPs