### PR TITLE
Add GenMeshPlaneData() for CPU-side mesh generation without GPU upload

### DIFF
--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1617,7 +1617,8 @@ RLAPI bool ExportMeshAsCode(Mesh mesh, const char *fileName);                   
 
 // Mesh generation functions
 RLAPI Mesh GenMeshPoly(int sides, float radius);                                            // Generate polygonal mesh
-RLAPI Mesh GenMeshPlane(float width, float length, int resX, int resZ);                     // Generate plane mesh (with subdivisions)
+RLAPI Mesh GenMeshPlane(float width, float length, int resX, int resZ);                     // Generate plane mesh (with subdivisions) and upload to GPU
+RLAPI Mesh GenMeshPlaneData(float width, float length, int resX, int resZ);                 // Generate plane mesh data (with subdivisions)
 RLAPI Mesh GenMeshCube(float width, float height, float length);                            // Generate cuboid mesh
 RLAPI Mesh GenMeshSphere(float radius, int rings, int slices);                              // Generate sphere mesh (standard sphere)
 RLAPI Mesh GenMeshHemiSphere(float radius, int rings, int slices);                          // Generate half-sphere mesh (no bottom cap)

--- a/src/rmodels.c
+++ b/src/rmodels.c
@@ -2634,8 +2634,20 @@ Mesh GenMeshPoly(int sides, float radius)
     return mesh;
 }
 
-// Generate plane mesh (with subdivisions)
+// Generate plane mesh (with subdivisions) and upload to GPU
 Mesh GenMeshPlane(float width, float length, int resX, int resZ)
+{
+    Mesh mesh = GenMeshPlaneData(width, length, resX, resZ);
+
+    // Upload vertex data to GPU (static mesh)
+    UploadMesh(&mesh, false);
+
+    return mesh;
+}
+
+// Generate plane mesh data (with subdivisions), no GPU upload
+// Allows CPU-side mesh manipulation (e.g. vertex deformation) before manually calling UploadMesh()
+Mesh GenMeshPlaneData(float width, float length, int resX, int resZ)
 {
     Mesh mesh = { 0 };
 
@@ -2760,9 +2772,6 @@ Mesh GenMeshPlane(float width, float length, int resX, int resZ)
 
     par_shapes_free_mesh(plane);
 #endif
-
-    // Upload vertex data to GPU (static mesh)
-    UploadMesh(&mesh, false);
 
     return mesh;
 }


### PR DESCRIPTION
Currently GenMeshPlane() generates the mesh and immediately uploads it to the GPU via UploadMesh(). This makes it impossible to manipulate vertex data on the CPU (e.g. procedural height deformation) before the GPU upload, without resorting to UpdateMeshBuffer() after the fact.  I have been kind of stuck using a modified 4.2 version of Raylib for the last few years and would like to get this into the main branch for future continuity with this PR; it introduces GenMeshPlaneData() which contains all the existing mesh generation logic but returns the mesh without uploading it to the GPU.
GenMeshPlane() is updated to delegate to GenMeshPlaneData() then call UploadMesh(), so existing behaviour is completely unchanged for all current callers.

Use case — procedural terrain generation:
```
// Generate the mesh on the CPU without uploading
Mesh mesh = GenMeshPlaneData(width, length, resX, resZ);

// Deform vertex Y values using noise
for (int i = 0; i < mesh.vertexCount; i++)
{
    mesh.vertices[i*3 + 1] = SampleHeight(mesh.vertices[i*3], mesh.vertices[i*3 + 2]);                                                      
}

// Recalculate normals, then upload once
RecalcNormals(&mesh);
UploadMesh(&mesh, false);
```

Changes:
- src/raylib.h — added GenMeshPlaneData() declaration
- src/rmodels.c — added GenMeshPlaneData() implementation; GenMeshPlane() now wraps it