### PR TITLE
[rcore_desktop_sdl] fix: handle monitor ID correctly on SDL3

### DIFF
--- a/src/platforms/rcore_desktop_sdl.c
+++ b/src/platforms/rcore_desktop_sdl.c
@@ -837,7 +837,11 @@ void SetWindowPosition(int x, int y)
 void SetWindowMonitor(int monitor)
 {
     const int monitorCount = SDL_GetNumVideoDisplays();
+#if defined(USING_VERSION_SDL3) // SDL3 Migration: Monitor is an id instead of index now, returns 0 on failure
+    if ((monitor > 0) && (monitor <= monitorCount))
+#else
     if ((monitor >= 0) && (monitor < monitorCount))
+#endif
     {
         // NOTE:
         // 1. SDL started supporting moving exclusive fullscreen windows between displays on SDL3,
@@ -961,7 +965,11 @@ int GetCurrentMonitor(void)
 Vector2 GetMonitorPosition(int monitor)
 {
     const int monitorCount = SDL_GetNumVideoDisplays();
+#if defined(USING_VERSION_SDL3) // SDL3 Migration: Monitor is an id instead of index now, returns 0 on failure
+    if ((monitor > 0) && (monitor <= monitorCount))
+#else
     if ((monitor >= 0) && (monitor < monitorCount))
+#endif
     {
         SDL_Rect displayBounds;
 
@@ -985,7 +993,11 @@ int GetMonitorWidth(int monitor)
     int width = 0;
 
     const int monitorCount = SDL_GetNumVideoDisplays();
+#if defined(USING_VERSION_SDL3) // SDL3 Migration: Monitor is an id instead of index now, returns 0 on failure
+    if ((monitor > 0) && (monitor <= monitorCount))
+#else
     if ((monitor >= 0) && (monitor < monitorCount))
+#endif
     {
         SDL_DisplayMode mode;
         SDL_GetCurrentDisplayMode(monitor, &mode);
@@ -1002,7 +1014,11 @@ int GetMonitorHeight(int monitor)
     int height = 0;
 
     const int monitorCount = SDL_GetNumVideoDisplays();
+#if defined(USING_VERSION_SDL3) // SDL3 Migration: Monitor is an id instead of index now, returns 0 on failure
+    if ((monitor > 0) && (monitor <= monitorCount))
+#else
     if ((monitor >= 0) && (monitor < monitorCount))
+#endif
     {
         SDL_DisplayMode mode;
         SDL_GetCurrentDisplayMode(monitor, &mode);
@@ -1019,7 +1035,11 @@ int GetMonitorPhysicalWidth(int monitor)
     int width = 0;
 
     const int monitorCount = SDL_GetNumVideoDisplays();
+#if defined(USING_VERSION_SDL3) // SDL3 Migration: Monitor is an id instead of index now, returns 0 on failure
+    if ((monitor > 0) && (monitor <= monitorCount))
+#else
     if ((monitor >= 0) && (monitor < monitorCount))
+#endif
     {
         float ddpi = 0.0f;
         SDL_GetDisplayDPI(monitor, &ddpi, NULL, NULL);
@@ -1039,7 +1059,11 @@ int GetMonitorPhysicalHeight(int monitor)
     int height = 0;
 
     const int monitorCount = SDL_GetNumVideoDisplays();
+#if defined(USING_VERSION_SDL3) // SDL3 Migration: Monitor is an id instead of index now, returns 0 on failure
+    if ((monitor > 0) && (monitor <= monitorCount))
+#else
     if ((monitor >= 0) && (monitor < monitorCount))
+#endif
     {
         float ddpi = 0.0f;
         SDL_GetDisplayDPI(monitor, &ddpi, NULL, NULL);
@@ -1059,7 +1083,11 @@ int GetMonitorRefreshRate(int monitor)
     int refresh = 0;
 
     const int monitorCount = SDL_GetNumVideoDisplays();
+#if defined(USING_VERSION_SDL3) // SDL3 Migration: Monitor is an id instead of index now, returns 0 on failure
+    if ((monitor > 0) && (monitor <= monitorCount))
+#else
     if ((monitor >= 0) && (monitor < monitorCount))
+#endif
     {
         SDL_DisplayMode mode;
         SDL_GetCurrentDisplayMode(monitor, &mode);
@@ -1075,7 +1103,14 @@ const char *GetMonitorName(int monitor)
 {
     const int monitorCount = SDL_GetNumVideoDisplays();
 
-    if ((monitor >= 0) && (monitor < monitorCount)) return SDL_GetDisplayName(monitor);
+#if defined(USING_VERSION_SDL3) // SDL3 Migration: Monitor is an id instead of index now, returns 0 on failure
+    if ((monitor > 0) && (monitor <= monitorCount))
+#else
+    if ((monitor >= 0) && (monitor < monitorCount))
+#endif
+    {
+        return SDL_GetDisplayName(monitor);
+    }
     else TRACELOG(LOG_WARNING, "SDL: Failed to find selected monitor");
 
     return "";


### PR DESCRIPTION
SDL3 uses ID when dealing with monitors, unlike SDL2 which uses Index for the same thing. This problem was already fixed in multiple places by use of preprocessor branches, so I did the very same thing elsewhere.

Please, notice that this is a pretty bad solution to this problem, and I only did it to keep it consistent with the rest of the code. The more about why it's not correct is mentioned here https://github.com/raysan5/raylib/issues/5256#issuecomment-3428782642 and here https://github.com/raysan5/raylib/issues/5256#issuecomment-3429156919 . Hopefully, someone will refactor it someday :)

Fixes: https://github.com/raysan5/raylib/issues/5256