### PR TITLE
WebRGFW: remapping mouse/touch position to canvas pixel coordinates

### DIFF
--- a/src/platforms/rcore_desktop_rgfw.c
+++ b/src/platforms/rcore_desktop_rgfw.c
@@ -1447,24 +1447,38 @@ void PollInputEvents(void)
             } break;
             case RGFW_mousePosChanged:
             {
+                float event_x = 0.0f, event_y = 0.0f;
                 if (RGFW_window_isCaptured(platform.window))
                 {
-                    CORE.Input.Mouse.currentPosition.x += (float)rgfw_event.mouse.vecX;
-                    CORE.Input.Mouse.currentPosition.y += (float)rgfw_event.mouse.vecY;
+                    event_x = (float)rgfw_event.mouse.vecX;
+                    event_y = (float)rgfw_event.mouse.vecY;
                 }
                 else
                 {
-                    CORE.Input.Mouse.currentPosition.x = (float)rgfw_event.mouse.x;
-                    CORE.Input.Mouse.currentPosition.y = (float)rgfw_event.mouse.y;
+                    event_x = (float)rgfw_event.mouse.x;
+                    event_y = (float)rgfw_event.mouse.y;
                 }
 
 #if defined(__EMSCRIPTEN__)
-                double canvasWidth = 0.0;
-                double canvasHeight = 0.0;
-                emscripten_get_element_css_size("#canvas", &canvasWidth, &canvasHeight);
-                CORE.Input.Mouse.currentPosition.x *= ((float)GetScreenWidth() / (float)canvasWidth);
-                CORE.Input.Mouse.currentPosition.y *= ((float)GetScreenHeight() / (float)canvasHeight);
+                {
+                    double canvasWidth = 0.0;
+                    double canvasHeight = 0.0;
+                    emscripten_get_element_css_size("#canvas", &canvasWidth, &canvasHeight);
+                    event_x *= ((float)GetScreenWidth() / (float)canvasWidth);
+                    event_y *= ((float)GetScreenHeight() / (float)canvasHeight);
+                }
 #endif
+
+                if (RGFW_window_isCaptured(platform.window))
+                {
+                    CORE.Input.Mouse.currentPosition.x += event_x;
+                    CORE.Input.Mouse.currentPosition.y += event_y;
+                }
+                else
+                {
+                    CORE.Input.Mouse.currentPosition.x = event_x;
+                    CORE.Input.Mouse.currentPosition.y = event_y;
+                }
 
                 CORE.Input.Touch.position[0] = CORE.Input.Mouse.currentPosition;
                 touchAction = 2;


### PR DESCRIPTION
Actually doing something very similar to what is done in rcore_web.
This probably should be fixed RGFW-side, but RGFW has more problems on web that should be addressed, so preapring this minimalistic change on the side of raylib is the best i could do here. Also opened an issue about this on RGFW repo: https://github.com/ColleagueRiley/RGFW/issues/493