### PR TITLE
OpenGL interop example fails to link on ES2.0 Desktop platforms

### DIFF
--- a/examples/others/raylib_opengl_interop.c
+++ b/examples/others/raylib_opengl_interop.c
@@ -30,6 +30,7 @@
 
 #if defined(PLATFORM_DESKTOP) || defined(PLATFORM_DESKTOP_SDL)
     #if defined(GRAPHICS_API_OPENGL_ES2)
+        #define GLAD_GLES2_IMPLEMENTATION
         #include "glad_gles2.h"       // Required for: OpenGL functionality
         #define glGenVertexArrays glGenVertexArraysOES
         #define glBindVertexArray glBindVertexArrayOES


### PR DESCRIPTION
The library is only sourced as a header, so the implementation for the glad interop functions are not present and do not link.

I am unsure if those functions are supposed to be included in raylib itself or not, but they are not.

I noticed that they are sourced in [rlgl.h](https://github.com/raysan5/raylib/blob/439448ad7ccfadd2adb15502e17564d873e4dc92/src/rlgl.h#L885), however `PLATFORM_DESKTOP_GLFW` is not defined when that code is compiled, despite it being set in [rcore.c](https://github.com/raysan5/raylib/blob/439448ad7ccfadd2adb15502e17564d873e4dc92/src/rcore.c#L525)