### PR TITLE
[examples] fix example compile error

### DIFF
--- a/examples/core/core_directory_files.c
+++ b/examples/core/core_directory_files.c
@@ -79,7 +79,7 @@ int main(void)
             GuiSetStyle(LISTVIEW, TEXT_ALIGNMENT, TEXT_ALIGN_LEFT);
             GuiSetStyle(LISTVIEW, TEXT_PADDING, 40);
             GuiListViewEx((Rectangle){ 0, 50, GetScreenWidth(), GetScreenHeight() - 50 },
-                files.paths, files.count, &listScrollIndex, &listItemActive, &listItemFocused);
+                (const char**)files.paths, files.count, &listScrollIndex, &listItemActive, &listItemFocused);
 
         EndDrawing();
         //----------------------------------------------------------------------------------


### PR DESCRIPTION
```
core/core_directory_files.c:82:17: error: passing argument 2 of ‘GuiListViewEx’ 
from incompatible pointer type [-Wincompatible-pointer-types]
```

raylib.h defines FilePathList.paths as `char**` (not const)
raygui `GuiListViewEx` requires `const char**` 