### PR TITLE
[examples] Move window for ball shake

### DIFF
--- a/examples/shapes/shapes_ball_physics.c
+++ b/examples/shapes/shapes_ball_physics.c
@@ -16,6 +16,7 @@
 ********************************************************************************************/
 
 #include "raylib.h"
+#include "raymath.h"
 
 #include <stdlib.h>         // Required for: malloc(), free()
 #include <math.h>           // Required for: hypot()
@@ -68,6 +69,8 @@ int main(void)
     Vector2 pressOffset = { 0 };    // Mouse press offset relative to the ball that grabbedd
 
     float gravity = 100;            // World gravity
+    
+    Vector2 windowPosition = GetWindowPosition();
 
     SetTargetFPS(60);               // Set our game to run at 60 frames-per-second
     //---------------------------------------------------------------------------------------
@@ -125,6 +128,15 @@ int main(void)
                     .color = { GetRandomValue(0, 255), GetRandomValue(0, 255), GetRandomValue(0, 255), 255 },
                     .grabbed = false
                 };
+            }
+        }
+
+        Vector2 windowPositionDiff = Vector2Subtract(windowPosition, GetWindowPosition());
+        if (Vector2Length(windowPositionDiff) > 5.0f) {
+            for (int i = 0; i < ballCount; i++) {
+                if (!balls[i].grabbed) {
+                    balls[i].speed = Vector2Add(balls[i].speed, Vector2Scale(windowPositionDiff, 10.0f));
+                }
             }
         }
 
@@ -194,6 +206,8 @@ int main(void)
                 ball->prevPosition = ball->position;
             }
         }
+
+        windowPosition = GetWindowPosition();
         //----------------------------------------------------------------------------------
 
         // Draw


### PR DESCRIPTION
Adds the ability to shake the balls in the `shapes_ball_physics` example via moving/shaking the window.  
I though this is a fun feature for this example. If you want, i can auto-disable this and let it be toggled via a keyboard input.  
  
I guess this may not work for all platforms though.


https://github.com/user-attachments/assets/71fc3ea0-e1de-4e52-9893-4d0157c7657a

