### PR TITLE
Fix typos in comments and documentation

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -565,7 +565,7 @@ Detailed changes:
 [rtext] ADDED: SetTextLineSpacing() to define line breaks text drawing spacing by @raysan5
 [rtext] RENAMED: LoadFont*() parameter names for consistency and coherence by @raysan5
 [rtext] REVIEWED: GetCodepointCount(), ignore unused return value of GetCodepointNext by @ashn-dot-dev
-[rtext] REVIEWED: TextFormat() warn user if buffer overflow occured (#3399) by @Murlocohol
+[rtext] REVIEWED: TextFormat() warn user if buffer overflow occurred (#3399) by @Murlocohol
 [rtext] REVIEWED: TextFormat(), added "..." for truncation (#3366) by @raysan5
 [rtext] REVIEWED: GetGlyphIndex() (#3000) by @raysan5
 [rtext] REVIEWED: GetCodepointNext() to return default value by @chocolate42

--- a/examples/shapes/shapes_ball_physics.c
+++ b/examples/shapes/shapes_ball_physics.c
@@ -83,7 +83,7 @@ int main(void)
                 pressOffset.y = mousePos.y - ball->pos.y;
 
                 // If the distance between the ball position and the mouse press position
-                // is less or equal the ball radius, the event occured inside the ball
+                // is less than or equal to the ball radius, the event occurred inside the ball
                 if (hypot(pressOffset.x, pressOffset.y) <= ball->radius)
                 {
                     ball->grabbed = true;

--- a/examples/shapes/shapes_double_pendulum.c
+++ b/examples/shapes/shapes_double_pendulum.c
@@ -42,7 +42,7 @@ int main(void)
     SetConfigFlags(FLAG_WINDOW_HIGHDPI);
     InitWindow(screenWidth, screenHeight, "raylib [shapes] example - double pendulum");
 
-    // Simulation Paramters
+    // Simulation Parameters
     float l1 = 15.0f, m1 = 0.2f, theta1 = DEG2RAD*170, w1 = 0;
     float l2 = 15.0f, m2 = 0.1f, theta2 = DEG2RAD*0, w2 = 0;
     float lengthScaler = 0.1f;

--- a/src/platforms/rcore_drm.c
+++ b/src/platforms/rcore_drm.c
@@ -1865,7 +1865,7 @@ static void ProcessKeyboard(void)
 }
 #endif  // SUPPORT_SSH_KEYBOARD_RPI
 
-// Initialise user input from evdev(/dev/input/event<N>)
+// Initialize user input from evdev(/dev/input/event<N>)
 // this means mouse, keyboard or gamepad devices
 static void InitEvdevInput(void)
 {
@@ -1873,7 +1873,7 @@ static void InitEvdevInput(void)
     DIR *directory = NULL;
     struct dirent *entity = NULL;
 
-    // Initialise keyboard file descriptor
+    // Initialize keyboard file descriptor
     platform.keyboardFd = -1;
     platform.mouseFd = -1;
 

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -4308,7 +4308,7 @@ const char *TextFormat(const char *text, ...)
     int requiredByteCount = vsnprintf(currentBuffer, MAX_TEXT_BUFFER_LENGTH, text, args);
     va_end(args);
 
-    // If requiredByteCount is larger than the MAX_TEXT_BUFFER_LENGTH, then overflow occured
+    // If requiredByteCount is larger than the MAX_TEXT_BUFFER_LENGTH, then overflow occurred
     if (requiredByteCount >= MAX_TEXT_BUFFER_LENGTH)
     {
         // Inserting "..." at the end of the string to mark as truncated

--- a/src/rtext.c
+++ b/src/rtext.c
@@ -1524,7 +1524,7 @@ const char *TextFormat(const char *text, ...)
     int requiredByteCount = vsnprintf(currentBuffer, MAX_TEXT_BUFFER_LENGTH, text, args);
     va_end(args);
 
-    // If requiredByteCount is larger than the MAX_TEXT_BUFFER_LENGTH, then overflow occured
+    // If requiredByteCount is larger than the MAX_TEXT_BUFFER_LENGTH, then overflow occurred
     if (requiredByteCount >= MAX_TEXT_BUFFER_LENGTH)
     {
         // Inserting "..." at the end of the string to mark as truncated


### PR DESCRIPTION
Fixed several typos found in code comments and documentation.

Mostly for "occured" to "occurred".
After that I looked for any others and ended up finding some other misc spelling improvements.

Since changes are only touching comments and .md files I didn't feel the need to a full "test". 

Continue with that as you wish of course.