### PR TITLE
[rcore] Determine whether or not an SDL3 monitor ID is valid using SDL_GetDisplayUsableBounds()

### DIFF
--- a/src/platforms/rcore_desktop_sdl.c
+++ b/src/platforms/rcore_desktop_sdl.c
@@ -463,7 +463,8 @@ void ToggleFullscreen(void)
     const int monitorCount = SDL_GetNumVideoDisplays();
 
 #if defined(USING_VERSION_SDL3) // SDL3 Migration: Monitor is an id instead of index now, returns 0 on failure
-    if ((monitor > 0) && (monitor <= monitorCount))
+    SDL_Rect displayBoundsRect; // Different SDL_Rect variable from displayBounds to avoid overwriting it
+    if (SDL_GetDisplayUsableBounds(monitor,  &displayBoundsRect)) // Returns true on success, which confirms that the monitor is valid
 #else
     if ((monitor >= 0) && (monitor < monitorCount))
 #endif
@@ -491,7 +492,8 @@ void ToggleBorderlessWindowed(void)
     const int monitorCount = SDL_GetNumVideoDisplays();
 
 #if defined(USING_VERSION_SDL3) // SDL3 Migration: Monitor is an id instead of index now, returns 0 on failure
-    if ((monitor > 0) && (monitor <= monitorCount))
+    SDL_Rect displayBoundsRect; // Different SDL_Rect variable from displayBounds to avoid overwriting it
+    if (SDL_GetDisplayUsableBounds(monitor,  &displayBoundsRect)) // Returns true on success, which confirms that the monitor is valid
 #else
     if ((monitor >= 0) && (monitor < monitorCount))
 #endif
@@ -548,7 +550,8 @@ void SetWindowState(unsigned int flags)
         const int monitorCount = SDL_GetNumVideoDisplays();
 
     #if defined(USING_VERSION_SDL3) // SDL3 Migration: Monitor is an id instead of index now, returns 0 on failure
-        if ((monitor > 0) && (monitor <= monitorCount))
+        SDL_Rect displayBoundsRect; // Different SDL_Rect variable from displayBounds to avoid overwriting it
+        if (SDL_GetDisplayUsableBounds(monitor,  &displayBoundsRect)) // Returns true on success, which confirms that the monitor is valid
     #else
         if ((monitor >= 0) && (monitor < monitorCount))
     #endif
@@ -612,7 +615,8 @@ void SetWindowState(unsigned int flags)
         const int monitorCount = SDL_GetNumVideoDisplays();
 
     #if defined(USING_VERSION_SDL3) // SDL3 Migration: Monitor is an id instead of index now, returns 0 on failure
-        if ((monitor > 0) && (monitor <= monitorCount))
+        SDL_Rect displayBoundsRect; // Different SDL_Rect variable from displayBounds to avoid overwriting it
+        if (SDL_GetDisplayUsableBounds(monitor,  &displayBoundsRect)) // Returns true on success, which confirms that the monitor is valid
     #else
         if ((monitor >= 0) && (monitor < monitorCount))
     #endif
