### PR TITLE
[rlsw] Remove position attribute from `sw_vertex_t`

### DIFF
--- a/src/external/rlsw.h
+++ b/src/external/rlsw.h
@@ -4371,7 +4371,7 @@ void swPopMatrix(void)
                 return;
             }
 
-            RLSW.currentMatrix = &RLSW.stackProjection[--RLSW.stackProjectionCounter];
+            RLSW.currentMatrix = &RLSW.stackProjection[(--RLSW.stackProjectionCounter) - 1];
             RLSW.isDirtyMVP = true; //< The MVP is considered to have been changed
         } break;
         case SW_MODELVIEW:
@@ -4382,7 +4382,7 @@ void swPopMatrix(void)
                 return;
             }
 
-            RLSW.currentMatrix = &RLSW.stackModelview[--RLSW.stackModelviewCounter];
+            RLSW.currentMatrix = &RLSW.stackModelview[(--RLSW.stackModelviewCounter) - 1];
             RLSW.isDirtyMVP = true; //< The MVP is considered to have been changed
         } break;
         case SW_TEXTURE:
@@ -4393,7 +4393,7 @@ void swPopMatrix(void)
                 return;
             }
 
-            RLSW.currentMatrix = &RLSW.stackTexture[--RLSW.stackTextureCounter];
+            RLSW.currentMatrix = &RLSW.stackTexture[(--RLSW.stackTextureCounter) - 1];
         } break;
         default: break;
     }


### PR DESCRIPTION
Just replace  `float coord[4]` with `float position[4]` instead.

Until now the world position was being preserved, but the only real point would be if we ever add lighting as defined in OpenGL 1.1, and therefore also at the rlgl level, but that doesn't seem to be planned.

By the way, positions were interpolated during clipping, so this should produce a marginal gain at this stage.