### PR TITLE
[examples] change d-pad text to shapes

### DIFF
--- a/examples/core/core_input_virtual_controls.c
+++ b/examples/core/core_input_virtual_controls.c
@@ -51,11 +51,31 @@ int main(void)
         { padPosition.x, padPosition.y + buttonRadius*1.5f }  // Down
     };
 
-    const char *buttonLabels[BUTTON_MAX] = {
-        "Y",    // Up
-        "X",    // Left
-        "B",    // Right
-        "A"     // Down
+    Vector2 arrowTris[4][3] = {
+        // Up
+        {
+            { buttonPositions[0].x,     buttonPositions[0].y - 12 },
+            { buttonPositions[0].x - 9, buttonPositions[0].y + 9  },
+            { buttonPositions[0].x + 9, buttonPositions[0].y + 9  }
+        },
+        // Left
+        {
+            { buttonPositions[1].x + 9,  buttonPositions[1].y - 9 },
+            { buttonPositions[1].x - 12, buttonPositions[1].y     },
+            { buttonPositions[1].x + 9,  buttonPositions[1].y + 9 }
+        },
+        // Right
+        {
+            { buttonPositions[2].x + 12, buttonPositions[2].y     },
+            { buttonPositions[2].x - 9,  buttonPositions[2].y - 9 },
+            { buttonPositions[2].x - 9,  buttonPositions[2].y + 9 }
+        },
+        // Down
+        {
+            { buttonPositions[3].x - 9, buttonPositions[3].y - 9  },
+            { buttonPositions[3].x,     buttonPositions[3].y + 12 },
+            { buttonPositions[3].x + 9, buttonPositions[3].y - 9  }
+        }
     };
 
     Color buttonLabelColors[BUTTON_MAX] = {
@@ -128,9 +148,12 @@ int main(void)
             {
                 DrawCircleV(buttonPositions[i], buttonRadius, (i == pressedButton)? DARKGRAY : BLACK);
 
-                DrawText(buttonLabels[i],
-                    (int)buttonPositions[i].x - 7, (int)buttonPositions[i].y - 8,
-                    20, buttonLabelColors[i]);
+                DrawTriangle(
+                    arrowTris[i][0],
+                    arrowTris[i][1],
+                    arrowTris[i][2],
+                    buttonLabelColors[i]
+                );
             }
 
             DrawText("move the player with D-Pad buttons", 10, 10, 20, DARKGRAY);


### PR DESCRIPTION
It says D-Pad but shows what looks like "face buttons", so i thought it would maybe be better to change it to shapes. I don't think it really matters, though, so you can close this if you want

before:
<img width="791" height="444" alt="image" src="https://github.com/user-attachments/assets/84132f35-8c15-41c8-8e92-1b54fe32a187" />

after:
<img width="791" height="444" alt="image" src="https://github.com/user-attachments/assets/16975778-76e7-4f87-8d23-26bdeb50ceea" />
