### PR TITLE
[rtext] fix error in textinsert, found by github user chrg127

### DIFF
--- a/src/rtext.c
+++ b/src/rtext.c
@@ -1875,7 +1875,7 @@ char *TextInsert(const char *text, const char *insert, int position)
         result = (char *)RL_MALLOC(textLen + insertLen + 1);
 
         for (int i = 0; i < position; i++) result[i] = text[i];
-        for (int i = position; i < insertLen + position; i++) result[i] = insert[i];
+        for (int i = position; i < insertLen + position; i++) result[i] = insert[i - position];
         for (int i = (insertLen + position); i < (textLen + insertLen); i++) result[i] = text[i];
 
         result[textLen + insertLen] = '\0'; // Add EOL


### PR DESCRIPTION
Fixes the bug found in https://github.com/raysan5/raylib/issues/5642

```cpp
#include <stdio.h>
#include <string.h>
#include <stdlib.h>

#include "raylib.h"

int main()
{
    const char *first_part = "hello";
    const char *second_part = " world";
    char *text = TextInsert(first_part, second_part, strlen(first_part));
    printf("%s\n", text);
    free(text);
    return 0;
}
```

expected: `hello world`
actual: `hellod`

(since it grabs out of bounds, the `actual` may vary)