### PR TITLE
[build.zig] Fix: add back missing fno-sanitize=undefined flag

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -107,10 +107,10 @@ fn compileRaylib(b: *std.Build, target: std.Build.ResolvedTarget, optimize: std.
     var raylib_flags_arr: std.ArrayList([]const u8) = .empty;
     defer raylib_flags_arr.deinit(b.allocator);
 
-    try raylib_flags_arr.append(
-        b.allocator,
+    try raylib_flags_arr.appendSlice(b.allocator, &.{
         "-std=gnu99",
-    );
+        "-fno-sanitize=undefined", // https://github.com/raysan5/raylib/issues/3674
+    });
 
     if (options.linkage == .dynamic) {
         try raylib_flags_arr.append(


### PR DESCRIPTION
Previous change for this file (https://github.com/raysan5/raylib/pull/5645) removed the `-fno-sanitize=undefined` compilation flag. This merge adds it back.

Compiling without it caused a random crash on my project, and also emits a couple of errors when linking a simple C program against raylib built with `zig build`. Such as:
```
/usr/bin/ld: /home/myUser/raylib/zig-out/lib/libraylib.a(.zig-cache/o/74bf45b7b58fa94e349ba88fe4af241b/rglfw.o): na função "writeTargetToProperty":
/home/rei-arthur/myUser/src/external/glfw/src/x11_window.c:914:(.text+0xcaad7): undefined reference to `__ubsan_handle_nonnull_arg'
/usr/bin/ld: /home/myUser/raylib/src/external/glfw/src/x11_window.c:916:(.text+0xcab5d): undefined reference to `__ubsan_handle_type_mismatch_v1'
/usr/bin/ld: /home/myUser/raylib/src/external/glfw/src/x11_window.c:916:(.text+0xcab9a): undefined reference to `__ubsan_handle_type_mismatch_v1'
/usr/bin/ld: /home/myUser/raylib/src/external/glfw/src/x11_window.c:901:(.text+0xcabe1): undefined reference to `__ubsan_handle_add_overflow'
/usr/bin/ld: /home/myUser/raylib/zig-out/lib/libraylib.a(.zig-cache/o/74bf45b7b58fa94e349ba88fe4af241b/rglfw.o): na função "translateKeyX11":
and so on...
```