### PR TITLE
[rcore] Process manipulation API for Windows and POSIX-compliant platforms

### DIFF
--- a/src/raylib.h
+++ b/src/raylib.h
@@ -961,6 +961,12 @@ typedef enum {
     NPATCH_THREE_PATCH_HORIZONTAL   // Npatch layout: 3x1 tiles
 } NPatchLayout;
 
+// Process info
+typedef struct Process {
+    int pid;                         // Process unique identifier
+    int exitCode;                    // Process exit code
+} Process;
+
 // Callbacks to hook some internal functions
 // WARNING: These callbacks are intended for advanced users
 typedef void (*TraceLogCallback)(int logLevel, const char *text, va_list args);  // Logging: Redirect trace log messages
@@ -1240,6 +1246,13 @@ RLAPI int GetTouchY(void);                                    // Get touch posit
 RLAPI Vector2 GetTouchPosition(int index);                    // Get touch position XY for a touch point index (relative to screen size)
 RLAPI int GetTouchPointId(int index);                         // Get touch point identifier for given index
 RLAPI int GetTouchPointCount(void);                           // Get number of touch points
+
+// Process execution functions
+RLAPI Process InitProcess(const char *command, char *const args[]); // Initialize a new process, returns a Process struct
+RLAPI bool CheckProcess(Process *process);                          // Check if a process is still running, updates Process struct
+RLAPI void PauseProcess(Process *process);                          // Pause process execution
+RLAPI void ResumeProcess(Process *process);                         // Resume paused process execution
+RLAPI void CloseProcess(Process *process);                          // Close process and free resources
 
 //------------------------------------------------------------------------------------
 // Gestures and Touch Handling Functions (Module: rgestures)

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1260,6 +1260,7 @@ RLAPI int GetTouchPointCount(void);                           // Get number of t
 // Process execution functions
 RLAPI Process InitProcess(const char *command, char *const args[]); // Initialize a new process, returns a Process struct
 RLAPI ProcessInfo CheckProcess(Process process);                    // Check if a process is still running
