### PR TITLE
[rlgl] add `RL_PIXELFORMAT_UNCOMPRESSED_DEPTH` to enum `rlPixelFormat`

### DIFF
--- a/src/rlgl.h
+++ b/src/rlgl.h
@@ -461,7 +461,7 @@ typedef enum {
     RL_PIXELFORMAT_UNCOMPRESSED_R16,               // 16 bpp (1 channel - half float)
     RL_PIXELFORMAT_UNCOMPRESSED_R16G16B16,         // 16*3 bpp (3 channels - half float)
     RL_PIXELFORMAT_UNCOMPRESSED_R16G16B16A16,      // 16*4 bpp (4 channels - half float)
-    RL_PIXELFORMAT_UNCOMPRESSED_DEPTH,             // Depth component (24 or 16 bit, depending on OpenGL version)
+    RL_PIXELFORMAT_UNCOMPRESSED_DEPTH,             // Depth component (32 or 24 or 16 bit, depending on OpenGL version)
     RL_PIXELFORMAT_COMPRESSED_DXT1_RGB,            // 4 bpp (no alpha)
     RL_PIXELFORMAT_COMPRESSED_DXT1_RGBA,           // 4 bpp (1 bit alpha)
     RL_PIXELFORMAT_COMPRESSED_DXT3_RGBA,           // 8 bpp


### PR DESCRIPTION
This PR adds `RL_PIXELFORMAT_UNCOMPRESSED_DEPTH` pixel format to rlgl.

Depth textures were already supported through `rlLoadTextureDepth`, but there was no explicit pixel format defined in `rlPixelFormat` for them.
This addition allows depth textures (including depth cubemaps) to be created through `rlLoadTexture` or `rlLoadTextureCubemap` instead of requiring manual OpenGL setup.

This is really useful for features such as point light shadow maps using depth cubemaps, depth-based post processing effects.

The internal format is selected automatically based on the supported depth precision and graphics API.