### PR TITLE
[rcore][sdl] REVIEWED: `GetTime()`, improve resolution

### DIFF
--- a/src/platforms/rcore_desktop_sdl.c
+++ b/src/platforms/rcore_desktop_sdl.c
@@ -1276,9 +1276,7 @@ void SwapScreenBuffer(void)
 // Get elapsed time measure in seconds
 double GetTime(void)
 {
-    unsigned int ms = SDL_GetTicks();    // Elapsed time in milliseconds since SDL_Init()
-    double time = (double)ms/1000;
-    return time;
+    return (double)SDL_GetPerformanceCounter() / SDL_GetPerformanceFrequency();
 }
 
 // Open URL with default system browser (if available)


### PR DESCRIPTION
Problem
-------
`GetTime()` in the SDL backend uses `SDL_GetTicks()`, which has only
millisecond resolution. This causes frame timing set with `SetTargetFPS()`
to be inaccurate at high frame rates. For example, targeting 240 Hz results
in an actual cap of ~200 Hz, because the inter-frame sleep is rounded up to
the nearest millisecond. This is observable in the `core_delta_time` example.

Cause
-----
`SDL_GetTicks()` has millisecond resolution, making it insufficient for
sub-millisecond frame timing.

Solution
--------
Calculate time via:

    (double)SDL_GetPerformanceCounter() / (double)SDL_GetPerformanceFrequency()

This uses an OS-specific high-resolution counter (typically micro- or
nanosecond precision). Note: unlike `SDL_GetTicks()`, the absolute value
returned is not relative to SDL initialization — its origin is OS-defined.
However, since `GetTime()` is used only to compute deltas between two calls,
this has no practical effect on behavior.

Tested
------
- MacBook Air M3
- macOS 26.3 (Tahoe) + SDL2 / SDL3
- examples/core/core_delta_time.c