### PR TITLE
[example] Small update to textured curve example.

### DIFF
--- a/examples/textures/textures_textured_curve.c
+++ b/examples/textures/textures_textured_curve.c
@@ -190,7 +190,7 @@ static void DrawTexturedCurve(void)
         Vector2 normal = Vector2Normalize((Vector2){ -delta.y, delta.x });
 
         // The v texture coordinate of the segment (add up the length of all the segments so far)
-        float v = previousV + Vector2Length(delta);
+        float v = previousV + Vector2Length(delta) / (float)(texRoad.height * 2);
 
         // Make sure the start point has a normal
         if (!tangentSet)


### PR DESCRIPTION
This PR updates the textured curve example to correctly use the texture size when computing the texture UV coordinates, so that repeating textures look good. The current code only looks good because the road texture can repeat on one pixel, if it was a pattern it would not look good. This change fixes that.