### PR TITLE
[build-windows.bat] Update build-windows script

### DIFF
--- a/projects/scripts/build-windows.bat
+++ b/projects/scripts/build-windows.bat
@@ -26,15 +26,13 @@ REM Checks if cl is available and skips to the argument loop if it is
 REM (Prevents calling vcvarsall every time you run this script)
 WHERE cl >nul 2>nul
 IF %ERRORLEVEL% == 0 goto READ_ARGS
+
 REM Activate the msvc build environment if cl isn't available yet
-IF EXIST "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" (
-  set VC_INIT="C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat"
-) ELSE IF EXIST "C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\VC\Auxiliary\Build\vcvarsall.bat" (
-  set VC_INIT="C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\VC\Auxiliary\Build\vcvarsall.bat"
-) ELSE IF EXIST "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Auxiliary\Build\vcvarsall.bat" (
-  set VC_INIT="C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Auxiliary\Build\vcvarsall.bat"
-) ELSE IF EXIST "C:\Program Files (x86)\Microsoft Visual C++ Build Tools\vcbuildtools.bat" (
-  set VC_INIT="C:\Program Files (x86)\Microsoft Visual C++ Build Tools\vcbuildtools.bat"
+for /f "tokens=*" %%i in (
+  '"C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath 2^>nul'
+) do set VS_PATH=%%i
+IF defined VS_PATH (
+  set VC_INIT="%VS_PATH%\VC\Auxiliary\Build\vcvarsall.bat"
 ) ELSE (
   REM Initialize your vc environment here if the defaults don't work
   REM  set VC_INIT="C:\your\path\here\vcvarsall.bat"

--- a/projects/scripts/build-windows.bat
+++ b/projects/scripts/build-windows.bat
@@ -31,6 +31,8 @@ IF EXIST "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxil
   set VC_INIT="C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat"
 ) ELSE IF EXIST "C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\VC\Auxiliary\Build\vcvarsall.bat" (
   set VC_INIT="C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\VC\Auxiliary\Build\vcvarsall.bat"
+) ELSE IF EXIST "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Auxiliary\Build\vcvarsall.bat" (
+  set VC_INIT="C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Auxiliary\Build\vcvarsall.bat"
 ) ELSE IF EXIST "C:\Program Files (x86)\Microsoft Visual C++ Build Tools\vcbuildtools.bat" (
   set VC_INIT="C:\Program Files (x86)\Microsoft Visual C++ Build Tools\vcbuildtools.bat"
 ) ELSE (
@@ -167,7 +169,7 @@ IF NOT EXIST !TEMP_DIR!\ (
   cd !TEMP_DIR!
   REM raylib source folder
   set "RAYLIB_DEFINES=/D_DEFAULT_SOURCE /DPLATFORM_DESKTOP /DGRAPHICS_API_OPENGL_33"
-  set RAYLIB_C_FILES="!RAYLIB_SRC!\rcore.c" "!RAYLIB_SRC!\rshapes.c" "!RAYLIB_SRC!\rtextures.c" "!RAYLIB_SRC!\rtext.c" "!RAYLIB_SRC!\rmodels.c" "!RAYLIB_SRC!\utils.c" "!RAYLIB_SRC!\raudio.c" "!RAYLIB_SRC!\rglfw.c"
+  set RAYLIB_C_FILES="!RAYLIB_SRC!\rcore.c" "!RAYLIB_SRC!\rshapes.c" "!RAYLIB_SRC!\rtextures.c" "!RAYLIB_SRC!\rtext.c" "!RAYLIB_SRC!\rmodels.c" "!RAYLIB_SRC!\raudio.c" "!RAYLIB_SRC!\rglfw.c"
   set RAYLIB_INCLUDE_FLAGS=/I"!RAYLIB_SRC!" /I"!RAYLIB_SRC!\external\glfw\include"
 
   IF DEFINED REALLY_QUIET (


### PR DESCRIPTION
### Problem:
Windows batch build script still referenced utils.c, which no longer exists in src
Script did not detect VS2019 BuildTools vcvarsall path

### Changes:
Added VS2019 BuildTools vcvarsall.bat detection
Removed stale utils.c from RAYLIB_C_FILES

### Impact:
Keeps Windows script aligned with current src layout
Improves MSVC environment detection on systems with VS2019 BuildTools

### Testing:
- Verified diff scope is limited to `build-windows.bat`
- Example builds correctly for release and `-DEBUG`