### PR TITLE
[rcore] Fix for undeclared function `_BitScanReverse` on Windows

### DIFF
--- a/src/external/sdefl.h
+++ b/src/external/sdefl.h
@@ -180,6 +180,14 @@ extern int zsdeflate(struct sdefl *s, void *o, const void *i, int n, int lvl);
 #include <string.h> /* memcpy */
 #include <limits.h> /* CHAR_BIT */
 
+/*
+ *  @ChrisGrams - In Windows, this header is required and was no longer
+ *  included in rcore.c after commit 0b4815b8fe861f8fbeac35f46f7e1ff78891b7b5.
+ */
+#ifdef _MSC_VER
+#include <intrin.h>
+#endif
+
 #define SDEFL_NIL               (-1)
 #define SDEFL_MAX_MATCH         258
 #define SDEFL_MAX_CODE_LEN      (15)

--- a/src/external/sinfl.h
+++ b/src/external/sinfl.h
@@ -143,6 +143,14 @@ extern int zsinflate(void *out, int cap, const void *in, int size);
 #include <string.h> /* memcpy, memset */
 #include <assert.h> /* assert */
 
+/*
+ *  @ChrisGrams - In Windows, this header is required and was no longer
+ *  included in rcore.c after commit 0b4815b8fe861f8fbeac35f46f7e1ff78891b7b5.
+ */
+#ifdef _MSC_VER
+#include <intrin.h>
+#endif
+
 #if defined(__GNUC__) || defined(__clang__)
 #define sinfl_likely(x)       __builtin_expect((x),1)
 #define sinfl_unlikely(x)     __builtin_expect((x),0)


### PR DESCRIPTION
This PR fixes a regression introduced in commit 0b4815b (Nov 9).

After this commit, `rcore.c` no longer included `msf_gif.h`, which previously
pulled in `<intrin.h>` under `_MSC_VER`. As a result, Clang+C99 builds on
Windows fail with `_BitScanReverse` undeclared.

**Fix**
Add explicit `#include <intrin.h>` under `_MSC_VER` in `sdefl.h` and `sinfl.h`.

**Tested**
- Clang on Windows 11
- `-std=c99 -Werror=implicit-function-declaration`