### PR TITLE
[Examples] fixed error in readme, found by discord user the.enemy

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -223,7 +223,7 @@ Examples using raylib models functionality, including models loading/generation 
 
 ### category: shaders [35]
 
-Examples using raylib shaders functionality, including shaders loading, parameters configuration and drawing using them (model shaders and postprocessing shaders). This functionality is directly provided by raylib [rlgl](../src/rlgl.c) module.
+Examples using raylib shaders functionality, including shaders loading, parameters configuration and drawing using them (model shaders and postprocessing shaders). This functionality is directly provided by raylib [rlgl](../src/rlgl.h) module.
 
 |  example  | image  | difficulty<br>level | version<br>created | last version<br>updated | original<br>developer |
 |-----------|--------|:-------------------:|:------------------:|:-----------------------:|:----------------------|


### PR DESCRIPTION
`rlgl.c` does not exist, it's `rlgl.h`

found by discord user `the.enemy`