### PR TITLE
[rlgl] Fix condition for WebGL depth texture support

### DIFF
--- a/src/rlgl.h
+++ b/src/rlgl.h
@@ -3429,7 +3429,11 @@ unsigned int rlLoadTextureDepth(int width, int height, bool useRenderBuffer)
     {
         if (RLGL.ExtSupported.maxDepthBits == 32) glInternalFormat = GL_DEPTH_COMPONENT32_OES;
         else if (RLGL.ExtSupported.maxDepthBits == 24) glInternalFormat = GL_DEPTH_COMPONENT24_OES;
+#if !defined(GRAPHICS_API_OPENGL_ES3)
+        else if (useRenderBuffer) glInternalFormat = GL_DEPTH_COMPONENT16;
+#else
         else glInternalFormat = GL_DEPTH_COMPONENT16;
+#endif
     }
 #endif
 


### PR DESCRIPTION
Condition looks to be incorrect. If texDepthWebGL is available, it should be using GL_DEPTH_COMPONENT16/24/32 but currently in WebGL always uses GL_DEPTH_COMPONENT which can fail especially in WebGL2.