### PR TITLE
raymath: add ZERO_INITIALIZE macro to support C++ compilers

### DIFF
--- a/src/raymath.h
+++ b/src/raymath.h
@@ -178,6 +178,12 @@ typedef struct float16 {
 #define RL_FLOAT16_TYPE
 #endif
 
+#if defined(__cplusplus)
+#define RL_ZERO_INITIALIZE {}
+#else
+#define RL_ZERO_INITIALIZE { 0 }
+#endif
+
 #include <math.h>       // Required for: sinf(), cosf(), tan(), atan2f(), sqrtf(), floor(), fminf(), fmaxf(), fabsf()
 
 #if RAYMATH_USE_SIMD_INTRINSICS
@@ -430,7 +436,7 @@ RMAPI Vector2 Vector2Divide(Vector2 v1, Vector2 v2)
 // Normalize provided vector
 RMAPI Vector2 Vector2Normalize(Vector2 v)
 {
-    Vector2 result = { 0 };
+    Vector2 result = RL_ZERO_INITIALIZE;
     float length = sqrtf((v.x*v.x) + (v.y*v.y));
 
     if (length > 0)
@@ -446,7 +452,7 @@ RMAPI Vector2 Vector2Normalize(Vector2 v)
 // Transforms a Vector2 by a given Matrix
 RMAPI Vector2 Vector2Transform(Vector2 v, Matrix mat)
 {
-    Vector2 result = { 0 };
+    Vector2 result = RL_ZERO_INITIALIZE;
 
     float x = v.x;
     float y = v.y;
@@ -461,7 +467,7 @@ RMAPI Vector2 Vector2Transform(Vector2 v, Matrix mat)
 // Calculate linear interpolation between two vectors
 RMAPI Vector2 Vector2Lerp(Vector2 v1, Vector2 v2, float amount)
 {
-    Vector2 result = { 0 };
+    Vector2 result = RL_ZERO_INITIALIZE;
 
     result.x = v1.x + amount*(v2.x - v1.x);
     result.y = v1.y + amount*(v2.y - v1.y);
@@ -472,7 +478,7 @@ RMAPI Vector2 Vector2Lerp(Vector2 v1, Vector2 v2, float amount)
 // Calculate reflected vector to normal
 RMAPI Vector2 Vector2Reflect(Vector2 v, Vector2 normal)
 {
-    Vector2 result = { 0 };
+    Vector2 result = RL_ZERO_INITIALIZE;
 
     float dotProduct = (v.x*normal.x + v.y*normal.y); // Dot product
 
@@ -485,7 +491,7 @@ RMAPI Vector2 Vector2Reflect(Vector2 v, Vector2 normal)
 // Get min value for each pair of components
 RMAPI Vector2 Vector2Min(Vector2 v1, Vector2 v2)
 {
-    Vector2 result = { 0 };
+    Vector2 result = RL_ZERO_INITIALIZE;
 
     result.x = fminf(v1.x, v2.x);
     result.y = fminf(v1.y, v2.y);
@@ -496,7 +502,7 @@ RMAPI Vector2 Vector2Min(Vector2 v1, Vector2 v2)
 // Get max value for each pair of components
 RMAPI Vector2 Vector2Max(Vector2 v1, Vector2 v2)
 {
-    Vector2 result = { 0 };
+    Vector2 result = RL_ZERO_INITIALIZE;
 
     result.x = fmaxf(v1.x, v2.x);
     result.y = fmaxf(v1.y, v2.y);
@@ -507,7 +513,7 @@ RMAPI Vector2 Vector2Max(Vector2 v1, Vector2 v2)
 // Rotate vector by angle
 RMAPI Vector2 Vector2Rotate(Vector2 v, float angle)
 {
-    Vector2 result = { 0 };
+    Vector2 result = RL_ZERO_INITIALIZE;
 
     float cosres = cosf(angle);
     float sinres = sinf(angle);
@@ -521,7 +527,7 @@ RMAPI Vector2 Vector2Rotate(Vector2 v, float angle)
 // Move Vector towards target
 RMAPI Vector2 Vector2MoveTowards(Vector2 v, Vector2 target, float maxDistance)
 {
-    Vector2 result = { 0 };
+    Vector2 result = RL_ZERO_INITIALIZE;
 
     float dx = target.x - v.x;
     float dy = target.y - v.y;
@@ -549,7 +555,7 @@ RMAPI Vector2 Vector2Invert(Vector2 v)
 // min and max values specified by the given vectors
 RMAPI Vector2 Vector2Clamp(Vector2 v, Vector2 min, Vector2 max)
 {
-    Vector2 result = { 0 };
+    Vector2 result = RL_ZERO_INITIALIZE;
 
     result.x = fminf(max.x, fmaxf(min.x, v.x));
     result.y = fminf(max.y, fmaxf(min.y, v.y));
@@ -598,7 +604,7 @@ RMAPI int Vector2Equals(Vector2 p, Vector2 q)
 // to the refractive index of the medium on the other side of the surface
 RMAPI Vector2 Vector2Refract(Vector2 v, Vector2 n, float r)
 {
-    Vector2 result = { 0 };
+    Vector2 result = RL_ZERO_INITIALIZE;
 
     float dot = v.x*n.x + v.y*n.y;
     float d = 1.0f - r*r*(1.0f - dot*dot);
@@ -695,7 +701,7 @@ RMAPI Vector3 Vector3CrossProduct(Vector3 v1, Vector3 v2)
 // Calculate one vector perpendicular vector
 RMAPI Vector3 Vector3Perpendicular(Vector3 v)
 {
-    Vector3 result = { 0 };
+    Vector3 result = RL_ZERO_INITIALIZE;
 
     float min = fabsf(v.x);
     Vector3 cardinalAxis = {1.0f, 0.0f, 0.0f};
@@ -821,7 +827,7 @@ RMAPI Vector3 Vector3Normalize(Vector3 v)
 //Calculate the projection of the vector v1 on to v2
 RMAPI Vector3 Vector3Project(Vector3 v1, Vector3 v2)
 {
-    Vector3 result = { 0 };
+    Vector3 result = RL_ZERO_INITIALIZE;
 
     float v1dv2 = (v1.x*v2.x + v1.y*v2.y + v1.z*v2.z);
     float v2dv2 = (v2.x*v2.x + v2.y*v2.y + v2.z*v2.z);
@@ -838,7 +844,7 @@ RMAPI Vector3 Vector3Project(Vector3 v1, Vector3 v2)
 //Calculate the rejection of the vector v1 on to v2
 RMAPI Vector3 Vector3Reject(Vector3 v1, Vector3 v2)
 {
-    Vector3 result = { 0 };
+    Vector3 result = RL_ZERO_INITIALIZE;
 
     float v1dv2 = (v1.x*v2.x + v1.y*v2.y + v1.z*v2.z);
     float v2dv2 = (v2.x*v2.x + v2.y*v2.y + v2.z*v2.z);
@@ -890,7 +896,7 @@ RMAPI void Vector3OrthoNormalize(Vector3 *v1, Vector3 *v2)
 // Transforms a Vector3 by a given Matrix
 RMAPI Vector3 Vector3Transform(Vector3 v, Matrix mat)
 {
-    Vector3 result = { 0 };
+    Vector3 result = RL_ZERO_INITIALIZE;
 
     float x = v.x;
     float y = v.y;
@@ -906,7 +912,7 @@ RMAPI Vector3 Vector3Transform(Vector3 v, Matrix mat)
 // Transform a vector by quaternion rotation
 RMAPI Vector3 Vector3RotateByQuaternion(Vector3 v, Quaternion q)
 {
-    Vector3 result = { 0 };
+    Vector3 result = RL_ZERO_INITIALIZE;
 
     result.x = v.x*(q.x*q.x + q.w*q.w - q.y*q.y - q.z*q.z) + v.y*(2*q.x*q.y - 2*q.w*q.z) + v.z*(2*q.x*q.z + 2*q.w*q.y);
     result.y = v.x*(2*q.w*q.z + 2*q.x*q.y) + v.y*(q.w*q.w - q.x*q.x + q.y*q.y - q.z*q.z) + v.z*(-2*q.w*q.x + 2*q.y*q.z);
@@ -970,7 +976,7 @@ RMAPI Vector3 Vector3RotateByAxisAngle(Vector3 v, Vector3 axis, float angle)
 // Move Vector towards target
 RMAPI Vector3 Vector3MoveTowards(Vector3 v, Vector3 target, float maxDistance)
 {
-    Vector3 result = { 0 };
+    Vector3 result = RL_ZERO_INITIALIZE;
 
     float dx = target.x - v.x;
     float dy = target.y - v.y;
@@ -991,7 +997,7 @@ RMAPI Vector3 Vector3MoveTowards(Vector3 v, Vector3 target, float maxDistance)
 // Calculate linear interpolation between two vectors
 RMAPI Vector3 Vector3Lerp(Vector3 v1, Vector3 v2, float amount)
 {
-    Vector3 result = { 0 };
+    Vector3 result = RL_ZERO_INITIALIZE;
 
     result.x = v1.x + amount*(v2.x - v1.x);
     result.y = v1.y + amount*(v2.y - v1.y);
@@ -1004,7 +1010,7 @@ RMAPI Vector3 Vector3Lerp(Vector3 v1, Vector3 v2, float amount)
 // as described in the GLTF 2.0 specification: https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#interpolation-cubic
 RMAPI Vector3 Vector3CubicHermite(Vector3 v1, Vector3 tangent1, Vector3 v2, Vector3 tangent2, float amount)
 {
-    Vector3 result = { 0 };
+    Vector3 result = RL_ZERO_INITIALIZE;
 
     float amountPow2 = amount*amount;
     float amountPow3 = amount*amount*amount;
@@ -1019,7 +1025,7 @@ RMAPI Vector3 Vector3CubicHermite(Vector3 v1, Vector3 tangent1, Vector3 v2, Vect
 // Calculate reflected vector to normal
 RMAPI Vector3 Vector3Reflect(Vector3 v, Vector3 normal)
 {
-    Vector3 result = { 0 };
+    Vector3 result = RL_ZERO_INITIALIZE;
 
     // I is the original vector
     // N is the normal of the incident plane
@@ -1037,7 +1043,7 @@ RMAPI Vector3 Vector3Reflect(Vector3 v, Vector3 normal)
 // Get min value for each pair of components
 RMAPI Vector3 Vector3Min(Vector3 v1, Vector3 v2)
 {
-    Vector3 result = { 0 };
+    Vector3 result = RL_ZERO_INITIALIZE;
 
     result.x = fminf(v1.x, v2.x);
     result.y = fminf(v1.y, v2.y);
@@ -1049,7 +1055,7 @@ RMAPI Vector3 Vector3Min(Vector3 v1, Vector3 v2)
 // Get max value for each pair of components
 RMAPI Vector3 Vector3Max(Vector3 v1, Vector3 v2)
 {
-    Vector3 result = { 0 };
+    Vector3 result = RL_ZERO_INITIALIZE;
 
     result.x = fmaxf(v1.x, v2.x);
     result.y = fmaxf(v1.y, v2.y);
@@ -1062,7 +1068,7 @@ RMAPI Vector3 Vector3Max(Vector3 v1, Vector3 v2)
 // NOTE: Assumes P is on the plane of the triangle
 RMAPI Vector3 Vector3Barycenter(Vector3 p, Vector3 a, Vector3 b, Vector3 c)
 {
-    Vector3 result = { 0 };
+    Vector3 result = RL_ZERO_INITIALIZE;
 
     Vector3 v0 = { b.x - a.x, b.y - a.y, b.z - a.z };   // Vector3Subtract(b, a)
     Vector3 v1 = { c.x - a.x, c.y - a.y, c.z - a.z };   // Vector3Subtract(c, a)
@@ -1086,7 +1092,7 @@ RMAPI Vector3 Vector3Barycenter(Vector3 p, Vector3 a, Vector3 b, Vector3 c)
 // NOTE: Self-contained function, no other raymath functions are called
 RMAPI Vector3 Vector3Unproject(Vector3 source, Matrix projection, Matrix view)
 {
-    Vector3 result = { 0 };
+    Vector3 result = RL_ZERO_INITIALIZE;
 
     // Calculate unprojected matrix (multiply view matrix by projection matrix) and invert it
     Matrix matViewProj = {      // MatrixMultiply(view, projection);
@@ -1169,7 +1175,7 @@ RMAPI Vector3 Vector3Unproject(Vector3 source, Matrix projection, Matrix view)
 // Get Vector3 as float array
 RMAPI float3 Vector3ToFloatV(Vector3 v)
 {
-    float3 buffer = { 0 };
+    float3 buffer = RL_ZERO_INITIALIZE;
 
     buffer.v[0] = v.x;
     buffer.v[1] = v.y;
@@ -1190,7 +1196,7 @@ RMAPI Vector3 Vector3Invert(Vector3 v)
 // min and max values specified by the given vectors
 RMAPI Vector3 Vector3Clamp(Vector3 v, Vector3 min, Vector3 max)
 {
-    Vector3 result = { 0 };
+    Vector3 result = RL_ZERO_INITIALIZE;
 
     result.x = fminf(max.x, fmaxf(min.x, v.x));
     result.y = fminf(max.y, fmaxf(min.y, v.y));
@@ -1242,7 +1248,7 @@ RMAPI int Vector3Equals(Vector3 p, Vector3 q)
 // to the refractive index of the medium on the other side of the surface
 RMAPI Vector3 Vector3Refract(Vector3 v, Vector3 n, float r)
 {
-    Vector3 result = { 0 };
+    Vector3 result = RL_ZERO_INITIALIZE;
 
     float dot = v.x*n.x + v.y*n.y + v.z*n.z;
     float d = 1.0f - r*r*(1.0f - dot*dot);
@@ -1388,7 +1394,7 @@ RMAPI Vector4 Vector4Divide(Vector4 v1, Vector4 v2)
 // Normalize provided vector
 RMAPI Vector4 Vector4Normalize(Vector4 v)
 {
-    Vector4 result = { 0 };
+    Vector4 result = RL_ZERO_INITIALIZE;
     float length = sqrtf((v.x*v.x) + (v.y*v.y) + (v.z*v.z) + (v.w*v.w));
 
     if (length > 0)
@@ -1406,7 +1412,7 @@ RMAPI Vector4 Vector4Normalize(Vector4 v)
 // Get min value for each pair of components
 RMAPI Vector4 Vector4Min(Vector4 v1, Vector4 v2)
 {
-    Vector4 result = { 0 };
+    Vector4 result = RL_ZERO_INITIALIZE;
 
     result.x = fminf(v1.x, v2.x);
     result.y = fminf(v1.y, v2.y);
@@ -1419,7 +1425,7 @@ RMAPI Vector4 Vector4Min(Vector4 v1, Vector4 v2)
 // Get max value for each pair of components
 RMAPI Vector4 Vector4Max(Vector4 v1, Vector4 v2)
 {
-    Vector4 result = { 0 };
+    Vector4 result = RL_ZERO_INITIALIZE;
 
     result.x = fmaxf(v1.x, v2.x);
     result.y = fmaxf(v1.y, v2.y);
@@ -1432,7 +1438,7 @@ RMAPI Vector4 Vector4Max(Vector4 v1, Vector4 v2)
 // Calculate linear interpolation between two vectors
 RMAPI Vector4 Vector4Lerp(Vector4 v1, Vector4 v2, float amount)
 {
-    Vector4 result = { 0 };
+    Vector4 result = RL_ZERO_INITIALIZE;
 
     result.x = v1.x + amount*(v2.x - v1.x);
     result.y = v1.y + amount*(v2.y - v1.y);
@@ -1445,7 +1451,7 @@ RMAPI Vector4 Vector4Lerp(Vector4 v1, Vector4 v2, float amount)
 // Move Vector towards target
 RMAPI Vector4 Vector4MoveTowards(Vector4 v, Vector4 target, float maxDistance)
 {
-    Vector4 result = { 0 };
+    Vector4 result = RL_ZERO_INITIALIZE;
 
     float dx = target.x - v.x;
     float dy = target.y - v.y;
@@ -1539,7 +1545,7 @@ RMAPI float MatrixTrace(Matrix mat)
 // Transposes provided matrix
 RMAPI Matrix MatrixTranspose(Matrix mat)
 {
-    Matrix result = { 0 };
+    Matrix result = RL_ZERO_INITIALIZE;
 
     result.m0 = mat.m0;
     result.m1 = mat.m4;
@@ -1564,7 +1570,7 @@ RMAPI Matrix MatrixTranspose(Matrix mat)
 // Invert provided matrix
 RMAPI Matrix MatrixInvert(Matrix mat)
 {
-    Matrix result = { 0 };
+    Matrix result = RL_ZERO_INITIALIZE;
 
     // Cache the matrix values (speed optimization)
     float a00 = mat.m0, a01 = mat.m1, a02 = mat.m2, a03 = mat.m3;
@@ -1622,7 +1628,7 @@ RMAPI Matrix MatrixIdentity(void)
 // Add two matrices
 RMAPI Matrix MatrixAdd(Matrix left, Matrix right)
 {
-    Matrix result = { 0 };
+    Matrix result = RL_ZERO_INITIALIZE;
 
     result.m0 = left.m0 + right.m0;
     result.m1 = left.m1 + right.m1;
@@ -1647,7 +1653,7 @@ RMAPI Matrix MatrixAdd(Matrix left, Matrix right)
 // Subtract two matrices (left - right)
 RMAPI Matrix MatrixSubtract(Matrix left, Matrix right)
 {
-    Matrix result = { 0 };
+    Matrix result = RL_ZERO_INITIALIZE;
 
     result.m0 = left.m0 - right.m0;
     result.m1 = left.m1 - right.m1;
@@ -1673,7 +1679,7 @@ RMAPI Matrix MatrixSubtract(Matrix left, Matrix right)
 // NOTE: When multiplying matrices... the order matters!
 RMAPI Matrix MatrixMultiply(Matrix left, Matrix right)
 {
-    Matrix result = { 0 };
+    Matrix result = RL_ZERO_INITIALIZE;
 
 #if defined(RAYMATH_SSE_ENABLED)
     // Load left side and right side
@@ -1685,7 +1691,7 @@ RMAPI Matrix MatrixMultiply(Matrix left, Matrix right)
     // Transpose so c0..c3 become *rows* of the right matrix in semantic order
     _MM_TRANSPOSE4_PS(c0, c1, c2, c3);
 
-    float tmp[4] = { 0 };
+    float tmp[4] = RL_ZERO_INITIALIZE;
     __m128 row;
 
     // Row 0 of result: [m0, m1, m2, m3]
@@ -1780,7 +1786,7 @@ RMAPI Matrix MatrixTranslate(float x, float y, float z)
 // NOTE: Angle should be provided in radians
 RMAPI Matrix MatrixRotate(Vector3 axis, float angle)
 {
-    Matrix result = { 0 };
+    Matrix result = RL_ZERO_INITIALIZE;
 
     float x = axis.x, y = axis.y, z = axis.z;
 
@@ -1917,7 +1923,7 @@ RMAPI Matrix MatrixRotateXYZ(Vector3 angle)
 // NOTE: Angle must be provided in radians
 RMAPI Matrix MatrixRotateZYX(Vector3 angle)
 {
-    Matrix result = { 0 };
+    Matrix result = RL_ZERO_INITIALIZE;
 
     float cz = cosf(angle.z);
     float sz = sinf(angle.z);
@@ -1963,7 +1969,7 @@ RMAPI Matrix MatrixScale(float x, float y, float z)
 // Get perspective projection matrix
 RMAPI Matrix MatrixFrustum(double left, double right, double bottom, double top, double nearPlane, double farPlane)
 {
-    Matrix result = { 0 };
+    Matrix result = RL_ZERO_INITIALIZE;
 
     float rl = (float)(right - left);
     float tb = (float)(top - bottom);
@@ -1996,7 +2002,7 @@ RMAPI Matrix MatrixFrustum(double left, double right, double bottom, double top,
 // NOTE: Fovy angle must be provided in radians
 RMAPI Matrix MatrixPerspective(double fovY, double aspect, double nearPlane, double farPlane)
 {
-    Matrix result = { 0 };
+    Matrix result = RL_ZERO_INITIALIZE;
 
     double top = nearPlane*tan(fovY*0.5);
     double bottom = -top;
@@ -2022,7 +2028,7 @@ RMAPI Matrix MatrixPerspective(double fovY, double aspect, double nearPlane, dou
 // Get orthographic projection matrix
 RMAPI Matrix MatrixOrtho(double left, double right, double bottom, double top, double nearPlane, double farPlane)
 {
-    Matrix result = { 0 };
+    Matrix result = RL_ZERO_INITIALIZE;
 
     float rl = (float)(right - left);
     float tb = (float)(top - bottom);
@@ -2051,7 +2057,7 @@ RMAPI Matrix MatrixOrtho(double left, double right, double bottom, double top, d
 // Get camera look-at matrix (view matrix)
 RMAPI Matrix MatrixLookAt(Vector3 eye, Vector3 target, Vector3 up)
 {
-    Matrix result = { 0 };
+    Matrix result = RL_ZERO_INITIALIZE;
 
     float length = 0.0f;
     float ilength = 0.0f;
@@ -2106,7 +2112,7 @@ RMAPI Matrix MatrixLookAt(Vector3 eye, Vector3 target, Vector3 up)
 // Get float array of matrix data
 RMAPI float16 MatrixToFloatV(Matrix mat)
 {
-    float16 result = { 0 };
+    float16 result = RL_ZERO_INITIALIZE;
 
     result.v[0] = mat.m0;
     result.v[1] = mat.m1;
@@ -2183,7 +2189,7 @@ RMAPI float QuaternionLength(Quaternion q)
 // Normalize provided quaternion
 RMAPI Quaternion QuaternionNormalize(Quaternion q)
 {
-    Quaternion result = { 0 };
+    Quaternion result = RL_ZERO_INITIALIZE;
 
     float length = sqrtf(q.x*q.x + q.y*q.y + q.z*q.z + q.w*q.w);
     if (length == 0.0f) length = 1.0f;
@@ -2220,7 +2226,7 @@ RMAPI Quaternion QuaternionInvert(Quaternion q)
 // Calculate two quaternion multiplication
 RMAPI Quaternion QuaternionMultiply(Quaternion q1, Quaternion q2)
 {
-    Quaternion result = { 0 };
+    Quaternion result = RL_ZERO_INITIALIZE;
 
     float qax = q1.x, qay = q1.y, qaz = q1.z, qaw = q1.w;
     float qbx = q2.x, qby = q2.y, qbz = q2.z, qbw = q2.w;
@@ -2236,7 +2242,7 @@ RMAPI Quaternion QuaternionMultiply(Quaternion q1, Quaternion q2)
 // Scale quaternion by float value
 RMAPI Quaternion QuaternionScale(Quaternion q, float mul)
 {
-    Quaternion result = { 0 };
+    Quaternion result = RL_ZERO_INITIALIZE;
 
     result.x = q.x*mul;
     result.y = q.y*mul;
@@ -2257,7 +2263,7 @@ RMAPI Quaternion QuaternionDivide(Quaternion q1, Quaternion q2)
 // Calculate linear interpolation between two quaternions
 RMAPI Quaternion QuaternionLerp(Quaternion q1, Quaternion q2, float amount)
 {
-    Quaternion result = { 0 };
+    Quaternion result = RL_ZERO_INITIALIZE;
 
     result.x = q1.x + amount*(q2.x - q1.x);
     result.y = q1.y + amount*(q2.y - q1.y);
@@ -2270,7 +2276,7 @@ RMAPI Quaternion QuaternionLerp(Quaternion q1, Quaternion q2, float amount)
 // Calculate slerp-optimized interpolation between two quaternions
 RMAPI Quaternion QuaternionNlerp(Quaternion q1, Quaternion q2, float amount)
 {
-    Quaternion result = { 0 };
+    Quaternion result = RL_ZERO_INITIALIZE;
 
     // QuaternionLerp(q1, q2, amount)
     result.x = q1.x + amount*(q2.x - q1.x);
@@ -2295,7 +2301,7 @@ RMAPI Quaternion QuaternionNlerp(Quaternion q1, Quaternion q2, float amount)
 // Calculates spherical linear interpolation between two quaternions
 RMAPI Quaternion QuaternionSlerp(Quaternion q1, Quaternion q2, float amount)
 {
-    Quaternion result = { 0 };
+    Quaternion result = RL_ZERO_INITIALIZE;
 
 #if !defined(EPSILON)
     #define EPSILON 0.000001f
@@ -2354,7 +2360,7 @@ RMAPI Quaternion QuaternionCubicHermiteSpline(Quaternion q1, Quaternion outTange
     Quaternion p1 = QuaternionScale(q2, h01);
     Quaternion m1 = QuaternionScale(inTangent2, h11);
 
-    Quaternion result = { 0 };
+    Quaternion result = RL_ZERO_INITIALIZE;
 
     result = QuaternionAdd(p0, m0);
     result = QuaternionAdd(result, p1);
@@ -2367,7 +2373,7 @@ RMAPI Quaternion QuaternionCubicHermiteSpline(Quaternion q1, Quaternion outTange
 // Calculate quaternion based on the rotation from one vector to another
 RMAPI Quaternion QuaternionFromVector3ToVector3(Vector3 from, Vector3 to)
 {
-    Quaternion result = { 0 };
+    Quaternion result = RL_ZERO_INITIALIZE;
 
     float cos2Theta = (from.x*to.x + from.y*to.y + from.z*to.z); // Vector3DotProduct(from, to)
     Vector3 cross = { from.y*to.z - from.z*to.y, from.z*to.x - from.x*to.z, from.x*to.y - from.y*to.x }; // Vector3CrossProduct(from, to)
@@ -2395,7 +2401,7 @@ RMAPI Quaternion QuaternionFromVector3ToVector3(Vector3 from, Vector3 to)
 // Get a quaternion for a given rotation matrix
 RMAPI Quaternion QuaternionFromMatrix(Matrix mat)
 {
-    Quaternion result = { 0 };
+    Quaternion result = RL_ZERO_INITIALIZE;
 
     float fourWSquaredMinus1 = mat.m0  + mat.m5 + mat.m10;
     float fourXSquaredMinus1 = mat.m0  - mat.m5 - mat.m10;
@@ -2575,7 +2581,7 @@ RMAPI void QuaternionToAxisAngle(Quaternion q, Vector3 *outAxis, float *outAngle
 // NOTE: Rotation order is ZYX
 RMAPI Quaternion QuaternionFromEuler(float pitch, float yaw, float roll)
 {
-    Quaternion result = { 0 };
+    Quaternion result = RL_ZERO_INITIALIZE;
 
     float x0 = cosf(pitch*0.5f);
     float x1 = sinf(pitch*0.5f);
@@ -2596,7 +2602,7 @@ RMAPI Quaternion QuaternionFromEuler(float pitch, float yaw, float roll)
 // NOTE: Angles are returned in a Vector3 struct in radians
 RMAPI Vector3 QuaternionToEuler(Quaternion q)
 {
-    Vector3 result = { 0 };
+    Vector3 result = RL_ZERO_INITIALIZE;
 
     // Roll (x-axis rotation)
     float x0 = 2.0f*(q.w*q.x + q.y*q.z);
@@ -2620,7 +2626,7 @@ RMAPI Vector3 QuaternionToEuler(Quaternion q)
 // Transform a quaternion given a transformation matrix
 RMAPI Quaternion QuaternionTransform(Quaternion q, Matrix mat)
 {
-    Quaternion result = { 0 };
+    Quaternion result = RL_ZERO_INITIALIZE;
 
     result.x = mat.m0*q.x + mat.m4*q.y + mat.m8*q.z + mat.m12*q.w;
     result.y = mat.m1*q.x + mat.m5*q.y + mat.m9*q.z + mat.m13*q.w;
@@ -2696,10 +2702,10 @@ RMAPI void MatrixDecompose(Matrix mat, Vector3 *translation, Quaternion *rotatio
                              { mat.m2, mat.m6, mat.m10 }};
 
     // Shear Parameters XY, XZ, and YZ (extract and ignored)
-    float shear[3] = { 0 };
+    float shear[3] = RL_ZERO_INITIALIZE;
 
     // Normalized Scale Parameters
-    Vector3 scl = { 0 };
+    Vector3 scl = RL_ZERO_INITIALIZE;
 
     // Max-Normalizing helps numerical stability
     float stabilizer = eps;


### PR DESCRIPTION
Thank you for this wonderful standalone library!

I know nobody likes adding more defines in header files. Sorry about that, but I think this one is necessary and hardly that bad. In C++, struct zero-initialization is `{}` and in C it is `{0}`.

It's fine not to support C++ compilers, but this lovely header file already contains 400 lines of C++-specific code (operator definitions). So if C++ is not supported, we should not include C++-only features. If we're including C++ features, we probably want to support C++ compilers :p