### PR TITLE
[rcore] Implemented SetWindowMaxSize, SetWindowMinSize, and SetWindowSize

### DIFF
--- a/src/platforms/rcore_desktop_win32.c
+++ b/src/platforms/rcore_desktop_win32.c
@@ -972,6 +972,12 @@ void SetWindowMonitor(int monitor)
 // Set window minimum dimensions (FLAG_WINDOW_RESIZABLE)
 void SetWindowMinSize(int width, int height)
 {
+    if ((width > CORE.Window.screenMax.width) || (height > CORE.Window.screenMax.height))
+    {
+        TRACELOG(LOG_WARNING, "WIN32: WINDOW: Cannot set minimum screen size higher than the maximum");
+        return;
+    }
+
     CORE.Window.screenMin.width = width;
     CORE.Window.screenMin.height = height;
 
@@ -981,6 +987,12 @@ void SetWindowMinSize(int width, int height)
 // Set window maximum dimensions (FLAG_WINDOW_RESIZABLE)
 void SetWindowMaxSize(int width, int height)
 {
+    if ((width < CORE.Window.screenMin.width) || (height < CORE.Window.screenMin.height))
+    {
+        TRACELOG(LOG_WARNING, "WIN32: WINDOW: Cannot set maximum screen size lower than the minimum");
+        return;
+    }
+
     CORE.Window.screenMax.width = width;
     CORE.Window.screenMax.height = height;
     


### PR DESCRIPTION
This PR implements the functions required to limit the window's size, as well as to directly set it (respecting said limits), for the native win32 backend. It behaves like the GLFW implementation (automatic resize upon setting limits that contradict the current window, warning and prevention when setting incompatible limits). It currently does not try to take DPI into account, as DPI doesn't work yet and that part will probably have to be reworked when DPI is tested regardless.

I would've preferred to call CalcWindowSize in SetWindowMax/MinSize so as to not repeat those operations on receiving WM_GETMINMAXINFO, but I didn't figure out a clean way to do it without adding extra variables to CORE.Window. I also set screenMax.width/height to 9999 by default in InitPlatform, as I don't think there's any downsides to doing so since screenMax doesn't seem to be used or retrieved anywhere else and it simplifies the constraint checks significantly; if it's preferable to keep it as 0 by default, I'll change it no problem.

I also removed the TODO inside HandleWindowResize, as I believe the function already modifies the framebuffer's size as requested correctly, unless I'm possibly missing something? Same with WM_APP_UPDATE_WINDOW_SIZE, I don't think this is being used nor is it useful for anything currently, but I could restore it if needed of course.