### PR TITLE
[WebGL 1.0 / OpenGL ES 2.0] Add power-of-two check to rlLoadTexture for GL_REPEAT wrap mode

### DIFF
--- a/src/rlgl.h
+++ b/src/rlgl.h
@@ -3366,8 +3366,15 @@ unsigned int rlLoadTexture(const void *data, int width, int height, int format, 
     // Texture parameters configuration
     // NOTE: glTexParameteri does NOT affect texture uploading
 #if defined(GRAPHICS_API_OPENGL_ES2)
+
+    // Check if texture is power-of-two (POT)
+    bool texIsPOT = false;
+
+    if (((width > 0) && ((width & (width - 1)) == 0)) &&
+        ((height > 0) && ((height & (height - 1)) == 0))) texIsPOT = true;
+
     // NOTE: OpenGL ES 2.0 with no GL_OES_texture_npot support (i.e. WebGL) has limited NPOT support, so CLAMP_TO_EDGE must be used
-    if (RLGL.ExtSupported.texNPOT)
+    if ((texIsPOT) || (RLGL.ExtSupported.texNPOT))
     {
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);       // Set texture to repeat on x-axis
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);       // Set texture to repeat on y-axis


### PR DESCRIPTION
Added texture dimension (width, height) check to ```GRAPHICS_API_OPENGL_ES2``` path in ```rlLoadTexture()```, to match ```rlGenTextureMipmaps()```. This allows us to use ```GL_REPEAT``` texture wrap mode, which is required for correct rendering of models with tiling textures like Khronos Sponza glTF. Tested on Safari (iPhone 11 iOS 16.6.1), and Firefox (Intel x86_64 Linux Mint 22.2) for custom Sponza scene program, and all ```models``` and ```shaders``` examples.

OpenGL ES 2.0 / WebGL 1.0 explicitly supports GL_REPEAT wrapping mode and mipmap generation for power of two textures. See section 3.8.2 of the OpenGL ES 2.0 spec for NPOT texture parameter restrictions: 
https://registry.khronos.org/OpenGL/specs/es/2.0/es_full_spec_2.0.pdf