### PR TITLE
[rtext] fix memory corruption and invalid size calculation in GenImageFontAtlas

### DIFF
--- a/src/rtext.c
+++ b/src/rtext.c
@@ -858,14 +858,15 @@ Image GenImageFontAtlas(const GlyphInfo *glyphs, Rectangle **glyphRecs, int glyp
                 if (offsetY > (atlas.height - fontSize - padding))
                 {
                     TRACELOG(LOG_WARNING, "FONT: Updating atlas size to fit all characters");
-                    
-                    // TODO: Increment atlas size (atlas.height*2) and continue adding glyphs
+
+                    // Update atlas size to fit all characters
                     int updatedAtlasHeight = atlas.height*2;
-                    int updatedAtlasDataSize = atlas.width*atlas.height;
+                    int updatedAtlasDataSize = atlas.width*updatedAtlasHeight;
                     unsigned char *updatedAtlasData = (unsigned char *)RL_CALLOC(updatedAtlasDataSize, 1);
                     
                     memcpy(updatedAtlasData, atlas.data, atlasDataSize);
                     RL_FREE(atlas.data);
+                    atlas.data = updatedAtlasData;
                     atlas.height = updatedAtlasHeight;
                     atlasDataSize = updatedAtlasDataSize;
                 }


### PR DESCRIPTION
i was just using `LoadFontEx` for font loading. and the program exited with segmentation fault. the font i'm using is `NotoSansJP`, a font for Japanese text, and what i'm trying to display is `1234567`

the backtrace tells that the `GenImageFontAtlas` caused this. when the font atlas exceeds its initial estimated size, the reallocation logic was using the old height to calculate the new buffer size and failing to update the atlas.data pointer after freeing it

so i wrote this patch which hopefully can fix the problem