### PR TITLE
fix(build): do not use != assignment in Makefiles

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -211,9 +211,9 @@ ifeq ($(TARGET_PLATFORM),$(filter $(TARGET_PLATFORM),PLATFORM_WEB PLATFORM_WEB_R
     ifeq ($(OS),Windows_NT)
         MAKE = mingw32-make
     else
-        EMMAKE != type emmake
+        EMMAKE := $(shell command -v emmake)
         ifneq (, $(EMMAKE))
-            MAKE = emmake make
+            MAKE = $(EMMAKE) make
         else
             MAKE = mingw32-make
         endif

--- a/examples/Makefile.Web
+++ b/examples/Makefile.Web
@@ -211,9 +211,9 @@ ifeq ($(TARGET_PLATFORM),$(filter $(TARGET_PLATFORM),PLATFORM_WEB PLATFORM_WEB_R
     ifeq ($(OS),Windows_NT)
         MAKE = mingw32-make
     else
-        EMMAKE != type emmake
+        EMMAKE := $(shell command -v emmake)
         ifneq (, $(EMMAKE))
-            MAKE = emmake make
+            MAKE = $(EMMAKE) make
         else
             MAKE = mingw32-make
         endif


### PR DESCRIPTION
For more information see the commit message and the linked issue.

I was unable to test it on MacOSX because I don't have a setup with working XCode, and Emscripten requires XCode even when installing from Brew. Hopefully, a CI or some other contributor will check it, but this _should just work_ ™

Fixes: https://github.com/raysan5/raylib/issues/5460