### PR TITLE
[rcore] Determine whether or not an SDL3 monitor ID is valid using SDL_GetDisplayProperties()

### DIFF
--- a/src/platforms/rcore_desktop_sdl.c
+++ b/src/platforms/rcore_desktop_sdl.c
@@ -463,8 +463,7 @@ void ToggleFullscreen(void)
     const int monitorCount = SDL_GetNumVideoDisplays();
 
 #if defined(USING_VERSION_SDL3) // SDL3 Migration: Monitor is an id instead of index now, returns 0 on failure
-    SDL_Rect displayBoundsRect; // Different SDL_Rect variable from displayBounds to avoid overwriting it
-    if (SDL_GetDisplayUsableBounds(monitor,  &displayBoundsRect)) // Returns true on success, which confirms that the monitor is valid
+    if (SDL_GetDisplayProperties(monitor) != 0) // Returns 0 on failure, so a value other than zero indicates that the monitor id is valid
 #else
     if ((monitor >= 0) && (monitor < monitorCount))
 #endif
@@ -492,8 +491,7 @@ void ToggleBorderlessWindowed(void)
     const int monitorCount = SDL_GetNumVideoDisplays();
 
 #if defined(USING_VERSION_SDL3) // SDL3 Migration: Monitor is an id instead of index now, returns 0 on failure
-    SDL_Rect displayBoundsRect; // Different SDL_Rect variable from displayBounds to avoid overwriting it
-    if (SDL_GetDisplayUsableBounds(monitor,  &displayBoundsRect)) // Returns true on success, which confirms that the monitor is valid
+    if (SDL_GetDisplayProperties(monitor) != 0) // Returns 0 on failure, so a value other than zero indicates that the monitor id is valid
 #else
     if ((monitor >= 0) && (monitor < monitorCount))
 #endif
@@ -550,8 +548,7 @@ void SetWindowState(unsigned int flags)
         const int monitorCount = SDL_GetNumVideoDisplays();
 
     #if defined(USING_VERSION_SDL3) // SDL3 Migration: Monitor is an id instead of index now, returns 0 on failure
-        SDL_Rect displayBoundsRect; // Different SDL_Rect variable from displayBounds to avoid overwriting it
-        if (SDL_GetDisplayUsableBounds(monitor,  &displayBoundsRect)) // Returns true on success, which confirms that the monitor is valid
+        if (SDL_GetDisplayProperties(monitor) != 0) // Returns 0 on failure, so a value other than zero indicates that the monitor id is valid
     #else
         if ((monitor >= 0) && (monitor < monitorCount))
     #endif
@@ -615,8 +612,7 @@ void SetWindowState(unsigned int flags)
         const int monitorCount = SDL_GetNumVideoDisplays();
 
     #if defined(USING_VERSION_SDL3) // SDL3 Migration: Monitor is an id instead of index now, returns 0 on failure
-        SDL_Rect displayBoundsRect; // Different SDL_Rect variable from displayBounds to avoid overwriting it
-        if (SDL_GetDisplayUsableBounds(monitor,  &displayBoundsRect)) // Returns true on success, which confirms that the monitor is valid
+        if (SDL_GetDisplayProperties(monitor) != 0) // Returns 0 on failure, so a value other than zero indicates that the monitor id is valid
     #else
         if ((monitor >= 0) && (monitor < monitorCount))
     #endif
