### PR TITLE
[rModels] Support 16 bit vec3 values in gltf reader

### DIFF
--- a/src/rmodels.c
+++ b/src/rmodels.c
@@ -5680,6 +5680,54 @@ static Model LoadGLTF(const char *fileName)
                                     normals[3 * k + 2] = nt.z;
                                 }
                             }
+                            else if ((attribute->type == cgltf_type_vec3) && (attribute->component_type == cgltf_component_type_r_8u))
+                            {
+                                // Init raylib mesh normals to copy glTF attribute data
+                                model.meshes[meshIndex].normals = (float*)RL_MALLOC(attribute->count * 3 * sizeof(float));
+
+                                // Load data into a temp buffer to be converted to raylib data type
+                                unsigned char* temp = (unsigned char*)RL_MALLOC(attribute->count * 3 * sizeof(unsigned char));
+                                LOAD_ATTRIBUTE(attribute, 3, unsigned char, temp);
+
+                                // Convert data to raylib normal data type (float)
+                                for (unsigned int t = 0; t < attribute->count * 3; t++) model.meshes[meshIndex].normals[t] = (float)temp[t];
+
+                                RL_FREE(temp);
+
+                                // Transform the normals
+                                float* normals = model.meshes[meshIndex].normals;
+                                for (unsigned int k = 0; k < attribute->count; k++)
+                                {
+                                    Vector3 nt = Vector3Normalize(Vector3Transform((Vector3) { normals[3 * k], normals[3 * k + 1], normals[3 * k + 2] }, worldMatrixNormals));
+                                    normals[3 * k] = nt.x;
+                                    normals[3 * k + 1] = nt.y;
+                                    normals[3 * k + 2] = nt.z;
+                                }
+                            }
+                            else if ((attribute->type == cgltf_type_vec3) && (attribute->component_type == cgltf_component_type_r_8))
+                            {
+                                // Init raylib mesh normals to copy glTF attribute data
+                                model.meshes[meshIndex].normals = (float*)RL_MALLOC(attribute->count * 3 * sizeof(float));
+
+                                // Load data into a temp buffer to be converted to raylib data type
+                                char* temp = (char*)RL_MALLOC(attribute->count * 3 * sizeof(char));
+                                LOAD_ATTRIBUTE(attribute, 3, char, temp);
+
+                                // Convert data to raylib normal data type (float)
+                                for (unsigned int t = 0; t < attribute->count * 3; t++) model.meshes[meshIndex].normals[t] = (float)temp[t];
+
+                                RL_FREE(temp);
+
+                                // Transform the normals
+                                float* normals = model.meshes[meshIndex].normals;
+                                for (unsigned int k = 0; k < attribute->count; k++)
+                                {
+                                    Vector3 nt = Vector3Normalize(Vector3Transform((Vector3) { normals[3 * k], normals[3 * k + 1], normals[3 * k + 2] }, worldMatrixNormals));
+                                    normals[3 * k] = nt.x;
+                                    normals[3 * k + 1] = nt.y;
+                                    normals[3 * k + 2] = nt.z;
+                                }
+                            }
                             else TRACELOG(LOG_WARNING, "MODEL: [%s] Normals attribute data format not supported, use vec3 float", fileName);
                         }
                     }


### PR DESCRIPTION
There are applications that output size optimized GLTF files. These pack mesh buffer data down into 16 bit formats and use the matrix transform to scale them back to the correct float values.

Raylib's gltf reader only reads float values, meaning that gltf files that are saved in these optimized formats will not read into raylib.

This PR adds support for 16 bit position and both 16 bit and 8 bit normal buffers, letting those files at least read in basic geometry. This change should not effect any end user APIs as the result is still a buffer of floats.

Tested using an optimized gltf file [optimzed.zip](https://github.com/user-attachments/files/23972323/optimzed.zip)