### PR TITLE
[raudio] Fix pthread_mutex_lock called on a destroyed mutex

### DIFF
--- a/src/raudio.c
+++ b/src/raudio.c
@@ -1763,6 +1763,8 @@ bool IsMusicValid(Music music)
 // Unload music stream
 void UnloadMusicStream(Music music)
 {
+    if (IsMusicStreamPlaying(music)) StopMusicStream(music);
+
     UnloadAudioStream(music.stream);
 
     if (music.ctxData != NULL)


### PR DESCRIPTION
Fixing an race issue when unloading music that still playing.

```
raylib                  ovh...edev.stressreleasebyparticles  I  STREAM: Unloaded audio stream data from RAM
AAudio                  ovh...edev.stressreleasebyparticles  D  AAudioStream_close(s#2) called ---------------
AudioStrea...nal_Client ovh...edev.stressreleasebyparticles  D  release_l(): mServiceStreamHandle = 0x0000001A
libc                    ovh...edev.stressreleasebyparticles  A  FORTIFY: pthread_mutex_lock called on a destroyed mutex (0x74443efd20)
libc                    ovh...edev.stressreleasebyparticles  A  Fatal signal 6 (SIGABRT), code -1 (SI_QUEUE) in tid 14016 (AAudio_2), pid 13915 (easebyparticles)
```