### PR TITLE
[web] Fix fullscreen mode in the provided shell.html file

### DIFF
--- a/src/shell.html
+++ b/src/shell.html
@@ -179,7 +179,7 @@ jwE50AGjLCVuS8Yt4H7OgZLKK5EKOsLviEWJSL/+0uMi7gLUSBseYwqEbXvSHCec1CJvZPyHCmYQffaB
 
         <span id='controls'>
           <span><input type="button" value="📜 SOURCE CODE" onclick="location.href='https://github.com/raysan5/raylib';"/></span>
-          <span><input type="button" value="🖵 FULLSCREEN" onclick="Module.requestFullscreen(false, false)"></span>
+          <span><input type="button" value="🖵 FULLSCREEN" onclick="Module.canvas.requestFullscreen(false, false)"></span>
           <span><input type="button" id="btn-audio" value="🔇 MUTE" onclick="toggleAudio()"></span>
         </span>
 


### PR DESCRIPTION
Pretty much applying this: https://github.com/emscripten-core/emscripten/issues/25203 to the existing shell.html file

Tested on a small app I'm building:

<details>
<summary> Before </summary>
<img width="1071" height="783" alt="image" src="https://github.com/user-attachments/assets/35cae68b-2c31-4750-bd13-6e2adbdb3fe9" />
</details>

<details>
<summary> After </summary>
<img width="1262" height="654" alt="image" src="https://github.com/user-attachments/assets/0dbdf8b5-5ae7-4db0-9557-39ea3988cb13" />
</details>
