### PR TITLE
[rtext] Add security check for `LoadCodepoints()`

### DIFF
--- a/src/rtext.c
+++ b/src/rtext.c
@@ -2175,7 +2175,10 @@ int *LoadCodepoints(const char *text, int *count)
         codepoints = temp;
     }
 
-    *count = codepointCount;
+    if (count != NULL)
+    {
+        *count = codepointCount;
+    }
     return codepoints;
 }
 


### PR DESCRIPTION
When the `count` parameter is specified as a null value, `LoadCodepoints()` function can cause segmentation fault. By checking whether the param is null can improve the robustness of the function.