+RLAPI int WaitProcess(Process process);                             // Wait for process to finish, returns exit code, blocking
 RLAPI void PauseProcess(Process process);                           // Pause process execution
 RLAPI void ResumeProcess(Process process);                          // Resume paused process execution
 RLAPI void CloseProcess(Process process);                           // Close process and free resources

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -964,6 +964,9 @@ typedef enum {
 // Process info
 typedef struct Process {
     int pid;                        // Process unique identifier
+
+    void *pipeStdoutRead;           // Process stdout and stderr read pipe [Windows only]
+    void *pipeStdinWrite;           // Process stdin write pipe [Windows only]
 } Process;
 
 typedef enum {
@@ -1261,6 +1264,7 @@ RLAPI int GetTouchPointCount(void);                           // Get number of t
 RLAPI Process InitProcess(const char *command, char *const args[]); // Initialize a new process, returns a Process struct
 RLAPI ProcessInfo CheckProcess(Process process);                    // Check if a process is still running
 RLAPI int WaitProcess(Process process);                             // Wait for process to finish, returns exit code, blocking
+RLAPI const char *ReadProcessOutput(Process process, int *length);  // Read process output as raw buffer (not null-terminated), returns pointer to a static buffer, so data must be copied before next call to ReadProcessOutput()
 RLAPI void PauseProcess(Process process);                           // Pause process execution
 RLAPI void ResumeProcess(Process process);                          // Resume paused process execution
 RLAPI void CloseProcess(Process process);                           // Close process and free resources

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -961,20 +961,20 @@ typedef enum {
     NPATCH_THREE_PATCH_HORIZONTAL   // Npatch layout: 3x1 tiles
 } NPatchLayout;
 
-// Process info
+// Process resources
 typedef struct Process {
-    int pid;                        // Process unique identifier
-
-    void *pipeStdoutRead;           // Process stdout and stderr read pipe [Windows only]
-    void *pipeStdinWrite;           // Process stdin write pipe [Windows only]
+    int pid;                          // Process unique identifier
+    struct ProcessInternal *internal; // Platform-specific process data
 } Process;
 
+// Process state
 typedef enum {
     PROCESS_STATE_NONE = 0,         // No state information
     PROCESS_STATE_RUNNING,          // Process is running
     PROCESS_STATE_FINISHED          // Process has exited
 } ProcessState;
 
+// Process information for CheckProcess() function
 typedef struct ProcessInfo {
     ProcessState state;             // Process state (PROCESS_STATE_*)
     int exitCode;                   // Process exit code (if finished)

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -961,10 +961,14 @@ typedef enum {
     NPATCH_THREE_PATCH_HORIZONTAL   // Npatch layout: 3x1 tiles
 } NPatchLayout;
 
+// Opaque structs declaration for Process
+// NOTE: actual definition in rcore.c
+typedef struct rProcessData rProcessData;
+
 // Process resources
 typedef struct Process {
     int pid;                          // Process unique identifier
-    struct ProcessInternal *internal; // Platform-specific process data
+    rProcessData *processData;        // Platform-specific process data
 } Process;
 
 // Process state

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -963,9 +963,19 @@ typedef enum {
 
 // Process info
 typedef struct Process {
-    int pid;                         // Process unique identifier
-    int exitCode;                    // Process exit code
+    int pid;                        // Process unique identifier
 } Process;
+
+typedef enum {
+    PROCESS_STATE_NONE = 0,         // No state information
+    PROCESS_STATE_RUNNING,          // Process is running
+    PROCESS_STATE_FINISHED          // Process has exited
+} ProcessState;
+
+typedef struct ProcessInfo {
+    ProcessState state;             // Process state (PROCESS_STATE_*)
+    int exitCode;                   // Process exit code (if finished)
+} ProcessInfo;
 
 // Callbacks to hook some internal functions
 // WARNING: These callbacks are intended for advanced users
@@ -1249,10 +1259,10 @@ RLAPI int GetTouchPointCount(void);                           // Get number of t
 
 // Process execution functions
 RLAPI Process InitProcess(const char *command, char *const args[]); // Initialize a new process, returns a Process struct
-RLAPI bool CheckProcess(Process *process);                          // Check if a process is still running, updates Process struct
-RLAPI void PauseProcess(Process *process);                          // Pause process execution
-RLAPI void ResumeProcess(Process *process);                         // Resume paused process execution
-RLAPI void CloseProcess(Process *process);                          // Close process and free resources
+RLAPI ProcessInfo CheckProcess(Process process);                    // Check if a process is still running
+RLAPI void PauseProcess(Process process);                           // Pause process execution
+RLAPI void ResumeProcess(Process process);                          // Resume paused process execution
+RLAPI void CloseProcess(Process process);                           // Close process and free resources
 
 //------------------------------------------------------------------------------------
 // Gestures and Touch Handling Functions (Module: rgestures)

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -210,7 +210,30 @@
     #define ACCESS(fn) access(fn, F_OK)
 #endif
 
-#if defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__APPLE__)
+// Platform specific defines for process execution API
+#if defined(_WIN32)
+    struct _STARTUPINFOA;
+    struct _PROCESS_INFORMATION;
+
+    __declspec(dllimport) void* __stdcall OpenProcess(unsigned long dwDesiredAccess, int bInheritHandle, unsigned long dwProcessId);
+    __declspec(dllimport) int __stdcall CloseHandle(void *hObject);
+    __declspec(dllimport) int __stdcall GetExitCodeProcess(void *hProcess, unsigned long *lpExitCode);
+    __declspec(dllimport) int __stdcall TerminateProcess(void *hProcess, unsigned int uExitCode);
+    __declspec(dllimport) unsigned long __stdcall WaitForSingleObject(void *hHandle, unsigned long dwMilliseconds);
+    __declspec(dllimport) unsigned long __stdcall SuspendThread(void *hThread);
+    __declspec(dllimport) unsigned long __stdcall ResumeThread(void *hThread);
+    __declspec(dllimport) int __stdcall CreateProcessA(
+        const char *lpApplicationName,
+        char *lpCommandLine,
+        void *lpProcessAttributes,
+        void *lpThreadAttributes,
+        int bInheritHandles,
+        unsigned long dwCreationFlags,
+        void *lpEnvironment,
+        const char *lpCurrentDirectory,
+        struct _STARTUPINFOA *lpStartupInfo,
+        struct _PROCESS_INFORMATION *lpProcessInformation);
+#elif defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__APPLE__)
     #include <sys/wait.h>           // Required for: waitpid() [Used in CheckProcess()]
     #include <signal.h>             // Required for: kill() [Used in PauseProcess(), ResumeProcess(), CloseProcess()]
     #include <sys/types.h>          // Required for: pid_t [Used as function local variable type and for Process PID type]
@@ -4221,6 +4244,16 @@ int GetTouchPointCount(void)
 // Module Functions Definition: Process Execution
 //----------------------------------------------------------------------------------
 
+#if defined(_WIN32)
+
+static void* GetProcessHandleByID(int pid)
+{
+    // PROCESS_QUERY_INFORMATION | PROCESS_TERMINATE | PROCESS_SUSPEND_RESUME
+    return OpenProcess(0x0400 | 0x0001 | 0x0800, 0, (unsigned long)pid);
+}
+
+#endif
+
 // Initialize a new process, returns a Process struct
 RLAPI Process InitProcess(const char *command, char *const args[])
 {
@@ -4228,7 +4261,75 @@ RLAPI Process InitProcess(const char *command, char *const args[])
 
     Process process = { 0 };
 
-#if defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__APPLE__)
+#if defined(_WIN32)
+    struct _STARTUPINFOA {
+        unsigned long cb;
+        char *lpReserved;
+        char *lpDesktop;
+        char *lpTitle;
+        unsigned long dwX;
+        unsigned long dwY;
+        unsigned long dwXSize;
+        unsigned long dwYSize;
+        unsigned long dwXCountChars;
+        unsigned long dwYCountChars;
+        unsigned long dwFillAttribute;
+        unsigned long dwFlags;
+        unsigned short wShowWindow;
+        unsigned short cbReserved2;
+        unsigned char *lpReserved2;
+        void *hStdInput;
+        void *hStdOutput;
+        void *hStdError;
+    };
+
+    struct _PROCESS_INFORMATION {
+        void *hProcess;
+        void *hThread;
+        unsigned long dwProcessId;
+        unsigned long dwThreadId;
+    };
+
+    // Windows requires a single command line string
+    char cmdLine[MAX_PATH * 4] = { 0 };
+    int position = 0;
+
+    TextAppend(cmdLine, command, &position);
+
+    if (args != NULL)
+    {
+        for (int i = 1; args[i] != NULL; i++) 
+        {
+            // TODO: Maybe use dynamic allocation for command line instead of aborting?
+            if (position + TextLength(args[i]) + 1 >= sizeof(cmdLine))
+            {
+                TRACELOG(LOG_WARNING, "PROCESS: Command line too long, process will not be created");
+                return process;
+            }
+
+            TextAppend(cmdLine, " ", &position);
+            TextAppend(cmdLine, args[i], &position);
+        }
+    }
+
+    struct _STARTUPINFOA si = { 0 };
+    si.cb = sizeof(struct _STARTUPINFOA);
+    struct _PROCESS_INFORMATION pi = { 0 };
+
+    // Application name is specified as the first command line argument, so pass NULL to CreateProcessA here
+    if (CreateProcessA(NULL, cmdLine, NULL, NULL, 0, 0, NULL, NULL, (void*)&si, (void*)&pi))
+    {
+        process.pid = (int)pi.dwProcessId;
+        CloseHandle(pi.hThread);
+        CloseHandle(pi.hProcess);
+    }
+    else
+    {
+        TRACELOG(LOG_WARNING, "PROCESS: Failed to create process");
+    }
+
+    return process;
+#elif defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__APPLE__)
     pid_t pid = fork();
 
     if (pid < 0)
@@ -4262,7 +4363,26 @@ RLAPI bool CheckProcess(Process *process)
         return false;
     }
 
-#if defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__APPLE__)
+#if defined(_WIN32)
+    // PROCESS_QUERY_INFORMATION
+    void* hProcess = OpenProcess(0x0400, 0, (unsigned long)process->pid);
+    if (hProcess == NULL) return false;
+
+    unsigned long exitCode = 0;
+    if (GetExitCodeProcess(hProcess, &exitCode))
+    {
+        CloseHandle(hProcess);
+        // STILL_ACTIVE (259) means the process is still running
+        if (exitCode == 259) return true;
+        
+        process->exitCode = (int)exitCode;
+        process->pid = 0;
+        return false;
+    }
+
+    CloseHandle(hProcess);
+    return false;
+#elif defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__APPLE__)
     int status = 0;
     pid_t result = waitpid(process->pid, &status, WNOHANG);
 
@@ -4305,7 +4425,9 @@ RLAPI bool CheckProcess(Process *process)
 // Pause process execution
 RLAPI void PauseProcess(Process *process)
 {
-#if defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__APPLE__)
+#if defined(_WIN32)
+    TRACELOG(LOG_WARNING, "PROCESS: Pausing process is not supported on Windows");
+#elif defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__APPLE__)
     if (kill(process->pid, SIGSTOP) != 0)
     {
         TRACELOG(LOG_WARNING, "PROCESS: Failed to pause process");
@@ -4318,7 +4440,9 @@ RLAPI void PauseProcess(Process *process)
 // Resume paused process execution
 RLAPI void ResumeProcess(Process *process)
 {
-#if defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__APPLE__)
+#if defined(_WIN32)
+    TRACELOG(LOG_WARNING, "PROCESS: Resuming process is not supported on Windows");
+#elif defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__APPLE__)
     if (kill(process->pid, SIGCONT) != 0)
     {
         TRACELOG(LOG_WARNING, "PROCESS: Failed to resume process");
@@ -4335,8 +4459,20 @@ RLAPI void CloseProcess(Process *process)
     {
         return;
     }
+#if defined(_WIN32)
+    void* hProcess = GetProcessHandleByID(process->pid);
+    if (hProcess == NULL)
+    {
+        TRACELOG(LOG_WARNING, "PROCESS: Failed to open process handle");
+        return;
+    }
 
-#if defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__APPLE__)
+    TerminateProcess(hProcess, 0);
+    CloseHandle(hProcess);
+
+    process->exitCode = -1;
+    process->pid = 0;
+#elif defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__APPLE__)
     if (!CheckProcess(process))
     {
         return;

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -210,6 +210,12 @@
     #define ACCESS(fn) access(fn, F_OK)
 #endif
 
+#if defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__APPLE__)
+    #include <sys/wait.h>           // Required for: waitpid() [Used in CheckProcess()]
+    #include <signal.h>             // Required for: kill() [Used in PauseProcess(), ResumeProcess(), CloseProcess()]
+    #include <sys/types.h>          // Required for: pid_t [Used as function local variable type and for Process PID type]
+#endif
+
 //----------------------------------------------------------------------------------
 // Defines and Macros
 //----------------------------------------------------------------------------------
@@ -4209,6 +4215,153 @@ int GetTouchPointId(int index)
 int GetTouchPointCount(void)
 {
     return CORE.Input.Touch.pointCount;
+}
+
+//----------------------------------------------------------------------------------
+// Module Functions Definition: Process Execution
+//----------------------------------------------------------------------------------
+
+// Initialize a new process, returns a Process struct
+RLAPI Process InitProcess(const char *command, char *const args[])
+{
+    // The last element of the args array must be NULL
+
+    Process process = { 0 };
+
+#if defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__APPLE__)
+    pid_t pid = fork();
+
+    if (pid < 0)
+    {
+        TRACELOG(LOG_WARNING, "PROCESS: Failed to create process");
+    }
+    else if (pid == 0)
+    {
+        // Child process
+        execvp(command, args);
+
+        // If execvp returns, it must have failed
+        _exit(1);
+    }
+    else
+    {
+        process.pid = pid;
+    }
+#else
+    TRACELOG(LOG_WARNING, "PROCESS: Process management not supported on this platform");
+#endif
+
+    return process;
+}
+
+// Check if a process is still running, updates Process struct
+RLAPI bool CheckProcess(Process *process)
+{
+    if ((process == NULL) || (process->pid <= 0))
+    {
+        return false;
+    }
+
+#if defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__APPLE__)
+    int status = 0;
+    pid_t result = waitpid(process->pid, &status, WNOHANG);
+
+    if (result == 0)
+    {
+        // Still running
+        return true;
+    }
+    else if (result == process->pid)
+    {
+        // Not running
+        if (WIFEXITED(status))
+        {
+            process->exitCode = WEXITSTATUS(status);
+        }
+        else if (WIFSIGNALED(status))
+        {
+            // Terminated by signal
+            process->exitCode = -1;
+        }
+    
+        // Mark as completed
+        process->pid = 0;
+    
+        return false;
+    }
+    else
+    {
+        // Error occurred
+        TRACELOG(LOG_WARNING, "PROCESS: Failed to check process status");
+        return false;
+    }
+#else
+    TRACELOG(LOG_WARNING, "PROCESS: Process management not supported on this platform");
+#endif
+
+    return false;
+}
+
+// Pause process execution
+RLAPI void PauseProcess(Process *process)
+{
+#if defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__APPLE__)
+    if (kill(process->pid, SIGSTOP) != 0)
+    {
+        TRACELOG(LOG_WARNING, "PROCESS: Failed to pause process");
+    }
+#else
+    TRACELOG(LOG_WARNING, "PROCESS: Process management not supported on this platform");
+#endif
+}
+
+// Resume paused process execution
+RLAPI void ResumeProcess(Process *process)
+{
+#if defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__APPLE__)
+    if (kill(process->pid, SIGCONT) != 0)
+    {
+        TRACELOG(LOG_WARNING, "PROCESS: Failed to resume process");
+    }
+#else
+    TRACELOG(LOG_WARNING, "PROCESS: Process management not supported on this platform");
+#endif
+}
+
+// Close process and free resources
+RLAPI void CloseProcess(Process *process)
+{
+    if ((process == NULL) || (process->pid <= 0))
+    {
+        return;
+    }
+
+#if defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__APPLE__)
+    if (!CheckProcess(process))
+    {
+        return;
+    }
+
+    // In case that the process is paused
+    kill(process->pid, SIGCONT);
+
+    if (kill(process->pid, SIGTERM) != 0)
+    {
+        TRACELOG(LOG_WARNING, "PROCESS: Failed to terminate process");
+
+        // Kill the process anyway
+        kill(process->pid, SIGKILL);
+    }
+
+    // Wait process termination
+    waitpid(process->pid, NULL, 0);
+
+    // Align as CheckProcess() would do for a killed process
+    process->exitCode = -1;
+    process->pid = 0;
+#else
+    TRACELOG(LOG_WARNING, "PROCESS: Process management not supported on this platform");
+#endif
 }
 
 //----------------------------------------------------------------------------------

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -4244,16 +4244,6 @@ int GetTouchPointCount(void)
 // Module Functions Definition: Process Execution
 //----------------------------------------------------------------------------------
 
-#if defined(_WIN32)
-
-static void* GetProcessHandleByID(int pid)
-{
-    // PROCESS_QUERY_INFORMATION | PROCESS_TERMINATE | PROCESS_SUSPEND_RESUME
-    return OpenProcess(0x0400 | 0x0001 | 0x0800, 0, (unsigned long)pid);
-}
-
-#endif
-
 // Initialize a new process, returns a Process struct
 RLAPI Process InitProcess(const char *command, char *const args[])
 {
@@ -4460,7 +4450,8 @@ RLAPI void CloseProcess(Process *process)
         return;
     }
 #if defined(_WIN32)
-    void* hProcess = GetProcessHandleByID(process->pid);
+    // PROCESS_QUERY_INFORMATION | PROCESS_TERMINATE | PROCESS_SUSPEND_RESUME
+    void* hProcess = OpenProcess(0x0400 | 0x0001 | 0x0800, 0, (unsigned long)process->pid);
     if (hProcess == NULL)
     {
         TRACELOG(LOG_WARNING, "PROCESS: Failed to open process handle");

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -212,10 +212,37 @@
 
 // Platform specific defines for process execution API
 #if defined(_WIN32)
-    struct _STARTUPINFOA;
-    struct _PROCESS_INFORMATION;
+    struct _STARTUPINFOA {
+        unsigned long cb;
+        char *lpReserved;
+        char *lpDesktop;
+        char *lpTitle;
+        unsigned long dwX;
+        unsigned long dwY;
+        unsigned long dwXSize;
+        unsigned long dwYSize;
+        unsigned long dwXCountChars;
+        unsigned long dwYCountChars;
+        unsigned long dwFillAttribute;
+        unsigned long dwFlags;
+        unsigned short wShowWindow;
+        unsigned short cbReserved2;
+        unsigned char *lpReserved2;
+        void *hStdInput;
+        void *hStdOutput;
+        void *hStdError;
+    };
 
-    __declspec(dllimport) void* __stdcall OpenProcess(unsigned long dwDesiredAccess, int bInheritHandle, unsigned long dwProcessId);
+    struct _PROCESS_INFORMATION {
+        void *hProcess;
+        void *hThread;
+        unsigned long dwProcessId;
+        unsigned long dwThreadId;
+    };
+
+    __declspec(dllimport) void *__stdcall GetModuleHandleA(const char *lpModuleName);
+    __declspec(dllimport) void *__stdcall GetProcAddress(void *hModule, const char *lpProcName);
+    __declspec(dllimport) void *__stdcall OpenProcess(unsigned long dwDesiredAccess, int bInheritHandle, unsigned long dwProcessId);
     __declspec(dllimport) int __stdcall CloseHandle(void *hObject);
     __declspec(dllimport) int __stdcall GetExitCodeProcess(void *hProcess, unsigned long *lpExitCode);
     __declspec(dllimport) int __stdcall TerminateProcess(void *hProcess, unsigned int uExitCode);
@@ -4252,34 +4279,6 @@ RLAPI Process InitProcess(const char *command, char *const args[])
     Process process = { 0 };
 
 #if defined(_WIN32)
-    struct _STARTUPINFOA {
-        unsigned long cb;
-        char *lpReserved;
-        char *lpDesktop;
-        char *lpTitle;
-        unsigned long dwX;
-        unsigned long dwY;
-        unsigned long dwXSize;
-        unsigned long dwYSize;
-        unsigned long dwXCountChars;
-        unsigned long dwYCountChars;
-        unsigned long dwFillAttribute;
-        unsigned long dwFlags;
-        unsigned short wShowWindow;
-        unsigned short cbReserved2;
-        unsigned char *lpReserved2;
-        void *hStdInput;
-        void *hStdOutput;
-        void *hStdError;
-    };
-
-    struct _PROCESS_INFORMATION {
-        void *hProcess;
-        void *hThread;
-        unsigned long dwProcessId;
-        unsigned long dwThreadId;
-    };
-
     // Windows requires a single command line string
     char cmdLine[MAX_PATH * 4] = { 0 };
     int position = 0;
@@ -4307,7 +4306,7 @@ RLAPI Process InitProcess(const char *command, char *const args[])
     struct _PROCESS_INFORMATION pi = { 0 };
 
     // Application name is specified as the first command line argument, so pass NULL to CreateProcessA here
-    if (CreateProcessA(NULL, cmdLine, NULL, NULL, 0, 0, NULL, NULL, (void*)&si, (void*)&pi))
+    if (CreateProcessA(NULL, cmdLine, NULL, NULL, 0, 0, NULL, NULL, &si, &pi))
     {
         process.pid = (int)pi.dwProcessId;
         CloseHandle(pi.hThread);
@@ -4355,7 +4354,7 @@ RLAPI bool CheckProcess(Process *process)
 
 #if defined(_WIN32)
     // PROCESS_QUERY_INFORMATION
-    void* hProcess = OpenProcess(0x0400, 0, (unsigned long)process->pid);
+    void *hProcess = OpenProcess(0x0400, 0, (unsigned long)process->pid);
     if (hProcess == NULL) return false;
 
     unsigned long exitCode = 0;
@@ -4415,8 +4414,43 @@ RLAPI bool CheckProcess(Process *process)
 // Pause process execution
 RLAPI void PauseProcess(Process *process)
 {
+    if ((process == NULL) || (process->pid <= 0))
+    {
+        return;
+    }
 #if defined(_WIN32)
-    TRACELOG(LOG_WARNING, "PROCESS: Pausing process is not supported on Windows");
+    typedef long (*PFN_NtSuspendProcess)(void *handle);
+    static PFN_NtSuspendProcess NtSuspendProcess = NULL;
+
+    // Load NtSuspendProcess from ntdll.dll
+    if (NtSuspendProcess == NULL)
+    {
+        void *hNtDll = GetModuleHandleA("ntdll.dll");
+        if (hNtDll == NULL)
+        {
+            TRACELOG(LOG_WARNING, "PROCESS: Failed to get handle for ntdll.dll");
+            return;
+        }
+
+        NtSuspendProcess = (PFN_NtSuspendProcess)GetProcAddress(hNtDll, "NtSuspendProcess");
+        if (NtSuspendProcess == NULL)    {
+            TRACELOG(LOG_WARNING, "PROCESS: Failed to get address for NtSuspendProcess");
+            return;
+        }
+    }
+
+    // PROCESS_SUSPEND_RESUME
+    void *hProcess = OpenProcess(0x0800, 0, (unsigned long)process->pid);
+    if (hProcess == NULL)    {
+        TRACELOG(LOG_WARNING, "PROCESS: Failed to open process handle");
+        return;
+    }
+
+    if (NtSuspendProcess(hProcess) != 0)
+    {
+        TRACELOG(LOG_WARNING, "PROCESS: Failed to pause process");
+    }
+    CloseHandle(hProcess);
 #elif defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__APPLE__)
     if (kill(process->pid, SIGSTOP) != 0)
     {
@@ -4430,8 +4464,45 @@ RLAPI void PauseProcess(Process *process)
 // Resume paused process execution
 RLAPI void ResumeProcess(Process *process)
 {
+    if ((process == NULL) || (process->pid <= 0))
+    {
+        return;
+    }
 #if defined(_WIN32)
-    TRACELOG(LOG_WARNING, "PROCESS: Resuming process is not supported on Windows");
+    typedef long (*PFN_NtResumeProcess)(void *handle);
+    static PFN_NtResumeProcess NtResumeProcess = NULL;
+
+    // Load NtResumeProcess from ntdll.dll
+    if (NtResumeProcess == NULL)
+    {
+        void *hNtDll = GetModuleHandleA("ntdll.dll");
+        if (hNtDll == NULL)
+        {
+            TRACELOG(LOG_WARNING, "PROCESS: Failed to get handle for ntdll.dll");
+            return;
+        }
+
+        NtResumeProcess = (PFN_NtResumeProcess)GetProcAddress(hNtDll, "NtResumeProcess");
+        if (NtResumeProcess == NULL)
+        {
+            TRACELOG(LOG_WARNING, "PROCESS: Failed to get address for NtResumeProcess");
+            return;
+        }
+    }
+
+    // PROCESS_SUSPEND_RESUME
+    void *hProcess = OpenProcess(0x0800, 0, (unsigned long)process->pid);
+    if (hProcess == NULL)
+    {
+        TRACELOG(LOG_WARNING, "PROCESS: Failed to open process handle");
+        return;
+    }
+
+    if (NtResumeProcess(hProcess) != 0)
+    {
+        TRACELOG(LOG_WARNING, "PROCESS: Failed to resume process");
+    }
+    CloseHandle(hProcess);
 #elif defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__APPLE__)
     if (kill(process->pid, SIGCONT) != 0)
     {
@@ -4450,8 +4521,8 @@ RLAPI void CloseProcess(Process *process)
         return;
     }
 #if defined(_WIN32)
-    // PROCESS_QUERY_INFORMATION | PROCESS_TERMINATE | PROCESS_SUSPEND_RESUME
-    void* hProcess = OpenProcess(0x0400 | 0x0001 | 0x0800, 0, (unsigned long)process->pid);
+    // PROCESS_TERMINATE
+    void *hProcess = OpenProcess(0x0001, 0, (unsigned long)process->pid);
     if (hProcess == NULL)
     {
         TRACELOG(LOG_WARNING, "PROCESS: Failed to open process handle");

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -4587,11 +4587,9 @@ RLAPI int WaitProcess(Process process)
             // Normal exit
             return WEXITSTATUS(status);
         }
-        else if (WIFSIGNALED(status))
-        {
-            // Terminated by signal
-            return -1;
-        }
+
+        // Terminated by signal or other non-normal exit
+        return -1;
     }
     else
     {

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -281,6 +281,7 @@
     #include <sys/wait.h>           // Required for: waitpid() [Used in CheckProcess()]
     #include <signal.h>             // Required for: kill() [Used in PauseProcess(), ResumeProcess(), CloseProcess()]
     #include <sys/types.h>          // Required for: pid_t [Used as function local variable type and for Process PID type]
+    #include <poll.h>               // Required for: pollfd, poll() [Used in ReadProcessOutput()]
 #endif
 
 //----------------------------------------------------------------------------------
@@ -4289,6 +4290,11 @@ int GetTouchPointCount(void)
 //----------------------------------------------------------------------------------
 
 #if defined(_WIN32)
+struct ProcessInternal {
+    void *pipeStdoutRead;           // Process stdout and stderr read pipe
+    void *pipeStdinWrite;           // Process stdin write pipe
+};
+
 static bool CreatePipeWindows(void** readPipe, void** writePipe) {
     struct _SECURITY_ATTRIBUTES sa = { 0 };
     sa.nLength = sizeof(struct _SECURITY_ATTRIBUTES);
@@ -4300,6 +4306,17 @@ static bool CreatePipeWindows(void** readPipe, void** writePipe) {
 static void CloseAllPipesWindows(void** pipes, int count) {
     for (int i = 0; i < count; i++) {
         if (pipes[i] != NULL) CloseHandle(pipes[i]);
+    }
+}
+#elif defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__APPLE__)
+struct ProcessInternal {
+    int pipefdStdout[2];           // Process stdout and stderr pipe file descriptors
+    int pipefdStdin[2];            // Process stdin pipe file descriptors
+};
+
+static void CloseAllPipesUnix(int* pipefds, int count) {
+    for (int i = 0; i < count; i++) {
+        if (pipefds[i] != -1) close(pipefds[i]);
     }
 }
 #endif
@@ -4366,8 +4383,9 @@ RLAPI Process InitProcess(const char *command, char *const args[])
         CloseHandle(pi.hThread);
         CloseHandle(pi.hProcess);
 
-        process.pipeStdoutRead = pipeStdoutRead;
-        process.pipeStdinWrite = pipeStdinWrite;
+        process.internal = (struct ProcessInternal *)RL_MALLOC(sizeof(struct ProcessInternal));
+        process.internal->pipeStdoutRead = pipeStdoutRead;
+        process.internal->pipeStdinWrite = pipeStdinWrite;
 
         // Free parent process handles
         CloseHandle(pipeStdoutWrite);
@@ -4380,15 +4398,46 @@ RLAPI Process InitProcess(const char *command, char *const args[])
 
     return process;
 #elif defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__APPLE__)
+    // Initialize fd to -1 for error checking
+    int pipefd[4] = { -1, -1, -1, -1 };
+
+    if ((pipe(&pipefd[0]) == -1) || 
+        (pipe(&pipefd[2]) == -1))
+    {
+        TRACELOG(LOG_WARNING, "PROCESS: Failed to create pipes");
+        CloseAllPipesUnix(pipefd, 4);
+        return process;
+    }
+
+    process.internal = (struct ProcessInternal *)RL_MALLOC(sizeof(struct ProcessInternal));
+    memcpy(process.internal->pipefdStdout, &pipefd[0], sizeof(int) * 2);
+    memcpy(process.internal->pipefdStdin, &pipefd[2], sizeof(int) * 2);
+
     pid_t pid = fork();
 
     if (pid < 0)
     {
         TRACELOG(LOG_WARNING, "PROCESS: Failed to create process");
+        CloseAllPipesUnix(pipefd, 4);
+        RL_FREE(process.internal);
+        return process;
     }
     else if (pid == 0)
     {
         // Child process
+
+        // Close pipe read end, redirect stdout and stderr to pipe write end
+        close(process.internal->pipefdStdout[0]);
+        dup2(process.internal->pipefdStdout[1], STDOUT_FILENO);
+        dup2(process.internal->pipefdStdout[1], STDERR_FILENO);
+        close(process.internal->pipefdStdout[1]);
+
+        // Close pipe write end, redirect stdin to pipe read end
+        close(process.internal->pipefdStdin[1]);
+        dup2(process.internal->pipefdStdin[0], STDIN_FILENO);
+        close(process.internal->pipefdStdin[0]);
+
+        // Execute command
         execvp(command, args);
 
         // If execvp returns, it must have failed
@@ -4396,7 +4445,12 @@ RLAPI Process InitProcess(const char *command, char *const args[])
     }
     else
     {
+        // Parent process
         process.pid = pid;
+
+        // Close stdout pipe write end and stdin pipe read end
+        close(process.internal->pipefdStdout[1]);
+        close(process.internal->pipefdStdin[0]);
     }
 
     return process;
@@ -4564,7 +4618,7 @@ RLAPI const char *ReadProcessOutput(Process process, int *length)
     // NOTE: This will read whatever in the pipe buffer
 
     unsigned long bytesRead = 0;
-    if (!ReadFile(process.pipeStdoutRead, output, sizeof(output), &bytesRead, NULL))
+    if (!ReadFile(process.internal->pipeStdoutRead, output, sizeof(output), &bytesRead, NULL))
     {
         *length = 0;
         return NULL;
@@ -4573,7 +4627,22 @@ RLAPI const char *ReadProcessOutput(Process process, int *length)
     *length = (int)bytesRead;
     return output;
 #elif defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__APPLE__)
-    TRACELOG(LOG_WARNING, "PROCESS: Reading process output not supported on this platform");
+    struct pollfd fds[1];
+    fds[0].fd = process.internal->pipefdStdout[0];
+    fds[0].events = POLLIN;
+
+    // No timeout, just check if there is data to read
+    int pollResult = poll(fds, 1, 0);
+    if ((pollResult > 0) && (fds[0].revents & POLLIN))
+    {
+        ssize_t bytesRead = read(process.internal->pipefdStdout[0], output, sizeof(output));
+        if (bytesRead > 0)
+        {
+            *length = (int)bytesRead;
+            return output;
+        }
+    }
+
     *length = 0;
     return NULL;
 #else
@@ -4704,7 +4773,7 @@ RLAPI void CloseProcess(Process process)
     CloseHandle(hProcess);
 
     // Clean up pipes
-    void* pipes[] = { process.pipeStdoutRead, process.pipeStdinWrite };
+    void *pipes[] = { process.internal->pipeStdoutRead, process.internal->pipeStdinWrite };
     CloseAllPipesWindows(pipes, sizeof(pipes) / sizeof(pipes[0]));
 
 #elif defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__APPLE__)
@@ -4728,6 +4797,10 @@ RLAPI void CloseProcess(Process process)
 
     // Wait process termination
     waitpid(process.pid, NULL, 0);
+
+    int pipefd[2] = { process.internal->pipefdStdout[0], process.internal->pipefdStdin[1] };
+    CloseAllPipesUnix(pipefd, 2);
+    RL_FREE(process.internal);
 #else
     TRACELOG(LOG_WARNING, "PROCESS: Process management not supported on this platform");
 #endif

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -271,6 +271,13 @@
         void **hWritePipe,
         struct _SECURITY_ATTRIBUTES *lpPipeAttributes,
         unsigned long nSize);
+    __declspec(dllimport) int __stdcall PeekNamedPipe(
+        void *hNamedPipe,
+        void *lpBuffer,
+        unsigned long nBufferSize,
+        unsigned long *lpBytesRead,
+        unsigned long *lpTotalBytesAvail,
+        unsigned long *lpBytesLeftThisMessage);
     __declspec(dllimport) int __stdcall ReadFile(
         void *hFile,
         void *lpBuffer,
@@ -4614,6 +4621,15 @@ RLAPI const char *ReadProcessOutput(Process process, int *length)
 #if defined(_WIN32)
     // Read from output pipe
     // NOTE: This will read whatever in the pipe buffer
+
+    // ReadFile will block if there is no data, so call PeekNamedPipe to check for data before reading
+    unsigned long bytesAvail = 0;
+    if ((!PeekNamedPipe(process.internal->pipeStdoutRead, NULL, 0, NULL, &bytesAvail, NULL)) ||
+        (bytesAvail == 0))
+    {
+        *length = 0;
+        return NULL;
+    }
 
     unsigned long bytesRead = 0;
     if (!ReadFile(process.internal->pipeStdoutRead, output, sizeof(output), &bytesRead, NULL))

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -4428,6 +4428,65 @@ RLAPI ProcessInfo CheckProcess(Process process)
     return info;
 }
 
+RLAPI int WaitProcess(Process process)
+{
+    if (process.pid <= 0)
+    {
+        return -1;
+    }
+
+#if defined(_WIN32)
+    // PROCESS_QUERY_INFORMATION | SYNCHRONIZE
+    // SYNCHRONIZE for WaitForSingleObject
+    void *hProcess = OpenProcess(0x0400 | 0x00100000, 0, (unsigned long)process.pid);
+    if (hProcess == NULL)
+    {
+        TRACELOG(LOG_WARNING, "PROCESS: Failed to open process handle");
+        return -1;
+    }
+
+    // Wait indefinitely for process termination
+    // INFINITE
+    WaitForSingleObject(hProcess, 0xFFFFFFFF);
+
+    // Get exit code
+    unsigned long exitCode = 0;
+    if (GetExitCodeProcess(hProcess, &exitCode))
+    {
+        CloseHandle(hProcess);
+        return (int)exitCode;
+    }
+
+    CloseHandle(hProcess);
+    return -1;
+#elif defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__APPLE__)
+    int status = 0;
+    pid_t result = waitpid(process.pid, &status, 0);
+
+    if (result == process.pid)
+    {
+        if (WIFEXITED(status))
+        {
+            // Normal exit
+            return WEXITSTATUS(status);
+        }
+        else if (WIFSIGNALED(status))
+        {
+            // Terminated by signal
+            return -1;
+        }
+    }
+    else
+    {
+        TRACELOG(LOG_WARNING, "PROCESS: Failed to wait for process");
+        return -1;
+    }
+#else
+    TRACELOG(LOG_WARNING, "PROCESS: Process management not supported on this platform");
+    return -1;
+#endif
+}
+
 // Pause process execution
 RLAPI void PauseProcess(Process process)
 {

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -4345,76 +4345,93 @@ RLAPI Process InitProcess(const char *command, char *const args[])
 }
 
 // Check if a process is still running, updates Process struct
-RLAPI bool CheckProcess(Process *process)
+RLAPI ProcessInfo CheckProcess(Process process)
 {
-    if ((process == NULL) || (process->pid <= 0))
+    ProcessInfo info = { 0 };
+
+    if (process.pid <= 0)
     {
-        return false;
+        info.state = PROCESS_STATE_NONE;
+        return info;
     }
 
 #if defined(_WIN32)
     // PROCESS_QUERY_INFORMATION
-    void *hProcess = OpenProcess(0x0400, 0, (unsigned long)process->pid);
-    if (hProcess == NULL) return false;
+    void *hProcess = OpenProcess(0x0400, 0, (unsigned long)process.pid);
+    if (hProcess == NULL)
+    {
+        // Process does not exist
+        info.state = PROCESS_STATE_NONE;
+        return info;
+    }
 
     unsigned long exitCode = 0;
     if (GetExitCodeProcess(hProcess, &exitCode))
     {
         CloseHandle(hProcess);
         // STILL_ACTIVE (259) means the process is still running
-        if (exitCode == 259) return true;
-        
-        process->exitCode = (int)exitCode;
-        process->pid = 0;
-        return false;
+        if (exitCode == 259)
+        {
+            info.state = PROCESS_STATE_RUNNING;
+            return info;
+        }
+
+        info.state = PROCESS_STATE_FINISHED;
+        info.exitCode = (int)exitCode;
+
+        return info;
     }
 
     CloseHandle(hProcess);
-    return false;
+
+    // If GetExitCodeProcess fails, we consider the process state as unknown
+    info.state = PROCESS_STATE_NONE;
+    return info;
 #elif defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__APPLE__)
     int status = 0;
-    pid_t result = waitpid(process->pid, &status, WNOHANG);
+    pid_t result = waitpid(process.pid, &status, WNOHANG);
 
     if (result == 0)
     {
         // Still running
-        return true;
+        info.state = PROCESS_STATE_RUNNING;
+        return info;
     }
-    else if (result == process->pid)
+    else if (result == process.pid)
     {
         // Not running
         if (WIFEXITED(status))
         {
-            process->exitCode = WEXITSTATUS(status);
+            // Normal exit
+            info.state = PROCESS_STATE_FINISHED;
+            info.exitCode = WEXITSTATUS(status);
         }
         else if (WIFSIGNALED(status))
         {
             // Terminated by signal
-            process->exitCode = -1;
+            info.state = PROCESS_STATE_FINISHED;
+            info.exitCode = -1;
         }
     
-        // Mark as completed
-        process->pid = 0;
-    
-        return false;
+        return info;
     }
     else
     {
         // Error occurred
-        TRACELOG(LOG_WARNING, "PROCESS: Failed to check process status");
-        return false;
+        info.state = PROCESS_STATE_NONE;
+        return info;
     }
 #else
     TRACELOG(LOG_WARNING, "PROCESS: Process management not supported on this platform");
 #endif
 
-    return false;
+    return info;
 }
 
 // Pause process execution
-RLAPI void PauseProcess(Process *process)
+RLAPI void PauseProcess(Process process)
 {
-    if ((process == NULL) || (process->pid <= 0))
+    if (process.pid <= 0)
     {
         return;
     }
@@ -4440,7 +4457,7 @@ RLAPI void PauseProcess(Process *process)
     }
 
     // PROCESS_SUSPEND_RESUME
-    void *hProcess = OpenProcess(0x0800, 0, (unsigned long)process->pid);
+    void *hProcess = OpenProcess(0x0800, 0, (unsigned long)process.pid);
     if (hProcess == NULL)    {
         TRACELOG(LOG_WARNING, "PROCESS: Failed to open process handle");
         return;
@@ -4452,7 +4469,7 @@ RLAPI void PauseProcess(Process *process)
     }
     CloseHandle(hProcess);
 #elif defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__APPLE__)
-    if (kill(process->pid, SIGSTOP) != 0)
+    if (kill(process.pid, SIGSTOP) != 0)
     {
         TRACELOG(LOG_WARNING, "PROCESS: Failed to pause process");
     }
@@ -4462,9 +4479,9 @@ RLAPI void PauseProcess(Process *process)
 }
 
 // Resume paused process execution
-RLAPI void ResumeProcess(Process *process)
+RLAPI void ResumeProcess(Process process)
 {
-    if ((process == NULL) || (process->pid <= 0))
+    if (process.pid <= 0)
     {
         return;
     }
@@ -4491,7 +4508,7 @@ RLAPI void ResumeProcess(Process *process)
     }
 
     // PROCESS_SUSPEND_RESUME
-    void *hProcess = OpenProcess(0x0800, 0, (unsigned long)process->pid);
+    void *hProcess = OpenProcess(0x0800, 0, (unsigned long)process.pid);
     if (hProcess == NULL)
     {
         TRACELOG(LOG_WARNING, "PROCESS: Failed to open process handle");
@@ -4504,7 +4521,7 @@ RLAPI void ResumeProcess(Process *process)
     }
     CloseHandle(hProcess);
 #elif defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__APPLE__)
-    if (kill(process->pid, SIGCONT) != 0)
+    if (kill(process.pid, SIGCONT) != 0)
     {
         TRACELOG(LOG_WARNING, "PROCESS: Failed to resume process");
     }
@@ -4514,15 +4531,15 @@ RLAPI void ResumeProcess(Process *process)
 }
 
 // Close process and free resources
-RLAPI void CloseProcess(Process *process)
+RLAPI void CloseProcess(Process process)
 {
-    if ((process == NULL) || (process->pid <= 0))
+    if (process.pid <= 0)
     {
         return;
     }
 #if defined(_WIN32)
     // PROCESS_TERMINATE
-    void *hProcess = OpenProcess(0x0001, 0, (unsigned long)process->pid);
+    void *hProcess = OpenProcess(0x0001, 0, (unsigned long)process.pid);
     if (hProcess == NULL)
     {
         TRACELOG(LOG_WARNING, "PROCESS: Failed to open process handle");
@@ -4532,31 +4549,27 @@ RLAPI void CloseProcess(Process *process)
     TerminateProcess(hProcess, 0);
     CloseHandle(hProcess);
 
-    process->exitCode = -1;
-    process->pid = 0;
 #elif defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__APPLE__)
-    if (!CheckProcess(process))
+    // If process is not running or not found, nothing to do
+    ProcessInfo info = CheckProcess(process);
+    if (info.state != PROCESS_STATE_RUNNING)
     {
         return;
     }
 
     // In case that the process is paused
-    kill(process->pid, SIGCONT);
+    kill(process.pid, SIGCONT);
 
-    if (kill(process->pid, SIGTERM) != 0)
+    if (kill(process.pid, SIGTERM) != 0)
     {
         TRACELOG(LOG_WARNING, "PROCESS: Failed to terminate process");
 
         // Kill the process anyway
-        kill(process->pid, SIGKILL);
+        kill(process.pid, SIGKILL);
     }
 
     // Wait process termination
-    waitpid(process->pid, NULL, 0);
-
-    // Align as CheckProcess() would do for a killed process
-    process->exitCode = -1;
-    process->pid = 0;
+    waitpid(process.pid, NULL, 0);
 #else
     TRACELOG(LOG_WARNING, "PROCESS: Process management not supported on this platform");
 #endif

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -4297,7 +4297,7 @@ int GetTouchPointCount(void)
 //----------------------------------------------------------------------------------
 
 #if defined(_WIN32)
-struct ProcessInternal {
+struct rProcessData {
     void *pipeStdoutRead;           // Process stdout and stderr read pipe
     void *pipeStdinWrite;           // Process stdin write pipe
 };
@@ -4316,7 +4316,7 @@ static void CloseAllPipesWindows(void** pipes, int count) {
     }
 }
 #elif defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__APPLE__)
-struct ProcessInternal {
+struct rProcessData {
     int pipefdStdout[2];           // Process stdout and stderr pipe file descriptors
     int pipefdStdin[2];            // Process stdin pipe file descriptors
 };
@@ -4390,9 +4390,9 @@ RLAPI Process InitProcess(const char *command, char *const args[])
         CloseHandle(pi.hThread);
         CloseHandle(pi.hProcess);
 
-        process.internal = (struct ProcessInternal *)RL_MALLOC(sizeof(struct ProcessInternal));
-        process.internal->pipeStdoutRead = pipeStdoutRead;
-        process.internal->pipeStdinWrite = pipeStdinWrite;
+        process.processData = (rProcessData *)RL_MALLOC(sizeof(rProcessData));
+        process.processData->pipeStdoutRead = pipeStdoutRead;
+        process.processData->pipeStdinWrite = pipeStdinWrite;
 
         // Free parent process handles
         CloseHandle(pipeStdoutWrite);
@@ -4416,9 +4416,9 @@ RLAPI Process InitProcess(const char *command, char *const args[])
         return process;
     }
 
-    process.internal = (struct ProcessInternal *)RL_MALLOC(sizeof(struct ProcessInternal));
-    memcpy(process.internal->pipefdStdout, &pipefd[0], sizeof(int) * 2);
-    memcpy(process.internal->pipefdStdin, &pipefd[2], sizeof(int) * 2);
+    process.processData = (rProcessData *)RL_MALLOC(sizeof(rProcessData));
+    memcpy(process.processData->pipefdStdout, &pipefd[0], sizeof(int) * 2);
+    memcpy(process.processData->pipefdStdin, &pipefd[2], sizeof(int) * 2);
 
     pid_t pid = fork();
 
@@ -4426,7 +4426,7 @@ RLAPI Process InitProcess(const char *command, char *const args[])
     {
         TRACELOG(LOG_WARNING, "PROCESS: Failed to create process");
         CloseAllPipesUnix(pipefd, 4);
-        RL_FREE(process.internal);
+        RL_FREE(process.processData);
         return process;
     }
     else if (pid == 0)
@@ -4434,15 +4434,15 @@ RLAPI Process InitProcess(const char *command, char *const args[])
         // Child process
 
         // Close pipe read end, redirect stdout and stderr to pipe write end
-        close(process.internal->pipefdStdout[0]);
-        dup2(process.internal->pipefdStdout[1], STDOUT_FILENO);
-        dup2(process.internal->pipefdStdout[1], STDERR_FILENO);
-        close(process.internal->pipefdStdout[1]);
+        close(process.processData->pipefdStdout[0]);
+        dup2(process.processData->pipefdStdout[1], STDOUT_FILENO);
+        dup2(process.processData->pipefdStdout[1], STDERR_FILENO);
+        close(process.processData->pipefdStdout[1]);
 
         // Close pipe write end, redirect stdin to pipe read end
-        close(process.internal->pipefdStdin[1]);
-        dup2(process.internal->pipefdStdin[0], STDIN_FILENO);
-        close(process.internal->pipefdStdin[0]);
+        close(process.processData->pipefdStdin[1]);
+        dup2(process.processData->pipefdStdin[0], STDIN_FILENO);
+        close(process.processData->pipefdStdin[0]);
 
         // Execute command
         execvp(command, args);
@@ -4456,8 +4456,8 @@ RLAPI Process InitProcess(const char *command, char *const args[])
         process.pid = pid;
 
         // Close stdout pipe write end and stdin pipe read end
-        close(process.internal->pipefdStdout[1]);
-        close(process.internal->pipefdStdin[0]);
+        close(process.processData->pipefdStdout[1]);
+        close(process.processData->pipefdStdin[0]);
     }
 
     return process;
@@ -4620,11 +4620,10 @@ RLAPI const char *ReadProcessOutput(Process process, int *length)
 
 #if defined(_WIN32)
     // Read from output pipe
-    // NOTE: This will read whatever in the pipe buffer
 
     // ReadFile will block if there is no data, so call PeekNamedPipe to check for data before reading
     unsigned long bytesAvail = 0;
-    if ((!PeekNamedPipe(process.internal->pipeStdoutRead, NULL, 0, NULL, &bytesAvail, NULL)) ||
+    if ((!PeekNamedPipe(process.processData->pipeStdoutRead, NULL, 0, NULL, &bytesAvail, NULL)) ||
         (bytesAvail == 0))
     {
         *length = 0;
@@ -4632,7 +4631,7 @@ RLAPI const char *ReadProcessOutput(Process process, int *length)
     }
 
     unsigned long bytesRead = 0;
-    if (!ReadFile(process.internal->pipeStdoutRead, output, sizeof(output), &bytesRead, NULL))
+    if (!ReadFile(process.processData->pipeStdoutRead, output, sizeof(output), &bytesRead, NULL))
     {
         *length = 0;
         return NULL;
@@ -4642,14 +4641,14 @@ RLAPI const char *ReadProcessOutput(Process process, int *length)
     return output;
 #elif defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__APPLE__)
     struct pollfd fds[1];
-    fds[0].fd = process.internal->pipefdStdout[0];
+    fds[0].fd = process.processData->pipefdStdout[0];
     fds[0].events = POLLIN;
 
     // No timeout, just check if there is data to read
     int pollResult = poll(fds, 1, 0);
     if ((pollResult > 0) && (fds[0].revents & POLLIN))
     {
-        ssize_t bytesRead = read(process.internal->pipefdStdout[0], output, sizeof(output));
+        ssize_t bytesRead = read(process.processData->pipefdStdout[0], output, sizeof(output));
         if (bytesRead > 0)
         {
             *length = (int)bytesRead;
@@ -4787,10 +4786,10 @@ RLAPI void CloseProcess(Process process)
     CloseHandle(hProcess);
 
     // Clean up pipes
-    void *pipes[] = { process.internal->pipeStdoutRead, process.internal->pipeStdinWrite };
+    void *pipes[] = { process.processData->pipeStdoutRead, process.processData->pipeStdinWrite };
     CloseAllPipesWindows(pipes, sizeof(pipes) / sizeof(pipes[0]));
 
-    RL_FREE(process.internal);
+    RL_FREE(process.processData);
 
 #elif defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__APPLE__)
     // If process is not running or not found, nothing to do
@@ -4814,9 +4813,9 @@ RLAPI void CloseProcess(Process process)
     // Wait process termination
     waitpid(process.pid, NULL, 0);
 
-    int pipefd[2] = { process.internal->pipefdStdout[0], process.internal->pipefdStdin[1] };
+    int pipefd[2] = { process.processData->pipefdStdout[0], process.processData->pipefdStdin[1] };
     CloseAllPipesUnix(pipefd, 2);
-    RL_FREE(process.internal);
+    RL_FREE(process.processData);
 #else
     TRACELOG(LOG_WARNING, "PROCESS: Process management not supported on this platform");
 #endif

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -4776,6 +4776,8 @@ RLAPI void CloseProcess(Process process)
     void *pipes[] = { process.internal->pipeStdoutRead, process.internal->pipeStdinWrite };
     CloseAllPipesWindows(pipes, sizeof(pipes) / sizeof(pipes[0]));
 
+    RL_FREE(process.internal);
+
 #elif defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__APPLE__)
     // If process is not running or not found, nothing to do
     ProcessInfo info = CheckProcess(process);

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -4602,14 +4602,14 @@ RLAPI int WaitProcess(Process process)
 
 RLAPI const char *ReadProcessOutput(Process process, int *length)
 {
-    static char output[4096] = { 0 };
-
     if (process.pid <= 0)
     {
         return NULL;
     }
 
 #if defined(_WIN32)
+    static char output[4096] = { 0 };
+
     // Read from output pipe
 
     // ReadFile will block if there is no data, so call PeekNamedPipe to check for data before reading
@@ -4631,6 +4631,8 @@ RLAPI const char *ReadProcessOutput(Process process, int *length)
     *length = (int)bytesRead;
     return output;
 #elif defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__APPLE__)
+    static char output[4096] = { 0 };
+
     struct pollfd fds[1];
     fds[0].fd = process.processData->pipefdStdout[0];
     fds[0].events = POLLIN;

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -233,6 +233,12 @@
         void *hStdError;
     };
 
+    struct _SECURITY_ATTRIBUTES {
+        unsigned long nLength;
+        void *lpSecurityDescriptor;
+        int bInheritHandle;
+    };
+
     struct _PROCESS_INFORMATION {
         void *hProcess;
         void *hThread;
@@ -260,6 +266,17 @@
         const char *lpCurrentDirectory,
         struct _STARTUPINFOA *lpStartupInfo,
         struct _PROCESS_INFORMATION *lpProcessInformation);
+    __declspec(dllimport) int __stdcall CreatePipe(
+        void **hReadPipe,
+        void **hWritePipe,
+        struct _SECURITY_ATTRIBUTES *lpPipeAttributes,
+        unsigned long nSize);
+    __declspec(dllimport) int __stdcall ReadFile(
+        void *hFile,
+        void *lpBuffer,
+        unsigned long nNumberOfBytesToRead,
+        unsigned long *lpNumberOfBytesRead,
+        void *lpOverlapped);
 #elif defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__APPLE__)
     #include <sys/wait.h>           // Required for: waitpid() [Used in CheckProcess()]
     #include <signal.h>             // Required for: kill() [Used in PauseProcess(), ResumeProcess(), CloseProcess()]
@@ -4271,6 +4288,22 @@ int GetTouchPointCount(void)
 // Module Functions Definition: Process Execution
 //----------------------------------------------------------------------------------
 
+#if defined(_WIN32)
+static bool CreatePipeWindows(void** readPipe, void** writePipe) {
+    struct _SECURITY_ATTRIBUTES sa = { 0 };
+    sa.nLength = sizeof(struct _SECURITY_ATTRIBUTES);
+    sa.bInheritHandle = 1;
+    sa.lpSecurityDescriptor = NULL;
+    return CreatePipe(readPipe, writePipe, &sa, 0) != 0;
+}
+
+static void CloseAllPipesWindows(void** pipes, int count) {
+    for (int i = 0; i < count; i++) {
+        if (pipes[i] != NULL) CloseHandle(pipes[i]);
+    }
+}
+#endif
+
 // Initialize a new process, returns a Process struct
 RLAPI Process InitProcess(const char *command, char *const args[])
 {
@@ -4301,16 +4334,44 @@ RLAPI Process InitProcess(const char *command, char *const args[])
         }
     }
 
+    // For stdout/stderr, read handles reserved for Raylib side, write handles passed to child process
+    // For stdin, write handle reserved for Raylib side, read handle passed to child process
+    // NOTE: stdout and stderr are merged into a single pipe
+    void *pipeStdoutRead, *pipeStdoutWrite;
+    void *pipeStdinRead, *pipeStdinWrite;
+
+    if ((!CreatePipeWindows(&pipeStdoutRead, &pipeStdoutWrite)) ||
+        (!CreatePipeWindows(&pipeStdinRead, &pipeStdinWrite)))
+    {
+        TRACELOG(LOG_WARNING, "PROCESS: Failed to create pipes for process I/O redirection");
+        void *pipes[] = { pipeStdoutRead, pipeStdoutWrite, pipeStdinRead, pipeStdinWrite };
+        CloseAllPipesWindows(pipes, sizeof(pipes) / sizeof(pipes[0]));
+        return process;
+    }
+
     struct _STARTUPINFOA si = { 0 };
     si.cb = sizeof(struct _STARTUPINFOA);
+    // STARTF_USESTDHANDLES
+    si.dwFlags = 0x00000100;
+    si.hStdError = pipeStdoutWrite;
+    si.hStdOutput = pipeStdoutWrite;
+    si.hStdInput = pipeStdinRead;
     struct _PROCESS_INFORMATION pi = { 0 };
 
     // Application name is specified as the first command line argument, so pass NULL to CreateProcessA here
-    if (CreateProcessA(NULL, cmdLine, NULL, NULL, 0, 0, NULL, NULL, &si, &pi))
+    // Flag bInheritHandles is set to TRUE, so child process will have access to the pipes
+    if (CreateProcessA(NULL, cmdLine, NULL, NULL, 1, 0, NULL, NULL, &si, &pi))
     {
         process.pid = (int)pi.dwProcessId;
         CloseHandle(pi.hThread);
         CloseHandle(pi.hProcess);
+
+        process.pipeStdoutRead = pipeStdoutRead;
+        process.pipeStdinWrite = pipeStdinWrite;
+
+        // Free parent process handles
+        CloseHandle(pipeStdoutWrite);
+        CloseHandle(pipeStdinRead);
     }
     else
     {
@@ -4337,11 +4398,12 @@ RLAPI Process InitProcess(const char *command, char *const args[])
     {
         process.pid = pid;
     }
-#else
-    TRACELOG(LOG_WARNING, "PROCESS: Process management not supported on this platform");
-#endif
 
     return process;
+#else
+    TRACELOG(LOG_WARNING, "PROCESS: Process management not supported on this platform");
+    return process;
+#endif
 }
 
 // Check if a process is still running, updates Process struct
@@ -4446,6 +4508,7 @@ RLAPI int WaitProcess(Process process)
     }
 
     // Wait indefinitely for process termination
+    // NOTE: calling WaitProcess while trying to read process output may cause deadlock
     // INFINITE
     WaitForSingleObject(hProcess, 0xFFFFFFFF);
 
@@ -4484,6 +4547,38 @@ RLAPI int WaitProcess(Process process)
 #else
     TRACELOG(LOG_WARNING, "PROCESS: Process management not supported on this platform");
     return -1;
+#endif
+}
+
+RLAPI const char *ReadProcessOutput(Process process, int *length)
+{
+    static char output[4096] = { 0 };
+
+    if (process.pid <= 0)
+    {
+        return NULL;
+    }
+
+#if defined(_WIN32)
+    // Read from output pipe
+    // NOTE: This will read whatever in the pipe buffer
+
+    unsigned long bytesRead = 0;
+    if (!ReadFile(process.pipeStdoutRead, output, sizeof(output), &bytesRead, NULL))
+    {
+        *length = 0;
+        return NULL;
+    }
+
+    *length = (int)bytesRead;
+    return output;
+#elif defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__APPLE__)
+    TRACELOG(LOG_WARNING, "PROCESS: Reading process output not supported on this platform");
+    *length = 0;
+    return NULL;
+#else
+    TRACELOG(LOG_WARNING, "PROCESS: Process management not supported on this platform");
+    return NULL;
 #endif
 }
 
@@ -4607,6 +4702,10 @@ RLAPI void CloseProcess(Process process)
 
     TerminateProcess(hProcess, 0);
     CloseHandle(hProcess);
+
+    // Clean up pipes
+    void* pipes[] = { process.pipeStdoutRead, process.pipeStdinWrite };
+    CloseAllPipesWindows(pipes, sizeof(pipes) / sizeof(pipes[0]));
 
 #elif defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__APPLE__)
     // If process is not running or not found, nothing to do

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -4301,31 +4301,11 @@ struct rProcessData {
     void *pipeStdoutRead;           // Process stdout and stderr read pipe
     void *pipeStdinWrite;           // Process stdin write pipe
 };
-
-static bool CreatePipeWindows(void** readPipe, void** writePipe) {
-    struct _SECURITY_ATTRIBUTES sa = { 0 };
-    sa.nLength = sizeof(struct _SECURITY_ATTRIBUTES);
-    sa.bInheritHandle = 1;
-    sa.lpSecurityDescriptor = NULL;
-    return CreatePipe(readPipe, writePipe, &sa, 0) != 0;
-}
-
-static void CloseAllPipesWindows(void** pipes, int count) {
-    for (int i = 0; i < count; i++) {
-        if (pipes[i] != NULL) CloseHandle(pipes[i]);
-    }
-}
 #elif defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__APPLE__)
 struct rProcessData {
     int pipefdStdout[2];           // Process stdout and stderr pipe file descriptors
     int pipefdStdin[2];            // Process stdin pipe file descriptors
 };
-
-static void CloseAllPipesUnix(int* pipefds, int count) {
-    for (int i = 0; i < count; i++) {
-        if (pipefds[i] != -1) close(pipefds[i]);
-    }
-}
 #endif
 
 // Initialize a new process, returns a Process struct
@@ -4361,15 +4341,22 @@ RLAPI Process InitProcess(const char *command, char *const args[])
     // For stdout/stderr, read handles reserved for Raylib side, write handles passed to child process
     // For stdin, write handle reserved for Raylib side, read handle passed to child process
     // NOTE: stdout and stderr are merged into a single pipe
-    void *pipeStdoutRead, *pipeStdoutWrite;
-    void *pipeStdinRead, *pipeStdinWrite;
+    void *pipeStdoutRead = NULL, *pipeStdoutWrite = NULL;
+    void *pipeStdinRead = NULL, *pipeStdinWrite = NULL;
 
-    if ((!CreatePipeWindows(&pipeStdoutRead, &pipeStdoutWrite)) ||
-        (!CreatePipeWindows(&pipeStdinRead, &pipeStdinWrite)))
+    struct _SECURITY_ATTRIBUTES sa = { 0 };
+    sa.nLength = sizeof(struct _SECURITY_ATTRIBUTES);
+    sa.bInheritHandle = 1;
+    sa.lpSecurityDescriptor = NULL;
+
+    if ((!CreatePipe(&pipeStdoutRead, &pipeStdoutWrite, &sa, 0)) ||
+        (!CreatePipe(&pipeStdinRead, &pipeStdinWrite, &sa, 0)))
     {
         TRACELOG(LOG_WARNING, "PROCESS: Failed to create pipes for process I/O redirection");
         void *pipes[] = { pipeStdoutRead, pipeStdoutWrite, pipeStdinRead, pipeStdinWrite };
-        CloseAllPipesWindows(pipes, sizeof(pipes) / sizeof(pipes[0]));
+        for (int i = 0; i < 4; i++) {
+            if (pipes[i] != NULL) CloseHandle(pipes[i]);
+        }
         return process;
     }
 
@@ -4412,7 +4399,9 @@ RLAPI Process InitProcess(const char *command, char *const args[])
         (pipe(&pipefd[2]) == -1))
     {
         TRACELOG(LOG_WARNING, "PROCESS: Failed to create pipes");
-        CloseAllPipesUnix(pipefd, 4);
+        for (int i = 0; i < 4; i++) {
+            if (pipefd[i] != -1) close(pipefd[i]);
+        }
         return process;
     }
 
@@ -4425,8 +4414,10 @@ RLAPI Process InitProcess(const char *command, char *const args[])
     if (pid < 0)
     {
         TRACELOG(LOG_WARNING, "PROCESS: Failed to create process");
-        CloseAllPipesUnix(pipefd, 4);
+
+        for (int i = 0; i < 4; i++) close(pipefd[i]);
         RL_FREE(process.processData);
+
         return process;
     }
     else if (pid == 0)
@@ -4786,8 +4777,8 @@ RLAPI void CloseProcess(Process process)
     CloseHandle(hProcess);
 
     // Clean up pipes
-    void *pipes[] = { process.processData->pipeStdoutRead, process.processData->pipeStdinWrite };
-    CloseAllPipesWindows(pipes, sizeof(pipes) / sizeof(pipes[0]));
+    if (process.processData->pipeStdoutRead != NULL) CloseHandle(process.processData->pipeStdoutRead);
+    if (process.processData->pipeStdinWrite != NULL) CloseHandle(process.processData->pipeStdinWrite);
 
     RL_FREE(process.processData);
 
@@ -4813,8 +4804,9 @@ RLAPI void CloseProcess(Process process)
     // Wait process termination
     waitpid(process.pid, NULL, 0);
 
-    int pipefd[2] = { process.processData->pipefdStdout[0], process.processData->pipefdStdin[1] };
-    CloseAllPipesUnix(pipefd, 2);
+    close(process.processData->pipefdStdout[0]);
+    close(process.processData->pipefdStdin[1]);
+
     RL_FREE(process.processData);
 #else
     TRACELOG(LOG_WARNING, "PROCESS: Process management not supported on this platform");


### PR DESCRIPTION
I noticed that in the wishlist for raylib7.0 (#5710) there are plans for process manipulation APIs, so I wrote the following functions for posix-compliant platforms:

- `InitProcess` to launch a new process
- `CheckProcess` which checks whether a process is still running
- `PauseProcess` to pause execution
- `CloseProcess` to terminate a process

And a counterpart for `PauseProcess`: `ResumeProcess`

Please let me know if any changes need to be made!