### PR TITLE
[examples] Update `core_monitor_change` to remove warnings

### DIFF
--- a/examples/core/core_monitor_change.c
+++ b/examples/core/core_monitor_change.c
@@ -22,7 +22,7 @@
 // Monitor Details
 typedef struct Monitor {
     Vector2 position;
-    char *name;
+    const char *name;
     int width;
     int height;
     int physicalWidth;
@@ -99,7 +99,6 @@ int main(void)
             // Get currentMonitorIndex if manually moved
             currentMonitorIndex = GetCurrentMonitor();
         }
-        const Monitor currentMonitor = monitors[currentMonitorIndex];
 
         float monitorScale = 0.6; 
 


### PR DESCRIPTION
Set name as const as it will not change and avoids the warning of  `initialization discards ‘const’ qualifier` and removed not in use variable `currentMonitor`.