### PR TITLE
[examples] text_inline_styling: make inline text and background colors respect base alpha

### DIFF
--- a/examples/text/text_inline_styling.c
+++ b/examples/text/text_inline_styling.c
@@ -70,6 +70,8 @@ int main(void)
             // - Define foreground color:      [cRRGGBBAA]
             // - Define background color:      [bRRGGBBAA]
             // - Reset formating:              [r]
+            // Colors defined with [cRRGGBBAA] or [bRRGGBBAA] are multiplied by the base color alpha
+            // This allows global transparency control while keeping per-section styling (ex. text fade effects)
             // Example: [bAA00AAFF][cFF0000FF]red text on gray background[r] normal text
 
             DrawTextStyled(GetFontDefault(), "This changes the [cFF0000FF]foreground color[r] of provided text!!!",
@@ -106,7 +108,7 @@ int main(void)
 //----------------------------------------------------------------------------------
 // Module Functions Definition
 //----------------------------------------------------------------------------------
-// Draw text using inline styling
+// Draw text using inline styling, using input color as the base alpha multiplied to inline styles
 // PARAM: color is the default text color, background color is BLANK by default
 static void DrawTextStyled(Font font, const char *text, Vector2 position, float fontSize, float spacing, Color color)
 {


### PR DESCRIPTION
### Summary
This makes `DrawTextStyled()` respect the alpha channel of the base `color` parameter when inline colors are used.
I am currently using this function in my game project, and having automatic alpha multiplier helps with text effects like fade animations.

### Changes
- Inline foreground `[cRRGGBBAA]` and background `[bRRGGBBAA]` alpha values are now **multiplied** by the base color's alpha. This allows global transparency while keeping per-section styling.
- Updated the example with a new demo line clearly showing the effect:
  ```c
  DrawTextStyled(..., "This changes the [c00ff00ff]alpha[r] relative [cffffffff][b000000ff]from source[r] [cff000088]color[r]!!!",
      ..., (Color){0, 0, 0, 100});

<img width="800" height="450" alt="image" src="https://github.com/user-attachments/assets/a49084c4-24dd-4017-b988-7873f54976a9" />
