### PR TITLE
Specified default for visible and enabled cursor, and event waiting

### DIFF
--- a/projects/Notepad++/raylib_npp_parser/raylib_npp.xml
+++ b/projects/Notepad++/raylib_npp_parser/raylib_npp.xml
@@ -197,12 +197,12 @@
             <Overload retVal="void" descr="Enable waiting for events on EndDrawing(), no automatic event polling"></Overload>
         </KeyWord>
         <KeyWord name="DisableEventWaiting" func="yes">
-            <Overload retVal="void" descr="Disable waiting for events on EndDrawing(), automatic events polling"></Overload>
+            <Overload retVal="void" descr="Disable waiting for events on EndDrawing(), automatic events polling (default)"></Overload>
         </KeyWord>
 
         <!-- Cursor-related functions -->
         <KeyWord name="ShowCursor" func="yes">
-            <Overload retVal="void" descr="Shows cursor"></Overload>
+            <Overload retVal="void" descr="Shows cursor (default)"></Overload>
         </KeyWord>
         <KeyWord name="HideCursor" func="yes">
             <Overload retVal="void" descr="Hides cursor"></Overload>
@@ -211,7 +211,7 @@
             <Overload retVal="bool" descr="Check if cursor is not visible"></Overload>
         </KeyWord>
         <KeyWord name="EnableCursor" func="yes">
-            <Overload retVal="void" descr="Enables cursor (unlock cursor)"></Overload>
+            <Overload retVal="void" descr="Enables cursor (unlock cursor) (default)"></Overload>
         </KeyWord>
         <KeyWord name="DisableCursor" func="yes">
             <Overload retVal="void" descr="Disables cursor (lock cursor)"></Overload>

--- a/projects/Notepad++/raylib_npp_parser/raylib_to_parse.h
+++ b/projects/Notepad++/raylib_npp_parser/raylib_to_parse.h
@@ -51,13 +51,13 @@ RLAPI void SetClipboardText(const char *text);                    // Set clipboa
 RLAPI const char *GetClipboardText(void);                         // Get clipboard text content
 RLAPI Image GetClipboardImage(void);                              // Get clipboard image
 RLAPI void EnableEventWaiting(void);                              // Enable waiting for events on EndDrawing(), no automatic event polling
-RLAPI void DisableEventWaiting(void);                             // Disable waiting for events on EndDrawing(), automatic events polling
+RLAPI void DisableEventWaiting(void);                             // Disable waiting for events on EndDrawing(), automatic events polling (default)
 
 // Cursor-related functions
-RLAPI void ShowCursor(void);                                      // Shows cursor
+RLAPI void ShowCursor(void);                                      // Shows cursor (default)
 RLAPI void HideCursor(void);                                      // Hides cursor
 RLAPI bool IsCursorHidden(void);                                  // Check if cursor is not visible
-RLAPI void EnableCursor(void);                                    // Enables cursor (unlock cursor)
+RLAPI void EnableCursor(void);                                    // Enables cursor (unlock cursor) (default)
 RLAPI void DisableCursor(void);                                   // Disables cursor (lock cursor)
 RLAPI bool IsCursorOnScreen(void);                                // Check if cursor is on the screen
 

--- a/src/platforms/rcore_android.c
+++ b/src/platforms/rcore_android.c
@@ -610,7 +610,7 @@ Image GetClipboardImage(void)
     return image;
 }
 
-// Show mouse cursor
+// Show mouse cursor (default)
 void ShowCursor(void)
 {
     CORE.Input.Mouse.cursorHidden = false;
@@ -622,7 +622,7 @@ void HideCursor(void)
     CORE.Input.Mouse.cursorHidden = true;
 }
 
-// Enables cursor (unlock cursor)
+// Enables cursor (unlock cursor) (default)
 void EnableCursor(void)
 {
     // Set cursor position in the middle

--- a/src/platforms/rcore_desktop_glfw.c
+++ b/src/platforms/rcore_desktop_glfw.c
@@ -1121,7 +1121,7 @@ Image GetClipboardImage(void)
     return image;
 }
 
