### PR TITLE
[RCORE] Fix windows forward declarations so all windows platforms work

### DIFF
--- a/src/rcore.c
+++ b/src/rcore.c
@@ -161,7 +161,7 @@
 #endif
 
 // Platform specific defines to handle GetApplicationDirectory()
-#if (defined(_WIN32) && !defined(PLATFORM_DESKTOP_RGFW)) || (defined(_MSC_VER) && defined(PLATFORM_DESKTOP_RGFW))
+#if (defined(_WIN32))
     #ifndef MAX_PATH
         #define MAX_PATH 1025
     #endif


### PR DESCRIPTION
The windows function forward declarations were not being done for RGFW and GCC (only MSVC), they need to be there for any compiler for RGFW to work. This PR enables them for all windows platforms.