### PR TITLE
Fix memory leak in LoadGLTF when model has no bones

### DIFF
--- a/src/rmodels.c
+++ b/src/rmodels.c
@@ -5511,8 +5511,10 @@ static Model LoadGLTF(const char *fileName)
 
         if (dracoCompression)
         {
-            return model;
             TRACELOG(LOG_WARNING, "MODEL: [%s] Failed to load glTF data", fileName);
+            cgltf_free(data);
+            UnloadFileData(fileData);
+            return model;
         }
 
         TRACELOG(LOG_DEBUG, "    > Primitives (triangles only) count based on hierarchy : %i", primitivesCount);
@@ -6333,6 +6335,14 @@ static Model LoadGLTF(const char *fileName)
         model.boneMatrices = (Matrix *)RL_CALLOC(model.skeleton.boneCount, sizeof(Matrix));
         for (int j = 0; j < model.skeleton.boneCount; j++) model.boneMatrices[j] = MatrixIdentity();
         //----------------------------------------------------------------------------------------------------
+
+        if (model.skeleton.boneCount == 0)
+        {
+                RL_FREE(model.currentPose);
+                RL_FREE(model.boneMatrices);
+                model.currentPose = NULL;
+                model.boneMatrices = NULL;
+        }
 
         // Free all cgltf loaded data
         cgltf_free(data);


### PR DESCRIPTION
Fix memory leak in LoadGLTF for models without skeletal animation

`currentPose` and `boneMatrices` are allocated but never freed when
boneCount == 0, causing an 18-byte leak detected with LeakSanitizer on Linux.

Also fixes unreachable code and missing cleanup in the Draco early-exit path.