### PR TITLE
[rlsw] Micro-optimizations, tighter pipeline and cleanup

### DIFF
--- a/src/external/rlsw.h
+++ b/src/external/rlsw.h
@@ -3800,6 +3800,7 @@ static void sw_immediate_begin(SWdraw mode)
     uint32_t state = RLSW.userState;
     if (!sw_is_texture_complete(RLSW.depthBuffer)) state &= ~SW_STATE_DEPTH_TEST;
     if (!sw_is_texture_complete(RLSW.boundTexture)) state &= ~SW_STATE_TEXTURE_2D;
+    else if (sw_pixel_is_depth_format(RLSW.boundTexture->format)) state &= ~SW_STATE_TEXTURE_2D;
 
     // Initialize required values
     RLSW.primitive.hasColorAlpha = false;


### PR DESCRIPTION
This PR focuses on micro-optimizations and cleanup work made possible by the previous refactor.

## Improvements

- **Blend function generation**: all blend factor combinations are now auto-generated, reducing indirect calls from two to one per invocation
- **Alpha channel analysis**: textures are analyzed at load time to skip alpha blending when unnecessary (extensible to binary transparency in the future) (vertex colors are also taken into account)
- **Tighter attribute layout**: the `screen` member has been removed; `coord` now carries data through every stage of the pipeline
- **Reduced interpolation cost**: unused vertex attributes are no longer interpolated during triangle row iteration, depending on active states
- **Affine block interpolation**: the span rasterizer now subdivides spans into blocks, reducing the number of reciprocal-W computations by ~x8 per triangle span (default block size to 16px, configurable at compile time)
- **Texture fetch dispatch at load time**: the per-pixel format switch has been replaced by a function pointer resolved at texture alloc, eliminating per-pixel dispatch overhead
- **SIMD reuse for texture fetch**: existing `uint8_t` <-> `float` SIMD conversion paths are now reused across more texture formats
- **Optional color conversion LUT**: an optional (enabled by default) 1KB lookup table accelerates `uint8_t` -> `float` color conversion as a non-SIMD fallback
- **Simplified draw calls**: `glDrawArrays` and `glDrawElements` have been cleaned up and simplified
- **Improved state safety**: better guards against inconsistent global states and unexpected state changes, with fewer redundant checks in the hot path

Plus various other minor adjustments and some code reorganization.

## Profiling results

There is no longer a single dominant bottleneck, costs are now fairly evenly distributed across the pipeline.

With these changes I can finally hit _(on my machine)_ a stable 60 FPS in O2 without manual SIMD in `models_first_person_maze` _(including in high overdraw areas)_.

With O3 + SSE2 this goes up to ~200 FPS in `models_first_person_maze` and ~2800 bunnies in `textures_bunnymark` before hitting 30 FPS.

## What's next

The next meaningful architectural improvement in the current state, while preserving current capabilities, would be to accumulate vertices and render per scanline rather than in fully immediate mode. This would also open the door to parallelization, which would likely be the most biggest remaining gain.

Beyond that, it may be worth exploring alternative rasterization methods alongside the current scanline approach, this would require some design thought but could open up better paths depending on the target hardware. A tile-based rasterizer in particular would also make lazy clearing more natural than now _(in addition to the other benefits it would bring)_.