### PR TITLE
[examples] fix extra drawtext()

### DIFF
--- a/examples/core/core_random_sequence.c
+++ b/examples/core/core_random_sequence.c
@@ -96,8 +96,6 @@ int main(void)
             {
                 DrawRectangleRec(rectangles[i].rect, rectangles[i].color);
 
-                DrawText("Press SPACE to shuffle the sequence", 10, screenHeight - 96, 20, BLACK);
-
                 DrawText("Press SPACE to shuffle the current sequence", 10, screenHeight - 96, 20, BLACK);
                 DrawText("Press UP to add a rectangle and generate a new sequence", 10, screenHeight - 64, 20, BLACK);
                 DrawText("Press DOWN to remove a rectangle and generate a new sequence", 10, screenHeight - 32, 20, BLACK);


### PR DESCRIPTION
The original has the 2 lines overlapping due to the same position. I think this was just overlooked and the change is what was desired

<img width="172" height="67" alt="image" src="https://github.com/user-attachments/assets/eb8b6e39-0c92-4c16-b03a-74bfc3203543" />
