### PR TITLE
[rcamera] update camera pan speed

### DIFF
--- a/src/rcamera.h
+++ b/src/rcamera.h
@@ -199,7 +199,7 @@ RLAPI Matrix GetCameraProjectionMatrix(Camera *camera, float aspect);
 //----------------------------------------------------------------------------------
 #define CAMERA_MOVE_SPEED                           5.4f       // Units per second
 #define CAMERA_ROTATION_SPEED                       0.03f
-#define CAMERA_PAN_SPEED                            0.2f
+#define CAMERA_PAN_SPEED                            2.0f
 
 // Camera mouse movement sensitivity
 #define CAMERA_MOUSE_MOVE_SENSITIVITY               0.003f


### PR DESCRIPTION
It was brought up before that when it updated to use `GetFrameTime()` with the camera speeds that the pan speed was too slow, but no one updated it yet

This feels way more comfortable and can be easily tested in `core/core_3d_camera_free`