### PR TITLE
[web] Fix Emscripten's Closure compiler error: undeclared canvas variable

### DIFF
--- a/src/platforms/rcore_web.c
+++ b/src/platforms/rcore_web.c
@@ -316,15 +316,16 @@ void ToggleBorderlessWindowed(void)
         // 2. The style unset handles the possibility of a width="value%" like on the default shell.html file
         EM_ASM
         (
+            const canvasId = UTF8ToString($0);
             setTimeout(function()
             {
                 Module.requestFullscreen(false, true);
                 setTimeout(function()
                 {
-                    document.getElementById("canvas").style.width="unset";
+                    document.querySelector(canvasId).style.width="unset";
                 }, 100);
             }, 100);
-        );
+        , platform.canvasId);
         FLAG_SET(CORE.Window.flags, FLAG_BORDERLESS_WINDOWED_MODE);
     }
 }
@@ -1238,9 +1239,9 @@ int InitPlatform(void)
     // Avoid creating a WebGL canvas, avoid calling glfwCreateWindow()
     emscripten_set_canvas_element_size(platform.canvasId, CORE.Window.screen.width, CORE.Window.screen.height);
     EM_ASM({
-        const canvas = document.getElementById("canvas");
+        const canvas = document.querySelector(UTF8ToString($0));
         Module.canvas = canvas;
-    });
+    }, platform.canvasId);
 
     // Load memory framebuffer with desired screen size
     // NOTE: Despite using a software framebuffer for blitting, GLFW still creates a WebGL canvas,

--- a/src/platforms/rcore_web_emscripten.c
+++ b/src/platforms/rcore_web_emscripten.c
@@ -280,15 +280,16 @@ void ToggleBorderlessWindowed(void)
         // 2. The style unset handles the possibility of a width="value%" like on the default shell.html file
         EM_ASM
         (
+            const canvasId = UTF8ToString($0);
             setTimeout(function()
             {
                 Module.requestFullscreen(false, true);
                 setTimeout(function()
                 {
-                    document.getElementById("canvas").style.width="unset";
+                    document.querySelector(canvasId).style.width="unset";
                 }, 100);
             }, 100);
-        );
+        , platform.canvasId);
         FLAG_SET(CORE.Window.flags, FLAG_BORDERLESS_WINDOWED_MODE);
     }
 }


### PR DESCRIPTION
The original implementation relied on a global `canvas` variable, which is typically defined in Emscripten's default shell. When using Emscripten's Closure compiler, this file is not visible to the compiler, causing minification to fail with
`ERROR - [JSC_UNDEFINED_VARIABLE] variable canvas is undeclared`.

This pull request resolves the issue by no longer relying on the implicit global and instead explicitly querying the document for the canvas element by its ID.

One potential (currently unverified) side effect is that projects using a custom Emscripten shell without a canvas element tagged with `id="canvas"` may need to update their HTML accordingly. However, the default Emscripten shell already queries the canvas using `id="canvas"`, so existing working setups should remain unaffected.