### PR TITLE
[rlsw] Fix clipping boundary overflow

### DIFF
--- a/src/external/rlsw.h
+++ b/src/external/rlsw.h
@@ -2118,12 +2118,12 @@ static inline int sw_clip_##name(                                               
 // Frustum cliping functions
 //-------------------------------------------------------------------------------------------
 #define IS_INSIDE_PLANE_W(h) ((h)[3] >= SW_CLIP_EPSILON)
-#define IS_INSIDE_PLANE_X_POS(h) ((h)[0] <= (h)[3])
-#define IS_INSIDE_PLANE_X_NEG(h) (-(h)[0] <= (h)[3])
-#define IS_INSIDE_PLANE_Y_POS(h) ((h)[1] <= (h)[3])
-#define IS_INSIDE_PLANE_Y_NEG(h) (-(h)[1] <= (h)[3])
-#define IS_INSIDE_PLANE_Z_POS(h) ((h)[2] <= (h)[3])
-#define IS_INSIDE_PLANE_Z_NEG(h) (-(h)[2] <= (h)[3])
+#define IS_INSIDE_PLANE_X_POS(h) ( (h)[0] <  (h)[3])        // Exclusive for +X
+#define IS_INSIDE_PLANE_X_NEG(h) (-(h)[0] <  (h)[3])        // Exclusive for -X
+#define IS_INSIDE_PLANE_Y_POS(h) ( (h)[1] <  (h)[3])        // Exclusive for +Y
+#define IS_INSIDE_PLANE_Y_NEG(h) (-(h)[1] <  (h)[3])        // Exclusive for -Y
+#define IS_INSIDE_PLANE_Z_POS(h) ( (h)[2] <= (h)[3])        // Inclusive for +Z
+#define IS_INSIDE_PLANE_Z_NEG(h) (-(h)[2] <= (h)[3])        // Inclusive for -Z
 
 #define COMPUTE_T_PLANE_W(hPrev, hCurr) ((SW_CLIP_EPSILON - (hPrev)[3])/((hCurr)[3] - (hPrev)[3]))
 #define COMPUTE_T_PLANE_X_POS(hPrev, hCurr) (((hPrev)[3] - (hPrev)[0])/(((hPrev)[3] - (hPrev)[0]) - ((hCurr)[3] - (hCurr)[0])))


### PR DESCRIPTION
Fixes the buffer overrun issue reported here: https://github.com/raysan5/raylib/issues/5326#issuecomment-3487022305

After investigating the problem, the most reasonable approach seems to be using exclusive tests for the X/Y planes during clipping while keeping inclusive tests for Z.

The current clipping implementation is based on multiple rewrites of the approach originally described in this blog:
https://fabiensanglard.net/polygon_codec/

Our original implementation followed the same conditional logic as in the blog post, but this behavior might also be related to the projection [NDC -> screen] convention we follow _(and which didn't seem to be a problem anyway in the context of the blog post)_, so clipping with exclusive X/Y borders seems more consistent in our case, while keeping Z inclusive avoids losing fragments.

For reference, here are the original papers that describes the logic:
* https://fabiensanglard.net/polygon_codec/clippingdocument/p245-blinn.pdf
* https://fabiensanglard.net/polygon_codec/clippingdocument/Clipping.pdf