### PR TITLE
fix(examples): don't bleed fog when on edge

### DIFF
--- a/examples/textures/textures_fog_of_war.c
+++ b/examples/textures/textures_fog_of_war.c
@@ -68,6 +68,7 @@ int main(void)
     // at a smaller size (one pixel per tile) and scale it on drawing with bilinear filtering
     RenderTexture2D fogOfWar = LoadRenderTexture(map.tilesX, map.tilesY);
     SetTextureFilter(fogOfWar.texture, TEXTURE_FILTER_BILINEAR);
+    SetTextureWrap(fogOfWar.texture, TEXTURE_WRAP_CLAMP);
 
     SetTargetFPS(60);               // Set our game to run at 60 frames-per-second
     //--------------------------------------------------------------------------------------


### PR DESCRIPTION
Steps to reproduce:
1. play textures_fog_of_war example
2. Move player to edge of screen
3. Note the light bleeds to the other side of the screen

Before: 
<img width="1600" height="964" alt="image" src="https://github.com/user-attachments/assets/39bbdbe8-7161-4d3b-a1ab-4ecd75af797e" />

After:
<img width="1600" height="964" alt="image" src="https://github.com/user-attachments/assets/7fd69eb5-10b4-451b-b33b-6a2f6c218e75" />
