### PR TITLE
[examples] change attenuation distance

### DIFF
--- a/examples/audio/audio_sound_positioning.c
+++ b/examples/audio/audio_sound_positioning.c
@@ -68,7 +68,7 @@ int main(void)
             .z = 5.0f*sinf(th)
         };
 
-        SetSoundPosition(camera, sound, spherePos, 20.0f);
+        SetSoundPosition(camera, sound, spherePos, 1.0f);
 
         if (!IsSoundPlaying(sound)) PlaySound(sound);
         //----------------------------------------------------------------------------------


### PR DESCRIPTION
The default works but you need to move a great distance from the source before it gets really noticeable. Lowering the distance shows the effect much better, i think, because even standing still you can hear the difference when it moves further or closer to the camera without breaking anything