### PR TITLE
[rcore][glfw] Fix window scaling on Wayland with GLFW 3.4+

### DIFF
--- a/src/platforms/rcore_desktop_glfw.c
+++ b/src/platforms/rcore_desktop_glfw.c
@@ -1469,10 +1469,8 @@ int InitPlatform(void)
 #if defined(__APPLE__)
         glfwWindowHint(GLFW_SCALE_FRAMEBUFFER, GLFW_FALSE);
 #endif
-        // GLFW 3.4+ defaults GLFW_SCALE_FRAMEBUFFER to TRUE, causing framebuffer/window
-        // size mismatch on Wayland with display scaling. Disable without FLAG_WINDOW_HIGHDPI.
-        if (glfwGetPlatform() == GLFW_PLATFORM_WAYLAND)
-            glfwWindowHint(GLFW_SCALE_FRAMEBUFFER, GLFW_FALSE);
+        // GLFW 3.4+ defaults GLFW_SCALE_FRAMEBUFFER to TRUE, causing framebuffer/window size mismatch on Wayland with display scaling
+        if (glfwGetPlatform() == GLFW_PLATFORM_WAYLAND) glfwWindowHint(GLFW_SCALE_FRAMEBUFFER, GLFW_FALSE);
     }
 
     // Mouse passthrough
@@ -1671,14 +1669,10 @@ int InitPlatform(void)
             // NOTE: On APPLE platforms system manage window and input scaling
             // Framebuffer scaling is activated with: glfwWindowHint(GLFW_SCALE_FRAMEBUFFER, GLFW_TRUE);
 
-            // Screen scaling matrix is required in case desired screen area is different from display area
-            CORE.Window.screenScale = MatrixScale(scaleDpi.x, scaleDpi.y, 1.0f);
-
 #if !defined(__APPLE__)
             if (glfwGetPlatform() == GLFW_PLATFORM_WAYLAND)
             {
-                // On Wayland, GLFW_SCALE_FRAMEBUFFER handles scaling; read actual framebuffer
-                // size instead of resizing the window (which would double-scale).
+                // On Wayland, GLFW_SCALE_FRAMEBUFFER handles scaling; read actual framebuffer size instead of resizing the window (which would double-scale)
                 int fbWidth, fbHeight;
                 glfwGetFramebufferSize(platform.handle, &fbWidth, &fbHeight);
                 CORE.Window.render.width = fbWidth;
@@ -1876,8 +1870,7 @@ static void FramebufferSizeCallback(GLFWwindow *window, int width, int height)
         CORE.Window.screenScale = MatrixScale(1.0f, 1.0f, 1.0f);
         SetMouseScale(1.0f, 1.0f);
 
-        // On Wayland with GLFW_SCALE_FRAMEBUFFER, the framebuffer is still scaled
-        // in fullscreen. Use logical window size as screen and apply screenScale.
+        // On Wayland with GLFW_SCALE_FRAMEBUFFER, the framebuffer is still scaled in fullscreen, use logical window size as screen and apply screenScale
         if ((glfwGetPlatform() == GLFW_PLATFORM_WAYLAND) &&
             FLAG_IS_SET(CORE.Window.flags, FLAG_WINDOW_HIGHDPI))
         {
@@ -1905,8 +1898,7 @@ static void FramebufferSizeCallback(GLFWwindow *window, int width, int height)
             CORE.Window.screenScale = MatrixScale(scaleDpi.x, scaleDpi.y, 1.0f);
 #if !defined(__APPLE__)
             // On Wayland, mouse coords are already in logical space
-            if (glfwGetPlatform() != GLFW_PLATFORM_WAYLAND)
-                SetMouseScale(1.0f/scaleDpi.x, 1.0f/scaleDpi.y);
+            if (glfwGetPlatform() != GLFW_PLATFORM_WAYLAND) SetMouseScale(1.0f/scaleDpi.x, 1.0f/scaleDpi.y);
 #endif
         }
         else
@@ -1936,8 +1928,7 @@ static void WindowContentScaleCallback(GLFWwindow *window, float scalex, float s
 
 #if !defined(__APPLE__)
     // On Wayland, mouse coords are already in logical space
-    if (glfwGetPlatform() != GLFW_PLATFORM_WAYLAND)
-        SetMouseScale(1.0f/scalex, 1.0f/scaley);
+    if (glfwGetPlatform() != GLFW_PLATFORM_WAYLAND) SetMouseScale(1.0f/scalex, 1.0f/scaley);
 #endif
 }
 


### PR DESCRIPTION
## Summary

GLFW 3.4 changed `GLFW_SCALE_FRAMEBUFFER` to default `TRUE` on all platforms. Previously only macOS set this hint explicitly. On Wayland with display scaling (1.5x, 2x, etc.), this causes:

- Content rendering in a subset of the window (typically bottom-left)
- Incorrect mouse coordinates
- Wrong `GetScreenWidth`/`GetScreenHeight` values

### Changes

- **Non-HiDPI path:** Disable `GLFW_SCALE_FRAMEBUFFER` on Wayland when `FLAG_WINDOW_HIGHDPI` is not set, restoring 1:1 window-to-framebuffer mapping
- **HiDPI init:** On Wayland, read actual framebuffer size from GLFW via `glfwGetFramebufferSize()` instead of calling `glfwSetWindowSize()` with scaled dimensions (which double-scales, since `GLFW_SCALE_TO_MONITOR` has no effect on Wayland but `GLFW_SCALE_FRAMEBUFFER` scales independently)
- **Mouse scaling:** Skip `SetMouseScale()` on Wayland since GLFW already reports mouse coordinates in logical (window) space — unlike X11/Windows where `GLFW_SCALE_TO_MONITOR` resizes the window and mouse coords are in pixel space

All changes are guarded by `glfwGetPlatform() == GLFW_PLATFORM_WAYLAND` to avoid affecting existing X11/Windows/macOS behavior.

## Test plan

- [x] Tested at 1x, 1.5x, and 2x display scaling on Niri (Wayland compositor)
- [x] Standard mode (no `FLAG_WINDOW_HIGHDPI`): grid fills window, corner rectangles touch edges, mouse tracks correctly
- [x] HiDPI mode (`FLAG_WINDOW_HIGHDPI`): same visual checks, `GetScreenWidth` returns logical size, `GetRenderWidth` returns physical size
- [ ] X11/Windows — existing behavior unchanged (no Wayland platform detected, original code paths execute)

**Environment:** NixOS, Niri compositor, GLFW 3.4, NVIDIA RTX 5060 Ti (driver 580.126.09)

Fixes #5504