-// Show mouse cursor
+// Show mouse cursor (default)
 void ShowCursor(void)
 {
     glfwSetInputMode(platform.handle, GLFW_CURSOR, GLFW_CURSOR_NORMAL);
@@ -1137,7 +1137,7 @@ void HideCursor(void)
     CORE.Input.Mouse.cursorHidden = true;
 }
 
-// Enables cursor (unlock cursor)
+// Enables cursor (unlock cursor) (default)
 void EnableCursor(void)
 {
     glfwSetInputMode(platform.handle, GLFW_CURSOR, GLFW_CURSOR_NORMAL);

--- a/src/platforms/rcore_desktop_rgfw.c
+++ b/src/platforms/rcore_desktop_rgfw.c
@@ -1083,7 +1083,7 @@ Image GetClipboardImage(void)
     return image;
 }
 
-// Show mouse cursor
+// Show mouse cursor (default)
 void ShowCursor(void)
 {
     RGFW_window_showMouse(platform.window, true);
@@ -1097,7 +1097,7 @@ void HideCursor(void)
     CORE.Input.Mouse.cursorHidden = true;
 }
 
-// Enables cursor (unlock cursor)
+// Enables cursor (unlock cursor) (default)
 void EnableCursor(void)
 {
     RGFW_window_captureRawMouse(platform.window, false);

--- a/src/platforms/rcore_desktop_sdl.c
+++ b/src/platforms/rcore_desktop_sdl.c
@@ -1216,7 +1216,7 @@ Image GetClipboardImage(void)
     return image;
 }
 
-// Show mouse cursor
+// Show mouse cursor (default)
 void ShowCursor(void)
 {
 #if defined(USING_VERSION_SDL3)
@@ -1238,7 +1238,7 @@ void HideCursor(void)
     CORE.Input.Mouse.cursorHidden = true;
 }
 
-// Enables cursor (unlock cursor)
+// Enables cursor (unlock cursor) (default)
 void EnableCursor(void)
 {
     SDL_SetRelativeMouseMode(SDL_FALSE);

--- a/src/platforms/rcore_desktop_win32.c
+++ b/src/platforms/rcore_desktop_win32.c
@@ -1139,7 +1139,7 @@ Image GetClipboardImage(void)
     return image;
 }
 
-// Show mouse cursor
+// Show mouse cursor (default)
 void ShowCursor(void)
 {
     SetCursor(LoadCursorW(NULL, (LPCWSTR)IDC_ARROW));
@@ -1155,7 +1155,7 @@ void HideCursor(void)
     CORE.Input.Mouse.cursorHidden = true;
 }
 
-// Enables cursor (unlock cursor)
+// Enables cursor (unlock cursor) (default)
 void EnableCursor(void)
 {
     if (CORE.Input.Mouse.cursorLocked)

--- a/src/platforms/rcore_drm.c
+++ b/src/platforms/rcore_drm.c
@@ -555,7 +555,7 @@ Image GetClipboardImage(void)
     return image;
 }
 
-// Show mouse cursor
+// Show mouse cursor (default)
 void ShowCursor(void)
 {
     CORE.Input.Mouse.cursorHidden = false;
@@ -567,7 +567,7 @@ void HideCursor(void)
     CORE.Input.Mouse.cursorHidden = true;
 }
 
-// Enables cursor (unlock cursor)
+// Enables cursor (unlock cursor) (default)
 void EnableCursor(void)
 {
     // Set cursor position in the middle

--- a/src/platforms/rcore_memory.c
+++ b/src/platforms/rcore_memory.c
@@ -318,7 +318,7 @@ Image GetClipboardImage(void)
     return image;
 }
 
-// Show mouse cursor
+// Show mouse cursor (default)
 void ShowCursor(void)
 {
     CORE.Input.Mouse.cursorHidden = false;
@@ -330,7 +330,7 @@ void HideCursor(void)
     CORE.Input.Mouse.cursorHidden = true;
 }
 
