### PR TITLE
Fix DrawBillboardPro so that flipped images work correctly.

### DIFF
--- a/src/rmodels.c
+++ b/src/rmodels.c
@@ -3899,14 +3899,14 @@ void DrawBillboardPro(Camera camera, Texture2D texture, Rectangle source, Vector
     // Flip the content of the billboard while maintaining the counterclockwise edge rendering order
     if (size.x < 0.0f)
     {
-        source.x += size.x;
+        source.x -= size.x;
         source.width *= -1.0;
         right = Vector3Negate(right);
         origin.x *= -1.0f;
     }
     if (size.y < 0.0f)
     {
-        source.y += size.y;
+        source.y -= size.y;
         source.height *= -1.0;
         up = Vector3Negate(up);
         origin.y *= -1.0f;


### PR DESCRIPTION
DrawBillboardPro was working correctly with flipped x/y axes for textures whose entire image was sampled by the source rectangle, but for textures drawn with a source rectangle that was smaller than the texture, the sampling was incorrect.  The attached source file and texture file can be used to demonstrate the issue before and after the fix.

[donutz.c](https://github.com/user-attachments/files/22935493/donutz.c)

<img width="256" height="64" alt="test" src="https://github.com/user-attachments/assets/c9001688-111e-4474-a52e-822b3edf8189" />
