### PR TITLE
[examples/makefile] remove path override/change for linux

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -155,15 +155,6 @@ ifeq ($(TARGET_PLATFORM),PLATFORM_DRM)
     endif
 endif
 
-# RAYLIB_PATH adjustment for LINUX platform
-# TODO: Do we really need this?
-ifeq ($(TARGET_PLATFORM),PLATFORM_DESKTOP_GLFW)
-    ifeq ($(PLATFORM_OS),LINUX)
-        RAYLIB_PREFIX  ?= ..
-        RAYLIB_PATH     = $(realpath $(RAYLIB_PREFIX))
-    endif
-endif
-
 # Default path for raylib on Raspberry Pi
 ifeq ($(TARGET_PLATFORM),PLATFORM_DRM)
     RAYLIB_PATH        ?= /home/pi/raylib


### PR DESCRIPTION
I noticed this `TODO`. on linux, it converts a relative path to an absolute path. both are valid when running from the `examples` folder, so i guess it being "needed" just depends if you want to guarantee absolute paths for symlink build scripts or ones that `cd` around? maybe its fine to keep it? :man_shrugging: 


EDIT: 
actually, this fixed an issue for me... i had a space in a filename and it adds the path without quotes, breaking the command. relative path does not break. so thats a win :joy_cat: 