### PR TITLE
[rcore] Fix typecast warnings in rcore

### DIFF
--- a/src/platforms/rcore_desktop_glfw.c
+++ b/src/platforms/rcore_desktop_glfw.c
@@ -227,8 +227,8 @@ void ToggleFullscreen(void)
         if (FLAG_IS_SET(CORE.Window.flags, FLAG_WINDOW_HIGHDPI))
         {
             Vector2 scaleDpi = GetWindowScaleDPI();
-            CORE.Window.screen.width *= scaleDpi.x;
-            CORE.Window.screen.height *= scaleDpi.y;
+            CORE.Window.screen.width = (unsigned int)(CORE.Window.screen.width * scaleDpi.x);
+            CORE.Window.screen.height = (unsigned int)(CORE.Window.screen.height * scaleDpi.y);
         }
 #endif
 
@@ -306,8 +306,8 @@ void ToggleBorderlessWindowed(void)
                 if (FLAG_IS_SET(CORE.Window.flags, FLAG_WINDOW_HIGHDPI))
                 {
                     Vector2 scaleDpi = GetWindowScaleDPI();
-                    CORE.Window.screen.width *= scaleDpi.x;
-                    CORE.Window.screen.height *= scaleDpi.y;
+                    CORE.Window.screen.width = (unsigned int)(CORE.Window.screen.width * scaleDpi.x);
+                    CORE.Window.screen.height = (unsigned int)(CORE.Window.screen.height * scaleDpi.y);
                 }
             #endif
 


### PR DESCRIPTION
multiply assignment of an int by a float is a float, thus it will generate a typecast warning, This PR casts the value correctly