-// Enables cursor (unlock cursor)
+// Enables cursor (unlock cursor) (default)
 void EnableCursor(void)
 {
     // Set cursor position in the middle

--- a/src/platforms/rcore_template.c
+++ b/src/platforms/rcore_template.c
@@ -297,7 +297,7 @@ Image GetClipboardImage(void)
     return image;
 }
 
-// Show mouse cursor
+// Show mouse cursor (default)
 void ShowCursor(void)
 {
     CORE.Input.Mouse.cursorHidden = false;
@@ -309,7 +309,7 @@ void HideCursor(void)
     CORE.Input.Mouse.cursorHidden = true;
 }
 
-// Enables cursor (unlock cursor)
+// Enables cursor (unlock cursor) (default)
 void EnableCursor(void)
 {
     // Set cursor position in the middle

--- a/src/platforms/rcore_web.c
+++ b/src/platforms/rcore_web.c
@@ -902,7 +902,7 @@ Image GetClipboardImage(void)
     return image;
 }
 
-// Show mouse cursor
+// Show mouse cursor (default)
 void ShowCursor(void)
 {
     if (CORE.Input.Mouse.cursorHidden)
@@ -924,7 +924,7 @@ void HideCursor(void)
     }
 }
 
-// Enables cursor (unlock cursor)
+// Enables cursor (unlock cursor) (default)
 void EnableCursor(void)
 {
     emscripten_exit_pointerlock();

--- a/src/platforms/rcore_web_emscripten.c
+++ b/src/platforms/rcore_web_emscripten.c
@@ -880,7 +880,7 @@ Image GetClipboardImage(void)
     return image;
 }
 
-// Show mouse cursor
+// Show mouse cursor (default)
 void ShowCursor(void)
 {
     if (CORE.Input.Mouse.cursorHidden)
@@ -902,7 +902,7 @@ void HideCursor(void)
     }
 }
 
-// Enables cursor (unlock cursor)
+// Enables cursor (unlock cursor) (default)
 void EnableCursor(void)
 {
     emscripten_exit_pointerlock();

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1031,13 +1031,13 @@ RLAPI void SetClipboardText(const char *text);                    // Set clipboa
 RLAPI const char *GetClipboardText(void);                         // Get clipboard text content
 RLAPI Image GetClipboardImage(void);                              // Get clipboard image content
 RLAPI void EnableEventWaiting(void);                              // Enable waiting for events on EndDrawing(), no automatic event polling
-RLAPI void DisableEventWaiting(void);                             // Disable waiting for events on EndDrawing(), automatic events polling
+RLAPI void DisableEventWaiting(void);                             // Disable waiting for events on EndDrawing(), automatic events polling (default)
 
 // Cursor-related functions
-RLAPI void ShowCursor(void);                                      // Shows cursor
+RLAPI void ShowCursor(void);                                      // Shows cursor (default)
 RLAPI void HideCursor(void);                                      // Hides cursor
 RLAPI bool IsCursorHidden(void);                                  // Check if cursor is not visible
-RLAPI void EnableCursor(void);                                    // Enables cursor (unlock cursor)
+RLAPI void EnableCursor(void);                                    // Enables cursor (unlock cursor) (default)
 RLAPI void DisableCursor(void);                                   // Disables cursor (lock cursor)
 RLAPI bool IsCursorOnScreen(void);                                // Check if cursor is on the screen
 

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -847,7 +847,7 @@ void EnableEventWaiting(void)
     CORE.Window.eventWaiting = true;
 }
 
