### PR TITLE
[PLATFORM WIN32] Fixes for MSVC

### DIFF
--- a/src/platforms/rcore_desktop_win32.c
+++ b/src/platforms/rcore_desktop_win32.c
@@ -72,6 +72,8 @@
 #include <shellscalingapi.h>
 #include <versionhelpers.h>
 
+#include <malloc.h>          // Required for alloca()
+
 #if !defined(GRAPHICS_API_OPENGL_11_SOFTWARE)
     #include <GL/gl.h>
 #endif


### PR DESCRIPTION
alloca requires malloc.h on MSVC.