### PR TITLE
[rcore][android] Document --wrap=fopen linker flag requirements per build system

### DIFF
--- a/src/platforms/rcore_android.c
+++ b/src/platforms/rcore_android.c
@@ -275,6 +275,22 @@ static int android_write(void *cookie, const char *buf, int size);
 static fpos_t android_seek(void *cookie, fpos_t offset, int whence);
 static int android_close(void *cookie);
 
+// WARNING: fopen() calls are intercepted via linker flag -Wl,--wrap=fopen: the linker renames
+// the original fopen -> __real_fopen and redirects all call sites to __wrap_fopen
+// The flag MUST be applied at every final link step that needs wrapping,
+// it has no effect when only building a static archive (.a)
+//
+//         CMake: no action required, raylib's CMakeLists.txt already sets 
+//                target_link_options(raylib INTERFACE -Wl,--wrap=fopen) which propagates to
+//                the final app link, wrapping app code and all static (.a) dependencies too
+// Make (SHARED): no action required for raylib itself, src/Makefile already sets 
+//                LDFLAGS += -Wl,--wrap=fopen wrapping fopen inside libraylib.so only;
+//                app code and static (.a) dependencies are NOT wrapped unless -Wl,--wrap=fopen
+//                is also added to the final app link step
+// Make (STATIC): pass -Wl,--wrap=fopen to the linker command producing the final artifact
+//     build.zig: no dedicated wrap helper; pass -Wl,--wrap=fopen to the linker command producing 
+//                the final artifact
+//        custom: pass -Wl,--wrap=fopen to the linker command producing the final artifact
 FILE *__real_fopen(const char *fileName, const char *mode); // Real fopen, provided by the linker (--wrap=fopen)
 FILE *__wrap_fopen(const char *fileName, const char *mode); // Replacement for fopen()
 


### PR DESCRIPTION
Follow-up to #5605, addressing @raysan5's suggestion for `// WARNING:` comments in code.

Adds a comment block before `__real_fopen`/`__wrap_fopen` explaining how and where `-Wl,--wrap=fopen` must be applied for each supported build system, including the behavioral difference between CMake (flag propagates to final app link) and Make (SHARED) (wraps libraylib.so only).

Tested on CMake and Make (both SHARED and STATIC). For build.zig, several approaches were attempted but none are available in the std.Build API required by raylib (0.16.0-dev.2349+); this will probably change in the near future, but for now the flag must be passed externally in the final link step.