### PR TITLE
[examples] Fix UI Cellular Automata

### DIFF
--- a/examples/textures/textures_cellular_automata.c
+++ b/examples/textures/textures_cellular_automata.c
@@ -165,7 +165,7 @@ int main(void)
 
                 // If the mouse is on this preset, highlight it
                 if (mouseInCell == i + 8)
-                    DrawRectangleLinesEx((Rectangle) { 2 + (presetsSizeX + 2.0f)*((float)i/2),
+                    DrawRectangleLinesEx((Rectangle) { 2 + (presetsSizeX + 2.0f)*(i/2),
                                                        (presetsSizeY + 2.0f)*(i%2),
                                                        presetsSizeX + 4.0f, presetsSizeY + 4.0f }, 3, RED);
             }


### PR DESCRIPTION
Fix bug in computing the red rectangle to draw when the mouse is hovering over: to compute correctly the X coordinate it must be an integer division (i/2) not a floating point division ((float)i/2). Now fixed