### PR TITLE
[rcore] Fix FileMove from delete file if FileCopy did not work

### DIFF
--- a/src/rcore.c
+++ b/src/rcore.c
@@ -2283,7 +2283,7 @@ int FileMove(const char *srcPath, const char *dstPath)
 
     if (FileExists(srcPath))
     {
-		if (FileCopy(srcPath, dstPath) == 0) result = FileRemove(srcPath);
+		if (FileCopy(srcPath, dstPath)) result = FileRemove(srcPath);
         else TRACELOG(LOG_WARNING, "FILEIO: [%s] Failed to copy file to [%s]", srcPath, dstPath);
     }
 	else TRACELOG(LOG_WARNING, "FILEIO: [%s] Source file does not exist", srcPath);


### PR DESCRIPTION
Hello!

I was making a file browser in my favourite graphics library (raylib), and needed file move functionality.

The issue was that despite the function running and leaving no errors, it was deleting my file instead of moving it!

I noticed that `FileCopy` seems to return `1` if `SaveFileData` returns `true` and `0` otherwise, but some other `FileX` functions return `0` if the operation succeeds - so I wasn't sure what to fix!

1. Is `FileCopy` supposed return `0` if it succeeds or
2. is the intended functionality for it to return `1` for success but the bug is in `FileMove`?

Anyway, I went with the solution that preserves backwards compatibility and assumes that `FileCopy` cannot change what it returns until... 7.0?