### PR TITLE
[examples][models] Change `GetRenderWidth()` to `GetScreenWidth()` in models_basic_voxel.c

### DIFF
--- a/examples/models/models_basic_voxel.c
+++ b/examples/models/models_basic_voxel.c
@@ -137,7 +137,7 @@ int main(void)
             EndMode3D();
             
             // Draw reference point for raycasting to delete blocks
-            DrawCircle(GetRenderWidth()/2, GetScreenHeight()/2, 4, RED);
+            DrawCircle(GetScreenWidth()/2, GetScreenHeight()/2, 4, RED);
 
             DrawText("Left-click a voxel to remove it!", 10, 10, 20, DARKGRAY);
             DrawText("WASD to move, mouse to look around", 10, 35, 10, GRAY);


### PR DESCRIPTION
I'm pretty sure that `GetRenderWidth()` is the wrong function for this situation.
`GetScreenHeight()` is used in the same line, so I changed it to `GetScreenWidth()` for consistency.