### PR TITLE
Update 2025->2026, 5.5->6.0

### DIFF
--- a/BINDINGS.md
+++ b/BINDINGS.md
@@ -6,7 +6,7 @@ Some people ported raylib to other languages in the form of bindings or wrappers
 
 | Name                                                                                     | raylib Version   | Language                                                             | License              |
 | :--------------------------------------------------------------------------------------- | :--------------: | :------------------------------------------------------------------: | :------------------: |
-| [raylib](https://github.com/raysan5/raylib)                                              | **5.5**          | [C/C++](https://en.wikipedia.org/wiki/C_(programming_language))      | Zlib                 |
+| [raylib](https://github.com/raysan5/raylib)                                              | **6.0**          | [C/C++](https://en.wikipedia.org/wiki/C_(programming_language))      | Zlib                 |
 | [raylib-ada](https://github.com/Fabien-Chouteau/raylib-ada)                                              | **5.5**          | [Ada](https://en.wikipedia.org/wiki/Ada_(programming_language))      | MIT                 |
 | [raylib-beef](https://github.com/Starpelly/raylib-beef)                                  | **5.5**          | [Beef](https://www.beeflang.org)                                     | MIT                  |
 | [raybit](https://github.com/Alex-Velez/raybit)                                           | **5.0**          | [Brainfuck](https://en.wikipedia.org/wiki/Brainfuck)                 | MIT                  |

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,7 @@
 changelog
 ---------
 
-Current Release:    raylib 5.5 (18 November 2024)
+Current Release:    raylib 6.0 (23 April 2026)
 
 -------------------------------------------------------------------------
 Release:     raylib 6.0 (23 April 2026)

--- a/examples/Makefile.Android
+++ b/examples/Makefile.Android
@@ -2,7 +2,7 @@
 #
 #   raylib makefile for Android project (APK building)
 #
-#   Copyright (c) 2017-2025 Ramon Santamaria (@raysan5)
+#   Copyright (c) 2017-2026 Ramon Santamaria (@raysan5)
 #
 #   This software is provided "as-is", without any express or implied warranty. In no event
 #   will the authors be held liable for any damages arising from the use of this software.

--- a/examples/examples.rc
+++ b/examples/examples.rc
@@ -1,8 +1,8 @@
 GLFW_ICON ICON "raylib.ico"
 
 1 VERSIONINFO
-FILEVERSION     5,5,0,0
-PRODUCTVERSION  5,5,0,0
+FILEVERSION     6,0,0,0
+PRODUCTVERSION  6,0,0,0
 BEGIN
   BLOCK "StringFileInfo"
   BEGIN
@@ -11,12 +11,12 @@ BEGIN
     BEGIN
       VALUE "CompanyName", "raylib technologies"
       VALUE "FileDescription", "raylib application (www.raylib.com)"
-      VALUE "FileVersion", "5.5.0"
+      VALUE "FileVersion", "6.0.0"
       VALUE "InternalName", "raylib-example"
-      VALUE "LegalCopyright", "(c) 2025 Ramon Santamaria (@raysan5)"
+      VALUE "LegalCopyright", "(c) 2026 Ramon Santamaria (@raysan5)"
       VALUE "OriginalFilename", "raylib-example"
       VALUE "ProductName", "raylib-example"
-      VALUE "ProductVersion", "5.5.0"
+      VALUE "ProductVersion", "6.0.0"
     END
   END
   BLOCK "VarFileInfo"

--- a/projects/CMake/CMakeLists.txt
+++ b/projects/CMake/CMakeLists.txt
@@ -5,7 +5,7 @@ project(example)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 # Dependencies
-set(RAYLIB_VERSION 5.5)
+set(RAYLIB_VERSION 6.0)
 find_package(raylib ${RAYLIB_VERSION} QUIET) # QUIET or REQUIRED
 if (NOT raylib_FOUND) # If there's none, fetch and build raylib
   include(FetchContent)

--- a/tools/rexm/LICENSE
+++ b/tools/rexm/LICENSE
@@ -1,4 +1,4 @@
-﻿Copyright (c) 2025 Ramon Santamaria (@raysan5)
+﻿Copyright (c) 2026 Ramon Santamaria (@raysan5)
 
 This software is provided "as-is", without any express or implied warranty. In no event 
 will the authors be held liable for any damages arising from the use of this software.

--- a/tools/rexm/Makefile
+++ b/tools/rexm/Makefile
@@ -2,7 +2,7 @@
 #
 #   raylib makefile for Desktop platforms, Web (Wasm), Raspberry Pi (DRM mode) and Android
 #
-#   Copyright (c) 2013-2025 Ramon Santamaria (@raysan5)
+#   Copyright (c) 2013-2026 Ramon Santamaria (@raysan5)
 #
 #   This software is provided "as-is", without any express or implied warranty. In no event
 #   will the authors be held liable for any damages arising from the use of this software.

--- a/tools/rexm/rexm.c
+++ b/tools/rexm/rexm.c
@@ -474,8 +474,8 @@ int main(int argc, char *argv[])
             exTextUpdated[1] = TextReplaceAlloc(exTextUpdated[0], "<name>", exName + strlen(exCategory) + 1);
             //TextReplaceAlloc(newExample, "<user_name>", "Ray");
             //TextReplaceAlloc(newExample, "@<user_github>", "@raysan5");
-            //TextReplaceAlloc(newExample, "<year_created>", 2025);
-            //TextReplaceAlloc(newExample, "<year_updated>", 2025);
+            //TextReplaceAlloc(newExample, "<year_created>", 2026);
+            //TextReplaceAlloc(newExample, "<year_updated>", 2026);
 
             SaveFileText(TextFormat("%s/%s/%s.c", exBasePath, exCategory, exName), exTextUpdated[1]);
             for (int i = 0; i < 6; i++) { MemFree(exTextUpdated[i]); exTextUpdated[i] = NULL; }
@@ -1875,7 +1875,7 @@ int main(int argc, char *argv[])
             printf("\n////////////////////////////////////////////////////////////////////////////////////////////\n");
             printf("//                                                                                        //\n");
             printf("// rexm [raylib examples manager] - A simple command-line tool to manage raylib examples  //\n");
-            printf("// powered by raylib v5.6-dev                                                             //\n");
+            printf("// powered by raylib v6.0                                                                 //\n");
             printf("//                                                                                        //\n");
             printf("// Copyright (c) 2025-2026 Ramon Santamaria (@raysan5)                                    //\n");
             printf("//                                                                                        //\n");

--- a/tools/rexm/rexm.rc
+++ b/tools/rexm/rexm.rc
@@ -13,7 +13,7 @@ BEGIN
       VALUE "FileDescription", "rexm | raylib examples manager"
       VALUE "FileVersion", "1.0"
       VALUE "InternalName", "rexm"
-      VALUE "LegalCopyright", "(c) 2025 Ramon Santamaria"
+      VALUE "LegalCopyright", "(c) 2026 Ramon Santamaria"
       //VALUE "OriginalFilename", "rexm.exe"
       VALUE "rexm", "rexm"
       VALUE "ProductVersion", "1.0"

--- a/tools/rlparser/rlparser.rc
+++ b/tools/rlparser/rlparser.rc
@@ -1,7 +1,7 @@
 IDI_APP_ICON ICON "rlparser.ico"
 1 VERSIONINFO
-FILEVERSION     5,5,0,0
-PRODUCTVERSION  5,5,0,0
+FILEVERSION     6,0,0,0
+PRODUCTVERSION  6,0,0,0
 BEGIN
   BLOCK "StringFileInfo"
   BEGIN
@@ -11,7 +11,7 @@ BEGIN
       VALUE "FileDescription", "rlparser | raylib header API parser"
       VALUE "FileVersion", "1.0"
       VALUE "InternalName", "rlparser"
-      VALUE "LegalCopyright", "(c) 2025 Ramon Santamaria (@raysan5)"
+      VALUE "LegalCopyright", "(c) 2026 Ramon Santamaria (@raysan5)"
       VALUE "OriginalFilename", "rlparser"
       VALUE "ProductName", "rlparser"
       VALUE "ProductVersion", "1.0"


### PR DESCRIPTION
Idea by @maiconpintoabreu in https://github.com/raysan5/raylib/pull/5748#issuecomment-4222530730

This PR does not include examples because im not 100% confident they should really be updated

## Note: if this is merged before official release of 6.0 it will cause some things to break or not make sense. Example, the cmake will search for "6.0" release etc etc