@@ -833,7 +837,8 @@ void SetWindowMonitor(int monitor)
 {
     const int monitorCount = SDL_GetNumVideoDisplays();
 #if defined(USING_VERSION_SDL3) // SDL3 Migration: Monitor is an id instead of index now, returns 0 on failure
-    if ((monitor > 0) && (monitor <= monitorCount))
+    SDL_Rect displayBoundsRect; // Different SDL_Rect variable from displayBounds to avoid overwriting it
+    if (SDL_GetDisplayUsableBounds(monitor,  &displayBoundsRect)) // Returns true on success, which confirms that the monitor is valid
 #else
     if ((monitor >= 0) && (monitor < monitorCount))
 #endif
@@ -849,7 +854,8 @@ void SetWindowMonitor(int monitor)
         SDL_Rect usableBounds;
 
     #if defined(USING_VERSION_SDL3) // Different style for success checking
-        if (SDL_GetDisplayUsableBounds(monitor, &usableBounds))
+        SDL_Rect displayBoundsRect; // Different SDL_Rect variable from displayBounds to avoid overwriting it
+        if (SDL_GetDisplayUsableBounds(monitor, &usableBounds)) // Returns true on success, which confirms that the monitor is valid
     #else
         if (SDL_GetDisplayUsableBounds(monitor, &usableBounds) == 0)
     #endif
@@ -961,7 +967,8 @@ Vector2 GetMonitorPosition(int monitor)
 {
     const int monitorCount = SDL_GetNumVideoDisplays();
 #if defined(USING_VERSION_SDL3) // SDL3 Migration: Monitor is an id instead of index now, returns 0 on failure
-    if ((monitor > 0) && (monitor <= monitorCount))
+    SDL_Rect displayBoundsRect; // Different SDL_Rect variable from displayBounds to avoid overwriting it
+    if (SDL_GetDisplayUsableBounds(monitor,  &displayBoundsRect)) // Returns true on success, which confirms that the monitor is valid
 #else
     if ((monitor >= 0) && (monitor < monitorCount))
 #endif
@@ -989,7 +996,8 @@ int GetMonitorWidth(int monitor)
 
     const int monitorCount = SDL_GetNumVideoDisplays();
 #if defined(USING_VERSION_SDL3) // SDL3 Migration: Monitor is an id instead of index now, returns 0 on failure
-    if ((monitor > 0) && (monitor <= monitorCount))
+    SDL_Rect displayBoundsRect; // Different SDL_Rect variable from displayBounds to avoid overwriting it
+    if (SDL_GetDisplayUsableBounds(monitor,  &displayBoundsRect)) // Returns true on success, which confirms that the monitor is valid
 #else
     if ((monitor >= 0) && (monitor < monitorCount))
 #endif
@@ -1010,7 +1018,8 @@ int GetMonitorHeight(int monitor)
 
     const int monitorCount = SDL_GetNumVideoDisplays();
 #if defined(USING_VERSION_SDL3) // SDL3 Migration: Monitor is an id instead of index now, returns 0 on failure
-    if ((monitor > 0) && (monitor <= monitorCount))
+    SDL_Rect displayBoundsRect; // Different SDL_Rect variable from displayBounds to avoid overwriting it
+    if (SDL_GetDisplayUsableBounds(monitor,  &displayBoundsRect)) // Returns true on success, which confirms that the monitor is valid
 #else
     if ((monitor >= 0) && (monitor < monitorCount))
 #endif
@@ -1031,7 +1040,8 @@ int GetMonitorPhysicalWidth(int monitor)
 
     const int monitorCount = SDL_GetNumVideoDisplays();
 #if defined(USING_VERSION_SDL3) // SDL3 Migration: Monitor is an id instead of index now, returns 0 on failure
-    if ((monitor > 0) && (monitor <= monitorCount))
+    SDL_Rect displayBoundsRect; // Different SDL_Rect variable from displayBounds to avoid overwriting it
+    if (SDL_GetDisplayUsableBounds(monitor,  &displayBoundsRect)) // Returns true on success, which confirms that the monitor is valid
 #else
     if ((monitor >= 0) && (monitor < monitorCount))
 #endif
@@ -1055,7 +1065,8 @@ int GetMonitorPhysicalHeight(int monitor)
 
     const int monitorCount = SDL_GetNumVideoDisplays();
 #if defined(USING_VERSION_SDL3) // SDL3 Migration: Monitor is an id instead of index now, returns 0 on failure
-    if ((monitor > 0) && (monitor <= monitorCount))
+    SDL_Rect displayBoundsRect; // Different SDL_Rect variable from displayBounds to avoid overwriting it
+    if (SDL_GetDisplayUsableBounds(monitor,  &displayBoundsRect)) // Returns true on success, which confirms that the monitor is valid
 #else
     if ((monitor >= 0) && (monitor < monitorCount))
 #endif
@@ -1079,7 +1090,8 @@ int GetMonitorRefreshRate(int monitor)
 
     const int monitorCount = SDL_GetNumVideoDisplays();
 #if defined(USING_VERSION_SDL3) // SDL3 Migration: Monitor is an id instead of index now, returns 0 on failure
-    if ((monitor > 0) && (monitor <= monitorCount))
+    SDL_Rect displayBoundsRect; // Different SDL_Rect variable from displayBounds to avoid overwriting it
+    if (SDL_GetDisplayUsableBounds(monitor,  &displayBoundsRect)) // Returns true on success, which confirms that the monitor is valid
 #else
     if ((monitor >= 0) && (monitor < monitorCount))
 #endif
@@ -1099,7 +1111,8 @@ const char *GetMonitorName(int monitor)
     const int monitorCount = SDL_GetNumVideoDisplays();
 
 #if defined(USING_VERSION_SDL3) // SDL3 Migration: Monitor is an id instead of index now, returns 0 on failure
-    if ((monitor > 0) && (monitor <= monitorCount))
+    SDL_Rect displayBoundsRect; // Different SDL_Rect variable from displayBounds to avoid overwriting it
+    if (SDL_GetDisplayUsableBounds(monitor,  &displayBoundsRect)) // Returns true on success, which confirms that the monitor is valid
 #else
     if ((monitor >= 0) && (monitor < monitorCount))
 #endif


### PR DESCRIPTION
On the SDL3 backend, when a laptop is connected to an external monitor and then the laptop lid is closed, the original SDL3 monitor ID for the laptop's monitor is invalidated and replaced with a monitor ID that exceeds the total amount of monitors upon reopening the laptop lid. Many of Raylib's functions in the file "rcore_desktop_sdl.c" do not properly handle such a situation, as they return an error message and do not actually run when the following condition is met:

#if defined(USING_VERSION_SDL3)
    if((monitor > 0) && (monitor <= monitorCount))

I think the monitor number ("monitor") should be validated not against the monitor count, but rather the code should attempt to call the SDL3 function "SDL_GetDisplayUsableBounds(monitor, &displayBoundsRectangle)", passing in the monitor number ("monitor") and the "SDL_Rect" object "displayBoundsRectangle" by address. This function returns "true" on success, and tells you that the requested monitor is valid.

It worked with the following example (I was able to toggle the borderless windowed mode, even though the monitor number was now 4 upon reopening the laptop lid):

```c++
#include <raylib.h>
#include <iostream>


int main()
{
    InitWindow(800, 600, "");
    SetWindowPosition(100, 100);
    SetTargetFPS(60);

    int currentMonitor{GetCurrentMonitor()};
    
    std::cout << "GetCurrentMonitor(): " << GetCurrentMonitor() << '\n';
    std::cout << "GetMonitorCount(): " << GetMonitorCount() << '\n';

    while (!WindowShouldClose())
    {
        int newMonitor{GetCurrentMonitor()};
        if (newMonitor != currentMonitor)
        {
            currentMonitor = newMonitor;
            std::cout << "GetCurrentMonitor(): " << GetCurrentMonitor() << '\n';
            std::cout << "GetMonitorCount(): " << GetMonitorCount() << '\n';
        }

        if (IsKeyPressed(KEY_F11)
        {
            ToggleBorderlessWindowed();
        }

        BeginDrawing();
        ClearBackground(BLACK);
        EndDrawing();
    }

    CloseWindow();
    return 0;
}


``` 