### PR TITLE
[cmake] Expose RGFW to cmake

### DIFF
--- a/CMakeOptions.txt
+++ b/CMakeOptions.txt
@@ -6,7 +6,7 @@ if(EMSCRIPTEN)
     # When configuring web builds with "emcmake cmake -B build -S .", set PLATFORM to Web by default
     SET(PLATFORM Web CACHE STRING "Platform to build for.")
 endif()
-enum_option(PLATFORM "Desktop;Web;Android;Raspberry Pi;DRM;SDL" "Platform to build for.")
+enum_option(PLATFORM "Desktop;Web;Android;Raspberry Pi;DRM;SDL;RGFW" "Platform to build for.")
 
 enum_option(OPENGL_VERSION "OFF;4.3;3.3;2.1;1.1;ES 2.0;ES 3.0;Software" "Force a specific OpenGL Version?")
 

--- a/cmake/LibraryConfigurations.cmake
+++ b/cmake/LibraryConfigurations.cmake
@@ -141,6 +141,8 @@ elseif ("${PLATFORM}" MATCHES "SDL")
 			add_compile_definitions(USING_SDL2_PACKAGE)
 		endif()
 	endif()	
+elseif ("${PLATFORM}" MATCHES "RGFW")
+    set(PLATFORM_CPP "PLATFORM_DESKTOP_RGFW")
 endif ()
 
 if (NOT ${OPENGL_VERSION} MATCHES "OFF")


### PR DESCRIPTION
Added checks for RGFW for cmake

I was trying to automate raylib setup for a simple script, and i ran into compile errors, and out of boredom i was like "yeah why not".

I was contemplating on having an external check like with GLFW, but i needed to sound out the idea first before committing to something stupid.