### PR TITLE
[examples][models] Adding `TEXTURE_WRAP_REPEAT` in `models_yaw_pitch_roll`

### DIFF
--- a/examples/models/models_yaw_pitch_roll.c
+++ b/examples/models/models_yaw_pitch_roll.c
@@ -41,6 +41,9 @@ int main(void)
 
     Model model = LoadModel("resources/models/obj/plane.obj");                  // Load model
     Texture2D texture = LoadTexture("resources/models/obj/plane_diffuse.png");  // Load model texture
+    
+    SetTextureWrap(texture, TEXTURE_WRAP_REPEAT);       // Force Repeat to avoid issue on Web version
+
     model.materials[0].maps[MATERIAL_MAP_DIFFUSE].texture = texture;            // Set map diffuse texture
 
     float pitch = 0.0f;


### PR DESCRIPTION
Adding `TEXTURE_WRAP_REPEAT` force the repeat to happen on Web version and works as normal on the other ones.

Web:

<img width="1674" height="1315" alt="image" src="https://github.com/user-attachments/assets/55ff1686-47f2-4e65-93f5-63be5b6c8c66" />

Desktop:

<img width="836" height="534" alt="image" src="https://github.com/user-attachments/assets/fe46a16c-e785-4982-a366-659ab16d653b" />
