### PR TITLE
[platform][glfw][rgfw] Implementing clipboard image linux

### DIFF
--- a/src/platforms/rcore_desktop_glfw.c
+++ b/src/platforms/rcore_desktop_glfw.c
@@ -1072,7 +1072,15 @@ Image GetClipboardImage(void)
     if (!dpy) return image;
 
     Window root = DefaultRootWindow(dpy);
-    Window win = XCreateSimpleWindow(dpy, root, 0, 0, 1, 1, 0, 0, 0);
+    Window win = XCreateSimpleWindow(
+        dpy,      // The connection to the X Server
+        root,     // The 'Parent' window (usually the desktop/root)
+        0, 0,     // X and Y position on the screen
+        1, 1,     // Width and Height (1x1 pixel)
+        0,        // Border width
+        0,        // Border color
+        0         // Background color
+    );
 
     Atom clipboard = XInternAtom(dpy, "CLIPBOARD", False);
     Atom targetType = XInternAtom(dpy, "image/png", False); // Ask for PNG

--- a/src/platforms/rcore_desktop_rgfw.c
+++ b/src/platforms/rcore_desktop_rgfw.c
@@ -1030,7 +1030,15 @@ Image GetClipboardImage(void)
     if (!dpy) return image;
 
     Window root = DefaultRootWindow(dpy);
-    Window win = XCreateSimpleWindow(dpy, root, 0, 0, 1, 1, 0, 0, 0);
+    Window win = XCreateSimpleWindow(
+        dpy,      // The connection to the X Server
+        root,     // The 'Parent' window (usually the desktop/root)
+        0, 0,     // X and Y position on the screen
+        1, 1,     // Width and Height (1x1 pixel)
+        0,        // Border width
+        0,        // Border color
+        0         // Background color
+    );
 
     Atom clipboard = XInternAtom(dpy, "CLIPBOARD", False);
     Atom targetType = XInternAtom(dpy, "image/png", False); // Ask for PNG


### PR DESCRIPTION
Added Clipboard Image implementation for Linux X11 using GLFW and RGFW based on https://github.com/ColleagueRiley/Clipboard-Copy-Paste/blob/main/x11.c

<img width="800" height="450" alt="image" src="https://github.com/user-attachments/assets/34468406-30ad-4dfd-8c1d-fe5c436e1cdf" />

