### PR TITLE
[rModel] Don't require a M3d animation only file to have a mesh. 

### DIFF
--- a/src/rmodels.c
+++ b/src/rmodels.c
@@ -7045,8 +7045,8 @@ static ModelAnimation *LoadModelAnimationsM3D(const char *fileName, int *animCou
         else TRACELOG(LOG_INFO, "MODEL: [%s] M3D data loaded successfully: %i animations, %i bones, %i skins", fileName,
             m3d->numaction, m3d->numbone, m3d->numskin);
 
-        // No animation or bone+skin?
-        if (!m3d->numaction || !m3d->numbone || !m3d->numskin)
+        // No animation or bones, exit out. skins are not required because some people use one animation for N models
+        if (!m3d->numaction || !m3d->numbone)
         {
             m3d_free(m3d);
             UnloadFileData(fileData);


### PR DESCRIPTION
The current M3d anim file loader checks to ensure that the file has at least one skinned mesh. There are valid use cases for animation only files that can be applied to N other meshes, and this check prevents that from happening.

This PR removes the skin check from animation loading so that users can load a file that has animations only, and then apply it to many different models (this is common in games with different player models, but the same animations for all).

Tested with LoadM3d example and it works fine. This should not change any existing behavors.