### PR TITLE
[backend/GLFW] Added bounds check

### DIFF
--- a/src/platforms/rcore_desktop_glfw.c
+++ b/src/platforms/rcore_desktop_glfw.c
@@ -2178,23 +2178,19 @@ static void CursorEnterCallback(GLFWwindow *window, int enter)
 // GLFW3: Joystick connected/disconnected callback
 static void JoystickCallback(int jid, int event)
 {
-    if (jid >= MAX_GAMEPADS)
+    if (jid < MAX_GAMEPADS)
     {
-        // WARNING: If jid is higher than maximum supported joysticks, just return. This
-        // prevents an out-of-bounds crash on linux when connecting a gamepad to a running app
-        return;
-    }
-
-    if (event == GLFW_CONNECTED)
-    {
-        // WARNING: If glfwGetJoystickName() is longer than MAX_GAMEPAD_NAME_LENGTH,
-        // only copy up to (MAX_GAMEPAD_NAME_LENGTH -1) to destination string
-        memset(CORE.Input.Gamepad.name[jid], 0, MAX_GAMEPAD_NAME_LENGTH);
-        strncpy(CORE.Input.Gamepad.name[jid], glfwGetJoystickName(jid), MAX_GAMEPAD_NAME_LENGTH - 1);
-    }
-    else if (event == GLFW_DISCONNECTED)
-    {
-        memset(CORE.Input.Gamepad.name[jid], 0, MAX_GAMEPAD_NAME_LENGTH);
+        if (event == GLFW_CONNECTED)
+        {
+            // WARNING: If glfwGetJoystickName() is longer than MAX_GAMEPAD_NAME_LENGTH,
+            // only copy up to (MAX_GAMEPAD_NAME_LENGTH -1) to destination string
+            memset(CORE.Input.Gamepad.name[jid], 0, MAX_GAMEPAD_NAME_LENGTH);
+            strncpy(CORE.Input.Gamepad.name[jid], glfwGetJoystickName(jid), MAX_GAMEPAD_NAME_LENGTH - 1);
+        }
+        else if (event == GLFW_DISCONNECTED)
+        {
+            memset(CORE.Input.Gamepad.name[jid], 0, MAX_GAMEPAD_NAME_LENGTH);
+        }
     }
 }
 


### PR DESCRIPTION
I ran into an issue where my apps were crashing if you connect a gamepad during runtime. Only on linux. 

I found this with the same issue, and it showed a commit where it "started": https://github.com/raysan5/raylib/issues/4954

in that issue, [this commit](https://github.com/raysan5/raylib/commit/74256943a41166b7f9b811727eb9d9fb03d83e25) was noted as the culprit.. and if you set the `MAX_GAMEPAD_NAME_LENGTH` back to 64 it masks the issue

If you add a debug log to this function, you will see the `jid` is beyond the array index. im not sure how glfw decides the IDs but i believe its some platform specific code they have that makes it not happen on windows? or maybe with the alignment its just been lucky. 

This must be why it has different behavior on different versions of raylib or different runs (RLGL has null context, fps cap changes, etc), because **its overwriting random memory with the overflow**