### PR TITLE
Fonts - Implement glyph lookup using a hashmap

### DIFF
--- a/src/raylib.h
+++ b/src/raylib.h
@@ -320,6 +320,7 @@ typedef struct Font {
     Texture2D texture;      // Texture atlas containing the glyphs
     Rectangle *recs;        // Rectangles in texture for the glyphs
     GlyphInfo *glyphs;      // Glyphs info data
+    void *glyphLookup;      // Interal glyphs lookup map 
 } Font;
 
 // Camera, defines position/orientation in 3d space


### PR DESCRIPTION
Hi, this is my first contribution to raylib itself! I have previously made a change on the website, but it's nice to finally open a PR on the main library. I've been working on this commit for just under a week.

### What my contribution solves
By default, raylib used a linear search to find the index of a character's glyph in the array. Linear search has a time complexity of O(n), which means that it's fine for smaller fonts (especially English ones where only ascii characters are being loaded), but when we use international fonts such as Noto Sans CJK, which I used in testing, there is a huge performance overhead.

My change replaces the slow search with an O(1) average hashmap lookup, which means that no matter the size of the font we're using, it will be the same amount of time to lookup.

### Description of changes

- Added glyphLookup to Font, which holds a pointer to the hashmap
- Implemented internal structs for an open-addressing hashmap in rtext.c. This uses a small FNV-1a hashing algorithm, of which I've included a link to the documentation about it.
- All font loading functions now call `GenFontGlyphLookupMap()`, which creates and populates the lookup map when a font is loaded. When a font is unloaded, we free up that memory using `DestroyGlyphLookupMap()`.
- GetGlyphIndex has been updated to use MapGet, which has an average complexity of O(1). It can fallback to the original linear search if there is a problem with generating the font glyph for a font.

### Benchmark

I ran a small benchmark, which showed results of 8.4x faster loading in large fonts and around 3x in smaller (ascii sized) fonts.