### PR TITLE
[raudio] Fix a 64 bit to 32 bit int cast warning.

### DIFF
--- a/src/raudio.c
+++ b/src/raudio.c
@@ -2545,7 +2545,7 @@ static ma_uint32 ReadAudioBufferFramesInMixingFormat(AudioBuffer *audioBuffer, f
                 }
 
                 memcpy(audioBuffer->converterResidual, inputBuffer + inputFramesProcessedThisIteration*bpf, (size_t)(residualFrameCount * bpf));
-                audioBuffer->converterResidualCount = residualFrameCount;
+                audioBuffer->converterResidualCount = (unsigned int)residualFrameCount;
             }
 
             if (inputFramesInInternalFormatCount < estimatedInputFrameCount) break;  // Reached the end of the sound


### PR DESCRIPTION
There is a 64 bit int that is assigned to a 32 bit int, and that generates a warning in MSVC. This PR adds a cast to fix it.