### PR TITLE
[examples] fix y-offset casting

### DIFF
--- a/examples/shapes/shapes_colors_palette.c
+++ b/examples/shapes/shapes_colors_palette.c
@@ -45,7 +45,7 @@ int main(void)
     for (int i = 0; i < MAX_COLORS_COUNT; i++)
     {
         colorsRecs[i].x = 20.0f + 100.0f *(i%7) + 10.0f *(i%7);
-        colorsRecs[i].y = 80.0f + 100.0f *((float)i/7) + 10.0f *((float)i/7);
+        colorsRecs[i].y = 80.0f + 100.0f *((int)i/7) + 10.0f *((float)i/7);
         colorsRecs[i].width = 100.0f;
         colorsRecs[i].height = 100.0f;
     }


### PR DESCRIPTION
In the original the float cast makes it shift slightly:

<img width="791" height="444" alt="image" src="https://github.com/user-attachments/assets/ee51b64d-750e-464b-98fc-555c80610277" />

changing the cast to int solves the issue and matches the desired result:
<img width="791" height="444" alt="image" src="https://github.com/user-attachments/assets/59d09c8f-801f-4c99-a5eb-57ae48dda11c" />
