### PR TITLE
[build] Code conventions auto-formatting with `.clang-format` -WIP-

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -7,7 +7,7 @@ AllowShortCaseLabelsOnASingleLine: true
 AllowShortFunctionsOnASingleLine: All
 AllowShortIfStatementsOnASingleLine: AllIfsAndElse
 AlwaysBreakAfterReturnType: None
-ColumnLimit: 9999
+ColumnLimit: 320
 IndentWidth: 4
 PointerAlignment: Right
 SpaceInEmptyParentheses: false
@@ -15,3 +15,14 @@ SpacesInCStyleCastParentheses: false
 TabWidth: 4
 UseTab: Never
 IndentPPDirectives: BeforeHash
+AlignConsecutiveAssignments: Consecutive
+BraceWrapping:
+  AfterEnum: false
+BreakFunctionDefinitionParameters: false
+Cpp11BracedListStyle: false
+IndentCaseLabels: false
+MaxEmptyLinesToKeep: 2
+# ReflowComments: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpacesBeforeTrailingComments: 1


### PR DESCRIPTION
Fixes https://github.com/raysan5/raylib/pull/5252#issuecomment-3403917757

## TODO: 
* Finalize the format. The current version is not perfect and is just here to provide an example on how to set it up. using this causes many files to change dramatically so it needs to be adjusted to better reflect the actual formatting used.
* can it be placed in a different location? 
  * I don't want *another* file in the root directory that clutters it up more. 