### PR TITLE
[tools/rexm] Respect RAYLIB_LIBTYPE=STATIC during desktop linking

### DIFF
--- a/tools/rexm/Makefile
+++ b/tools/rexm/Makefile
@@ -42,6 +42,14 @@ RAYLIB_LIB_PATH       ?= $(RAYLIB_SRC_PATH)
 # Library type used for raylib: STATIC (.a) or SHARED (.so/.dll)
 RAYLIB_LIBTYPE        ?= STATIC
 
+# Select raylib linkage mode explicitly to avoid pulling a local shared
+# library when static linking is requested.
+ifeq ($(RAYLIB_LIBTYPE),STATIC)
+    RAYLIB_LINK_LIB = $(RAYLIB_LIB_PATH)/libraylib.a
+else
+    RAYLIB_LINK_LIB = -lraylib
+endif
+
 # Define compiler path on Windows
 COMPILER_PATH         ?= C:\raylib\w64devkit\bin
 
@@ -264,14 +272,14 @@ ifeq ($(PLATFORM),PLATFORM_DESKTOP)
     ifeq ($(PLATFORM_OS),WINDOWS)
         # Libraries for Windows desktop compilation
         # NOTE: WinMM library required to set high-res timer resolution
-        LDLIBS = -lraylib -lopengl32 -lgdi32 -lwinmm
+        LDLIBS = $(RAYLIB_LINK_LIB) -lopengl32 -lgdi32 -lwinmm
         # Required for physac examples
         #LDLIBS += -static -lpthread
     endif
     ifeq ($(PLATFORM_OS),LINUX)
         # Libraries for Debian GNU/Linux desktop compiling
         # NOTE: Required packages: libegl1-mesa-dev
-        LDLIBS = -lraylib -lGL -lm -lpthread -ldl -lrt
+        LDLIBS = $(RAYLIB_LINK_LIB) -lGL -lm -lpthread -ldl -lrt
 
         # On Wayland windowing system, additional libraries requires
         ifeq ($(USE_WAYLAND_DISPLAY),TRUE)
@@ -290,12 +298,12 @@ ifeq ($(PLATFORM),PLATFORM_DESKTOP)
     ifeq ($(PLATFORM_OS),OSX)
         # Libraries for OSX 10.9 desktop compiling
         # NOTE: Required packages: libopenal-dev libegl1-mesa-dev
-        LDLIBS = -lraylib -framework OpenGL -framework Cocoa -framework IOKit -framework CoreAudio -framework CoreVideo
+        LDLIBS = $(RAYLIB_LINK_LIB) -framework OpenGL -framework Cocoa -framework IOKit -framework CoreAudio -framework CoreVideo
     endif
     ifeq ($(PLATFORM_OS),BSD)
         # Libraries for FreeBSD, OpenBSD, NetBSD, DragonFly desktop compiling
         # NOTE: Required packages: mesa-libs
-        LDLIBS = -lraylib -lGL -lpthread -lm
+        LDLIBS = $(RAYLIB_LINK_LIB) -lGL -lpthread -lm
 
         # On XWindow requires also below libraries
         LDLIBS += -lX11 -lXrandr -lXinerama -lXi -lXxf86vm -lXcursor


### PR DESCRIPTION
## Summary
Fix `tools/rexm/Makefile` so desktop builds actually honor `RAYLIB_LIBTYPE=STATIC` when selecting the raylib library to link.

Before this change, `RAYLIB_LIBTYPE` defaulted to `STATIC` but `LDLIBS` still used `-lraylib`, which can resolve to a shared library when one is present in `src`.

## Problem Reproduction
Environment: macOS (clang), working from repository root.

1. Build raylib shared library:
   ```bash
   cd src
   make PLATFORM=PLATFORM_DESKTOP RAYLIB_LIBTYPE=SHARED CUSTOM_CFLAGS="-DGL_SILENCE_DEPRECATION" -B
   ```
2. Build and run rexm with defaults:
   ```bash
   cd ../tools/rexm
   make clean && make
   ./rexm validate ../../examples/examples.h
   ```
3. Runtime failure:
   ```text
   dyld: Library not loaded: @rpath/libraylib.550.dylib
   Referenced from: .../tools/rexm/rexm
   Reason: no LC_RPATH's found
   ```

## Root Cause
`tools/rexm/Makefile` sets `RAYLIB_LIBTYPE ?= STATIC`, but for desktop targets it still links with `-lraylib`, allowing the linker to pick a shared artifact when available.

## Fix
- Added `RAYLIB_LINK_LIB`:
  - `$(RAYLIB_LIB_PATH)/libraylib.a` when `RAYLIB_LIBTYPE=STATIC`
  - `-lraylib` otherwise
- Replaced desktop `LDLIBS` raylib entry to use `$(RAYLIB_LINK_LIB)` on Windows/Linux/macOS/BSD.

## Validation
- `make clean && make` in `tools/rexm` now links explicitly to `../../src/libraylib.a` by default.
- `otool -L ./rexm` no longer shows a dynamic `libraylib` dependency in static mode.
- `./rexm --help` and `./rexm validate ../../examples/examples.h` run successfully in static mode, even with shared raylib artifacts present in `src`.

## Scope
Small Makefile-only change in `tools/rexm/Makefile`; no behavior changes outside library selection for linking.
