### PR TITLE
[rtext] Add option to load TTF fonts without anti-aliasing (LoadFontExBitmap)

### DIFF
--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1474,8 +1474,10 @@ RLAPI int GetPixelDataSize(int width, int height, int format);              // G
 RLAPI Font GetFontDefault(void);                                                            // Get the default Font
 RLAPI Font LoadFont(const char *fileName);                                                  // Load font from file into GPU memory (VRAM)
 RLAPI Font LoadFontEx(const char *fileName, int fontSize, const int *codepoints, int codepointCount); // Load font from file with extended parameters, use NULL for codepoints and 0 for codepointCount to load the default character set, font size is provided in pixels height
+RLAPI Font LoadFontExBitmap(const char *fileName, int fontSize, const int *codepoints, int codepointCount); // Load font from file with bitmap glyphs (no anti-aliasing for TTF/OTF)
 RLAPI Font LoadFontFromImage(Image image, Color key, int firstChar);                        // Load font from Image (XNA style)
 RLAPI Font LoadFontFromMemory(const char *fileType, const unsigned char *fileData, int dataSize, int fontSize, const int *codepoints, int codepointCount); // Load font from memory buffer, fileType refers to extension: i.e. '.ttf'
+RLAPI Font LoadFontFromMemoryBitmap(const char *fileType, const unsigned char *fileData, int dataSize, int fontSize, const int *codepoints, int codepointCount); // Load font from memory buffer with bitmap glyphs (no anti-aliasing for TTF/OTF)
 RLAPI bool IsFontValid(Font font);                                                          // Check if a font is valid (font data loaded, WARNING: GPU texture not checked)
 RLAPI GlyphInfo *LoadFontData(const unsigned char *fileData, int dataSize, int fontSize, const int *codepoints, int codepointCount, int type, int *glyphCount); // Load font data for further use
 RLAPI Image GenImageFontAtlas(const GlyphInfo *glyphs, Rectangle **glyphRecs, int glyphCount, int fontSize, int padding, int packMethod); // Generate image font atlas using chars info


### PR DESCRIPTION
This PR adds optional support for loading **TTF fonts without anti-aliasing**, addressing **issue #5385**.
Fixes #5385

Raylib currently always loads TTF glyphs using `FONT_DEFAULT`, which applies anti-aliasing.
Pixel-style fonts such as *Monogram* become blurry when scaled or used in low-resolution UI.

This PR introduces a simple and non-breaking addition that allows users to explicitly request **bitmap/no-AA** font loading.


A shared internal function handles both AA and non-AA paths:

```c
static Font LoadFontFromMemoryInternal(..., bool antialias)
```

#### 2. Existing APIs remain unchanged

`LoadFontFromMemory()` and `LoadFontEx()` still default to anti-aliasing:

```c
LoadFontFromMemory(..., /* antialias = */ true);
```

#### 3. New public API for bitmap/no-AA loading

```c
Font LoadFontExBitmap(const char *fileName, int fontSize,
                      const int *codepoints, int codepointCount);
```

This function loads TTF glyphs using `FONT_BITMAP`, producing crisp pixel-aligned rendering without smoothing.

---

### Usage Example

```c
Font aa = LoadFontEx("monogram.ttf", 32, NULL, 0);           // Anti-aliased (default)
Font bitmap = LoadFontExBitmap("monogram.ttf", 32, NULL, 0); // Pixel-perfect, no AA
```

---

### Visual Comparison

<img width="410" height="273" alt="image" src="https://github.com/user-attachments/assets/44fdf538-2ea4-4519-b172-74497851ddcd" />
