### PR TITLE
fix black screen when using zig master: config.h macro extraction in build.zig

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,6 +116,7 @@ GRTAGS
 GTAGS
 
 # Zig programming language
+zig-pkg/
 .zig-cache/
 zig-cache/
 zig-out/

--- a/build.zig
+++ b/build.zig
@@ -107,10 +107,17 @@ const config_h_flags = outer: {
         if (std.mem.startsWith(u8, line, "#if")) continue;
 
         var flag = std.mem.trimStart(u8, line, " \t"); // Trim whitespace
-        flag = flag["#define ".len - 1 ..]; // Remove #define
-        flag = std.mem.trimStart(u8, flag, " \t"); // Trim whitespace
-        flag = flag[0 .. std.mem.indexOf(u8, flag, " ") orelse continue]; // Flag is only one word, so capture till space
-        flag = "-D" ++ flag; // Prepend with -D
+
+        if (!std.mem.startsWith(u8, flag, "#define ")) continue; // Skip non-#define lines
+
+        // '#define<whitespace><flag name><whitespace><flag value>
+        flag = flag["#define ".len - 1 ..]; // remove #define
+        flag = std.mem.trimStart(u8, flag, " \t"); // trim whitespace after "#define"
+        const whitespace_idx = std.mem.find(u8, flag, " \t") orelse continue;
+        const flag_name = flag[0..whitespace_idx];
+        const flag_value = std.mem.trim(u8, flag[whitespace_idx + 1 ..], " \t");
+
+        flag = "-D" ++ flag_name ++ "=" ++ flag_value;
 
         flags[i] = flag;
         i += 1;


### PR DESCRIPTION
**Problem**:
On linux X11, using the latest zig master (0.16.0-dev.2860+9c5460316), every example was resulting in a non-interactive black screen.

**Solution**:
Using git bisect I tracked the [bad commit 5361265](https://github.com/raysan5/raylib/commit/5361265a7d5d1ef662077350ef3db9747333b95b). The new config system introduced in that commit uses values instead of just checking `defined(MACRO)`, but the config macro parsing in `build.zig` wasn't updated to take that into account.

I just fixed the parsing, so now it works. Also added `zig-pkg/` to .gitignore, since it is created when building with the latest zig version.