@@ -837,8 +833,7 @@ void SetWindowMonitor(int monitor)
 {
     const int monitorCount = SDL_GetNumVideoDisplays();
 #if defined(USING_VERSION_SDL3) // SDL3 Migration: Monitor is an id instead of index now, returns 0 on failure
-    SDL_Rect displayBoundsRect; // Different SDL_Rect variable from displayBounds to avoid overwriting it
-    if (SDL_GetDisplayUsableBounds(monitor,  &displayBoundsRect)) // Returns true on success, which confirms that the monitor is valid
+    if (SDL_GetDisplayProperties(monitor) != 0) // Returns 0 on failure, so a value other than zero indicates that the monitor id is valid
 #else
     if ((monitor >= 0) && (monitor < monitorCount))
 #endif
@@ -854,8 +849,7 @@ void SetWindowMonitor(int monitor)
         SDL_Rect usableBounds;
 
     #if defined(USING_VERSION_SDL3) // Different style for success checking
-        SDL_Rect displayBoundsRect; // Different SDL_Rect variable from displayBounds to avoid overwriting it
-        if (SDL_GetDisplayUsableBounds(monitor, &usableBounds)) // Returns true on success, which confirms that the monitor is valid
+        if (SDL_GetDisplayUsableBounds(monitor, &usableBounds))
     #else
         if (SDL_GetDisplayUsableBounds(monitor, &usableBounds) == 0)
     #endif
@@ -967,8 +961,7 @@ Vector2 GetMonitorPosition(int monitor)
 {
     const int monitorCount = SDL_GetNumVideoDisplays();
 #if defined(USING_VERSION_SDL3) // SDL3 Migration: Monitor is an id instead of index now, returns 0 on failure
-    SDL_Rect displayBoundsRect; // Different SDL_Rect variable from displayBounds to avoid overwriting it
-    if (SDL_GetDisplayUsableBounds(monitor,  &displayBoundsRect)) // Returns true on success, which confirms that the monitor is valid
+    if (SDL_GetDisplayProperties(monitor) != 0) // Returns 0 on failure, so a value other than zero indicates that the monitor id is valid
 #else
     if ((monitor >= 0) && (monitor < monitorCount))
 #endif
@@ -996,8 +989,7 @@ int GetMonitorWidth(int monitor)
 
     const int monitorCount = SDL_GetNumVideoDisplays();
 #if defined(USING_VERSION_SDL3) // SDL3 Migration: Monitor is an id instead of index now, returns 0 on failure
-    SDL_Rect displayBoundsRect; // Different SDL_Rect variable from displayBounds to avoid overwriting it
-    if (SDL_GetDisplayUsableBounds(monitor,  &displayBoundsRect)) // Returns true on success, which confirms that the monitor is valid
+    if (SDL_GetDisplayProperties(monitor) != 0) // Returns 0 on failure, so a value other than zero indicates that the monitor id is valid
 #else
     if ((monitor >= 0) && (monitor < monitorCount))
 #endif
@@ -1018,8 +1010,7 @@ int GetMonitorHeight(int monitor)
 
     const int monitorCount = SDL_GetNumVideoDisplays();
 #if defined(USING_VERSION_SDL3) // SDL3 Migration: Monitor is an id instead of index now, returns 0 on failure
-    SDL_Rect displayBoundsRect; // Different SDL_Rect variable from displayBounds to avoid overwriting it
-    if (SDL_GetDisplayUsableBounds(monitor,  &displayBoundsRect)) // Returns true on success, which confirms that the monitor is valid
+    if (SDL_GetDisplayProperties(monitor) != 0) // Returns 0 on failure, so a value other than zero indicates that the monitor id is valid
 #else
     if ((monitor >= 0) && (monitor < monitorCount))
 #endif
@@ -1040,8 +1031,7 @@ int GetMonitorPhysicalWidth(int monitor)
 
     const int monitorCount = SDL_GetNumVideoDisplays();
 #if defined(USING_VERSION_SDL3) // SDL3 Migration: Monitor is an id instead of index now, returns 0 on failure
-    SDL_Rect displayBoundsRect; // Different SDL_Rect variable from displayBounds to avoid overwriting it
-    if (SDL_GetDisplayUsableBounds(monitor,  &displayBoundsRect)) // Returns true on success, which confirms that the monitor is valid
+    if (SDL_GetDisplayProperties(monitor) != 0) // Returns 0 on failure, so a value other than zero indicates that the monitor id is valid
 #else
     if ((monitor >= 0) && (monitor < monitorCount))
 #endif
@@ -1065,8 +1055,7 @@ int GetMonitorPhysicalHeight(int monitor)
 
     const int monitorCount = SDL_GetNumVideoDisplays();
 #if defined(USING_VERSION_SDL3) // SDL3 Migration: Monitor is an id instead of index now, returns 0 on failure
-    SDL_Rect displayBoundsRect; // Different SDL_Rect variable from displayBounds to avoid overwriting it
-    if (SDL_GetDisplayUsableBounds(monitor,  &displayBoundsRect)) // Returns true on success, which confirms that the monitor is valid
+    if (SDL_GetDisplayProperties(monitor) != 0) // Returns 0 on failure, so a value other than zero indicates that the monitor id is valid
 #else
     if ((monitor >= 0) && (monitor < monitorCount))
 #endif
@@ -1090,8 +1079,7 @@ int GetMonitorRefreshRate(int monitor)
 
     const int monitorCount = SDL_GetNumVideoDisplays();
 #if defined(USING_VERSION_SDL3) // SDL3 Migration: Monitor is an id instead of index now, returns 0 on failure
-    SDL_Rect displayBoundsRect; // Different SDL_Rect variable from displayBounds to avoid overwriting it
-    if (SDL_GetDisplayUsableBounds(monitor,  &displayBoundsRect)) // Returns true on success, which confirms that the monitor is valid
+    if (SDL_GetDisplayProperties(monitor) != 0) // Returns 0 on failure, so a value other than zero indicates that the monitor id is valid
 #else
     if ((monitor >= 0) && (monitor < monitorCount))
 #endif
@@ -1111,8 +1099,7 @@ const char *GetMonitorName(int monitor)
     const int monitorCount = SDL_GetNumVideoDisplays();
 
 #if defined(USING_VERSION_SDL3) // SDL3 Migration: Monitor is an id instead of index now, returns 0 on failure
-    SDL_Rect displayBoundsRect; // Different SDL_Rect variable from displayBounds to avoid overwriting it
-    if (SDL_GetDisplayUsableBounds(monitor,  &displayBoundsRect)) // Returns true on success, which confirms that the monitor is valid
+    if (SDL_GetDisplayProperties(monitor) != 0) // Returns 0 on failure, so a value other than zero indicates that the monitor id is valid
 #else
     if ((monitor >= 0) && (monitor < monitorCount))
 #endif


### PR DESCRIPTION
On the SDL3 backend, when a laptop is connected to an external monitor and then the laptop lid is closed, the original SDL3 monitor ID for the laptop's monitor is invalidated and replaced with a monitor ID that exceeds the total amount of monitors upon reopening the laptop lid. Many of Raylib's functions in the file "rcore_desktop_sdl.c" do not properly handle such a situation, as they return an error message and do not actually run when the following condition is met:

```c++
#if defined(USING_VERSION_SDL3)
if((monitor > 0) && (monitor <= monitorCount))
``` 

I think the monitor id/number ("monitor") shouln't be validated against the monitor count, but rather the code should attempt to call the SDL3 function "SDL_GetDisplayProperties(monitor)". This function returns a valid property ID on success or 0 on failure, so a returned value other than zero tells you that the monitor id is valid.

See this link for more details: [https://wiki.libsdl.org/SDL3/SDL_GetDisplayProperties](url)

It worked with the following example (I was able to toggle the borderless windowed mode on and off, even though the monitor number was now 4 upon reopening the laptop lid):

```c++
#include <raylib.h>
#include <iostream>


int main()
{
    InitWindow(800, 600, "");
    SetWindowPosition(100, 100);
    SetTargetFPS(60);

    int currentMonitor{GetCurrentMonitor()};
    
    std::cout << "GetCurrentMonitor(): " << GetCurrentMonitor() << '\n';
    std::cout << "GetMonitorCount(): " << GetMonitorCount() << '\n';

    while (!WindowShouldClose())
    {
        int newMonitor{GetCurrentMonitor()};
        if (newMonitor != currentMonitor)
        {
            currentMonitor = newMonitor;
            std::cout << "GetCurrentMonitor(): " << GetCurrentMonitor() << '\n';
            std::cout << "GetMonitorCount(): " << GetMonitorCount() << '\n';
        }

        if (IsKeyPressed(KEY_F11)
        {
            ToggleBorderlessWindowed();
        }

        BeginDrawing();
        ClearBackground(BLACK);
        EndDrawing();
    }

    CloseWindow();
    return 0;
}
``` 