### PR TITLE
[text_words_alignment] - Windows (GCC)

### DIFF
--- a/examples/text/text_words_alignment.c
+++ b/examples/text/text_words_alignment.c
@@ -50,7 +50,7 @@ int main(void)
     // Define the text we're going to draw in the rectangle
     int wordIndex = 0;
     int wordCount = 0;
-    char **words = TextSplit("raylib is a simple and easy-to-use library to enjoy videogames programming", ' ', &wordCount);
+    const char **words = TextSplit("raylib is a simple and easy-to-use library to enjoy videogames programming", ' ', &wordCount);
 
     // Initialize the font size we're going to use
     int fontSize = 40;


### PR DESCRIPTION
At line 53, the example uses:

`char **words = TextSplit(...);`

However, `TextSplit(...)` returns a `const char **`.

This causes a compilation error with strict GCC due to incompatible pointer types.

Suggested fix: 

`const char **words = TextSplit(...);`

This change helps avoid confusion for beginners and ensures compatibility with strict GCC/Clang builds.