### PR TITLE
Update sola-raylib Raylib supported version to 6.0

### DIFF
--- a/BINDINGS.md
+++ b/BINDINGS.md
@@ -77,7 +77,7 @@ Some people ported raylib to other languages in the form of bindings or wrappers
 | [raylibr](https://github.com/jeroenjanssens/raylibr)                                     | 4.0              | [R](https://www.r-project.org)                                       | MIT                  |
 | [raylib-ffi](https://github.com/ewpratten/raylib-ffi)                                    | 5.5              | [Rust](https://www.rust-lang.org)                                    | GPLv3                |
 | [raylib-rs](https://github.com/raylib-rs/raylib-rs)                                      | **5.5**          | [Rust](https://www.rust-lang.org)                                    | Zlib                 |
-| [sola-raylib](https://github.com/brettchalupa/sola-raylib)                               | **5.5**          | [Rust](https://www.rust-lang.org)                                    | Zlib                 |
+| [sola-raylib](https://github.com/brettchalupa/sola-raylib)                               | **6.0**          | [Rust](https://www.rust-lang.org)                                    | Zlib                 |
 | [raylib-ruby](https://github.com/wilsonsilva/raylib-ruby)                                | 4.5              | [Ruby](https://www.ruby-lang.org)                                    | Zlib                 |
 | [Relib](https://github.com/RedCubeDev-ByteSpace/Relib)                                   | 3.5              | [ReCT](https://github.com/RedCubeDev-ByteSpace/ReCT)                 | **???**              |
 | [racket-raylib](https://github.com/eutro/racket-raylib)                                  | **5.5**          | [Racket](https://racket-lang.org)                                    | MIT/Apache-2.0       |


### PR DESCRIPTION
I just published crate version 6.0.0 which supports Raylib 6's new
functions and platforms.

https://github.com/brettchalupa/sola-raylib/releases/tag/v6.0.0
