### PR TITLE
Fix typo in RPI cross-compiler variable name

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -283,7 +283,7 @@ ifeq ($(TARGET_PLATFORM),PLATFORM_DESKTOP_GLFW)
     endif
 endif
 ifeq ($(TARGET_PLATFORM),PLATFORM_DRM)
-    ifeq ($(USE_RPI_CROSS_COMPILER),TRUE)
+    ifeq ($(USE_RPI_CROSSCOMPILER),TRUE)
         # Define RPI cross-compiler
         #CC = armv6j-hardfloat-linux-gnueabi-gcc
         CC = $(RPI_TOOLCHAIN)/bin/$(RPI_TOOLCHAIN_NAME)-gcc


### PR DESCRIPTION
It's called USE_RPI_CROSSCOMPILER in other places and only here as USE_RPI_CROSS_COMPILER. Which was causing me to compile incorrectly with gcc instead of RPI_TOOLCHAIN.