### PR TITLE
[build.zig.zon] Fix: replace deleted hexops/xcode-frameworks with pkg…

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -7,8 +7,8 @@
 
     .dependencies = .{
         .xcode_frameworks = .{
-            .url = "git+https://github.com/hexops/xcode-frameworks#9a45f3ac977fd25dff77e58c6de1870b6808c4a7",
-            .hash = "N-V-__8AABHMqAWYuRdIlflwi8gksPnlUMQBiSxAqQAAZFms",
+            .url = "https://pkg.machengine.org/xcode-frameworks/9a45f3ac977fd25dff77e58c6de1870b6808c4a7.tar.gz",
+            .hash = "122098b9174895f9708bc824b0f9e550c401892c40a900006459acf2cbf78acd99bb",
             .lazy = true,
         },
         .emsdk = .{


### PR DESCRIPTION
The [xcode-frameworks](https://github.com/hexops/xcode-frameworks) GitHub repo no longer exists, causing zig fetch to fail on macOS builds. This replaces the URL with the [machengine](https://pkg.machengine.org) mirror.

The URL was taken from the mach [build.zig.zon](https://github.com/hexops/mach/blob/main/build.zig.zon) which uses the updated mirror.

```
Run zig build --release=fast -Dtarget=aarch64-macos -Dsysroot "$SDKROOT"
  zig build --release=fast -Dtarget=aarch64-macos -Dsysroot "$SDKROOT"
  shell: /bin/bash -e {0}
  env:
    ZIG_GLOBAL_CACHE_DIR: /Users/runner/work/xcode_test/xcode_test/.zig-cache
    ZIG_LOCAL_CACHE_DIR: /Users/runner/work/xcode_test/xcode_test/.zig-cache
    SSL_CERT_FILE: /Users/runner/work/xcode_test/xcode_test/cert.pem
    SDKROOT: /Applications/Xcode_16.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.5.sdk
.zig-cache/p/raylib-5.6.0-dev-whq8uKcqDQWBSifz7ukF2u4sZUlgZxcrN5_p3ONMw1Sy/build.zig.zon:10:20: error: unable to discover remote git server capabilities: ProtocolError
            .url = "git+https://github.com/hexops/xcode-frameworks#9a45f3ac977fd25dff77e58c6de1870b6808c4a7",
                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```