### PR TITLE
[examples] Change make `clean` (testing requested)

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -766,20 +766,20 @@ ifeq ($(TARGET_PLATFORM),PLATFORM_DESKTOP_GLFW)
 		del *.o *.exe /s
     endif
     ifeq ($(PLATFORM_OS),BSD)
-		find . -type f -perm -ugo+x -delete
+		find . -type f -executable -exec file {} + 2>/dev/null | grep 'executable' | cut -d: -f1 | xargs -r rm
 		rm -fv *.o
     endif
     ifeq ($(PLATFORM_OS),LINUX)
-		find . -type f -executable -delete
+		find . -type f -executable -exec file {} + 2>/dev/null | grep 'executable' | cut -d: -f1 | xargs -r rm
 		rm -fv *.o
     endif
     ifeq ($(PLATFORM_OS),OSX)
-		find . -type f -perm +ugo+x -delete
+		find . -type f -executable -exec file {} + 2>/dev/null | grep 'executable' | cut -d: -f1 | xargs -r rm
 		rm -f *.o
     endif
 endif
 ifeq ($(TARGET_PLATFORM),PLATFORM_DRM)
-	find . -type f -executable -delete
+	find . -type f -executable -exec file {} + 2>/dev/null | grep 'executable' | cut -d: -f1 | xargs -r rm
 	rm -fv *.o
 endif
 ifeq ($(TARGET_PLATFORM),$(filter $(TARGET_PLATFORM),PLATFORM_WEB PLATFORM_WEB_RGFW))


### PR DESCRIPTION
The previous version was tested on Linux+Mac and will wipe ALL files in the example folder. This is because it was only checking that they have the "executable" flag on them, but many files have that flag including the Makefile itself

I tested this new command on Linux+Mac but if possible can someone else check and see if they have the same behavior on these platforms?

DRM and BSD are untested by me but since their commands are similar to unix it should also work