### PR TITLE
 Remap stb_vorbis malloc/free calls to RL_MALLOC/RL_FREE

### DIFF
--- a/src/raudio.c
+++ b/src/raudio.c
@@ -210,8 +210,11 @@ typedef struct tagBITMAPINFOHEADER {
 #endif
 
 #if SUPPORT_FILEFORMAT_OGG
-    // TODO: Remap stb_vorbis malloc()/free() calls to RL_MALLOC/RL_FREE
+    #define malloc RL_MALLOC
+    #define free RL_FREE
     #include "external/stb_vorbis.c"    // OGG loading functions
+    #undef malloc
+    #undef free
 #endif
 
 #if SUPPORT_FILEFORMAT_MP3


### PR DESCRIPTION
  Implements the TODO comment in `src/raudio.c`. `stb_vorbis` was the only audio format not respecting raylib's custom
  allocator hooks, making it consistent with `dr_wav`, `dr_mp3`, and `qoa`. 