### PR TITLE
Fixed FLAG_IS_SET to check if all bits in the flag are set in the value

### DIFF
--- a/src/rcore.c
+++ b/src/rcore.c
@@ -273,7 +273,7 @@
 #define FLAG_SET(n, f) ((n) |= (f))
 #define FLAG_CLEAR(n, f) ((n) &= ~(f))
 #define FLAG_TOGGLE(n, f) ((n) ^= (f))
-#define FLAG_IS_SET(n, f) (((n) & (f)) > 0)
+#define FLAG_IS_SET(n, f) (((n) & (f)) == (f))
 
 //----------------------------------------------------------------------------------
 // Types and Structures Definition


### PR DESCRIPTION
The problem affected Android volume buttons because:

Volume buttons are AINPUT_SOURCE_KEYBOARD (0x00000101)
This shares bit 0 with AINPUT_SOURCE_GAMEPAD (0x00000401)
With the broken macro, volume button events were incorrectly detected as gamepad input and consumed by the gamepad handler instead of being processed normally