### PR TITLE
[rcCamera] Fix CameraMove forward and right with Z up cameras

### DIFF
--- a/src/rcamera.h
+++ b/src/rcamera.h
@@ -252,8 +252,13 @@ void CameraMoveForward(Camera *camera, float distance, bool moveInWorldPlane)
 
     if (moveInWorldPlane)
     {
-        // Project vector onto world plane
-        forward.y = 0;
+        // Project vector onto world plane (the plane defined by the up vector)
+        if (fabsf(camera->up.z) > 0)
+            forward.z = 0;
+        else if (fabsf(camera->up.x) > 0)
+            forward.x = 0;
+        else
+            forward.y = 0;
         forward = Vector3Normalize(forward);
     }
 
@@ -285,8 +290,14 @@ void CameraMoveRight(Camera *camera, float distance, bool moveInWorldPlane)
 
     if (moveInWorldPlane)
     {
-        // Project vector onto world plane
-        right.y = 0;
+        // Project vector onto world plane (the plane defined by the up vector)
+        if (fabsf(camera->up.z) > 0)
+            right.z = 0;
+        else if (fabsf(camera->up.x) > 0)
+            right.x = 0;
+        else
+            right.y = 0;
+
         right = Vector3Normalize(right);
     }
 


### PR DESCRIPTION
CameraMoveForward and CameraMoveRight make the assumption that the camera up is Y when MoveInWorldPlane is true. This does not work if the camera up is not Y.

This PR forces the axis component that the camera up vector is in to 0 so that the world plane is normal to the up vector regardless of what axis is up.