### PR TITLE
[rlsw] Some platform fixes

### DIFF
--- a/src/platforms/rcore_desktop_sdl.c
+++ b/src/platforms/rcore_desktop_sdl.c
@@ -1528,6 +1528,10 @@ void PollInputEvents(void)
                             if ((width + borderLeft + borderRight != usableBounds.w) && (height + borderTop + borderBottom != usableBounds.h)) FLAG_CLEAR(CORE.Window.flags, FLAG_WINDOW_MAXIMIZED);
                         }
                         #endif
+
+                        #if defined(GRAPHICS_API_OPENGL_SOFTWARE)
+                        swResize(width, height);
+                        #endif
                     } break;
 
                     case SDL_WINDOWEVENT_ENTER: CORE.Input.Mouse.cursorOnScreen = true; break;

--- a/src/platforms/rcore_desktop_win32.c
+++ b/src/platforms/rcore_desktop_win32.c
@@ -2091,6 +2091,10 @@ static void HandleWindowResize(HWND hwnd, int *width, int *height)
 
     CORE.Window.screenScale = MatrixScale( (float)CORE.Window.render.width/CORE.Window.screen.width,
         (float)CORE.Window.render.height/CORE.Window.screen.height, 1.0f);
+
+    #if defined(GRAPHICS_API_OPENGL_SOFTWARE)
+    swResize(clientSize.cx, clientSize.cy);
+    #endif
 }
 
 // Update window style

--- a/src/platforms/rcore_drm.c
+++ b/src/platforms/rcore_drm.c
@@ -837,14 +837,8 @@ void SwapScreenBuffer(void)
     uint32_t height = mode->vdisplay;
 
     // Dumb buffers use a fixed format based on bpp
-#if SW_COLOR_BUFFER_BITS == 24
     const uint32_t bpp = 32;    // 32 bits per pixel (XRGB8888 format)
     const uint32_t depth = 24;  // Color depth, here only 24 bits, alpha is not used
-#else
-    // REVIEW: Not sure how it will be interpreted (RGB or RGBA?)
-    const uint32_t bpp = SW_COLOR_BUFFER_BITS;
-    const uint32_t depth = SW_COLOR_BUFFER_BITS;
-#endif
 
     // Create a dumb buffer for software rendering
     struct drm_mode_create_dumb creq = { 0 };
@@ -899,7 +893,7 @@ void SwapScreenBuffer(void)
 
     // Copy the software rendered buffer to the dumb buffer with scaling if needed
     // NOTE: RLSW will make a simple copy if the dimensions match
-    swBlitFramebuffer(0, 0, width, height, 0, 0, width, height, SW_RGBA, SW_UNSIGNED_BYTE, dumbBuffer);
+    swBlitPixels(0, 0, width, height, 0, 0, width, height, SW_RGBA, SW_UNSIGNED_BYTE, dumbBuffer);
 
     // Unmap the buffer
     munmap(dumbBuffer, creq.size);


### PR DESCRIPTION
Fixes compilation errors for DRM and handles resizing for SDL and WIN32

- Fixes https://github.com/raysan5/raylib/issues/5714
- Fixes https://github.com/raysan5/raylib/issues/5715

---

A little validation for WIN32 would be preferable; I don't have a Windows machine to test on, but I simply added this to `HandleWindowResize`:
```c
#if defined(GRAPHICS_API_OPENGL_SOFTWARE)
swResize(clientSize.cx, clientSize.cy);
#endif
```

Also, I had added it for RGFW, but when I tried to test it I realized that blitting is not implemented, black screen, so I didn't do anything.



