### PR TITLE
[rlgl] fix vertex calculation precision in vertex shader for depth buffer

### DIFF
--- a/src/rlgl.h
+++ b/src/rlgl.h
@@ -4994,7 +4994,7 @@ static void rlLoadShaderDefault(void)
 #if defined(GRAPHICS_API_OPENGL_ES3)
     "#version 300 es                    \n"
     "precision mediump float;           \n"     // Precision required for OpenGL ES3 (WebGL 2) (on some browsers)
-    "in vec3 vertexPosition;            \n"
+    "in highp vec3 vertexPosition;      \n"
     "in vec2 vertexTexCoord;            \n"
     "in vec4 vertexColor;               \n"
     "out vec2 fragTexCoord;             \n"
@@ -5002,14 +5002,14 @@ static void rlLoadShaderDefault(void)
 #elif defined(GRAPHICS_API_OPENGL_ES2)
     "#version 100                       \n"
     "precision mediump float;           \n"     // Precision required for OpenGL ES2 (WebGL) (on some browsers)
-    "attribute vec3 vertexPosition;     \n"
+    "attribute highp vec3 vertexPosition; \n"
     "attribute vec2 vertexTexCoord;     \n"
     "attribute vec4 vertexColor;        \n"
     "varying vec2 fragTexCoord;         \n"
     "varying vec4 fragColor;            \n"
 #endif
 
-    "uniform mat4 mvp;                  \n"
+    "uniform highp mat4 mvp;            \n"
     "void main()                        \n"
     "{                                  \n"
     "    fragTexCoord = vertexTexCoord; \n"


### PR DESCRIPTION
Insufficient precision in vertex calculations causes depth calculation issues when 3D rendering, resulting in Z-fighting or clipping error.
I fixed specify highp to ensure sufficient precision.

The screen flickers with every camera movement, I'm took two screenshots of the issues occurring.
environment: RG40XXH (Allwinner h700; Quad-core ARM Cortex-A53; G31 MP2 GPU)

<img width="640" height="480" alt="error-screen-2" src="https://github.com/user-attachments/assets/97d823e3-fd26-489d-9fb5-3315030b21eb" />

the ground is clipped.

<img width="640" height="480" alt="error-screen-3" src="https://github.com/user-attachments/assets/309e0d26-3cf2-45e4-82e9-8d5230ed69ab" />

the character's some polygon is z-fighting. the ground depth is weird also.
