### PR TITLE
Adding SwiftForth language binding

### DIFF
--- a/BINDINGS.md
+++ b/BINDINGS.md
@@ -31,6 +31,7 @@ Some people ported raylib to other languages in the form of bindings or wrappers
 | [rayex](https://github.com/shiryel/rayex)                                                | 3.7              | [elixir](https://elixir-lang.org)                                    | Apache-2.0           |
 | [raylib-factor](https://github.com/factor/factor/blob/master/extra/raylib/raylib.factor) | 4.5              | [Factor](https://factorcode.org)                                     | BSD                  |
 | [raylib-freebasic](https://github.com/WIITD/raylib-freebasic)                            | **5.0**          | [FreeBASIC](https://www.freebasic.net)                               | MIT                  |
+| [raylib.f](https://github.com/cthulhuology/raylib.f)                                     | **5.5**          | [Forth](https://forth.com)                                           | Zlib                 |
 | [fortran-raylib](https://github.com/interkosmos/fortran-raylib)                          | **5.5**          | [Fortran](https://fortran-lang.org)                                  | ISC                  |
 | [raylib-go](https://github.com/gen2brain/raylib-go)                                      | **5.5**          | [Go](https://golang.org)                                             | Zlib                 |
 | [raylib-guile](https://github.com/petelliott/raylib-guile)                               | **auto**         | [Guile](https://www.gnu.org/software/guile)                          | Zlib                 |


### PR DESCRIPTION
I've created a mostly functional Forth wrapper that works with Forth Inc's SwiftForth.  Currently, I am testing on Windows, but will begin Linux and MacOS testing in the next couple weeks.  Right now it supports all of the functions in raylib.h, and will be adding the additional header files next week.

SwiftForth is a cross platform Forth implementation, that is written in Forth, and has its own assembler, compiler, ide, and runtime environment.  Forth Inc. was originally founded in 1971 by Charles Moore, who invented Forth, and SwiftForth https://www.forth.com/product/swiftforth/ is a for-profit environment which comes with all of it's source code!