### PR TITLE
Make LoadFontFromImage limit its scanning to image dimensions.

### DIFF
--- a/src/rtext.c
+++ b/src/rtext.c
@@ -446,7 +446,8 @@ Font LoadFontFromImage(Image image, Color key, int firstChar)
     int charHeight = 0;
     int j = 0;
 
-    while (!COLOR_EQUAL(pixels[(lineSpacing + j)*image.width + charSpacing], key)) j++;
+    while ((lineSpacing + j) < image.height && 
+          !COLOR_EQUAL(pixels[(lineSpacing + j)*image.width + charSpacing], key)) j++;
 
     charHeight = j;
 
@@ -469,7 +470,8 @@ Font LoadFontFromImage(Image image, Color key, int firstChar)
 
             int charWidth = 0;
 
-            while (!COLOR_EQUAL(pixels[(lineSpacing + (charHeight+lineSpacing)*lineToRead)*image.width + xPosToRead + charWidth], key)) charWidth++;
+            while ((xPosToRead + charWidth) < image.width && 
+                  !COLOR_EQUAL(pixels[(lineSpacing + (charHeight+lineSpacing)*lineToRead)*image.width + xPosToRead + charWidth], key)) charWidth++;
 
             tempCharRecs[index].width = (float)charWidth;
 


### PR DESCRIPTION
Currently, if you give LoadFontFromImage a font that doesn't have the key color all the way around, it wanders off into random memory.  This will often mostly work, just with an slightly incorrect font height; other times it will get a wildly incorrect height (with the visible symptom that it appears to draw the font over and over, like the screen shot below); and yet other times, it will crash the app.

<img width="1028" height="736" alt="Screenshot 2026-03-05 at 8 03 10 AM" src="https://github.com/user-attachments/assets/d2579150-6125-4316-8f87-f2665ef34e14" />

I got myself into this pickle because I didn't understand exactly what LoadFontFromImage required (only later did I discover [this handy web page explaining it](https://shawnhargreaves.com/blog/bitmap-fonts-in-xna.html)).  So I had created my font image like this (10 digits which are white on clear, and so hard to see here, but it's the magenta border that is the problem):

<img width="320" height="48" alt="digits" src="https://github.com/user-attachments/assets/289287b2-b98c-45b3-9cb7-09950c40be29" />

So yes, that's on me; my font image is invalid.  But I feel like Raylib should not do random things or crash even under such conditions if it can be easily avoided — which it can, just by adding a bit of bounds-checking to the loops that scan the image.

This PR adds that bounds checking.  I have tested it with the faulty font image, and the behavior now is correct and robust.