### PR TITLE
[cmake] update cmake for PLATFORM_MEMORY

### DIFF
--- a/CMakeOptions.txt
+++ b/CMakeOptions.txt
@@ -6,7 +6,7 @@ if(EMSCRIPTEN)
     # When configuring web builds with "emcmake cmake -B build -S .", set PLATFORM to Web by default
     SET(PLATFORM Web CACHE STRING "Platform to build for.")
 endif()
-enum_option(PLATFORM "Desktop;Web;WebRGFW;Android;Raspberry Pi;DRM;SDL;RGFW" "Platform to build for.")
+enum_option(PLATFORM "Desktop;Web;WebRGFW;Android;Raspberry Pi;DRM;SDL;RGFW;Memory" "Platform to build for.")
 
 enum_option(OPENGL_VERSION "OFF;4.3;3.3;2.1;1.1;ES 2.0;ES 3.0;Software" "Force a specific OpenGL Version?")
 

--- a/cmake/LibraryConfigurations.cmake
+++ b/cmake/LibraryConfigurations.cmake
@@ -156,6 +156,7 @@ elseif ("${PLATFORM}" STREQUAL "SDL")
 			add_compile_definitions(USING_SDL2_PACKAGE)
 		endif()
 	endif()	
+
 elseif ("${PLATFORM}" STREQUAL "RGFW")
     set(PLATFORM_CPP "PLATFORM_DESKTOP_RGFW")
 
@@ -181,6 +182,11 @@ elseif ("${PLATFORM}" STREQUAL "WebRGFW")
     set(PLATFORM_CPP "PLATFORM_WEB_RGFW")
     set(GRAPHICS "GRAPHICS_API_OPENGL_ES2")
     set(CMAKE_STATIC_LIBRARY_SUFFIX ".a")
+
+elseif ("${PLATFORM}" STREQUAL "Memory")
+    set(PLATFORM_CPP "PLATFORM_MEMORY")
+    set(GRAPHICS "GRAPHICS_API_OPENGL_SOFTWARE")
+    set(OPENGL_VERSION "Software")
 endif ()
 
 if (NOT ${OPENGL_VERSION} MATCHES "OFF")

--- a/cmake/LibraryConfigurations.cmake
+++ b/cmake/LibraryConfigurations.cmake
@@ -187,6 +187,10 @@ elseif ("${PLATFORM}" STREQUAL "Memory")
     set(PLATFORM_CPP "PLATFORM_MEMORY")
     set(GRAPHICS "GRAPHICS_API_OPENGL_SOFTWARE")
     set(OPENGL_VERSION "Software")
+
+    if(WIN32 OR CMAKE_C_COMPILER MATCHES "mingw|mingw32|mingw64")
+        set(LIBS_PRIVATE winmm)
+    endif()
 endif ()
 
 if (NOT ${OPENGL_VERSION} MATCHES "OFF")

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -105,6 +105,9 @@ elseif ("${PLATFORM}" STREQUAL "DRM")
     list(REMOVE_ITEM example_sources ${CMAKE_CURRENT_SOURCE_DIR}/others/rlgl_standalone.c)
     list(REMOVE_ITEM example_sources ${CMAKE_CURRENT_SOURCE_DIR}/others/raylib_opengl_interop.c)
 
+elseif ("${PLATFORM}" MATCHES "Memory")
+    list(REMOVE_ITEM example_sources ${CMAKE_CURRENT_SOURCE_DIR}/others/raylib_opengl_interop.c)
+
 elseif ("${OPENGL_VERSION}" STREQUAL "Software")
     list(REMOVE_ITEM example_sources ${CMAKE_CURRENT_SOURCE_DIR}/others/rlgl_standalone.c)
     list(REMOVE_ITEM example_sources ${CMAKE_CURRENT_SOURCE_DIR}/others/raylib_opengl_interop.c)


### PR DESCRIPTION
taken from https://github.com/raysan5/raylib/issues/5731

also tagging cmake maintainers ray mentioned: @Peter0x44 @manuel5975p @JohnnyCena123 (victorHM doesnt appear for me)


How to test:
```
mkdir build
cd build
cmake .. -DPLATFORM=Memory
make
```

how to test cross compile (windows for linux users):
```
mkdir build
cd build
cmake .. -DPLATFORM=Memory -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc
make
```