### PR TITLE
[rcore][android] Fix CMake shared build and improve --wrap WARNING docs

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -78,7 +78,7 @@ endif()
 if (${PLATFORM} MATCHES "Android")
     # Wrap fopen at link time so all code (including third-party libs) goes
     # through __wrap_fopen, which handles Android APK asset loading
-    target_link_options(raylib INTERFACE -Wl,--wrap=fopen)
+    target_link_options(raylib PUBLIC -Wl,--wrap=fopen)
 endif()
 
 set_target_properties(raylib PROPERTIES

--- a/src/platforms/rcore_android.c
+++ b/src/platforms/rcore_android.c
@@ -276,21 +276,29 @@ static fpos_t android_seek(void *cookie, fpos_t offset, int whence);
 static int android_close(void *cookie);
 
 // WARNING: fopen() calls are intercepted via linker flag -Wl,--wrap=fopen: the linker renames
-// the original fopen -> __real_fopen and redirects all call sites to __wrap_fopen
-// The flag MUST be applied at every final link step that needs wrapping,
-// it has no effect when only building a static archive (.a)
+// the original fopen -> __real_fopen and redirects all call sites to __wrap_fopen.
+// The flag MUST be applied at every final link step that needs wrapping;
+// it has no effect when only building a static archive (.a).
 //
-//         CMake: no action required, raylib's CMakeLists.txt already sets 
-//                target_link_options(raylib INTERFACE -Wl,--wrap=fopen) which propagates to
-//                the final app link, wrapping app code and all static (.a) dependencies too
-// Make (SHARED): no action required for raylib itself, src/Makefile already sets 
-//                LDFLAGS += -Wl,--wrap=fopen wrapping fopen inside libraylib.so only;
-//                app code and static (.a) dependencies are NOT wrapped unless -Wl,--wrap=fopen
-//                is also added to the final app link step
-// Make (STATIC): pass -Wl,--wrap=fopen to the linker command producing the final artifact
-//     build.zig: no dedicated wrap helper; pass -Wl,--wrap=fopen to the linker command producing 
-//                the final artifact
-//        custom: pass -Wl,--wrap=fopen to the linker command producing the final artifact
+// STATIC library (.a) — wrapping deferred to consumer's final link step:
+//   both raylib and consumer fopen calls are wrapped together in one link
+//       CMake: handled automatically — the PUBLIC flag propagates as INTERFACE_LINK_OPTIONS
+//              to the consumer's final link via target_link_libraries
+//        Make: pass -Wl,--wrap=fopen to the linker command producing the final artifact
+//   build.zig: pass -Wl,--wrap=fopen to the linker command producing the final artifact
+//      custom: pass -Wl,--wrap=fopen to the linker command producing the final artifact
+//
+// SHARED library (.so) — wrapping is self-contained:
+//   only fopen calls linked into the .so are wrapped; the consumer's own fopen calls
+//   are NOT wrapped unless the consumer also links with -Wl,--wrap=fopen independently
+//       CMake: handled automatically — CMakeLists.txt sets target_link_options(raylib PUBLIC
+//              -Wl,--wrap=fopen) which applies the flag to the .so link;
+//              only raylib internals are wrapped, app code requires a separate flag
+//        Make: handled automatically — src/Makefile sets LDFLAGS += -Wl,--wrap=fopen;
+//              only raylib internals are wrapped, app code requires a separate flag
+//   build.zig: NOT supported — std.Build has no dedicated linker wrap helper, the flag
+//              is not correctly applied at the .so link step
+//      custom: apply -Wl,--wrap=fopen to the linker command producing the .so
 FILE *__real_fopen(const char *fileName, const char *mode); // Real fopen, provided by the linker (--wrap=fopen)
 FILE *__wrap_fopen(const char *fileName, const char *mode); // Replacement for fopen()
 
@@ -1542,7 +1550,7 @@ static void SetupFramebuffer(int width, int height)
 
 // Replacement for fopen(), used as linker wrap entry point (-Wl,--wrap=fopen)
 // REF: https://developer.android.com/ndk/reference/group/asset
-FILE *__wrap_fopen(const char *fileName, const char *mode)
+__attribute__((visibility("default"))) FILE *__wrap_fopen(const char *fileName, const char *mode)
 {
     FILE *file = NULL;
 


### PR DESCRIPTION
## Problem

When building raylib as a **CMake shared library** (`-DBUILD_SHARED_LIBS=ON`) for Android, `__wrap_fopen` is **absent** from the resulting `libraylib.so` and all internal `fopen()` calls bypass `AAssetManager` entirely.

Root cause: `target_link_options(raylib INTERFACE -Wl,--wrap=fopen)` in `src/CMakeLists.txt`. With `INTERFACE`, CMake does **not** apply the flag to the library's own link step — it only propagates it to consumers. As a consequence the linker never redirects `fopen` to `__wrap_fopen` inside the `.so`.

Verified with `llvm-nm -D`:

```
# before — __wrap_fopen absent, fopen goes directly to libc
                 U fopen@LIBC
```

This **does not affect** the static library build, which is the most common Android workflow (e.g. raymob and similar templates include raylib source directly and link it statically). In that case the wrapping is applied at the consumer's final link step, where `INTERFACE` propagation was already working correctly.

The bug only manifests when explicitly building raylib as a shared library (`-DBUILD_SHARED_LIBS=ON`) via CMake, whether using a pre-built .so or integrating via add_subdirectory`add_subdirectory`.

## Fix

Two changes are required:

**`src/CMakeLists.txt`** — `INTERFACE` → `PUBLIC`:

```cmake
target_link_options(raylib PUBLIC -Wl,--wrap=fopen)
```

`PUBLIC` applies the flag both to the `.so` link step itself **and** keeps propagating it to CMake consumers (the `INTERFACE` part). For static builds `PUBLIC` is equivalent to `INTERFACE` — no regression.

**`src/platforms/rcore_android.c`** — add `visibility("default")` to `__wrap_fopen`:

```c
__attribute__((visibility("default"))) FILE *__wrap_fopen(const char *fileName, const char *mode)
```

LLD compiles Android shared libraries with `-fvisibility=hidden` by default. Without this attribute `__wrap_fopen` is marked local (`t`) in the dynamic table and not accessible to consumers of the `.so`.

After both fixes:

```
# after — __wrap_fopen exported, wrapping active
000000000008a49c T __wrap_fopen
                 U fopen@LIBC
```

Identical to the Make SHARED behavior documented in #5624.

## Also improved

The `WARNING` comment block above the `__real_fopen`/`__wrap_fopen` forward declarations has been restructured to make the STATIC vs SHARED distinction explicit.
