### PR TITLE
[raymath] Adds missing macro define for `RAYMATH_USE_SIMD_INTRINSICS`

### DIFF
--- a/src/raymath.h
+++ b/src/raymath.h
@@ -84,6 +84,11 @@
     #endif
 #endif
 
+// Default define for RAYMATH_USE_SIMD_INTRINSICS
+#ifndef RAYMATH_USE_SIMD_INTRINSICS
+    #define RAYMATH_USE_SIMD_INTRINSICS 0
+#endif
+
 //----------------------------------------------------------------------------------
 // Defines and Macros
 //----------------------------------------------------------------------------------


### PR DESCRIPTION
Missing `RAYMATH_USE_SIMD_INTRINSICS` define causes compiler errors when it needs to be checked later on with a `#if`