### PR TITLE
[examples][models_decals][WEB] store bytes at global data seg

### DIFF
--- a/examples/models/models_decals.c
+++ b/examples/models/models_decals.c
@@ -108,7 +108,7 @@ int main(void)
     decalMaterial.maps[MATERIAL_MAP_DIFFUSE].color = RAYWHITE;
 
     bool showModel = true;
-    Model decalModels[MAX_DECALS] = { 0 };
+    static Model decalModels[MAX_DECALS] = { 0 };
     int decalCount = 0;
 
     SetTargetFPS(60);                   // Set our game to run at 60 frames-per-second


### PR DESCRIPTION
Hello,

sure of: 
- the example must not store large bytes to Asyncify stack. the error is on Asyncify side.
- making decalModels static, fix the issue.

not sure:
- is using global data seg for the example OK?

thank you,

```
models_decals.html:246 Stack overflow detected.  You can try increasing -sSTACK_SIZE (currently set to 65536)
...
models_decals.js:229 Uncaught RuntimeError: memory access out of bounds
    at models_decals.wasm.stbi__parse_png_file (models_decals.wasm:0x3b0df)
    at models_decals.wasm.stbi__load_main (models_decals.wasm:0x30658)
    at models_decals.wasm.stbi__load_and_postprocess_8bit (models_decals.wasm:0x2f269)
    at models_decals.wasm.LoadImageFromMemory (models_decals.wasm:0x518e1)
    at models_decals.wasm.LoadImage (models_decals.wasm:0x512f0)
    at models_decals.wasm.LoadTexture (models_decals.wasm:0x5974d)
    at models_decals.wasm.__original_main (models_decals.wasm:0x491f)
    at models_decals.wasm.main (models_decals.wasm:0x1096c)
    at __asyncify_wrapper_303 (models_decals.js:9050:20)
    at models_decals.js:723:12
```