### PR TITLE
[rmodels] opengl11 fixes added texture consistency check to DrawMesh and fixed LoadOBJ texcoord issues

### DIFF
--- a/src/rmodels.c
+++ b/src/rmodels.c
@@ -1435,7 +1435,7 @@ void DrawMesh(Mesh mesh, Material material, Matrix transform)
     #define GL_COLOR_ARRAY          0x8076
     #define GL_TEXTURE_COORD_ARRAY  0x8078
 
-    rlEnableTexture(material.maps[MATERIAL_MAP_DIFFUSE].texture.id);
+    if (mesh.texcoords && material.maps[MATERIAL_MAP_DIFFUSE].texture.id > 0) rlEnableTexture(material.maps[MATERIAL_MAP_DIFFUSE].texture.id);
 
     if (mesh.animVertices) rlEnableStatePointer(GL_VERTEX_ARRAY, mesh.animVertices);
     else rlEnableStatePointer(GL_VERTEX_ARRAY, mesh.vertices);
@@ -4429,10 +4429,12 @@ static Model LoadOBJ(const char *fileName)
 
         model.meshes[i].vertices = (float *)MemAlloc(sizeof(float)*vertexCount*3);
         model.meshes[i].normals = (float *)MemAlloc(sizeof(float)*vertexCount*3);
-        model.meshes[i].texcoords = (float *)MemAlloc(sizeof(float)*vertexCount*2);
     #if defined(GRAPHICS_API_OPENGL_33) || defined(GRAPHICS_API_OPENGL_ES2)
+        model.meshes[i].texcoords = (float *)MemAlloc(sizeof(float)*vertexCount*2);
         model.meshes[i].colors = (unsigned char *)MemAlloc(sizeof(unsigned char)*vertexCount*4);
     #else
+        if (objAttributes.texcoords != NULL && objAttributes.num_texcoords > 0) model.meshes[i].texcoords = (float *)MemAlloc(sizeof(float)*vertexCount*2);
+        else model.meshes[i].texcoords = NULL;
         model.meshes[i].colors = NULL;
     #endif
     }
@@ -4488,15 +4490,10 @@ static Model LoadOBJ(const char *fileName)
 
             for (int i = 0; i < 3; i++) model.meshes[meshIndex].vertices[localMeshVertexCount*3 + i] = objAttributes.vertices[vertIndex*3 + i];
 
-            if ((objAttributes.texcoords != NULL) && (texcordIndex != TINYOBJ_INVALID_INDEX) && (texcordIndex >= 0))
+            if ((objAttributes.texcoords != NULL) && (texcordIndex != TINYOBJ_INVALID_INDEX) && (texcordIndex >= 0) && (model.meshes[meshIndex].texcoords))
             {
                 for (int i = 0; i < 2; i++) model.meshes[meshIndex].texcoords[localMeshVertexCount*2 + i] = objAttributes.texcoords[texcordIndex*2 + i];
                 model.meshes[meshIndex].texcoords[localMeshVertexCount*2 + 1] = 1.0f - model.meshes[meshIndex].texcoords[localMeshVertexCount*2 + 1];
-            }
-            else
-            {
-                model.meshes[meshIndex].texcoords[localMeshVertexCount*2 + 0] = 0.0f;
-                model.meshes[meshIndex].texcoords[localMeshVertexCount*2 + 1] = 0.0f;
             }
 
             if ((objAttributes.normals != NULL) && (normalIndex != TINYOBJ_INVALID_INDEX) && (normalIndex >= 0))


### PR DESCRIPTION
These are some fixes for OpenGL11 that add behavioral consistency to:
`DrawMesh` 
 - proper null checks for allowing draws on simplified meshes in opengl11 context
`LoadOBJ`:
 - correct the texcoord optionality issues I accidentally introduced in https://github.com/raysan5/raylib/pull/5207
 
These have been tested with ps2 backend behavior tests, and can be tested with opengl11 demo: https://github.com/raysan5/raylib/pull/5320 
NOTE: This demo^^ will be moved to raylib-extras due to over-complexity as an example).