### PR TITLE
[tools/rexm] Update nextCatIndex

### DIFF
--- a/tools/rexm/rexm.c
+++ b/tools/rexm/rexm.c
@@ -1034,13 +1034,13 @@ int main(int argc, char *argv[])
 
                     if (catIndex > -1)
                     {
-                        int nextCatIndex = catIndex;
+                        int nextCatIndex = catIndex + 1;
                         if (nextCatIndex > (REXM_MAX_EXAMPLE_CATEGORIES - 1)) nextCatIndex = -1; // EOF
 
                         // Find position to add new example on list, just before the following category
                         // Category order: core, shapes, textures, text, models, shaders, audio
                         int exListNextCatIndex = -1;
-                        if (nextCatIndex != -1) exListNextCatIndex = TextFindIndex(exList, exCategories[nextCatIndex]);
+                        if (nextCatIndex != -1) exListNextCatIndex = TextFindIndex(exList, TextFormat("\n%s", exCategories[nextCatIndex])) + 1;
                         else exListNextCatIndex = exListLen; // EOF
 
                         strncpy(exListUpdated, exList, exListNextCatIndex);


### PR DESCRIPTION
taken from https://github.com/raysan5/raylib/issues/5612

~~i am less familiar with this tool so please advise :pray: i don't know what the purpose of the `+1` was~~

```
category list:
  [0]: core
  [1]: shapes
  [2]: textures  <-- nextCatIndex
  [3]: text      <-- +1
  [4]: models
  [5]: shaders
```

when searching for "`textures`" it was adding +1 and trying to affect "`text`", which messed up the generated output

it also crashes when running `rexm validate` (tested on linux) with current `master` with a segfault

with the PR changes it detects all categories perfectly and the crash doesn't happen anymore
