### PR TITLE
[build][android] fix newer NDK version compile errors

### DIFF
--- a/examples/Makefile.Android
+++ b/examples/Makefile.Android
@@ -130,7 +130,7 @@ ifeq ($(ANDROID_ARCH),ARM)
     CFLAGS = -std=c99 -march=armv7-a -mfloat-abi=softfp -mfpu=vfpv3-d16
 endif
 ifeq ($(ANDROID_ARCH),ARM64)
-    CFLAGS = -std=c99 -target aarch64 -mfix-cortex-a53-835769
+    CFLAGS = -std=c99 -mfix-cortex-a53-835769
 endif
 # Compilation functions attributes options
 CFLAGS += -ffunction-sections -funwind-tables -fstack-protector-strong -fPIC

--- a/projects/4coder/Makefile.Android
+++ b/projects/4coder/Makefile.Android
@@ -96,7 +96,7 @@ ifeq ($(ANDROID_ARCH),ARM)
     CFLAGS = -std=c99 -march=armv7-a -mfloat-abi=softfp -mfpu=vfpv3-d16
 endif
 ifeq ($(ANDROID_ARCH),ARM64)
-    CFLAGS = -std=c99 -target aarch64 -mfix-cortex-a53-835769
+    CFLAGS = -std=c99 -mfix-cortex-a53-835769
 endif
 # Compilation functions attributes options
 CFLAGS += -ffunction-sections -funwind-tables -fstack-protector-strong -fPIC

--- a/projects/VSCode/Makefile.Android
+++ b/projects/VSCode/Makefile.Android
@@ -96,7 +96,7 @@ ifeq ($(ANDROID_ARCH),ARM)
     CFLAGS = -std=c99 -march=armv7-a -mfloat-abi=softfp -mfpu=vfpv3-d16
 endif
 ifeq ($(ANDROID_ARCH),ARM64)
-    CFLAGS = -std=c99 -target aarch64 -mfix-cortex-a53-835769
+    CFLAGS = -std=c99 -mfix-cortex-a53-835769
 endif
 # Compilation functions attributes options
 CFLAGS += -ffunction-sections -funwind-tables -fstack-protector-strong -fPIC

--- a/src/Makefile
+++ b/src/Makefile
@@ -406,7 +406,7 @@ ifeq ($(TARGET_PLATFORM),PLATFORM_ANDROID)
         CFLAGS += -march=armv7-a -mfloat-abi=softfp -mfpu=vfpv3-d16
     endif
     ifeq ($(ANDROID_ARCH),arm64)
-        CFLAGS += -target aarch64 -mfix-cortex-a53-835769
+        CFLAGS += -mfix-cortex-a53-835769
     endif
     ifeq ($(ANDROID_ARCH),x86)
         CFLAGS += -march=i686


### PR DESCRIPTION
-target already gets assigned by the clang macro it points to, overwriting it causes it to target linux instead of android, making it check for usr directories instead of the NDK's directories
this makes raylib error during compile in versions of the NDK higher than r23b citing usr/include as the problem when it shouldn't even be there
```
/usr/include/bits/libc-header-start.h:74:5: error: function-like macro '__GLIBC_USE' is not defined
   74 | #if __GLIBC_USE (IEC_60559_BFP_EXT) || __GLIBC_USE (ISOC23)
      |     ^
```
case in point:
<img width="678" height="242" alt="image" src="https://github.com/user-attachments/assets/a97af583-7886-47c8-aac2-649eac0c6682" />
get overwritten by
<img width="740" height="242" alt="image" src="https://github.com/user-attachments/assets/63b3d0e3-1914-4397-bc48-118256865231" />
specifically -target aarch64 overwrites --target=aarch64-linux-android34 from the macro

aarch64 is a valid target by clang but it also points to linux aarch64 and not android aarch64

now the piece of mystery in all of this is, why does r23b work with no errors? and to be honest i've been trying to figure that out for 2 days straight and the only conclusion i could come up to is that it shouldn't work, yet it does.
as if the files it needed just so happened to be similar enough to the native linux libraries that it compiled just fine with no errors.
if anyone knows more please chime in, because by all accounts it doesn't make sense.