### PR TITLE
Remove unnecessary define from raylib_opengl_interop.c

### DIFF
--- a/examples/others/raylib_opengl_interop.c
+++ b/examples/others/raylib_opengl_interop.c
@@ -30,7 +30,6 @@
 
 #if defined(PLATFORM_DESKTOP) || defined(PLATFORM_DESKTOP_SDL)
     #if defined(GRAPHICS_API_OPENGL_ES2)
-        #define GLAD_GLES2_IMPLEMENTATION
         #include "glad_gles2.h"       // Required for: OpenGL functionality
         #define glGenVertexArrays glGenVertexArraysOES
         #define glBindVertexArray glBindVertexArrayOES


### PR DESCRIPTION
I tried to compile `raylib` with `cmake .. -DPLATFORM=SDL -DOPENGL_VERSION="ES 2.0"` and got these error messages: 

```
[ 43%] Linking C executable raylib_opengl_interop
/usr/bin/ld: ../raylib/libraylib.a(rcore.c.o):(.bss+0x0): multiple definition of `GLAD_GL_ES_VERSION_2_0'; CMakeFiles/raylib_opengl_interop.dir/others/raylib_opengl_interop.c.o:(.bss+0x0): first defined here
/usr/bin/ld: ../raylib/libraylib.a(rcore.c.o):(.bss+0x4): multiple definition of `GLAD_GL_EXT_EGL_image_array'; CMakeFiles/raylib_opengl_interop.dir/others/raylib_opengl_interop.c.o:(.bss+0x4): first defined here
/usr/bin/ld: ../raylib/libraylib.a(rcore.c.o):(.bss+0x8): multiple definition of `GLAD_GL_EXT_EGL_image_storage'; CMakeFiles/raylib_opengl_interop.dir/others/raylib_opengl_interop.c.o:(.bss+0x8): first defined here
/usr/bin/ld: ../raylib/libraylib.a(rcore.c.o):(.bss+0xc): multiple definition of `GLAD_GL_EXT_EGL_image_storage_compression'; CMakeFiles/raylib_opengl_interop.dir/others/raylib_opengl_interop.c.o:(.bss+0xc): first defined here
/usr/bin/ld: ../raylib/libraylib.a(rcore.c.o):(.bss+0x10): multiple definition of `GLAD_GL_EXT_YUV_target'; CMakeFiles/raylib_opengl_interop.dir/others/raylib_opengl_interop.c.o:(.bss+0x10): first defined here
/usr/bin/ld: ../raylib/libraylib.a(rcore.c.o):(.bss+0x14): multiple definition of `GLAD_GL_EXT_base_instance'; CMakeFiles/raylib_opengl_interop.dir/others/raylib_opengl_interop.c.o:(.bss+0x14): first defined here
/usr/bin/ld: ../raylib/libraylib.a(rcore.c.o):(.bss+0x18): multiple definition of `GLAD_GL_EXT_blend_func_extended'; CMakeFiles/raylib_opengl_interop.dir/others/raylib_opengl_interop.c.o:(.bss+0x18): first defined here
/usr/bin/ld: ../raylib/libraylib.a(rcore.c.o):(.bss+0x1c): multiple definition of `GLAD_GL_EXT_blend_minmax'; CMakeFiles/raylib_opengl_interop.dir/others/raylib_opengl_interop.c.o:(.bss+0x1c): first defined here
/usr/bin/ld: ../raylib/libraylib.a(rcore.c.o):(.bss+0x20): multiple definition of `GLAD_GL_EXT_buffer_storage'; CMakeFiles/raylib_opengl_interop.dir/others/raylib_opengl_interop.c.o:(.bss+0x20): first defined here
/usr/bin/ld: ../raylib/libraylib.a(rcore.c.o):(.bss+0x24): multiple definition of `GLAD_GL_EXT_clear_texture'; CMakeFiles/raylib_opengl_interop.dir/others/raylib_opengl_interop.c.o:(.bss+0x24): first defined here
/usr/bin/ld: ../raylib/libraylib.a(rcore.c.o):(.bss+0x28): multiple definition of `GLAD_GL_EXT_clip_control'; CMakeFiles/raylib_opengl_interop.dir/others/raylib_opengl_interop.c.o:(.bss+0x28): first defined here
/usr/bin/ld: ../raylib/libraylib.a(rcore.c.o):(.bss+0x2c): multiple definition of `GLAD_GL_EXT_clip_cull_distance'; CMakeFiles/raylib_opengl_interop.dir/others/raylib_opengl_interop.c.o:(.bss+0x2c): first defined here
/usr/bin/ld: ../raylib/libraylib.a(rcore.c.o):(.bss+0x30): multiple definition of `GLAD_GL_EXT_color_buffer_float'; CMakeFiles/raylib_opengl_interop.dir/others/raylib_opengl_interop.c.o:(.bss+0x30): first defined here
/usr/bin/ld: ../raylib/libraylib.a(rcore.c.o):(.bss+0x34): multiple definition of `GLAD_GL_EXT_color_buffer_half_float'; CMakeFiles/raylib_opengl_interop.dir/others/raylib_opengl_interop.c.o:(.bss+0x34): first defined here
/usr/bin/ld: ../raylib/libraylib.a(rcore.c.o):(.bss+0x38): multiple definition of `GLAD_GL_EXT_conservative_depth'; CMakeFiles/raylib_opengl_interop.dir/others/raylib_opengl_interop.c.o:(.bss+0x38): first defined here
/usr/bin/ld: ../raylib/libraylib.a(rcore.c.o):(.bss+0x3c): multiple definition of `GLAD_GL_EXT_copy_image'; CMakeFiles/raylib_opengl_interop.dir/others/raylib_opengl_interop.c.o:(.bss+0x3c): first defined here
/usr/bin/ld: ../raylib/libraylib.a(rcore.c.o):(.bss+0x40): multiple definition of `GLAD_GL_EXT_debug_label'; CMakeFiles/raylib_opengl_interop.dir/others/raylib_opengl_interop.c.o:(.bss+0x40): first defined here
/usr/bin/ld: ../raylib/libraylib.a(rcore.c.o):(.bss+0x44): multiple definition of `GLAD_GL_EXT_debug_marker'; CMakeFiles/raylib_opengl_interop.dir/others/raylib_opengl_interop.c.o:(.bss+0x44): first defined here
...
Many more lines
...
/usr/bin/ld: ../raylib/libraylib.a(rcore.c.o):(.bss+0xed0): multiple definition of `glad_glViewportIndexedfvOES'; CMakeFiles/raylib_opengl_interop.dir/others/raylib_opengl_interop.c.o:(.bss+0xed0): first defined here
/usr/bin/ld: ../raylib/libraylib.a(rcore.c.o):(.bss+0xed8): multiple definition of `glad_glWaitSemaphoreEXT'; CMakeFiles/raylib_opengl_interop.dir/others/raylib_opengl_interop.c.o:(.bss+0xed8): first defined here
/usr/bin/ld: ../raylib/libraylib.a(rcore.c.o):(.bss+0xee0): multiple definition of `glad_glWindowRectanglesEXT'; CMakeFiles/raylib_opengl_interop.dir/others/raylib_opengl_interop.c.o:(.bss+0xee0): first defined here
/usr/bin/ld: ../raylib/libraylib.a(rcore.c.o): in function `gladLoadGLES2UserPtr':
rcore.c:(.text+0x680c): multiple definition of `gladLoadGLES2UserPtr'; CMakeFiles/raylib_opengl_interop.dir/others/raylib_opengl_interop.c.o:raylib_opengl_interop.c:(.text+0x680c): first defined here
/usr/bin/ld: ../raylib/libraylib.a(rcore.c.o): in function `gladLoadGLES2':
rcore.c:(.text+0x6bf4): multiple definition of `gladLoadGLES2'; CMakeFiles/raylib_opengl_interop.dir/others/raylib_opengl_interop.c.o:raylib_opengl_interop.c:(.text+0x6bf4): first defined here
collect2: error: ld returned 1 exit status
make[2]: *** [examples/CMakeFiles/raylib_opengl_interop.dir/build.make:99: examples/raylib_opengl_interop] Error 1
make[1]: *** [CMakeFiles/Makefile2:2905: examples/CMakeFiles/raylib_opengl_interop.dir/all] Error 2
make: *** [Makefile:166: all] Error 2
```

After some research, I found that directive `GLAD_GLES2_IMPLEMENTATION` is only needed in `rlgl.h`, but not in `raylib_opengl_interop.c`.

After this fix, I've successfully built the library.