### PR TITLE
chore: add GetAppDir for wasm returning root VFS

### DIFF
--- a/src/rcore.c
+++ b/src/rcore.c
@@ -2738,6 +2738,9 @@ const char *GetApplicationDirectory(void)
         appDir[0] = '.';
         appDir[1] = '/';
     }
+
+#elif defined(__wasm__)
+    appDir[0] = '/';
 #endif
 
     return appDir;


### PR DESCRIPTION
This addition enables the use on GetApplicationDirectory on wasm builds. 
Based in the virtual file system of emscripten (https://emscripten.org/docs/porting/files/file_systems_overview.html)

<img width="619" height="368" alt="image" src="https://github.com/user-attachments/assets/86b503fe-0db3-4ff4-bfad-ad849d929e26" />

> MEMFS is mounted at / when the runtime is initialized. Files to be added to the MEMFS virtual file system are specified at compile time using emcc, as discussed in [Packaging Files](https://emscripten.org/docs/porting/files/packaging_files.html#packaging-files). The files are loaded asynchronously by JavaScript using [Synchronous XHRs](https://emscripten.org/docs/porting/files/Synchronous-Virtual-XHR-Backed-File-System-Usage.html#synchronous-virtual-xhr-backed-file-system-usage) when the page is first loaded. The compiled code is only allowed to run (and call synchronous APIs) when the asynchronous download has completed and the files are available in the virtual file system.