### PR TITLE
Fix build.zig typos

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -155,7 +155,7 @@ fn compileRaylib(b: *std.Build, target: std.Build.ResolvedTarget, optimize: std.
         );
     }
 
-    // Sets a flag indiciating the use of a custom `config.h`
+    // Sets a flag indicating the use of a custom `config.h`
     try raylib_flags_arr.append(b.allocator, "-DEXTERNAL_CONFIG_FLAGS");
     if (options.config.len > 0) {
         // Splits a space-separated list of config flags into multiple flags
@@ -187,7 +187,7 @@ fn compileRaylib(b: *std.Build, target: std.Build.ResolvedTarget, optimize: std.
             try raylib_flags_arr.append(b.allocator, flag);
         }
     } else {
-        // Set default config if no custome config got set
+        // Set default config if no custom config got set
         try raylib_flags_arr.appendSlice(b.allocator, &config_h_flags);
     }
 


### PR DESCRIPTION
# Small typos
* Fixes small typos in the build.zig build script
* Found when experimenting with zig+cpp+raylib for first time, tried to make sure I didn't miss other typos in the script
* Doesn't change executable code, so shouldn't affect build behavior