### PR TITLE
[rlsw] Review depth formats and fix depth writing

### DIFF
--- a/src/external/rlsw.h
+++ b/src/external/rlsw.h
@@ -1346,7 +1346,7 @@ static inline void sw_framebuffer_write_color(sw_pixel_t *dst, const float src[4
 
 static inline void sw_framebuffer_write_depth(sw_pixel_t *dst, float depth)
 {
-    depth = sw_saturate(depth);
+    depth = sw_saturate(depth); // REVIEW: An overflow can occur in certain circumstances with clipping, and needs to be reviewed...
 
 #if SW_DEPTH_IS_PACKED
     dst->depth[0] = SW_PACK_DEPTH(depth);


### PR DESCRIPTION
I reviewed the depth formats and removed the 8-bit one. It could have been marginally useful for orthographic projection, but without heavier adjustments it would never really be practical.

I also added a 32-bit floating-point depth format, which avoids conversions, though after testing it turned out to be slightly slower than 16-bit with conversion. So 16-bit remains the default.

I also added saturation when writing depth values, since in some cases, when the camera was very close to a clipped triangle, the depth value could exceed the limit and cause an overflow.

This might require reviewing some details in the clipping, I find it strange at first glance...

This issue seems to mention the related UB problem: https://github.com/raysan5/raylib/issues/5309

I compiled in debug mode with UBSan and ran several examples, didn't notice any issues on my side with this update.

The 24-bit format has also been quickly reviewed and tested, everything seems perfect!