### PR TITLE
Fix text input on SDL3

### DIFF
--- a/src/platforms/rcore_desktop_sdl.c
+++ b/src/platforms/rcore_desktop_sdl.c
@@ -2016,6 +2016,22 @@ int InitPlatform(void)
     // Init window
 #if defined(USING_VERSION_SDL3)
     platform.window = SDL_CreateWindow(CORE.Window.title, CORE.Window.screen.width, CORE.Window.screen.height, flags);
+
+    // NOTE: SDL3 no longer enables TextInput by default, so this is needed to preserve the behaviour and keep GetCharPressed working.
+    // This code is derived from SDL before the change was made: https://github.com/libsdl-org/SDL/commit/72fc6f86e5d605a3787222bc7dc18c5379047f4a.
+    const char *enableOSK = SDL_GetHint(SDL_HINT_ENABLE_SCREEN_KEYBOARD);
+    if (enableOSK == NULL)
+    {
+        SDL_SetHint(SDL_HINT_ENABLE_SCREEN_KEYBOARD, "0");
+    }
+    if (!SDL_StartTextInput(platform.window))
+    {
+        TRACELOG(LOG_WARNING, "SDL: Failed to start text input: %s", SDL_GetError());
+    }
+    if (enableOSK == NULL) 
+    {
+        SDL_SetHint(SDL_HINT_ENABLE_SCREEN_KEYBOARD, NULL);
+    }
 #else
     platform.window = SDL_CreateWindow(CORE.Window.title, SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, CORE.Window.screen.width, CORE.Window.screen.height, flags);
 #endif


### PR DESCRIPTION
Tested with https://github.com/raysan5/raylib/blob/master/examples/text/text_input_box.c. Before this change you can't type anything - that is because SDL3 requires text input to explicitly be enabled: https://wiki.libsdl.org/SDL3/README-migration#sdl_keyboardh.

Unfortunately this has its issues such as https://github.com/libsdl-org/SDL/issues/9268... perhaps there's a workaround?

Should there be something in the license header? :P