### PR TITLE
[examples][text] preload pixantiqua files so that web build can find them

### DIFF
--- a/examples/Makefile.Web
+++ b/examples/Makefile.Web
@@ -1153,7 +1153,10 @@ text/text_font_filters: text/text_font_filters.c
     --preload-file text/resources/KAISG.ttf@resources/KAISG.ttf
 
 text/text_font_loading: text/text_font_loading.c
-	$(CC) -o $@$(EXT) $< $(CFLAGS) $(INCLUDE_PATHS) $(LDFLAGS) $(LDLIBS) -D$(PLATFORM)
+	$(CC) -o $@$(EXT) $< $(CFLAGS) $(INCLUDE_PATHS) $(LDFLAGS) $(LDLIBS) -D$(PLATFORM) \
+	--preload-file text/resources/pixantiqua.fnt@resources/pixantiqua.fnt \
+    --preload-file text/resources/pixantiqua.png@resources/pixantiqua.png \
+    --preload-file text/resources/pixantiqua.ttf@resources/pixantiqua.ttf
 
 text/text_font_sdf: text/text_font_sdf.c
 	$(CC) -o $@$(EXT) $< $(CFLAGS) $(INCLUDE_PATHS) $(LDFLAGS) $(LDLIBS) -D$(PLATFORM) \


### PR DESCRIPTION
saw https://github.com/raysan5/raylib/issues/5664

text/text_font_loading example on web build was not finding the resources
so i added them on Makefile.Web.

```
WARNING: FILEIO: [resources/pixantiqua.fnt] Failed to open text file
WARNING: FONT: [resources/pixantiqua.fnt] Failed to load font texture -> Using default font
WARNING: FILEIO: [resources/pixantiqua.ttf] Failed to open file
```

i am not so well acquinted to the repo, so if i've missed anything, please tell.
thank you,