### PR TITLE
[raymath] Add missing float*Vector multiplication C++ operator overloads

### DIFF
--- a/src/raymath.h
+++ b/src/raymath.h
@@ -2802,6 +2802,11 @@ inline const Vector2& operator -= (Vector2& lhs, const Vector2& rhs)
     return lhs;
 }
 
+inline Vector2 operator * (const float& lhs, const Vector2& rhs)
+{
+    return Vector2Scale(rhs, lhs);
+}
+
 inline Vector2 operator * (const Vector2& lhs, const float& rhs)
 {
     return Vector2Scale(lhs, rhs);
@@ -2894,6 +2899,11 @@ inline const Vector3& operator -= (Vector3& lhs, const Vector3& rhs)
 {
     lhs = Vector3Subtract(lhs, rhs);
     return lhs;
+}
+
+inline Vector3 operator * (const float& lhs, const Vector3& rhs)
+{
+    return Vector3Scale(rhs, lhs);
 }
 
 inline Vector3 operator * (const Vector3& lhs, const float& rhs)
@@ -2989,6 +2999,11 @@ inline const Vector4& operator -= (Vector4& lhs, const Vector4& rhs)
 {
     lhs = Vector4Subtract(lhs, rhs);
     return lhs;
+}
+
+inline Vector4 operator * (const float& lhs, const Vector4& rhs)
+{
+    return Vector4Scale(rhs, lhs);
 }
 
 inline Vector4 operator * (const Vector4& lhs, const float& rhs)


### PR DESCRIPTION
Is there a reason **raymath.h** only supports `Vector` * `float` C++ math operators, **but `float` * `Vector` isn't supported**?

I'm talking about just swapping the vector and scalar multiplication order like so:

```cpp
#include "raymath.h"

  Vector2 velocity;

  Vector2 delta = ... ;
  float overlapLen = ... ;

  // This works as intended
  velocity += delta * overlapLen * 0.5f;

  // THIS DOESN'T COMPILE
  velocity += 0.5f * delta * overlapLen;
```

```
Example1.cpp: error: no match for 'operator*' (operand types are 'float' and 'Vector2')
   69 |                                       velocity += 0.5f * delta * overlapLen;
      |                                                   ~~~~ ^ ~~~~~
      |                                                   |      |
      |                                                   float  Vector2
```

I kept finding myself constantly writing `float` constants first before vectors and wondering why a build failed before remembering *Oh yeah, raymath.h doesn't allow that for some reason...* over and over

Extra annoying if it's not just some simple constant like the 0.5 above, but a `float` variable (in my examples the "overlapLen" variable):

```cpp
  // This works as intended
  velocity += delta * overlapLen * 0.5f;

  // THIS DOESN'T COMPILE
  velocity += overlapLen * delta * 0.5f;
```

```
Example2.cpp: error: no match for 'operator*' (operand types are 'float' and 'Vector2')
   69 |                                       velocity += overlapLen * delta * 0.5f;
      |                                                   ~~~~~~~~~~ ^ ~~~~~
      |                                                   |            |
      |                                                   float        Vector2
```

Constantly keeping an eye on this weird arbitrary order of operations issue is unnecessary.

In math, **multiplying a vector by scalars is commutative** and there is **nothing wrong with writing the scalar first**.

In fact, **it is the more common way of doing it**, even for matrices:

<img width="732" height="161" alt="image" src="https://github.com/user-attachments/assets/893bf89f-166f-49d6-9dc8-2a25c01ca9d1" />

<img width="837" height="220" alt="image" src="https://github.com/user-attachments/assets/12f32792-935e-4b2a-af1f-202da4931895" />

source: https://en.wikipedia.org/wiki/Scalar_multiplication

---

Is there like a philosophy or formatting reason for not doing this? Or to keep a strict rule of `Vector` or `Matrix` **always** being the first parameter in the `VectorNDoSomething(VectorN ...)` and `MatrixDoSomething(Matrix ...)` pure C functions?

Feel free to close the Pull Request if there is some reason against this.