### PR TITLE
Fixed doesn't property load when 1 frame animation.

### DIFF
--- a/src/rmodels.c
+++ b/src/rmodels.c
@@ -6244,7 +6244,10 @@ static bool GetPoseAtTimeGLTF(cgltf_interpolation_type interpolationType, cgltf_
     }
 
     // Constant animation, no need to interpolate
-    if (FloatEquals(tend, tstart)) return true;
+    if (FloatEquals(tend, tstart))
+    {
+        interpolationType = cgltf_interpolation_type_step;
+    }
 
     float duration = fmaxf((tend - tstart), EPSILON);
     float t = (time - tstart)/duration;


### PR DESCRIPTION
`LoadModelAnimationsGLTF` doesn't properly loads 1 frame animation.
This is because `GetPoseAtTimeGLTF` will be returns interpolated value to `void *data`.
but It doesn't set any values for no need interpolate animations.
