### PR TITLE
[rlgl] Add opt-in highp precision for default GLES shaders

### DIFF
--- a/src/rlgl.h
+++ b/src/rlgl.h
@@ -220,6 +220,14 @@
     #define RL_DEFAULT_BATCH_MAX_TEXTURE_UNITS       4      // Maximum number of textures units that can be activated on batch drawing (SetShaderValueTexture())
 #endif
 
+#ifndef RLGL_ENABLE_GLES_DEFAULT_HIGHP_PRECISION
+    // Enable high precision floats in the default GLES shaders.
+    // Useful on some mobile GPUs/drivers where mediump causes visible 2D shape artifacts.
+    // Define RLGL_ENABLE_GLES_DEFAULT_HIGHP_PRECISION as 1 before including rlgl.h
+    // or pass it from the build system, e.g. -DRLGL_ENABLE_GLES_DEFAULT_HIGHP_PRECISION=1.
+    #define RLGL_ENABLE_GLES_DEFAULT_HIGHP_PRECISION 0
+#endif
+
 // Internal Matrix stack
 #ifndef RL_MAX_MATRIX_STACK_SIZE
     #define RL_MAX_MATRIX_STACK_SIZE                32      // Maximum size of Matrix stack
@@ -5011,7 +5019,11 @@ static void rlLoadShaderDefault(void)
 
 #if defined(GRAPHICS_API_OPENGL_ES3)
     "#version 300 es                    \n"
+#if RLGL_ENABLE_GLES_DEFAULT_HIGHP_PRECISION
+    "precision highp float;             \n"     // Use high precision on GLES to reduce device-specific vertex/edge artifacts
+#else
     "precision mediump float;           \n"     // Precision required for OpenGL ES3 (WebGL 2) (on some browsers)
+#endif
     "in vec3 vertexPosition;            \n"
     "in vec2 vertexTexCoord;            \n"
     "in vec4 vertexColor;               \n"
@@ -5019,7 +5031,11 @@ static void rlLoadShaderDefault(void)
     "out vec4 fragColor;                \n"
 #elif defined(GRAPHICS_API_OPENGL_ES2)
     "#version 100                       \n"
+#if RLGL_ENABLE_GLES_DEFAULT_HIGHP_PRECISION
+    "precision highp float;             \n"     // Use high precision on GLES to reduce device-specific vertex/edge artifacts
+#else
     "precision mediump float;           \n"     // Precision required for OpenGL ES2 (WebGL) (on some browsers)
+#endif
     "attribute vec3 vertexPosition;     \n"
     "attribute vec2 vertexTexCoord;     \n"
     "attribute vec4 vertexColor;        \n"
@@ -5064,7 +5080,11 @@ static void rlLoadShaderDefault(void)
 
 #if defined(GRAPHICS_API_OPENGL_ES3)
     "#version 300 es                    \n"
+#if RLGL_ENABLE_GLES_DEFAULT_HIGHP_PRECISION
+    "precision highp float;             \n"     // Use high precision on GLES to reduce device-specific fragment artifacts
+#else
     "precision mediump float;           \n"     // Precision required for OpenGL ES3 (WebGL 2)
+#endif
     "in vec2 fragTexCoord;              \n"
     "in vec4 fragColor;                 \n"
     "out vec4 finalColor;               \n"
@@ -5077,7 +5097,11 @@ static void rlLoadShaderDefault(void)
     "}                                  \n";
 #elif defined(GRAPHICS_API_OPENGL_ES2)
     "#version 100                       \n"
+#if RLGL_ENABLE_GLES_DEFAULT_HIGHP_PRECISION
+    "precision highp float;             \n"     // Use high precision on GLES to reduce device-specific fragment artifacts
+#else
     "precision mediump float;           \n"     // Precision required for OpenGL ES2 (WebGL)
+#endif
     "varying vec2 fragTexCoord;         \n"
     "varying vec4 fragColor;            \n"
     "uniform sampler2D texture0;        \n"


### PR DESCRIPTION
## Problem

On certain Android devices (tested: **Redmi Note 14 Pro**), the default GLES fragment shader precision `mediump float` is not sufficient for stable rendering of 2D geometry. The result is visibly irregular rounded corners when using `DrawRectangleRounded()`, regardless of segment count.

Snapping coordinates to integers doesn't solve nor mitigate the issue on the affected device.

This PR adds an opt-in compile-time flag that switches the default GLES shader float precision from `mediump` to `highp`.

## Root Cause

`mediump float` on GLES is specified to have at least 10 bits of mantissa (~3 decimal digits). On certain Mali drivers this is insufficient to maintain sub-pixel accuracy for arc vertices computed from screen-space positions at typical UI resolutions, causing visible snapping artifacts in the rendered curve.

`highp float` (IEEE 754 single precision, 23-bit mantissa) eliminates the precision loss and produces smooth curves on the same hardware.

### Why Samsung was unaffected

Investigation revealed a key difference in the underlying GLES implementation between the two devices:

- **Samsung Galaxy A56** uses **ANGLE** as its GLES backend, running on top of Vulkan via the **Samsung Xclipse 540** GPU (`Renderer: ANGLE (Samsung Xclipse 540) on Vulkan 1.3.279`). ANGLE translates GLES calls to a higher-level API (Vulkan or desktop GL), and in doing so it normalises float precision internally — `mediump` effectively behaves closer to `highp` regardless of what the shader declares.
- **Redmi Note 14 Pro 5G** uses the **Mali driver directly**, with no translation layer (`Renderer: Mali-G57 MC2`). The driver therefore enforces `mediump` strictly as specified, exposing the precision loss in the rendered geometry.

This explains why the artifact is device-specific and not reproducible across all Android hardware, and why simply testing on a Samsung device is not sufficient to catch the issue.

As far as I could tell, whether ANGLE is used is decided by the OS/vendor and cannot be forced from application code, meaning there may be no workaround available at the raylib or app level short of changing the shader precision.

## Fix

A new macro `RLGL_ENABLE_GLES_DEFAULT_HIGHP_PRECISION` is added at the top of `rlgl.h`.

The flag defaults to `0` (no behaviour change).

I intentionally kept this as a boolean-style opt-in flag for clarity and readability, even though the conditional could have been expressed without an explicit `0`/`1` default.

@raysan5 I kept this as an explicit compile-time flag so the choice remains with the user, but if you would prefer enabling it by default for Android builds, I can update the PR accordingly.

## Visual Evidence

### Samsung Galaxy A56 — `mediump`, correct rendering (no fix needed)

Corners are smooth and correct with the default `mediump` precision:

<img width="525" height="480" alt="samsung" src="https://github.com/user-attachments/assets/b7f8ba98-5a47-4dee-b1e7-6c7a6a6f10d3" />

### Redmi Note 14 Pro — `mediump`, broken rendering

Rounded corners are jagged and irregular on the same code:

<img width="522" height="459" alt="redmi" src="https://github.com/user-attachments/assets/900f704e-fecc-4cd3-bc64-8764cc33999e" />

### Redmi Note 14 Pro — `highp` via flag

Corners now match the Samsung result almost exactly:

<img width="491" height="416" alt="redmi_after" src="https://github.com/user-attachments/assets/ec0e4c89-00d6-4e1e-8f46-c76fb14cc47e" />
