### PR TITLE
rcore: fix GetFileNameWithoutExt returning wrong value on repeated calls

### DIFF
--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1152,7 +1152,7 @@ RLAPI int GetFileLength(const char *fileName);                      // Get file 
 RLAPI long GetFileModTime(const char *fileName);                    // Get file modification time (last write time)
 RLAPI const char *GetFileExtension(const char *fileName);           // Get pointer to extension for a filename string (includes dot: '.png')
 RLAPI const char *GetFileName(const char *filePath);                // Get pointer to filename for a path string
-RLAPI const char *GetFileNameWithoutExt(const char *filePath);      // Get filename string without extension (uses static string)
+RLAPI const char *GetFileNameWithoutExt(const char *filePath);      // Get filename string without extension (uses rotating static strings)
 RLAPI const char *GetDirectoryPath(const char *filePath);           // Get full path for a given fileName with path (uses static string)
 RLAPI const char *GetPrevDirectoryPath(const char *dirPath);        // Get previous directory path for a given path (uses static string)
 RLAPI const char *GetWorkingDirectory(void);                        // Get current working directory (uses static string)

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -2503,31 +2503,42 @@ const char *GetFileName(const char *filePath)
     return fileName + 1;
 }
 
-// Get filename string without extension (uses static string)
+// Get filename string without extension (uses rotating static strings)
+// WARNING: String returned will expire after this function is called MAX_FILENAME_BUFFERS times
 const char *GetFileNameWithoutExt(const char *filePath)
 {
     #define MAX_FILENAME_LENGTH     256
+#ifndef MAX_FILENAME_BUFFERS
+    #define MAX_FILENAME_BUFFERS    4        // Maximum number of static buffers for filename without extension
+#endif
 
-    static char fileName[MAX_FILENAME_LENGTH] = { 0 };
-    memset(fileName, 0, MAX_FILENAME_LENGTH);
+    // Create an array of buffers so strings don't expire until MAX_FILENAME_BUFFERS invocations
+    static char fileName[MAX_FILENAME_BUFFERS][MAX_FILENAME_LENGTH] = { 0 };
+    static int index = 0;
+
+    char *currentBuffer = fileName[index];
+    memset(currentBuffer, 0, MAX_FILENAME_LENGTH); // Clear buffer before using
 
     if (filePath != NULL)
     {
-        strncpy(fileName, GetFileName(filePath), MAX_FILENAME_LENGTH - 1); // Get filename.ext without path
-        int fileNameLenght = (int)strlen(fileName); // Get size in bytes
+        strncpy(currentBuffer, GetFileName(filePath), MAX_FILENAME_LENGTH - 1); // Get filename.ext without path
+        int fileNameLength = (int)strlen(currentBuffer); // Get size in bytes
 
-        for (int i = fileNameLenght; i > 0; i--) // Reverse search '.'
+        for (int i = fileNameLength; i > 0; i--) // Reverse search '.'
         {
-            if (fileName[i] == '.')
+            if (currentBuffer[i] == '.')
             {
                 // NOTE: Break on first '.' found
-                fileName[i] = '\0';
+                currentBuffer[i] = '\0';
                 break;
             }
         }
+
+        index += 1;     // Move to next buffer for next function call
+        if (index >= MAX_FILENAME_BUFFERS) index = 0;
     }
 
-    return fileName;
+    return currentBuffer;
 }
 
 // Get directory for a given filePath


### PR DESCRIPTION
## Problem

`GetFileNameWithoutExt` writes into a single shared `static char[256]` and returns a pointer to it. Two calls alias the same memory:

```c
const char *road = GetFileNameWithoutExt("scenarios/roads/open-75km-2lane-ramp.json");
const char *sim  = GetFileNameWithoutExt("scenarios/sims/baseline.json");
printf("%s__%s\n", road, sim);
// Expected:  open-75km-2lane-ramp__baseline
// Unpatched: baseline__baseline
```

Both pointers land on the same buffer; the second call silently overwrites what the first returned. Inlining both calls into a single `snprintf` triggers the same bug with a compiler-dependent flavour because argument evaluation order is unspecified in C.

## Fix

Mirror the rotating-buffer idiom `TextFormat` already uses at `rtext.c:1565` (and its `!SUPPORT_MODULE_RTEXT` fallback at `rcore.c:4588`): `MAX_FILENAME_BUFFERS` (default 4, overridable via `-DMAX_FILENAME_BUFFERS=N`) slots with a rotating index. Same lifetime contract as `TextFormat`. No API/ABI change.

## About the approach

This mirrors `TextFormat`; it's pragmatic, not structurally clean. The standardized C answer for this class of bug is caller-supplied buffers with a `_r` / `*Copy` suffix. Happy to rewrite the PR as a full API-adding version with caller-buffer variants for every affected helper if you prefer that direction.

## Scope

Fixes only `GetFileNameWithoutExt`. Same root cause affects `GetDirectoryPath`, `GetPrevDirectoryPath`, `GetWorkingDirectory`, `GetApplicationDirectory` in `rcore.c`, and `TextSubtext`, `TextRemoveSpaces`, `GetTextBetween`, `TextReplace`, `TextReplaceBetween`, `TextInsert`, `TextJoin`, `TextSplit`, `TextTo{Upper,Lower,Pascal,Snake,Camel}`, `CodepointToUTF8` in `rtext.c`.

## Drive-by

Pre-existing `fileNameLenght → fileNameLength` typo fixed in the same function; happy to split if preferred.
