### PR TITLE
[rlgl] ADDED: `rlClearScreenBuffersEx()` to clear the depth buffer (and clear other buffers good, too)

### DIFF
--- a/src/rlgl.h
+++ b/src/rlgl.h
@@ -2126,7 +2126,7 @@ void rlClearScreenBuffersEx(rlBufferBitFlags flags)
 // Clear used screen buffers (color and depth)
 void rlClearScreenBuffers(void)
 {
-    rlClearScreenBuffersEX(RL_COLOR_BUFFER_BIT | RL_DEPTH_BUFFER_BIT);     // Clear used buffers: Color and Depth (Depth is used for 3D)
+    rlClearScreenBuffersEx(RL_COLOR_BUFFER_BIT | RL_DEPTH_BUFFER_BIT);     // Clear used buffers: Color and Depth (Depth is used for 3D)
     //glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);     // Stencil buffer not used...
 }
 


### PR DESCRIPTION
Very useful for making FPS games, as it allows you to draw the HUD weapon over top the rendered scene without it clipping through world geometry.

`rlClearScreenBuffers()` clears ***BOTH*** the color and depth buffers, so if you were to call that, you'd wipe away the entire frame you just rendered just to draw the weapon on top of it, which would defeat the point entirely.

This single function solves not having to import `<GL/gl.h>` just to call one function AND allows for rendering 3D stuff over top the scene, such as HUD weapons in FPS games or the floating arrow in Crazy Taxi  on systems which only support OpenGL 1.1, as they can't make use of RenderTextures.