### PR TITLE
[rshape] added checkcollisiontriangles function

### DIFF
--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1316,6 +1316,7 @@ RLAPI Vector2 GetSplinePointBezierCubic(Vector2 p1, Vector2 c2, Vector2 c3, Vect
 // Basic shapes collision detection functions
 RLAPI bool CheckCollisionRecs(Rectangle rec1, Rectangle rec2);                                           // Check collision between two rectangles
 RLAPI bool CheckCollisionCircles(Vector2 center1, float radius1, Vector2 center2, float radius2);        // Check collision between two circles
+RLAPI bool CheckCollisionTriangles(Vector2 t1p1, Vector2 t1p2, Vector2 t1p3, Vector2 t2p1, Vector2 t2p2, Vector2 t2p3); // Check collision between two triangles
 RLAPI bool CheckCollisionCircleRec(Vector2 center, float radius, Rectangle rec);                         // Check collision between circle and rectangle
 RLAPI bool CheckCollisionCircleLine(Vector2 center, float radius, Vector2 p1, Vector2 p2);               // Check if circle collides with a line created betweeen two points [p1] and [p2]
 RLAPI bool CheckCollisionPointRec(Vector2 point, Rectangle rec);                                         // Check if point is inside rectangle

--- a/src/rshapes.c
+++ b/src/rshapes.c
@@ -2336,6 +2336,31 @@ bool CheckCollisionCircles(Vector2 center1, float radius1, Vector2 center2, floa
     return collision;
 }
 
+// Check collision between two triangles
+bool CheckCollisionTriangles(Vector2 t1p1, Vector2 t1p2, Vector2 t1p3, Vector2 t2p1, Vector2 t2p2, Vector2 t2p3)
+{
+    bool collision = CheckCollisionPointTriangle(t2p1, t1p1, t1p2, t1p3) || CheckCollisionPointTriangle(t1p1, t2p1, t2p2, t2p3);
+
+    if (!collision)
+    {
+        int pointSize = 3;
+        const Vector2 t1_points[3] = {t1p1, t1p2, t1p3};
+        const Vector2 t2_points[3] = {t2p1, t2p2, t2p3};
+        Vector2 collisionPoint;
+        for (int i = 0; i < pointSize; i++)
+        {
+            for (int j = 0; j < pointSize; j++)
+            {
+                if (CheckCollisionLines(t1_points[i], t1_points[(i + 1) % pointSize], t2_points[j], t2_points[(j + 1) % pointSize], &collisionPoint))
+                {
+                    return collision = true;
+                }
+            }
+        }
+    }
+    return collision;
+}
+
 // Check collision between circle and rectangle
 // NOTE: Reviewed version to take into account corner limit case
 bool CheckCollisionCircleRec(Vector2 center, float radius, Rectangle rec)


### PR DESCRIPTION
I have added `CheckCollisionTriangles()` function. That function first checks if one of the vertices of the triangles are contained by each other. If not, then, it secondly checks if the edges of the triangles are colliding.