### PR TITLE
Zig build improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,6 +118,7 @@ GTAGS
 # Zig programming language
 .zig-cache/
 zig-cache/
+zig-pkg/
 zig-out/
 build/
 build-*/

--- a/build.zig
+++ b/build.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const builtin = @import("builtin");
 
 /// Minimum supported version of Zig
-const min_ver = "0.16.0-dev.2349+204fa8959";
+const min_ver = "0.16.0-dev.3013+abd131e33";
 
 const emccOutputDir = "zig-out" ++ std.fs.path.sep_str ++ "htmlout" ++ std.fs.path.sep_str;
 const emccOutputFile = "index.html";
@@ -264,7 +264,10 @@ fn compileRaylib(b: *std.Build, target: std.Build.ResolvedTarget, optimize: std.
 
                 setDesktopPlatform(raylib, .android);
             } else {
-                try c_source_files.append(b.allocator, "src/rglfw.c");
+                switch (options.platform) {
+                    .glfw => try c_source_files.append(b.allocator, "src/rglfw.c"),
+                    .rgfw, .sdl, .drm, .android => {},
+                }
 
                 if (options.linux_display_backend == .X11 or options.linux_display_backend == .Both) {
                     raylib.root_module.addCMacro("_GLFW_X11", "");
@@ -434,6 +437,7 @@ pub const OpenglVersion = enum {
 };
 
 pub const LinuxDisplayBackend = enum {
+    None,
     X11,
     Wayland,
     Both,

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -7,8 +7,8 @@
 
     .dependencies = .{
         .xcode_frameworks = .{
-            .url = "https://pkg.machengine.org/xcode-frameworks/9a45f3ac977fd25dff77e58c6de1870b6808c4a7.tar.gz",
-            .hash = "122098b9174895f9708bc824b0f9e550c401892c40a900006459acf2cbf78acd99bb",
+            .url = "https://pkg.machengine.org/xcode-frameworks/8a1cfb373587ea4c9bb1468b7c986462d8d4e10e.tar.gz",
+            .hash = "N-V-__8AALShqgXkvqYU6f__FrA22SMWmi2TXCJjNTO1m8XJ",
             .lazy = true,
         },
         .emsdk = .{


### PR DESCRIPTION
This fixes a minor dependency issue I was having and tweaks the `build.zig` a bit.

For some context, I was looking to use raylib to create games/apps with zig for the [Miyoo Mini+](https://web.archive.org/web/20260328201028/https://www.miyoogame.com/product/miyoo-mini-plus-retro-handheld-game-console/) (a small linux gameboy like handheld) with the SDL backend.

I've done all this development on macos so apologies ahead of time that I can't test other platforms (except a niche linux one). However since this only affects the zig build, it should be reasonably low risk, and I think it's fair to expect the zig usage to come with some rough edges.

## Changes

**Zig min version bump**

Past issues/PRs have agreed to follow the zig nightly builds. So this just bumps that version to the most recent one that I tested this PR with.

**Added zig-pkg directory to gitignore**

Zigs latest package manager places the packages/dependencies in the project root under `zig-pkg` so it can be ignored by git. (Similar to nodejs `node_modules` directory).

**Add a `None` option for the `LinuxDisplayBackend` enum**

In my niche case, Miyoo Mini+ doesn't have a desktop environment of any kind and the SDL implementation just directly talks to the frame buffer, so this option allows me to still build for linux, but omit X11 and Wayland sources.

**Linux build potentially unnecessarily links `rglfw.c`**

For some reason when I had SDL as the platform selected, it would still add `rglfw.c` for compilation causing issues (as glfw expects there to be X11 or Wayland on linux). There may be a couple more places this issue occurs but I have left them unchanged without any way to test currently.

**xcode-frameworks dependency was incorrect**

Zig could never build as the hash was not the correct format. The version being downloaded was not the latest commit so in fixing the hash, I've brought the dependency commit up to the most recent.