### PR TITLE
[examples] fix wrong name

### DIFF
--- a/examples/core/core_input_actions.c
+++ b/examples/core/core_input_actions.c
@@ -117,7 +117,7 @@ int main(void)
 
             DrawRectangleV(position, size, releaseAction? BLUE : RED);
 
-            DrawText((actionSet == 0)? "Current input set: WASD (default)" : "Current input set: Cursor", 10, 10, 20, WHITE);
+            DrawText((actionSet == 0)? "Current input set: WASD (default)" : "Current input set: Arrow keys", 10, 10, 20, WHITE);
             DrawText("Use TAB key to toggles Actions keyset", 10, 50, 20, GREEN);
 
         EndDrawing();


### PR DESCRIPTION
It says "Cursor" which sounds like a mouse or something, but what it actually means is that the input is done via arrow keys so i think it makes sense to rename it

<img width="434" height="173" alt="image" src="https://github.com/user-attachments/assets/8a459fd5-911a-4215-8844-cf197acbb904" />
