### PR TITLE
Fix VSCode template Makefile for PLATFORM_WEB

### DIFF
--- a/projects/VSCode/Makefile
+++ b/projects/VSCode/Makefile
@@ -343,7 +343,7 @@ ifeq ($(PLATFORM),PLATFORM_RPI)
 endif
 ifeq ($(PLATFORM),PLATFORM_WEB)
     # Libraries for web (HTML5) compiling
-    LDLIBS = $(RAYLIB_RELEASE_PATH)/libraylib.a
+    LDLIBS = $(RAYLIB_RELEASE_PATH)/libraylib.web.a
 endif
 
 # Define a recursive wildcard function


### PR DESCRIPTION
This fixes the VSCode template Makefile for PLATFORM_WEB when using the Windows Installer package.

The installer provides libraylib.web.a for web builds, but the template was linking to libraylib.a, causing a link error.

Tested locally with the Windows Installer package.