### PR TITLE
[Examples] glfw makefile consistency

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -90,6 +90,11 @@ BUILD_MODE            ?= RELEASE
 # Use external GLFW library instead of rglfw module
 USE_EXTERNAL_GLFW     ?= FALSE
 
+# Enable support for X11 by default on Linux when using GLFW
+# NOTE: Wayland is disabled by default, only enable if you are sure
+GLFW_LINUX_ENABLE_WAYLAND  ?= FALSE
+GLFW_LINUX_ENABLE_X11      ?= TRUE
+
 # PLATFORM_DESKTOP_SDL: It requires SDL library to be provided externally
 # WARNING: Library is not included in raylib, it MUST be configured by users
 SDL_INCLUDE_PATH      ?= $(RAYLIB_SRC_PATH)/external/SDL2/include
@@ -394,9 +399,11 @@ ifeq ($(TARGET_PLATFORM),PLATFORM_DESKTOP_GLFW)
         LDLIBS = -lraylib -lGL -lm -lpthread -ldl -lrt
 
         # On Wayland, additional libraries requires
-        ifeq ($(USE_WAYLAND_DISPLAY),TRUE)
+        ifeq ($(GLFW_LINUX_ENABLE_WAYLAND),TRUE)
             LDLIBS += -lwayland-client -lwayland-cursor -lwayland-egl -lxkbcommon
-        else
+        endif
+
+        ifeq ($(GLFW_LINUX_ENABLE_X11),TRUE)
             # On X11, additional libraries required
             LDLIBS += -lX11
             # NOTE: It seems additional libraries are not required any more, latest GLFW just dlopen them


### PR DESCRIPTION
In the `src` Makefile we have the following available+used by glfw:
```make
# Enable support for X11 by default on Linux when using GLFW
# NOTE: Wayland is disabled by default, only enable if you are sure
GLFW_LINUX_ENABLE_WAYLAND  ?= FALSE
GLFW_LINUX_ENABLE_X11      ?= TRUE
```

however, this is not used in the `example` Makefile, leading to inconsistent builds and possibly misconfiguration. it should also be possible to allow both, for x11 fallback options, which the current does not allow

the current `USE_WAYLAND_DISPLAY` is only used by SDL in the `src` Makefile