### PR TITLE
fix memory leak in rcore_drm.c InitPlatform()

### DIFF
--- a/src/platforms/rcore_drm.c
+++ b/src/platforms/rcore_drm.c
@@ -1161,7 +1161,8 @@ int InitPlatform(void)
     platform.fd = open("/dev/dri/by-path/platform-gpu-card", O_RDWR); // VideoCore VI (Raspberry Pi 4)
     if (platform.fd != -1) TRACELOG(LOG_INFO, "DISPLAY: platform-gpu-card opened successfully");
 
-    if ((platform.fd == -1) || (drmModeGetResources(platform.fd) == NULL))
+    drmModeRes *res = NULL;
+    if ((platform.fd == -1) || ((res = drmModeGetResources(platform.fd)) == NULL))
     {
         if (platform.fd != -1) close(platform.fd);
         TRACELOG(LOG_WARNING, "DISPLAY: Failed to open platform-gpu-card, trying card1");
@@ -1169,7 +1170,7 @@ int InitPlatform(void)
         if (platform.fd != -1) TRACELOG(LOG_INFO, "DISPLAY: card1 opened successfully");
     }
 
-    if ((platform.fd == -1) || (drmModeGetResources(platform.fd) == NULL))
+    if ((platform.fd == -1) || ((res = drmModeGetResources(platform.fd)) == NULL))
     {
         if (platform.fd != -1) close(platform.fd);
         TRACELOG(LOG_WARNING, "DISPLAY: Failed to open graphic card1, trying card0");
@@ -1177,7 +1178,7 @@ int InitPlatform(void)
         if (platform.fd != -1) TRACELOG(LOG_INFO, "DISPLAY: card0 opened successfully");
     }
 
-    if ((platform.fd == -1) || (drmModeGetResources(platform.fd) == NULL))
+    if ((platform.fd == -1) || ((res = drmModeGetResources(platform.fd)) == NULL))
     {
         if (platform.fd != -1) close(platform.fd);
         TRACELOG(LOG_WARNING, "DISPLAY: Failed to open graphic card0, trying card2");
@@ -1192,7 +1193,6 @@ int InitPlatform(void)
         return -1;
     }
 
-    drmModeRes *res = drmModeGetResources(platform.fd);
     if (!res)
     {
         TRACELOG(LOG_WARNING, "DISPLAY: Failed get DRM resources");


### PR DESCRIPTION
Fixes leak of the result from the double call to `drmModeGetResources`. Found with ASAN, looks like this (4 similar allocations from one call to `drmModeGetResources`:

```
Direct leak of 80 byte(s) in 1 object(s) allocated from:
    #0 0x5555b60114d0 in calloc (app+0x1f14d0)
    #1 0x7ffeee22eeb4 in drmModeGetResources (/lib/aarch64-linux-gnu/libdrm.so.2+0xeeb4)
    #2 0x5555b61f8ddc in InitPlatform raylib/src/platforms/rcore_drm.c:1177:33
    #3 0x5555b61fb030 in InitWindow raylib/src/rcore.c:688:18
```

The bug is that when one of the `if ((platform.fd == -1) || (drmModeGetResources(platform.fd) == NULL))` succeeds, the resulting resources pointer is dropped on the floor. The one that gets used from the following call gets freed, but not the one used to check that the device exists.

This change just stores the one used for the check directly in `res` rather than calling `drmModeGetResources` again.