### PR TITLE
[rmodels] Removing powf function from `CheckCollisionBoxSphere`

### DIFF
--- a/src/rmodels.c
+++ b/src/rmodels.c
@@ -4131,18 +4131,15 @@ bool CheckCollisionBoxSphere(BoundingBox box, Vector3 center, float radius)
 {
     bool collision = false;
 
-    float dmin = 0;
+    Vector3 closestPoint = {
+        Clamp(center.x, box.min.x, box.max.x),
+        Clamp(center.y, box.min.y, box.max.y),
+        Clamp(center.z, box.min.z, box.max.z)
+    };
 
-    if (center.x < box.min.x) dmin += powf(center.x - box.min.x, 2);
-    else if (center.x > box.max.x) dmin += powf(center.x - box.max.x, 2);
+    float distanceSquared = Vector3DistanceSqr(center, closestPoint);
 
-    if (center.y < box.min.y) dmin += powf(center.y - box.min.y, 2);
-    else if (center.y > box.max.y) dmin += powf(center.y - box.max.y, 2);
-
-    if (center.z < box.min.z) dmin += powf(center.z - box.min.z, 2);
-    else if (center.z > box.max.z) dmin += powf(center.z - box.max.z, 2);
-
-    if (dmin <= (radius*radius)) collision = true;
+    collision = distanceSquared <= (radius * radius);
 
     return collision;
 }


### PR DESCRIPTION
Removing powf with a similar way to calculate used in `CheckCollisionSpheres`

Test:
```
#import "raylib.h"

int main(void) 
{
    // Define a 2x2x2 box centered at the origin
    BoundingBox box = {
        .min = {-1.0f, -1.0f, -1.0f},
        .max = { 1.0f,  1.0f,  1.0f}
    };

    // Test Case 1: Sphere inside the box
    Vector3 center1 = {0.0f, 0.0f, 0.0f};
    float radius1 = 0.5f;
    
    // Test Case 2: Sphere touching the edge
    Vector3 center2 = {2.0f, 0.0f, 0.0f};
    float radius2 = 1.0f; // Distance is exactly 1.0 from box.max.x

    // Test Case 3: Sphere far away
    Vector3 center3 = {5.0f, 5.0f, 5.0f};
    float radius3 = 1.0f;

    TraceLog(LOG_INFO, "--- Collision Tests ---");
    TraceLog(LOG_INFO, "Test 1 (Inside): %s", CheckCollisionBoxSphere(box, center1, radius1) ? "COLLISION" : "NO COLLISION");
    TraceLog(LOG_INFO, "Test 2 (Touching): %s", CheckCollisionBoxSphere(box, center2, radius2) ? "COLLISION" : "NO COLLISION");
    TraceLog(LOG_INFO, "Test 3 (Far Away): %s", CheckCollisionBoxSphere(box, center3, radius3) ? "COLLISION" : "NO COLLISION");

    return 0;
}
```
The benchmark on my machine the change did not improve a lot but it should improve on low end devices.

Changed the benchmark tool to use bench.h instead of poop (it was too noise)
```
1 Call
[==========] Running 2 benchmarks.
[ RUN      ] CollisionSuite.Old_Powf
[       OK ] CollisionSuite.Old_Powf (mean 0.051us, confidence interval +- 0.237557%)
[ RUN      ] CollisionSuite.New_Clamp
[       OK ] CollisionSuite.New_Clamp (mean 0.039us, confidence interval +- 0.582900%)
[==========] 2 benchmarks ran.
[  PASSED  ] 2 benchmarks.

10000 Calls
[==========] Running 2 benchmarks.
[ RUN      ] BatchSuite.Old_Powf
[       OK ] BatchSuite.Old_Powf (mean 148.454us, confidence interval +- 1.816232%)
[ RUN      ] BatchSuite.New_Clamp
[       OK ] BatchSuite.New_Clamp (mean 7.330us, confidence interval +- 2.055348%)
[==========] 2 benchmarks ran.
[  PASSED  ] 2 benchmarks.
```