### PR TITLE
[rCamera] Add a tolerance to camera movement plane detection

### DIFF
--- a/src/rcamera.h
+++ b/src/rcamera.h
@@ -255,8 +255,8 @@ void CameraMoveForward(Camera *camera, float distance, bool moveInWorldPlane)
     if (moveInWorldPlane)
     {
         // Project vector onto world plane (the plane defined by the up vector)
-        if (fabsf(camera->up.z) > 0) forward.z = 0;
-        else if (fabsf(camera->up.x) > 0) forward.x = 0;
+        if (fabsf(camera->up.z) > 0.7071f) forward.z = 0;
+        else if (fabsf(camera->up.x) > 0.7071f) forward.x = 0;
         else forward.y = 0;
 
         forward = Vector3Normalize(forward);
@@ -291,8 +291,8 @@ void CameraMoveRight(Camera *camera, float distance, bool moveInWorldPlane)
     if (moveInWorldPlane)
     {
         // Project vector onto world plane (the plane defined by the up vector)
-        if (fabsf(camera->up.z) > 0) right.z = 0;
-        else if (fabsf(camera->up.x) > 0) right.x = 0;
+        if (fabsf(camera->up.z) > 0.7071f) right.z = 0;
+        else if (fabsf(camera->up.x) > 0.7071f) right.x = 0;
         else right.y = 0;
 
         right = Vector3Normalize(right);


### PR DESCRIPTION
This PR adds a fix to PR #5458, a non zero value in an up vector component is not enough to determine what axis is up, some up vectors may be non-orthogonal. This PR adds a tolerance to see if the up axis is mostly pointing along an axis, then picks a plane from that. This should just prevent edge cases from giving people odd behaviors, and always ensure we fallback to Y up if we can't figure it out for legacy compatibility.