### PR TITLE
[rmodel] fix for devices without VAO support

### DIFF
--- a/src/rmodels.c
+++ b/src/rmodels.c
@@ -1281,7 +1281,6 @@ void UploadMesh(Mesh *mesh, bool dynamic)
 
 #if defined(GRAPHICS_API_OPENGL_33) || defined(GRAPHICS_API_OPENGL_ES2)
     mesh->vaoId = rlLoadVertexArray();
-    if (mesh->vaoId == 0) return;
 
     rlEnableVertexArray(mesh->vaoId);
 


### PR DESCRIPTION
Resolve #5690 

Avoid return for devices without VAO support, because they will use VBO.