### PR TITLE
[rcore][Android] Allow setting window size on Android.

### DIFF
--- a/src/platforms/rcore_android.c
+++ b/src/platforms/rcore_android.c
@@ -465,13 +465,10 @@ void SetWindowSize(int width, int height)
     CORE.Window.screen.width = width;
     CORE.Window.screen.height = height;
 
-    EGLint displayFormat = 0;
-    eglGetConfigAttrib(platform.device, platform.config, EGL_NATIVE_VISUAL_ID, &displayFormat);
-
     ANativeWindow_setBuffersGeometry(platform.app->window,
         CORE.Window.render.width + CORE.Window.renderOffset.x,
         CORE.Window.render.height + CORE.Window.renderOffset.y,
-        displayFormat);
+        0);
 }
 
 // Set window opacity, value opacity is between 0.0 and 1.0

--- a/src/platforms/rcore_android.c
+++ b/src/platforms/rcore_android.c
@@ -455,7 +455,23 @@ void SetWindowMaxSize(int width, int height)
 // Set window dimensions
 void SetWindowSize(int width, int height)
 {
-    TRACELOG(LOG_WARNING, "SetWindowSize() not available on target platform");
+	CORE.Window.display.width = width;
+    CORE.Window.display.height = height;
+
+    SetupViewport(width, height);
+    CORE.Window.currentFbo.width = width;
+    CORE.Window.currentFbo.height = height;
+
+    CORE.Window.screen.width = width;
+    CORE.Window.screen.height = height;
+
+    EGLint displayFormat = 0;
+    eglGetConfigAttrib(platform.device, platform.config, EGL_NATIVE_VISUAL_ID, &displayFormat);
+
+    ANativeWindow_setBuffersGeometry(platform.app->window,
+        CORE.Window.render.width + CORE.Window.renderOffset.x,
+        CORE.Window.render.height + CORE.Window.renderOffset.y,
+        displayFormat);
 }
 
 // Set window opacity, value opacity is between 0.0 and 1.0


### PR DESCRIPTION
# My situation

1. User rotates device while app is open.
2. Android sends `APP_CMD_CONFIG_CHANGED`.
3. Resizing the framebuffer and setting screen sizes to reflect the new 'window size' causes stretching due to Android-reported width and height still **(usually - see below)** reporting with values from before the orientation change.

## Why not just add this in `AndroidCommandCallback`'s `APP_CMD_CONFIG_CHANGED` case?
Android does not send the correct width and height in time, therefore leading to you having to manually switch the height and width. This is fine, until you notice that Android has a somewhat-common chance to send the correct width and height and then everything gets stretched because you swapped the width to be the height to account for the wrong timing.

You could make a variable to mark the window as dirty then in a place that is triggered every frame, if that variable is true and the Android-reported size != current window size, set the variable to false and then update to the new size.

## The solution for devs using raylib
1. Allow `SetWindowSize` to be usable, via this patch, on android.
2. Devs can now use the NDK themselves to check every frame if a resize occured:
```c
extern struct android_app* GetAndroidApp();

static int ndk_window_width() {
	struct android_app* app = GetAndroidApp();
	if (!app || !app->window) return 0;

    return ANativeWindow_getWidth(app->window);
}
static int ndk_window_height() {
    struct android_app* app = GetAndroidApp();
    if (!app || !app->window) return 0;

    return ANativeWindow_getHeight(app->window);
}
```
3. Devs call these every frame, and do manual resize checking. If a resize is detected, call `SetWindowSize(int width, int height)`.

## Additional comments
Let me know if this is okay - personally I wouldn't accept this PR as I'm sure there is a solution that allows putting this code in `APP_CMD_CONFIG_CHANGED` while receiving correct sizes from Android (see my 'Why not ...' above for why we can't do this already).

This also is a better solution as it also correctly sets the size when INIT_WINDOW happens. So, if the app is in landscape and the users turns off the phone screen then turns it back on with the orientation in portrait, then that is also handled as the size change is detected.

## Demos
Fix from this PR:

https://github.com/user-attachments/assets/a118dbe4-5482-489b-a3fc-1e41d63ce05b

Default behaviour:

https://github.com/user-attachments/assets/66a6fc0d-cff7-4c6f-8032-63f9519a248b
