### PR TITLE
[rcore] fix memory leak found by maiconpintoabreu

### DIFF
--- a/src/rcore.c
+++ b/src/rcore.c
@@ -3546,11 +3546,11 @@ AutomationEventList LoadAutomationEventList(const char *fileName)
 {
     AutomationEventList list = { 0 };
 
+#if SUPPORT_AUTOMATION_EVENTS
     // Allocate and empty automation event list, ready to record new events
     list.events = (AutomationEvent *)RL_CALLOC(MAX_AUTOMATION_EVENTS, sizeof(AutomationEvent));
     list.capacity = MAX_AUTOMATION_EVENTS;
-
-#if SUPPORT_AUTOMATION_EVENTS
+    
     if (fileName == NULL) TRACELOG(LOG_INFO, "AUTOMATION: New empty events list loaded successfully");
     else
     {


### PR DESCRIPTION
move the calloc to inside the `#if`

Tested the `core/core_automation_events` with and without the flag enabled


EDIT: original discovery by  `QuantumKarl`