### PR TITLE
[rcore] `IsMouseButton*()`, random key codes return unexpected results

### DIFF
--- a/src/rcore.c
+++ b/src/rcore.c
@@ -4053,13 +4053,16 @@ bool IsMouseButtonPressed(int button)
 {
     bool pressed = false;
     
-    if ((button < 0) || (button > MOUSE_BUTTON_BACK)) return false;
+    if ((button >= 0) && (button <= MOUSE_BUTTON_BACK))
+    {
     
-    if ((CORE.Input.Mouse.currentButtonState[button] == 1) && (CORE.Input.Mouse.previousButtonState[button] == 0)) pressed = true;
+        if ((CORE.Input.Mouse.currentButtonState[button] == 1) && (CORE.Input.Mouse.previousButtonState[button] == 0)) pressed = true;
 
-    // Map touches to mouse buttons checking
-    if ((CORE.Input.Touch.currentTouchState[button] == 1) && (CORE.Input.Touch.previousTouchState[button] == 0)) pressed = true;
-
+        // Map touches to mouse buttons checking
+        if ((CORE.Input.Touch.currentTouchState[button] == 1) && (CORE.Input.Touch.previousTouchState[button] == 0)) pressed = true;
+        
+    }
+    
     return pressed;
 }
 
@@ -4068,13 +4071,16 @@ bool IsMouseButtonDown(int button)
 {
     bool down = false;
     
-    if ((button < 0) || (button > MOUSE_BUTTON_BACK)) return false;
+    if ((button >= 0) && (button <= MOUSE_BUTTON_BACK))
+    {
+        
+        if (CORE.Input.Mouse.currentButtonState[button] == 1) down = true;
+
+        // NOTE: Touches are considered like mouse buttons
+        if (CORE.Input.Touch.currentTouchState[button] == 1) down = true;
+        
+    }
     
-    if (CORE.Input.Mouse.currentButtonState[button] == 1) down = true;
-
-    // NOTE: Touches are considered like mouse buttons
-    if (CORE.Input.Touch.currentTouchState[button] == 1) down = true;
-
     return down;
 }
 
@@ -4083,13 +4089,16 @@ bool IsMouseButtonReleased(int button)
 {
     bool released = false;
     
-    if ((button < 0) || (button > MOUSE_BUTTON_BACK)) return false;
+    if ((button >= 0) && (button <= MOUSE_BUTTON_BACK))
+    {
+        
+        if ((CORE.Input.Mouse.currentButtonState[button] == 0) && (CORE.Input.Mouse.previousButtonState[button] == 1)) released = true;
+
+        // Map touches to mouse buttons checking
+        if ((CORE.Input.Touch.currentTouchState[button] == 0) && (CORE.Input.Touch.previousTouchState[button] == 1)) released = true;
+            
+    }
     
-    if ((CORE.Input.Mouse.currentButtonState[button] == 0) && (CORE.Input.Mouse.previousButtonState[button] == 1)) released = true;
-
-    // Map touches to mouse buttons checking
-    if ((CORE.Input.Touch.currentTouchState[button] == 0) && (CORE.Input.Touch.previousTouchState[button] == 1)) released = true;
-
     return released;
 }
 
@@ -4098,13 +4107,16 @@ bool IsMouseButtonUp(int button)
 {
     bool up = false;
     
-    if ((button < 0) || (button > MOUSE_BUTTON_BACK)) return false;
+    if ((button >= 0) && (button <= MOUSE_BUTTON_BACK))
+    {
+        
+        if (CORE.Input.Mouse.currentButtonState[button] == 0) up = true;
+
+        // NOTE: Touches are considered like mouse buttons
+        if (CORE.Input.Touch.currentTouchState[button] == 0) up = true;
+            
+    }
     
-    if (CORE.Input.Mouse.currentButtonState[button] == 0) up = true;
-
-    // NOTE: Touches are considered like mouse buttons
-    if (CORE.Input.Touch.currentTouchState[button] == 0) up = true;
-
     return up;
 }
 


### PR DESCRIPTION
Hi, today I've encountered a weird behaviour when I accidentally wrote
``` 
IsMouseButtonDown(KEY_S);
```
In my raylib project, it will sometimes return true when I'm moving my cursor. So I've written a simple test code as such
```
//------------------------------------------------------------------------------------
// Program main entry point
//------------------------------------------------------------------------------------
int main(void)
{
    // Initialization
    //--------------------------------------------------------------------------------------
    const int screenWidth = 1000;
    const int screenHeight = 1000;

    InitWindow(screenWidth, screenHeight, "raylib [shapes] example - starfield effect");

    Color bgColor = ColorLerp(DARKBLUE, BLACK, 0.69f);

    SetTargetFPS(60);               // Set our game to run at 60 frames-per-second
    //--------------------------------------------------------------------------------------
    
     unsigned int press_count = 0, down_count = 0, release_count = 0, up_count = 0;
    
    // Main game loop
    while (!WindowShouldClose())    // Detect window close button or ESC key
    {
        
        // Draw
        //----------------------------------------------------------------------------------
        BeginDrawing();
        
        ClearBackground(bgColor);
        
        if (IsMouseButtonPressed(KEY_S))
        {
            press_count++;
        }
        
        if (IsMouseButtonDown(KEY_S))
        {
            down_count++;
        }
        
        if (IsMouseButtonReleased(KEY_S))
        {
            release_count++;
        }
        
        DrawCircleV(GetMousePosition(), 5, RED);
        
        DrawText(TextFormat("KeyCode: %d\nPressed %d times\nDowned %d times\nReleased %d times", 
                            KEY_S, press_count, down_count, release_count), GetScreenWidth() / 2, GetScreenHeight() / 2, 20, RAYWHITE);
        
            DrawFPS(10, 10);
        EndDrawing();
        //----------------------------------------------------------------------------------
    }

    // De-Initialization
    //--------------------------------------------------------------------------------------
    CloseWindow();          // Close window and OpenGL context
    //--------------------------------------------------------------------------------------

    return 0;
}
```
And I got the same result, when I move around the cursor on the screen, it will increase ```down_count``` and ```press_count```. 
Here is the video of it. 

https://github.com/user-attachments/assets/3132438f-e594-4f73-beb5-38d22d76ed39

What I did to fix this was return false when the keycodes are not valid. i.e
``` if ((button < 0) || (button > MOUSE_BUTTON_BACK)) return false; ```


