### PR TITLE
[examples][shaders_texture_tiling][WEB] explicitly state TEXTURE_WRAP_REPEAT for web build

### DIFF
--- a/examples/shaders/shaders_texture_tiling.c
+++ b/examples/shaders/shaders_texture_tiling.c
@@ -56,6 +56,7 @@ int main(void)
     // Set the texture tiling using a shader
     float tiling[2] = { 3.0f, 3.0f };
     Shader shader = LoadShader(0, TextFormat("resources/shaders/glsl%i/tiling.fs", GLSL_VERSION));
+    SetTextureWrap(texture, TEXTURE_WRAP_REPEAT);
     SetShaderValue(shader, GetShaderLocation(shader, "tiling"), tiling, SHADER_UNIFORM_VEC2);
     model.materials[0].shader = shader;
 


### PR DESCRIPTION
issue: 
- WEB example does not fallback to TEXTURE_WRAP_REPEAT default

RLGL.ExtSupported.texNPOT is 1 on desktop,
but 0 for the web.
this is environment capability, so one cannot simply change this.

the problem i believe is that 
inside rlLoadTexture, if texNPOT is false, it fallbacks to CLAMP_TO_EDGE, even if the example png is a POT.

the code is not checking actual POT at the moment.

we should add that, 
or explicitly call SetTextureWrap(texture, TEXTURE_WRAP_REPEAT); for web.

as a newcomer, i limited myself to example change here.
thank you,

