### PR TITLE
[rlsw] Simplify framebuffer logic and add blit/copy fast path

### DIFF
--- a/src/external/rlsw.h
+++ b/src/external/rlsw.h
@@ -1092,15 +1092,15 @@ static inline void sw_float_to_unorm8_simd(uint8_t dst[4], const float src[4])
     __m128 values = _mm_loadu_ps(src);
     __m128 scaled = _mm_mul_ps(values, _mm_set1_ps(255.0f));
     __m128i clamped = _mm_cvtps_epi32(scaled);      // f32 -> s32 (truncated)
-    clamped = _mm_packus_epi32(clamped, clamped);   // s32 -> u16 (saturated < 0 à 0)
-    clamped = _mm_packus_epi16(clamped, clamped);   // u16 -> u8 (saturated > 255 à 255)
+    clamped = _mm_packus_epi32(clamped, clamped);   // s32 -> u16 (saturated < 0 to 0)
+    clamped = _mm_packus_epi16(clamped, clamped);   // u16 -> u8 (saturated > 255 to 255)
     *(uint32_t*)dst = _mm_cvtsi128_si32(clamped);
 #elif defined(SW_HAS_SSE2)
     __m128 values = _mm_loadu_ps(src);
     __m128 scaled = _mm_mul_ps(values, _mm_set1_ps(255.0f));
     __m128i clamped = _mm_cvtps_epi32(scaled);      // f32 -> s32 (truncated)
     clamped = _mm_packs_epi32(clamped, clamped);    // s32 -> s16 (saturated)
-    clamped = _mm_packus_epi16(clamped, clamped);   // s16 -> u8 (saturated < 0 à 0)
+    clamped = _mm_packus_epi16(clamped, clamped);   // s16 -> u8 (saturated < 0 to 0)
     *(uint32_t*)dst = _mm_cvtsi128_si32(clamped);
 #else
     for (int i = 0; i < 4; i++)


### PR DESCRIPTION
I further simplified the framebuffer management logic, mainly by unifying the color and depth buffers.

I also added a fast path for blit/copy operations where a blit with identical dst/src dimensions now falls back to a simple copy, and a copy with the same dimensions and format (RGBA32/RGB16) as the framebuffer performs a simple linear copy.

`glClearDepth()` and `GL_DEPTH_CLEAR_VALUE` (getter) have also been added.

There was also a fix in the framebuffer copy, if the dimensions weren't exact, the pointer was being incorrectly incremented.

I also revisited the SIMD functions for `float <=> unorm8` color conversion, they now avoid explicit clamp (min/max) operations.

___

Regarding the unified buffer, it has both advantages and drawbacks...

The main drawback is that it's an AoS, which is suboptimal (or even incompatible) if we ever move to fully manual SIMD rasterization.
However, reverting to separate buffers at that point would be trivial compared to the rest of the work.

The advantages are a cleaner and more natural logic, a bit less pointer arithmetic, and logically fewer cache misses during rasterization.

Initially, after unifying the buffers, I saw no visible performance difference on my side with `-O3`, which is good considering the code simplification.

With the subsequent changes, I noticed a slight performance increase on the bunnymark test.