### PR TITLE
[examples] change on-screen text

### DIFF
--- a/examples/core/core_2d_camera_platformer.c
+++ b/examples/core/core_2d_camera_platformer.c
@@ -148,10 +148,11 @@ int main(void)
             DrawText("Controls:", 20, 20, 10, BLACK);
             DrawText("- Right/Left to move", 40, 40, 10, DARKGRAY);
             DrawText("- Space to jump", 40, 60, 10, DARKGRAY);
-            DrawText("- Mouse Wheel to Zoom in-out, R to reset zoom", 40, 80, 10, DARKGRAY);
-            DrawText("- C to change camera mode", 40, 100, 10, DARKGRAY);
-            DrawText("Current camera mode:", 20, 120, 10, BLACK);
-            DrawText(cameraDescriptions[cameraOption], 40, 140, 10, DARKGRAY);
+            DrawText("- Mouse Wheel to Zoom in-out", 40, 80, 10, DARKGRAY);
+            DrawText("- R to reset position + zoom", 40, 100, 10, DARKGRAY);
+            DrawText("- C to change camera mode", 40, 120, 10, DARKGRAY);
+            DrawText("Current camera mode:", 20, 140, 10, BLACK);
+            DrawText(cameraDescriptions[cameraOption], 40, 160, 10, DARKGRAY);
 
         EndDrawing();
         //----------------------------------------------------------------------------------


### PR DESCRIPTION
There are a few things i didnt really like about this example:

1) The `R` command is on the same line as mouse wheel
2) It doesn't mention the player position is also reset

This is really minor so you can close it instead if you want

before:
<img width="310" height="193" alt="image" src="https://github.com/user-attachments/assets/c58131cc-5432-4a1c-a0f6-b33f63769289" />

after:
<img width="310" height="193" alt="image" src="https://github.com/user-attachments/assets/06afad40-3268-46d3-9963-d0f26c642a52" />
