### PR TITLE
BINDINGS: Update raylib-cpp version to 6.0

### DIFF
--- a/BINDINGS.md
+++ b/BINDINGS.md
@@ -112,7 +112,7 @@ Some people ported raylib to other languages in the form of bindings or wrappers
 These are utility wrappers for specific languages, they are not required to use raylib in the language but may adapt the raylib API to be more inline with the language's paradigm.
 | Name                                                 | raylib Version | Language                                     | License |
 | ---------------------------------------------------- | :------------: | :------------------------------------------: | :-----: |
-| [raylib-cpp](https://github.com/robloach/raylib-cpp) | **5.5**        | [C++](https://en.wikipedia.org/wiki/C%2B%2B) | Zlib    |
+| [raylib-cpp](https://github.com/robloach/raylib-cpp) | **6.0**        | [C++](https://en.wikipedia.org/wiki/C%2B%2B) | Zlib    |
 | [claylib](https://github.com/defun-games/claylib)    | 4.5            | [Common Lisp](https://common-lisp.net)       | Zlib    |
 | [rayed-bqn](https://github.com/Brian-ED/rayed-bqn)   | **5.0**        | [BQN](https://mlochbaum.github.io/BQN)       | MIT     |
 | [DOOR](https://github.com/RealDoigt/DOOR)            | 4.0            | [D](https://dlang.org)                       | MIT     |


### PR DESCRIPTION
The C++ wrapper, [raylib-cpp](https://github.com/RobLoach/raylib-cpp), now works with raylib 6.0: https://github.com/RobLoach/raylib-cpp/releases/tag/v6.0.0