### PR TITLE
[rcore] Fix OS Command Injection and Protocol Abuse in OpenURL()

### DIFF
--- a/src/platforms/rcore_android.c
+++ b/src/platforms/rcore_android.c
@@ -51,6 +51,8 @@
 
 #include <errno.h>                      // Required for: error types
 #include <jni.h>                        // Required for: JNIEnv and JavaVM [Used in OpenURL() and GetCurrentMonitor()]
+#include <string.h>
+#include <ctype.h>                      // Required for: isspace()
 
 #include <EGL/egl.h>                    // Native platform windowing system interface
 
@@ -670,9 +672,20 @@ double GetTime(void)
 void OpenURL(const char *url)
 {
     // Security check to (partially) avoid malicious code
-    if (strchr(url, '\'') != NULL) TRACELOG(LOG_WARNING, "SYSTEM: Provided URL could be potentially malicious, avoid [\'] character");
+    if ((strchr(url, '\'') != NULL) || (strchr(url, '\"') != NULL)) TRACELOG(LOG_WARNING, "SYSTEM: Provided URL could be potentially malicious, avoid [\'\"] characters");
     else
     {
+        // Restriction: Only allow http:// and https:// protocols
+        const char *p = url;
+        while (*p && isspace((unsigned char)*p)) p++;
+        char protocol[9] = { 0 };
+        for (int i = 0; (i < 8) && p[i]; i++) protocol[i] = (char)tolower((unsigned char)p[i]);
+        if ((strncmp(protocol, "http://", 7) != 0) && (strncmp(protocol, "https://", 8) != 0))
+        {
+            TRACELOG(LOG_WARNING, "SYSTEM: Provided URL protocol is not allowed; only http:// and https:// are permitted");
+            return;
+        }
+
         JNIEnv *env = NULL;
         JavaVM *vm = platform.app->activity->vm;
         (*vm)->AttachCurrentThread(vm, &env, NULL);

--- a/src/platforms/rcore_desktop_glfw.c
+++ b/src/platforms/rcore_desktop_glfw.c
@@ -105,6 +105,7 @@
 #endif
 
 #include <stddef.h>  // Required for: size_t
+#include <ctype.h>   // Required for: isspace()
 
 //----------------------------------------------------------------------------------
 // Types and Structures Definition
@@ -1191,9 +1192,20 @@ double GetTime(void)
 void OpenURL(const char *url)
 {
     // Security check to (partially) avoid malicious code
-    if (strchr(url, '\'') != NULL) TRACELOG(LOG_WARNING, "SYSTEM: Provided URL could be potentially malicious, avoid [\'] character");
+    if ((strchr(url, '\'') != NULL) || (strchr(url, '\"') != NULL)) TRACELOG(LOG_WARNING, "SYSTEM: Provided URL could be potentially malicious, avoid [\'\"] characters");
     else
     {
+        // Restriction: Only allow http:// and https:// protocols
+        const char *p = url;
+        while (*p && isspace((unsigned char)*p)) p++;
+        char protocol[9] = { 0 };
+        for (int i = 0; (i < 8) && p[i]; i++) protocol[i] = (char)tolower((unsigned char)p[i]);
+        if ((strncmp(protocol, "http://", 7) != 0) && (strncmp(protocol, "https://", 8) != 0))
+        {
+            TRACELOG(LOG_WARNING, "SYSTEM: Provided URL protocol is not allowed; only http:// and https:// are permitted");
+            return;
+        }
+
         char *cmd = (char *)RL_CALLOC(strlen(url) + 32, sizeof(char));
 #if defined(_WIN32)
         sprintf(cmd, "explorer \"%s\"", url);

--- a/src/platforms/rcore_desktop_rgfw.c
+++ b/src/platforms/rcore_desktop_rgfw.c
@@ -169,6 +169,7 @@ extern "C" {
 #endif
 
 #include <stdbool.h>
+#include <ctype.h>   // Required for: isspace()
 
 //----------------------------------------------------------------------------------
 // Types and Structures Definition
@@ -1179,9 +1180,20 @@ double GetTime(void)
 void OpenURL(const char *url)
 {
     // Security check to (partially) avoid malicious code on target platform
-    if (strchr(url, '\'') != NULL) TRACELOG(LOG_WARNING, "SYSTEM: Provided URL could be potentially malicious, avoid [\'] character");
+    if ((strchr(url, '\'') != NULL) || (strchr(url, '\"') != NULL)) TRACELOG(LOG_WARNING, "SYSTEM: Provided URL could be potentially malicious, avoid [\'\"] characters");
     else
     {
+        // Restriction: Only allow http:// and https:// protocols
+        const char *p = url;
+        while (*p && isspace((unsigned char)*p)) p++;
+        char protocol[9] = { 0 };
+        for (int i = 0; (i < 8) && p[i]; i++) protocol[i] = (char)tolower((unsigned char)p[i]);
+        if ((strncmp(protocol, "http://", 7) != 0) && (strncmp(protocol, "https://", 8) != 0))
+        {
+            TRACELOG(LOG_WARNING, "SYSTEM: Provided URL protocol is not allowed; only http:// and https:// are permitted");
+            return;
+        }
+
         char *cmd = (char *)RL_CALLOC(strlen(url) + 32, sizeof(char));
 #if defined(_WIN32)
         sprintf(cmd, "explorer \"%s\"", url);

--- a/src/platforms/rcore_desktop_sdl.c
+++ b/src/platforms/rcore_desktop_sdl.c
@@ -91,6 +91,9 @@
 
 #define SCANCODE_MAPPED_NUM     232
 
+#include <string.h>
+#include <ctype.h>      // Required for: isspace()
+
 //----------------------------------------------------------------------------------
 // Types and Structures Definition
 //----------------------------------------------------------------------------------
@@ -1289,8 +1292,22 @@ double GetTime(void)
 void OpenURL(const char *url)
 {
     // Security check to (partially) avoid malicious code
-    if (strchr(url, '\'') != NULL) TRACELOG(LOG_WARNING, "SYSTEM: Provided URL could be potentially malicious, avoid [\'] character");
-    else SDL_OpenURL(url);
+    if ((strchr(url, '\'') != NULL) || (strchr(url, '\"') != NULL)) TRACELOG(LOG_WARNING, "SYSTEM: Provided URL could be potentially malicious, avoid [\'\"] characters");
+    else
+    {
+        // Restriction: Only allow http:// and https:// protocols
+        const char *p = url;
+        while (*p && isspace((unsigned char)*p)) p++;
+        char protocol[9] = { 0 };
+        for (int i = 0; (i < 8) && p[i]; i++) protocol[i] = (char)tolower((unsigned char)p[i]);
+        if ((strncmp(protocol, "http://", 7) != 0) && (strncmp(protocol, "https://", 8) != 0))
+        {
+            TRACELOG(LOG_WARNING, "SYSTEM: Provided URL protocol is not allowed; only http:// and https:// are permitted");
+            return;
+        }
+
+        SDL_OpenURL(url);
+    }
 }
 
 //----------------------------------------------------------------------------------

--- a/src/platforms/rcore_desktop_win32.c
+++ b/src/platforms/rcore_desktop_win32.c
@@ -70,6 +70,7 @@
 #include <versionhelpers.h>
 
 #include <malloc.h>          // Required for alloca()
+#include <ctype.h>           // Required for: isspace()
 
 #if !defined(GRAPHICS_API_OPENGL_SOFTWARE)
     #include <GL/gl.h>
@@ -1254,9 +1255,20 @@ double GetTime(void)
 void OpenURL(const char *url)
 {
     // Security check to (partially) avoid malicious code on target platform
-    if (strchr(url, '\'') != NULL) TRACELOG(LOG_WARNING, "SYSTEM: Provided URL could be potentially malicious, avoid [\'] character");
+    if ((strchr(url, '\'') != NULL) || (strchr(url, '\"') != NULL)) TRACELOG(LOG_WARNING, "SYSTEM: Provided URL could be potentially malicious, avoid [\'\"] characters");
     else
     {
+        // Restriction: Only allow http:// and https:// protocols
+        const char *p = url;
+        while (*p && isspace((unsigned char)*p)) p++;
+        char protocol[9] = { 0 };
+        for (int i = 0; (i < 8) && p[i]; i++) protocol[i] = (char)tolower((unsigned char)p[i]);
+        if ((strncmp(protocol, "http://", 7) != 0) && (strncmp(protocol, "https://", 8) != 0))
+        {
+            TRACELOG(LOG_WARNING, "SYSTEM: Provided URL protocol is not allowed; only http:// and https:// are permitted");
+            return;
+        }
+
         char *cmd = (char *)RL_CALLOC(strlen(url) + 32, sizeof(char));
         sprintf(cmd, "explorer \"%s\"", url);
         int result = system(cmd);

--- a/src/platforms/rcore_memory.c
+++ b/src/platforms/rcore_memory.c
@@ -52,6 +52,9 @@
     #include <fcntl.h>
 #endif
 
+#include <string.h>
+#include <ctype.h>   // Required for: isspace()
+
 //----------------------------------------------------------------------------------
 // Types and Structures Definition
 //----------------------------------------------------------------------------------
@@ -384,9 +387,20 @@ double GetTime(void)
 void OpenURL(const char *url)
 {
     // Security check to (partially) avoid malicious code on target platform
-    if (strchr(url, '\'') != NULL) TRACELOG(LOG_WARNING, "SYSTEM: Provided URL could be potentially malicious, avoid [\'] character");
+    if ((strchr(url, '\'') != NULL) || (strchr(url, '\"') != NULL)) TRACELOG(LOG_WARNING, "SYSTEM: Provided URL could be potentially malicious, avoid [\'\"] characters");
     else
     {
+        // Restriction: Only allow http:// and https:// protocols
+        const char *p = url;
+        while (*p && isspace((unsigned char)*p)) p++;
+        char protocol[9] = { 0 };
+        for (int i = 0; (i < 8) && p[i]; i++) protocol[i] = (char)tolower((unsigned char)p[i]);
+        if ((strncmp(protocol, "http://", 7) != 0) && (strncmp(protocol, "https://", 8) != 0))
+        {
+            TRACELOG(LOG_WARNING, "SYSTEM: Provided URL protocol is not allowed; only http:// and https:// are permitted");
+            return;
+        }
+
         char *cmd = (char *)RL_CALLOC(strlen(url) + 32, sizeof(char));
         sprintf(cmd, "explorer \"%s\"", url);
         int result = system(cmd);

--- a/src/platforms/rcore_template.c
+++ b/src/platforms/rcore_template.c
@@ -48,6 +48,9 @@
 
 // TODO: Include the platform specific libraries
 
+#include <string.h>
+#include <ctype.h>   // Required for: isspace()
+
 //----------------------------------------------------------------------------------
 // Types and Structures Definition
 //----------------------------------------------------------------------------------
@@ -357,9 +360,20 @@ double GetTime(void)
 void OpenURL(const char *url)
 {
     // Security check to (partially) avoid malicious code on target platform
-    if (strchr(url, '\'') != NULL) TRACELOG(LOG_WARNING, "SYSTEM: Provided URL could be potentially malicious, avoid [\'] character");
+    if ((strchr(url, '\'') != NULL) || (strchr(url, '\"') != NULL)) TRACELOG(LOG_WARNING, "SYSTEM: Provided URL could be potentially malicious, avoid [\'\"] characters");
     else
     {
+        // Restriction: Only allow http:// and https:// protocols
+        const char *p = url;
+        while (*p && isspace((unsigned char)*p)) p++;
+        char protocol[9] = { 0 };
+        for (int i = 0; (i < 8) && p[i]; i++) protocol[i] = (char)tolower((unsigned char)p[i]);
+        if ((strncmp(protocol, "http://", 7) != 0) && (strncmp(protocol, "https://", 8) != 0))
+        {
+            TRACELOG(LOG_WARNING, "SYSTEM: Provided URL protocol is not allowed; only http:// and https:// are permitted");
+            return;
+        }
+
         // TODO: Load url using default browser
     }
 }

--- a/src/platforms/rcore_web.c
+++ b/src/platforms/rcore_web.c
@@ -50,6 +50,8 @@
 #include <emscripten/html5.h>           // Emscripten HTML5 library
 
 #include <sys/time.h>   // Required for: timespec, nanosleep(), select() - POSIX
+#include <string.h>
+#include <ctype.h>      // Required for: isspace()
 
 //----------------------------------------------------------------------------------
 // Defines and Macros
@@ -997,8 +999,22 @@ double GetTime(void)
 void OpenURL(const char *url)
 {
     // Security check to (partially) avoid malicious code on target platform
-    if (strchr(url, '\'') != NULL) TRACELOG(LOG_WARNING, "SYSTEM: Provided URL could be potentially malicious, avoid [\'] character");
-    else emscripten_run_script(TextFormat("window.open('%s', '_blank')", url));
+    if ((strchr(url, '\'') != NULL) || (strchr(url, '\"') != NULL)) TRACELOG(LOG_WARNING, "SYSTEM: Provided URL could be potentially malicious, avoid [\'\"] characters");
+    else
+    {
+        // Restriction: Only allow http:// and https:// protocols
+        const char *p = url;
+        while (*p && isspace((unsigned char)*p)) p++;
+        char protocol[9] = { 0 };
+        for (int i = 0; (i < 8) && p[i]; i++) protocol[i] = (char)tolower((unsigned char)p[i]);
+        if ((strncmp(protocol, "http://", 7) != 0) && (strncmp(protocol, "https://", 8) != 0))
+        {
+            TRACELOG(LOG_WARNING, "SYSTEM: Provided URL protocol is not allowed; only http:// and https:// are permitted");
+            return;
+        }
+
+        emscripten_run_script(TextFormat("window.open('%s', '_blank')", url));
+    }
 }
 
 //----------------------------------------------------------------------------------

--- a/src/platforms/rcore_web_emscripten.c
+++ b/src/platforms/rcore_web_emscripten.c
@@ -45,6 +45,8 @@
 #include <emscripten/html5.h>           // Emscripten HTML5 library
 
 #include <sys/time.h>   // Required for: timespec, nanosleep(), select() - POSIX
+#include <string.h>
+#include <ctype.h>      // Required for: isspace()
 
 //----------------------------------------------------------------------------------
 // Defines and Macros
@@ -974,8 +976,22 @@ double GetTime(void)
 void OpenURL(const char *url)
 {
     // Security check to (partially) avoid malicious code on target platform
-    if (strchr(url, '\'') != NULL) TRACELOG(LOG_WARNING, "SYSTEM: Provided URL could be potentially malicious, avoid [\'] character");
-    else emscripten_run_script(TextFormat("window.open('%s', '_blank')", url));
+    if ((strchr(url, '\'') != NULL) || (strchr(url, '\"') != NULL)) TRACELOG(LOG_WARNING, "SYSTEM: Provided URL could be potentially malicious, avoid [\'\"] characters");
+    else
+    {
+        // Restriction: Only allow http:// and https:// protocols
+        const char *p = url;
+        while (*p && isspace((unsigned char)*p)) p++;
+        char protocol[9] = { 0 };
+        for (int i = 0; (i < 8) && p[i]; i++) protocol[i] = (char)tolower((unsigned char)p[i]);
+        if ((strncmp(protocol, "http://", 7) != 0) && (strncmp(protocol, "https://", 8) != 0))
+        {
+            TRACELOG(LOG_WARNING, "SYSTEM: Provided URL protocol is not allowed; only http:// and https:// are permitted");
+            return;
+        }
+
+        emscripten_run_script(TextFormat("window.open('%s', '_blank')", url));
+    }
 }
 
 //----------------------------------------------------------------------------------


### PR DESCRIPTION
Description

  This PR fixes two security vulnerabilities identified in the OpenURL() function across multiple platforms:

   1. OS Command Injection via Double Quotes ("):
      On Windows, the URL was wrapped in double quotes in the system() call (explorer "%s"). If a URL contained a double quote, an attacker could break out of the string literal and
  execute arbitrary shell commands using operators like &.
       * Fix: Added a security check to block both single quotes (') and double quotes (").

   2. Protocol Abuse via file:// and others:
      The OpenURL() function allowed any protocol handled by the system, including file://. This could be abused to launch local executable files (e.g.,
  file:///C:/Windows/System32/calc.exe).
       * Fix: Implemented a protocol allow-list. Now OpenURL() only permits http:// and https:// protocols.

  Changes

  The following files were updated to include the enhanced security checks and protocol filtering:
   - src/platforms/rcore_desktop_glfw.c
   - src/platforms/rcore_desktop_win32.c
   - src/platforms/rcore_desktop_rgfw.c
   - src/platforms/rcore_desktop_sdl.c
   - src/platforms/rcore_android.c
   - src/platforms/rcore_web.c
   - src/platforms/rcore_web_emscripten.c
   - src/platforms/rcore_memory.c
   - src/platforms/rcore_template.c

  Verification Results

   - Build: Successfully compiled the static library using make on Linux.
   - Security Logic:
       - URLs with " or ' now trigger a LOG_WARNING and are blocked.
       - URLs starting with http:// or https:// (case-insensitive) are allowed.
       - URLs with other protocols (like file://) are blocked with a LOG_WARNING.

  Related Issues #5801 

IF this PR approved, close #5801 