### PR TITLE
Remap stb_vorbis malloc/free calls to RL_MALLOC/RL_FREE

### DIFF
--- a/src/external/stb_vorbis.c
+++ b/src/external/stb_vorbis.c
@@ -957,13 +957,21 @@ static void *setup_malloc(vorb *f, int sz)
       f->setup_offset += sz;
       return p;
    }
+   #ifdef STB_VORBIS_MALLOC
+   return sz ? STB_VORBIS_MALLOC(sz) : NULL;
+   #else  
    return sz ? malloc(sz) : NULL;
+   #endif
 }
 
 static void setup_free(vorb *f, void *p)
 {
    if (f->alloc.alloc_buffer) return; // do nothing; setup mem is a stack
+   #ifdef STB_VORBIS_FREE 
+   STB_VORBIS_FREE(p);
+   #else
    free(p);
+   #endif
 }
 
 static void *setup_temp_malloc(vorb *f, int sz)

--- a/src/raudio.c
+++ b/src/raudio.c
@@ -210,11 +210,9 @@ typedef struct tagBITMAPINFOHEADER {
 #endif
 
 #if SUPPORT_FILEFORMAT_OGG
-    #define malloc RL_MALLOC
-    #define free RL_FREE
+    #define STB_VORBIS_MALLOC RL_MALLOC
+    #define STB_VORBIS_FREE RL_FREE
     #include "external/stb_vorbis.c"    // OGG loading functions
-    #undef malloc
-    #undef free
 #endif
 
 #if SUPPORT_FILEFORMAT_MP3

--- a/src/raudio.c
+++ b/src/raudio.c
@@ -210,8 +210,11 @@ typedef struct tagBITMAPINFOHEADER {
 #endif
 
 #if SUPPORT_FILEFORMAT_OGG
-    // TODO: Remap stb_vorbis malloc()/free() calls to RL_MALLOC/RL_FREE
+    #define malloc RL_MALLOC
+    #define free RL_FREE
     #include "external/stb_vorbis.c"    // OGG loading functions
+    #undef malloc
+    #undef free
 #endif
 
 #if SUPPORT_FILEFORMAT_MP3


### PR DESCRIPTION
Implements the TODO in `src/raudio.c`. Adds STB_VORBIS_MALLOC and STB_VORBIS_FREE hooks to `stb_vorbis.c`, consistent with the named macro pattern used by dr_wav, dr_mp3, and qoa. Previous PR #5763 used a raw `#define malloc` approach which conflicted with stb_vorbis's internal stdlib.h include. 