### PR TITLE
Replace sprintf() with snprintf() for buffer safety

### DIFF
--- a/src/rcore.c
+++ b/src/rcore.c
@@ -4313,7 +4313,7 @@ const char *TextFormat(const char *text, ...)
     {
         // Inserting "..." at the end of the string to mark as truncated
         char *truncBuffer = buffers[index] + MAX_TEXT_BUFFER_LENGTH - 4; // Adding 4 bytes = "...\0"
-        sprintf(truncBuffer, "...");
+        snprintf(truncBuffer, 4, "...");
     }
 
     index += 1;     // Move to next buffer for next function call

--- a/src/rtext.c
+++ b/src/rtext.c
@@ -1529,7 +1529,7 @@ const char *TextFormat(const char *text, ...)
     {
         // Inserting "..." at the end of the string to mark as truncated
         char *truncBuffer = buffers[index] + MAX_TEXT_BUFFER_LENGTH - 4; // Adding 4 bytes = "...\0"
-        sprintf(truncBuffer, "...");
+        snprintf(truncBuffer, 4, "...");
     }
 
     index += 1;     // Move to next buffer for next function call


### PR DESCRIPTION
Replace `sprintf()` with `snprintf()` in two locations to prevent potential buffer overflows.
Both calls now explicitly limit the buffer size to 4 bytes.