### PR TITLE
[rcore] fix - sha1 computation on messages longer than 31 bytes

### DIFF
--- a/src/rcore.c
+++ b/src/rcore.c
@@ -2926,8 +2926,15 @@ unsigned int *ComputeSHA1(unsigned char *data, int dataSize)
     memcpy(msg, data, dataSize);
     msg[dataSize] = 128; // Write the '1' bit
 
-    unsigned int bitsLen = 8*dataSize;
-    msg[newDataSize-1] = bitsLen;
+    unsigned long long bitsLen = 8ULL * dataSize;
+    msg[newDataSize-1] = (unsigned char)(bitsLen);
+    msg[newDataSize-2] = (unsigned char)(bitsLen >> 8);
+    msg[newDataSize-3] = (unsigned char)(bitsLen >> 16);
+    msg[newDataSize-4] = (unsigned char)(bitsLen >> 24);
+    msg[newDataSize-5] = (unsigned char)(bitsLen >> 32);
+    msg[newDataSize-6] = (unsigned char)(bitsLen >> 40);
+    msg[newDataSize-7] = (unsigned char)(bitsLen >> 48);
+    msg[newDataSize-8] = (unsigned char)(bitsLen >> 56);
 
     // Process the message in successive 512-bit chunks
     for (int offset = 0; offset < newDataSize; offset += (512/8))


### PR DESCRIPTION
Fixes #5398

The current implementation of `ComputeSHA1` incorrectly encodes the message length, resulting in invalid SHA-1 hashes for messages longer than 31 bytes.

The SHA-1 specification requires the original message length (in bits) to be appended as a 64-bit big-endian integer at the end of the padded message. However, the current code only writes the lowest 8 bits:

```c
unsigned int bitsLen = 8*dataSize;
msg[newDataSize-1] = bitsLen;  // Only writes 1 byte
```

This causes incorrect hash outputs for any message where `dataSize > 31` bytes. For example, a message of 150 bytes:

`bitsLen = 8 * 150 = 1200` (`0x000004B0` in hex)
Only `0xB0` gets written to `msg[newDataSize-1]`
The other 7 bytes remain zeros

This PR fixes the issue by properly encoding the full 64-bit message length in big-endian format across 8 bytes:

```
unsigned long long bitsLen = 8ULL * dataSize;
msg[newDataSize-1] = (unsigned char)(bitsLen);
msg[newDataSize-2] = (unsigned char)(bitsLen >> 8);
msg[newDataSize-3] = (unsigned char)(bitsLen >> 16);
msg[newDataSize-4] = (unsigned char)(bitsLen >> 24);
msg[newDataSize-5] = (unsigned char)(bitsLen >> 32);
msg[newDataSize-6] = (unsigned char)(bitsLen >> 40);
msg[newDataSize-7] = (unsigned char)(bitsLen >> 48);
msg[newDataSize-8] = (unsigned char)(bitsLen >> 56);
```

For that same 150-byte message where `bitsLen = 1200` (`0x00000000000004B0`):

`msg[newDataSize-8] = 0x00` (bits 63-56)
`msg[newDataSize-7] = 0x00` (bits 55-48)
`msg[newDataSize-6] = 0x00` (bits 47-40)
`msg[newDataSize-5] = 0x00` (bits 39-32)
`msg[newDataSize-4] = 0x00` (bits 31-24)
`msg[newDataSize-3] = 0x00` (bits 23-16)
`msg[newDataSize-2] = 0x04` (bits 15-8)
`msg[newDataSize-1] = 0xB0` (bits 7-0)

All 8 bytes are written in big-endian order, as required by the SHA-1 specification.
