### PR TITLE
[rcore] refactor possible data loss on FileMove()

### DIFF
--- a/src/rcore.c
+++ b/src/rcore.c
@@ -2274,14 +2274,16 @@ int FileCopy(const char *srcPath, const char *dstPath)
 // NOTE: If dst directories do not exists they are created
 int FileMove(const char *srcPath, const char *dstPath)
 {
-    int result = 0;
+    int result = -1;
 
     if (FileExists(srcPath))
     {
-        FileCopy(srcPath, dstPath);
-        FileRemove(srcPath);
+		if (FileCopy(srcPath, dstPath) == 0)
+            result = FileRemove(srcPath);
+        else
+            TRACELOG(LOG_WARNING, "FILEIO: [%s] Failed to copy file to [%s]", srcPath, dstPath);
     }
-    else result = -1;
+	else TRACELOG(LOG_WARNING, "FILEIO: [%s] Source file does not exist", srcPath);
 
     return result;
 }


### PR DESCRIPTION
The FireRemove() function was called without any checks. If FileCopy encountered an error for any reason, FileRemove() would irreversibly delete the copied data.

Also `result` was initialized to `0` (success) making the return 
value meaningless when `FileCopy()` or `FileRemove()` failed.

Fix by checking `FileCopy()` return value before removing the source 
file, and initializing `result` to `-1`.