### PR TITLE
Required change for ESP-IDF 6

### DIFF
--- a/src/external/rlsw.h
+++ b/src/external/rlsw.h
@@ -689,6 +689,7 @@ SWAPI void swClear(uint32_t bitmask);
 SWAPI void swBlendFunc(SWfactor sfactor, SWfactor dfactor);
 SWAPI void swPolygonMode(SWpoly mode);
 SWAPI void swCullFace(SWface face);
+SWAPI void *swGetColorBuffer(int *width, int *height); // Restored for ESP-IDF compatibility
 
 SWAPI void swPointSize(float size);
 SWAPI void swLineWidth(float width);
@@ -4198,6 +4199,15 @@ void swCullFace(SWface face)
     }
 
     RLSW.cullFace = face;
+}
+
+// Get direct pointer to the default framebuffer's pixel data
+// Restored for ESP-IDF compatibility - removed in Raylib 6.0 PR #5655
+void *swGetColorBuffer(int *width, int *height)
+{
+    if (width) *width = RLSW.colorBuffer->width;
+    if (height) *height = RLSW.colorBuffer->height;
+    return RLSW.colorBuffer->pixels;
 }
 
 void swPointSize(float size)

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -682,6 +682,18 @@ void InitWindow(int width, int height, const char *title)
         TRACELOG(LOG_WARNING, "SYSTEM: Failed to initialize platform");
         return;
     }
+
+    // FIX: Initialize render dimensions for embedded platforms
+    // On desktop platforms (GLFW, SDL, etc.), CORE.Window.render.width/height are
+    // set during window creation. On embedded platforms with no window manager,
+    // InitPlatform() doesn't set these values, so we initialize them here from
+    // the screen dimensions (which are set from the InitWindow parameters).
+    // This fix is required for embedded platforms.
+    if (CORE.Window.render.width == 0 || CORE.Window.render.height == 0)
+    {
+        CORE.Window.render.width = CORE.Window.screen.width;
+        CORE.Window.render.height = CORE.Window.screen.height;
+    }
     //--------------------------------------------------------------
 
     // Initialize rlgl default data (buffers and shaders)


### PR DESCRIPTION
I would like to open a conversation, how to get support for embedded platforms in Raylib 6.

Basically I found two changes that were necessary to make for Raylib 6 to get it working with ESP32: https://github.com/georgik/esp-idf-component-raylib

Note: Raylib 5.6 already works with ESP-IDF.

Suggested changes:
- swGetColorBuffer - expose pixel buffer, so that it could be sent to SPI display directly using DMA transactions.
- in case of `CORE.Window.render.width` == 0 set it to `CORE.Window.screen.width`, since embedded platforms does not have window manager. I can imagine moving this part to compat layer. I value opinions.