### PR TITLE
[rcore] Remove some tags to make it more readable 

### DIFF
--- a/src/platforms/rcore_desktop_glfw.c
+++ b/src/platforms/rcore_desktop_glfw.c
@@ -1048,11 +1048,8 @@ Image GetClipboardImage(void)
 {
     Image image = { 0 };
 
-#if SUPPORT_CLIPBOARD_IMAGE
-#if SUPPORT_MODULE_RTEXTURES
+#if SUPPORT_CLIPBOARD_IMAGE && SUPPORT_MODULE_RTEXTURES
 #if defined(_WIN32)
-
-#if SUPPORT_FILEFORMAT_BMP
     unsigned long long int dataSize = 0;
     void *bmpData = NULL;
     int width = 0;
@@ -1063,14 +1060,10 @@ Image GetClipboardImage(void)
     if (bmpData == NULL) TRACELOG(LOG_WARNING, "Clipboard image: Couldn't get clipboard data.");
     else image = LoadImageFromMemory(".bmp", (const unsigned char *)bmpData, (int)dataSize);
 #else
-    TRACELOG(LOG_WARNING, "WARNING: Enabling SUPPORT_CLIPBOARD_IMAGE requires SUPPORT_FILEFORMAT_BMP, specially on Windows");
-#endif // SUPPORT_FILEFORMAT_BMP
-#else
     TRACELOG(LOG_WARNING, "GetClipboardImage() not implemented on target platform");
 #endif // defined(_WIN32)
-#else // !SUPPORT_MODULE_RTEXTURES
-    TRACELOG(LOG_WARNING, "Enabling SUPPORT_CLIPBOARD_IMAGE requires SUPPORT_MODULE_RTEXTURES to work properly");
-#endif // SUPPORT_MODULE_RTEXTURES
+#else
+    TRACELOG(LOG_WARNING, "Clipboard image: SUPPORT_CLIPBOARD_IMAGE requires SUPPORT_MODULE_RTEXTURES to work properly");
 #endif // SUPPORT_CLIPBOARD_IMAGE
 
     return image;

--- a/src/platforms/rcore_desktop_rgfw.c
+++ b/src/platforms/rcore_desktop_rgfw.c
@@ -1006,11 +1006,9 @@ const char *GetClipboardText(void)
 Image GetClipboardImage(void)
 {
     Image image = { 0 };
-#if SUPPORT_CLIPBOARD_IMAGE
-#if SUPPORT_MODULE_RTEXTURES
+#if SUPPORT_CLIPBOARD_IMAGE && SUPPORT_MODULE_RTEXTURES
 #if defined(_WIN32)
 
-#if SUPPORT_FILEFORMAT_BMP
     unsigned long long int dataSize = 0; // moved into _WIN32 scope until other platforms gain support
     void *fileData = NULL; // moved into _WIN32 scope until other platforms gain support
 
@@ -1021,14 +1019,10 @@ Image GetClipboardImage(void)
     if (fileData == NULL) TRACELOG(LOG_WARNING, "Clipboard image: Couldn't get clipboard data");
     else image = LoadImageFromMemory(".bmp", (const unsigned char *)fileData, dataSize);
 #else
-    TRACELOG(LOG_WARNING, "WARNING: Enabling SUPPORT_CLIPBOARD_IMAGE requires SUPPORT_FILEFORMAT_BMP, specially on Windows");
-#endif // SUPPORT_FILEFORMAT_BMP
-#else
     TRACELOG(LOG_WARNING, "Clipboard image: PLATFORM_DESKTOP_RGFW doesn't implement GetClipboardImage() for this OS");
 #endif // defined(_WIN32)
-#else // !SUPPORT_MODULE_RTEXTURES
-    TRACELOG(LOG_WARNING, "Enabling SUPPORT_CLIPBOARD_IMAGE requires SUPPORT_MODULE_RTEXTURES to work properly");
-#endif // SUPPORT_MODULE_RTEXTURES
+#else
+    TRACELOG(LOG_WARNING, "Clipboard image: SUPPORT_CLIPBOARD_IMAGE requires SUPPORT_MODULE_RTEXTURES to work properly");
 #endif // SUPPORT_CLIPBOARD_IMAGE
 
     return image;

--- a/src/platforms/rcore_desktop_sdl.c
+++ b/src/platforms/rcore_desktop_sdl.c
@@ -1177,7 +1177,6 @@ Image GetClipboardImage(void)
 // From what I've tested applications on Wayland saves images on clipboard as PNG
 #if (!SUPPORT_FILEFORMAT_PNG || !SUPPORT_FILEFORMAT_JPG) && !defined(_WIN32)
     TRACELOG(LOG_WARNING, "WARNING: Getting image from the clipboard might not work without SUPPORT_FILEFORMAT_PNG or SUPPORT_FILEFORMAT_JPG");
-    return image;
 #endif
     // Let's hope compiler put these arrays in static memory
     const char *imageFormats[] = {


### PR DESCRIPTION
Removed check for `SUPPORT_FILEFORMAT_BMP` on Windows devices as it is guarantied.
Combining `SUPPORT_CLIPBOARD_IMAGE` and `SUPPORT_MODULE_RTEXTURES` as it is a hard requirement.
