### PR TITLE
fix: zig build accessing env var

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -448,7 +448,7 @@ pub const Options = struct {
             .linux_display_backend = b.option(LinuxDisplayBackend, "linux_display_backend", "Linux display backend to use") orelse defaults.linux_display_backend,
             .opengl_version = b.option(OpenglVersion, "opengl_version", "OpenGL version to use") orelse defaults.opengl_version,
             .config = b.option([]const u8, "config", "Compile with custom define macros overriding config.h") orelse &.{},
-            .android_ndk = b.option([]const u8, "android_ndk", "specify path to android ndk") orelse std.process.getEnvVarOwned(b.allocator, "ANDROID_NDK_HOME") catch "",
+            .android_ndk = b.option([]const u8, "android_ndk", "specify path to android ndk") orelse "",
             .android_api_version = b.option([]const u8, "android_api_version", "specify target android API level") orelse defaults.android_api_version,
         };
     }


### PR DESCRIPTION
Fixes #5489.

Accessing env vars in this fashion was removed in https://codeberg.org/ziglang/zig/pulls/30644.