### PR TITLE
[cmake][X11] Add x11 libraries for raylib as glfw make private

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -117,6 +117,21 @@ target_include_directories(raylib
 
 # Copy the header files to the build directory for convenience
 file(COPY ${raylib_public_headers} DESTINATION "include")
+if (PLATFORM STREQUAL "Desktop")
+    if (UNIX AND NOT APPLE)
+        if (GLFW_BUILD_X11)
+            find_package(X11 REQUIRED)
+
+            target_compile_definitions(raylib PRIVATE _GLFW_X11)
+
+            target_link_libraries(raylib PRIVATE 
+                ${X11_LIBRARIES}
+            )
+            
+            message(STATUS "X11 support enabled for raylib")
+        endif()
+    endif()
+endif()
 
 # Includes information on how the library will be installed on the system
 # when cmake --install is run


### PR DESCRIPTION
Initial log: INFO: PLATFORM: DESKTOP (GLFW - X11): Initialized successfully
Quick Check
```
#if defined(_GLFW_X11)
    TraceLog(LOG_INFO, "BACKEND: X11");
#elif defined(_GLFW_WAYLAND)
    TraceLog(LOG_INFO, "BACKEND: Wayland");
#else
    TraceLog(LOG_WARNING, "BACKEND: Unknown");
#endif
#if defined(__linux__)
    TRACELOG(LOG_WARNING, "On LINUX");
#endif
```

CMAKE  Result
```
WARNING: BACKEND: Unknown
WARNING: On LINUX
```

Make Result

```
INFO: BACKEND: X11
WARNING: On LINUX
 ```
 
 The issue is because on Cmake the `_GLFW_X11` is defined as PRIVATE and not readeable outside of the glfw library