### PR TITLE
Issue 5259: Fix DrawBillboardPro so that flipped textures draw correctly when sampling parts of a texture

### DIFF
--- a/src/rmodels.c
+++ b/src/rmodels.c
@@ -3904,14 +3904,14 @@ void DrawBillboardPro(Camera camera, Texture2D texture, Rectangle source, Vector
     // Flip the content of the billboard while maintaining the counterclockwise edge rendering order
     if (size.x < 0.0f)
     {
-        source.x += size.x;
+        source.x -= size.x;
         source.width *= -1.0;
         right = Vector3Negate(right);
         origin.x *= -1.0f;
     }
     if (size.y < 0.0f)
     {
-        source.y += size.y;
+        source.y -= size.y;
         source.height *= -1.0;
         up = Vector3Negate(up);
         origin.y *= -1.0f;


### PR DESCRIPTION
Previously, DrawBillboardPro would not sample a texture from the correct UV coordinates if the size had negative values and the whole texture was not being used (the issue would not be seen if the whole texture was used and flipped).

This PR corrects that issue.

The test code has comments that explain what parts were broken before and will be fixed afterward.  It also shows that flipping of whole textures worked before and after the fix.

<img width="256" height="64" alt="htest" src="https://github.com/user-attachments/assets/9e4eb40c-16ce-44c2-99cb-60fe9f764b9a" />
<img width="64" height="256" alt="vtest" src="https://github.com/user-attachments/assets/0b16a9ed-d4b6-4fef-8396-0aa49a34dc1e" />

[donutz.txt](https://github.com/user-attachments/files/22939132/donutz.txt)

