### PR TITLE
[rtext] Add `MeasureTextCodepoints()` for direct measurement of codepoints

### DIFF
--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1509,8 +1509,7 @@ RLAPI void DrawTextCodepoints(Font font, const int *codepoints, int codepointCou
 RLAPI void SetTextLineSpacing(int spacing);                                                 // Set vertical line spacing when drawing with line-breaks
 RLAPI int MeasureText(const char *text, int fontSize);                                      // Measure string width for default font
 RLAPI Vector2 MeasureTextEx(Font font, const char *text, float fontSize, float spacing);    // Measure string size for Font
-RLAPI int MeasureCodepoints(const int *codepoints, int length, int fontSize);               // Measure string width for an existing array of codepoints for default font
-RLAPI Vector2 MeasureCodepointsEx(Font font, const int *codepoints, int length, float fontSize, float spacing); // Measure string size for an existing array of codepoints for Font
+RLAPI Vector2 MeasureTextCodepoints(Font font, const int *codepoints, int length, float fontSize, float spacing); // Measure string size for an existing array of codepoints for Font
 RLAPI int GetGlyphIndex(Font font, int codepoint);                                          // Get glyph index position in font for a codepoint (unicode character), fallback to '?' if not found
 RLAPI GlyphInfo GetGlyphInfo(Font font, int codepoint);                                     // Get glyph font info data for a codepoint (unicode character), fallback to '?' if not found
 RLAPI Rectangle GetGlyphAtlasRec(Font font, int codepoint);                                 // Get glyph rectangle in font atlas for a codepoint (unicode character), fallback to '?' if not found

--- a/src/rtext.c
+++ b/src/rtext.c
@@ -1388,40 +1388,29 @@ Vector2 MeasureTextEx(Font font, const char *text, float fontSize, float spacing
     return textSize;
 }
 
-// Measure string width for an existing array of codepoints for default font
-int MeasureCodepoints(const int *codepoints, int length, int fontSize) {
-    Vector2 textSize = { 0.0f, 0.0f };
-
-    // Check if default font has been loaded
-    if (GetFontDefault().texture.id != 0)
-    {
-        int defaultFontSize = 10;   // Default Font glyphs height in pixel
-        if (fontSize < defaultFontSize) fontSize = defaultFontSize;
-        int spacing = fontSize/defaultFontSize;
-
-        textSize = MeasureCodepointsEx(GetFontDefault(), codepoints, length, fontSize, spacing);
-    }
-
-    return (int)textSize.x;
-}
-
 // Measure string size for an existing array of codepoints for Font
-Vector2 MeasureCodepointsEx(Font font, const int *codepoints, int length, float fontSize, float spacing) {
+Vector2 MeasureTextCodepoints(Font font, const int *codepoints, int length, float fontSize, float spacing)
+{
     Vector2 textSize = { 0 };
 
-    if ((font.texture.id == 0) || (codepoints == NULL) || (length == 0)) return textSize; // Security check
+    // Security check
+    if ((font.texture.id == 0) || (codepoints == NULL) || (length == 0)) return textSize;
 
     float textWidth = 0.0f;
-    float tempTextWidth = 0.0f;     // Used to count longer text line width
+    // Used to count longer text line width
+    float tempTextWidth = 0.0f;
 
-    int tempGlyphCounter = 0;       // Used to count longer text line num chars
+    // Used to count longer text line num chars
+    int tempGlyphCounter = 0;
     int glyphCounter = 0;
 
     float textHeight = fontSize;
     float scaleFactor = fontSize/(float)font.baseSize;
 
-    int letter = 0;                 // Current character
-    int index = 0;                  // Index position in sprite font
+    // Current character
+    int letter = 0;
+    // Index position in sprite font
+    int index = 0;
 
     for (int i = 0; i < length; i++)
     {


### PR DESCRIPTION
currently, raylib has `DrawTextCodepoints` function for rendering a sequence of codepoints but lacks a corresponding measurement function.

i'm working on a program which needs to handle some CJK text. first i converted the UTF8 sequence to unicode codepoints by `LoadCodepoints` function, and freed the original buffer. However later in that program i have to measure the length of a certain slice of the text. so i resorted to converting it back to UTF8 and use `MeasureTextEx` function, which does not require too much extra work but is less efficient.

so i wrote these two functions, which are basically analogous to `MeasureText` and `MeasureTextEx` but takes unicode codepoints as arguments.