### PR TITLE
fix: set correct default axes for gamepads that are not connected (inside rcore_desktop_glfw.c)

### DIFF
--- a/src/platforms/rcore_desktop_glfw.c
+++ b/src/platforms/rcore_desktop_glfw.c
@@ -1269,7 +1269,7 @@ void PollInputEvents(void)
             int isGamepadConnected = glfwGetGamepadState(i, &state); // This remapps all gamepads so they have their buttons mapped like an xbox controller
             if (!isGamepadConnected)
             {
-                // setting axes to expected value instead of GLFW's 0.0f default when gamepad isnt connected
+                // setting axes to expected resting value instead of GLFW's 0.0f default when gamepad isnt connected
                 state.axes[GAMEPAD_AXIS_LEFT_TRIGGER] = -1.0f;
                 state.axes[GAMEPAD_AXIS_RIGHT_TRIGGER] = -1.0f;
             }


### PR DESCRIPTION
## Description

`glfwGetGamepadState` will set all gamepad state variables to 0.0 if requested gamepad is not connected, but `RecordAutomationEvent()` inside rcore.c expects trigger axes to be -1.0f when gamepad is not connected. Since SDL and RGFW return -1.0f in such case, this change is aligning it with them

### Related Issues
Fixes [#5443 ](https://github.com/raysan5/raylib/issues/5443)