### PR TITLE
Close opened directory in `GetDirectoryFileCountEx()`

### DIFF
--- a/src/rcore.c
+++ b/src/rcore.c
@@ -3004,6 +3004,7 @@ unsigned int GetDirectoryFileCountEx(const char *basePath, const char *filter, b
                 }
             }
         }
+        closedir(dir);
     }
     else TRACELOG(LOG_WARNING, "FILEIO: Directory cannot be opened (%s)", basePath);  // Maybe it's a file...
     return fileCounter;


### PR DESCRIPTION
The directory opened in `GetDirectoryFileCountEx()` was never closed, introducing a memory leak.