### PR TITLE
Fix ToggleBorderlessFullscreen() Not Hiding Taskbar

### DIFF
--- a/src/platforms/rcore_desktop_glfw.c
+++ b/src/platforms/rcore_desktop_glfw.c
@@ -265,18 +265,15 @@ void ToggleBorderlessWindowed(void)
                 const int monitorHeight = mode->height;
 
                 // Set screen position and size
-            	glfwSetWindowMonitor(
-					platform.handle,
-					monitors[monitor],
-					monitorPosX,
-					monitorPosY,
-					monitorWidth,
-					monitorHeight,
-					mode->refreshRate
-				);
-
-                // glfwSetWindowPos(platform.handle, monitorPosX, monitorPosY);
-                // glfwSetWindowSize(platform.handle, monitorWidth, monitorHeight);
+                glfwSetWindowMonitor(
+                    platform.handle,
+                    monitors[monitor],
+                    monitorPosX,
+                    monitorPosY,
+                    monitorWidth,
+                    monitorHeight,
+                    mode->refreshRate
+                );
 
                 // Refocus window
                 glfwFocusWindow(platform.handle);
@@ -291,8 +288,15 @@ void ToggleBorderlessWindowed(void)
 
                 // Return previous screen size and position
                 // NOTE: The order matters here, it must set size first, then set position, otherwise the screen will be positioned incorrectly
-                glfwSetWindowSize(platform.handle,  CORE.Window.previousScreen.width, CORE.Window.previousScreen.height);
-                glfwSetWindowPos(platform.handle, CORE.Window.previousPosition.x, CORE.Window.previousPosition.y);
+                glfwSetWindowMonitor(
+                    platform.handle,
+                    NULL,
+                    CORE.Window.previousPosition.x,
+                    CORE.Window.previousPosition.y,
+                    CORE.Window.previousScreen.width,
+                    CORE.Window.previousScreen.height,
+            	    mode->refreshRate
+            	);
 
                 // Refocus window
                 glfwFocusWindow(platform.handle);


### PR DESCRIPTION
Replace the `glfwSetWindowPos` and `glfwSetWindowSize` functions with `glfwSetWindowMonitor` to properly set the window to borderless fullscreen mode.

I did not change any of the other window size or position editing functions to keep this resolution self-contained. This can be amended in a future commit.

Intended to be tested with the following:
```c
#include <raylib.h>

int main(void) {
	InitWindow(800, 600, "Raylib Game");

	while (!WindowShouldClose()) {
		if (IsKeyPressed(KEY_F1)) {
			ToggleBorderlessWindowed();
		}

		BeginDrawing();
		ClearBackground(RED);
		EndDrawing();
	}

	CloseWindow();

	return 0;
}
```