### PR TITLE
[rcore] Fixed win32 vsync flag not being applied

### DIFF
--- a/src/platforms/rcore_desktop_win32.c
+++ b/src/platforms/rcore_desktop_win32.c
@@ -2149,10 +2149,10 @@ static void UpdateFlags(HWND hwnd, unsigned desiredFlags, int width, int height)
     // Flags that just apply immediately without needing any operations
     CORE.Window.flags |= (desiredFlags & FLAG_MASK_NO_UPDATE);
 
-    int vsync = (CORE.Window.flags & FLAG_VSYNC_HINT)? 1 : 0;
+    int vsync = (desiredFlags & FLAG_VSYNC_HINT)? 1 : 0;
     if (wglSwapIntervalEXT)
     {
-        (*wglSwapIntervalEXT)(vsync);
+        wglSwapIntervalEXT(vsync);
         if (vsync) CORE.Window.flags |= FLAG_VSYNC_HINT;
         else CORE.Window.flags &= ~FLAG_VSYNC_HINT;
     }


### PR DESCRIPTION
CORE.Window.flags is supposed to reflect the window's current state, but it is currently being used to determine whether VSync needs to be turned on or off, so it will always remain off. This PR fixes this so VSync can be turned on or off. I also simplified the call to wglSwapIntervalEXT for easier reading.