### PR TITLE
[examples/makefile] remove duplicate line in makefile

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -304,7 +304,7 @@ endif
 
 # Define library paths containing required libs: LDFLAGS
 #------------------------------------------------------------------------------------------------
-LDFLAGS = -L. -L$(RAYLIB_RELEASE_PATH) -L$(RAYLIB_PATH)/src
+LDFLAGS = -L. -L$(RAYLIB_RELEASE_PATH)
 
 ifeq ($(TARGET_PLATFORM),PLATFORM_DESKTOP_GLFW)
     ifeq ($(PLATFORM_OS),WINDOWS)


### PR DESCRIPTION
`RAYLIB_RELEASE_PATH` is already set to `RAYLIB_PATH/src` so this just adds a duplicate entry. im guessing this was done at some point when they were different? or maybe it was renamed etc?