### PR TITLE
Fix Uninstall Process to Remove rcamera Header File in Makefile

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -959,6 +959,7 @@ ifeq ($(ROOT),root)
         endif
 		rm --force --interactive --verbose $(RAYLIB_H_INSTALL_PATH)/raylib.h
 		rm --force --interactive --verbose $(RAYLIB_H_INSTALL_PATH)/raymath.h
+		rm --force --interactive --verbose $(RAYLIB_H_INSTALL_PATH)/rcamera.h
 		rm --force --interactive --verbose $(RAYLIB_H_INSTALL_PATH)/rlgl.h
 		@echo "raylib development files removed!"
     else


### PR DESCRIPTION
Addressing _(which i think)_ an oversight in the uninstall functionality within the Makefile, which may lead to leftover files after uninstall.
### Changes Made

- Updated the uninstall section of the Makefile to include the command to remove `rcamera.h` header file.