-// Disable waiting for events on EndDrawing(), automatic events polling
+// Disable waiting for events on EndDrawing(), automatic events polling (default)
 void DisableEventWaiting(void)
 {
     CORE.Window.eventWaiting = false;

--- a/tools/rlparser/output/raylib_api.json
+++ b/tools/rlparser/output/raylib_api.json
@@ -3568,12 +3568,12 @@
     },
     {
       "name": "DisableEventWaiting",
-      "description": "Disable waiting for events on EndDrawing(), automatic events polling",
+      "description": "Disable waiting for events on EndDrawing(), automatic events polling (default)",
       "returnType": "void"
     },
     {
       "name": "ShowCursor",
-      "description": "Shows cursor",
+      "description": "Shows cursor (default)",
       "returnType": "void"
     },
     {
@@ -3588,7 +3588,7 @@
     },
     {
       "name": "EnableCursor",
-      "description": "Enables cursor (unlock cursor)",
+      "description": "Enables cursor (unlock cursor) (default)",
       "returnType": "void"
     },
     {

--- a/tools/rlparser/output/raylib_api.lua
+++ b/tools/rlparser/output/raylib_api.lua
@@ -3445,12 +3445,12 @@ return {
     },
     {
       name = "DisableEventWaiting",
-      description = "Disable waiting for events on EndDrawing(), automatic events polling",
+      description = "Disable waiting for events on EndDrawing(), automatic events polling (default)",
       returnType = "void"
     },
     {
       name = "ShowCursor",
-      description = "Shows cursor",
+      description = "Shows cursor (default)",
       returnType = "void"
     },
     {
@@ -3465,7 +3465,7 @@ return {
     },
     {
       name = "EnableCursor",
-      description = "Enables cursor (unlock cursor)",
+      description = "Enables cursor (unlock cursor) (default)",
       returnType = "void"
     },
     {

--- a/tools/rlparser/output/raylib_api.txt
+++ b/tools/rlparser/output/raylib_api.txt
@@ -1252,12 +1252,12 @@ Function 048: EnableEventWaiting() (0 input parameters)
 Function 049: DisableEventWaiting() (0 input parameters)
   Name: DisableEventWaiting
   Return type: void
-  Description: Disable waiting for events on EndDrawing(), automatic events polling
+  Description: Disable waiting for events on EndDrawing(), automatic events polling (default)
   No input parameters
 Function 050: ShowCursor() (0 input parameters)
   Name: ShowCursor
   Return type: void
-  Description: Shows cursor
+  Description: Shows cursor (default)
   No input parameters
 Function 051: HideCursor() (0 input parameters)
   Name: HideCursor
@@ -1272,7 +1272,7 @@ Function 052: IsCursorHidden() (0 input parameters)
 Function 053: EnableCursor() (0 input parameters)
   Name: EnableCursor
   Return type: void
-  Description: Enables cursor (unlock cursor)
+  Description: Enables cursor (unlock cursor) (default)
   No input parameters
 Function 054: DisableCursor() (0 input parameters)
   Name: DisableCursor

--- a/tools/rlparser/output/raylib_api.xml
+++ b/tools/rlparser/output/raylib_api.xml
@@ -807,15 +807,15 @@
         </Function>
         <Function name="EnableEventWaiting" retType="void" paramCount="0" desc="Enable waiting for events on EndDrawing(), no automatic event polling">
         </Function>
-        <Function name="DisableEventWaiting" retType="void" paramCount="0" desc="Disable waiting for events on EndDrawing(), automatic events polling">
+        <Function name="DisableEventWaiting" retType="void" paramCount="0" desc="Disable waiting for events on EndDrawing(), automatic events polling (default)">
         </Function>
-        <Function name="ShowCursor" retType="void" paramCount="0" desc="Shows cursor">
+        <Function name="ShowCursor" retType="void" paramCount="0" desc="Shows cursor (default)">
         </Function>
         <Function name="HideCursor" retType="void" paramCount="0" desc="Hides cursor">
         </Function>
         <Function name="IsCursorHidden" retType="bool" paramCount="0" desc="Check if cursor is not visible">
         </Function>
-        <Function name="EnableCursor" retType="void" paramCount="0" desc="Enables cursor (unlock cursor)">
+        <Function name="EnableCursor" retType="void" paramCount="0" desc="Enables cursor (unlock cursor) (default)">
         </Function>
         <Function name="DisableCursor" retType="void" paramCount="0" desc="Disables cursor (lock cursor)">
         </Function>


### PR DESCRIPTION
The reference documentation for the following on/off settings didn't specify which one was set by default. This PR fixes that. No logic code was modified.

```c
void EnableEventWaiting(void);
void DisableEventWaiting(void);
void ShowCursor(void);
void HideCursor(void);
void EnableCursor(void);
void DisableCursor(void);
```