### PR TITLE
[rcore][GLFW] REVIEWED: `SetWindowSize()`, scaling issues on Retina display

### DIFF
--- a/src/platforms/rcore_desktop_glfw.c
+++ b/src/platforms/rcore_desktop_glfw.c
@@ -739,6 +739,22 @@ void SetWindowSize(int width, int height)
     CORE.Window.screen.height = height;
 
     glfwSetWindowSize(platform.handle, width, height);
+
+    // Update render size and viewport to match new screen size immediately,
+    // rather than waiting for the async FramebufferSizeCallback.
+    if (FLAG_IS_SET(CORE.Window.flags, FLAG_WINDOW_HIGHDPI))
+    {
+        Vector2 scaleDpi = GetWindowScaleDPI();
+        CORE.Window.render.width = (int)(width*scaleDpi.x);
+        CORE.Window.render.height = (int)(height*scaleDpi.y);
+    }
+    else
+    {
+        CORE.Window.render.width = width;
+        CORE.Window.render.height = height;
+    }
+    CORE.Window.currentFbo = CORE.Window.render;
+    SetupViewport(CORE.Window.render.width, CORE.Window.render.height);
 }
 
 // Set window opacity, value opacity is between 0.0 and 1.0


### PR DESCRIPTION
I ran into the following issue (on MacOS):

1. On app startup, I call SetWindowSize 800,600.  I then enter my usual drawing loop.
2. If I launch this on the external display, it works fine.  But if I launch it on the Retina display, it's blank.  Even if my drawing loop is nothing but ClearBackground and DrawFPS (between Begin/EndDrawing of course), all I see is the background color — no FPS.
3. If I drag the window over to my external monitor, suddenly I see all the content (FPS and any other drawing).
4. If I then drag it back to the retina display, I still see the correct content.

The issue seemed to be that SetWindowSize updated CORE.Window.screen but not CORE.Window.render (and moving the window to another display caused the render to update, thus "fixing" the issue).

This PR adds code to update the render right away.  Now my resized windows correctly show their rendering, even on a retina display.  Tested both with and without the FLAG_WINDOW_HIDPI flag.