### PR TITLE
[rcore_rgfw] Updating render resolution as well on SetWindowSize

### DIFF
--- a/src/platforms/rcore_desktop_rgfw.c
+++ b/src/platforms/rcore_desktop_rgfw.c
@@ -823,8 +823,7 @@ void SetWindowSize(int width, int height)
 
     if (!CORE.Window.usingFbo)
     {
-        CORE.Window.render.width = CORE.Window.screen.width;
-        CORE.Window.render.height = CORE.Window.screen.height;
+        SetupViewport(CORE.Window.screen.width, CORE.Window.screen.height);
     }
 
     RGFW_window_resize(platform.window, CORE.Window.screen.width, CORE.Window.screen.height);


### PR DESCRIPTION
Shouldnt we update `CORE.Window.render` resolution here as well? Otherwise it is never updated correctly, unless handling of window resize event updates it. Which is never on WebRGFW unfortunately since resize event handling  intentionally (related to https://github.com/raysan5/raylib/issues/5658 ) doesn't update any sizes.
So: if window (canvas in case of web) is only ever resized with `SetWindowSize()` calls, then `CORE.Window.render` size will always be equal to initial window size.

### Explanation
In my case it was breaking scissor calls on web, after exiting "texture mode" (i.e. rendering to texture):

rcore.c:EndTextureMode:
```
// Reset current fbo to screen size
CORE.Window.currentFbo.width = CORE.Window.render.width;
CORE.Window.currentFbo.height = CORE.Window.render.height;
CORE.Window.usingFbo = false;
```

rcore.c:BeginScissorMode:
```
rlScissor(x, CORE.Window.currentFbo.height - (y + height), width, height);
```

`EndTextureMode` was "resetting" `currentFbo` size to initial window's size, so subseqent `BeginScissorMode` scissor would pass incorrect value as 2nd parameter to rlScissor (sometimes even negative if scissor's y+height was bigger than initial window's size).
