### PR TITLE
[rcore] Fix high DPI render size and window deformation

### DIFF
--- a/src/platforms/rcore_desktop_glfw.c
+++ b/src/platforms/rcore_desktop_glfw.c
@@ -1808,30 +1808,35 @@ static void WindowSizeCallback(GLFWwindow *window, int width, int height)
     // WARNING: On window minimization, callback is called,
     // but we don't want to change internal screen values, it breaks things
     if ((width == 0) || (height == 0)) return;
+    int fbWidth, fbHeight;
+    glfwGetFramebufferSize(window, &fbWidth, &fbHeight);
 
     // Reset viewport and projection matrix for new size
-    SetupViewport(width, height);
+    SetupViewport(fbWidth, fbHeight);
 
-    CORE.Window.currentFbo.width = width;
-    CORE.Window.currentFbo.height = height;
+    CORE.Window.currentFbo.width = fbWidth;
+    CORE.Window.currentFbo.height = fbHeight;
     CORE.Window.resizedLastFrame = true;
 
     if (IsWindowFullscreen()) return;
+    int logicalWidth = width;
+    int logicalHeight = height;
 
     // if we are doing automatic DPI scaling, then the "screen" size is divided by the window scale
     if (IsWindowState(FLAG_WINDOW_HIGHDPI))
     {
-        width = (int)(width/GetWindowScaleDPI().x);
-        height = (int)(height/GetWindowScaleDPI().y);
+        Vector2 dpiScale = GetWindowScaleDPI();
+        logicalWidth  = (int)(fbWidth / dpiScale.x);
+        logicalHeight = (int)(fbHeight / dpiScale.y);
     }
 
     // Set render size
-    CORE.Window.render.width = width;
-    CORE.Window.render.height = height;
+    CORE.Window.render.width = fbWidth;
+    CORE.Window.render.height = fbHeight;
 
     // Set current screen size
-    CORE.Window.screen.width = width;
-    CORE.Window.screen.height = height;
+    CORE.Window.screen.width = logicalWidth;
+    CORE.Window.screen.height = logicalHeight;
 
     // WARNING: If using a render texture, it is not scaled to new size
 }


### PR DESCRIPTION
Closes #5335

Initial Window
<img width="1004" height="603" alt="image" src="https://github.com/user-attachments/assets/7202a7e4-c374-4e60-b957-94c56215ddba" />
After window resize
<img width="1138" height="643" alt="image" src="https://github.com/user-attachments/assets/6f598a77-0ce7-4979-ba81-00e1f4f8a3f4" />

New Logs

```
INFO: Initializing raylib 5.6-dev
INFO: Platform backend: DESKTOP (GLFW)
INFO: Supported raylib modules:
INFO:     > rcore:..... loaded (mandatory)
INFO:     > rlgl:...... loaded (mandatory)
INFO:     > rshapes:... loaded (optional)
INFO:     > rtextures:. loaded (optional)
INFO:     > rtext:..... loaded (optional)
INFO:     > rmodels:... loaded (optional)
INFO:     > raudio:.... loaded (optional)
INFO: DISPLAY: Device initialized successfully
INFO:     > Display size: 1920 x 1080
INFO:     > Screen size:  800 x 450
INFO:     > Render size:  800 x 450
INFO:     > Viewport offsets: 0, 0
INFO: GLAD: OpenGL extensions loaded successfully
INFO: GL: Supported extensions count: 401
INFO: GL: OpenGL device information:
INFO:     > Vendor:   NVIDIA Corporation
INFO:     > Renderer: NVIDIA GeForce RTX 2060 SUPER/PCIe/SSE2
INFO:     > Version:  3.3.0 NVIDIA 581.57
INFO:     > GLSL:     3.30 NVIDIA via Cg compiler
INFO: GL: VAO extension detected, VAO functions loaded successfully
INFO: GL: NPOT textures extension detected, full NPOT textures supported
INFO: GL: DXT compressed textures supported
INFO: GL: ETC2/EAC compressed textures supported
INFO: PLATFORM: DESKTOP (GLFW - Win32): Initialized successfully
INFO: TEXTURE: [ID 1] Texture loaded successfully (1x1 | R8G8B8A8 | 1 mipmaps)
INFO: TEXTURE: [ID 1] Default texture loaded successfully
INFO: SHADER: [ID 1] Vertex shader compiled successfully
INFO: SHADER: [ID 2] Fragment shader compiled successfully
INFO: SHADER: [ID 3] Program shader loaded successfully
INFO: SHADER: [ID 3] Default shader loaded successfully
INFO: RLGL: Render batch vertex buffers loaded successfully in RAM (CPU)
INFO: RLGL: Render batch vertex buffers loaded successfully in VRAM (GPU)
INFO: RLGL: Default OpenGL state initialized successfully
INFO: TEXTURE: [ID 2] Texture loaded successfully (128x128 | GRAY_ALPHA | 1 mipmaps)
INFO: FONT: Default font loaded successfully (224 glyphs)
INFO: SYSTEM: Working Directory: C:\WINDOWS\System32
INFO: TIMER: Target time per frame: 16.667 milliseconds
```
