### PR TITLE
[rcore_android] Restore face-button input on Android gamepads

### DIFF
--- a/src/platforms/rcore_android.c
+++ b/src/platforms/rcore_android.c
@@ -1273,27 +1273,28 @@ static int32_t AndroidInputCallback(struct android_app *app, AInputEvent *event)
         int32_t keycode = AKeyEvent_getKeyCode(event);
         //int32_t AKeyEvent_getMetaState(event);
 
-        // Handle gamepad button presses and releases
-        // NOTE: Skip gamepad handling if this is a keyboard event, as some devices
-        // report both AINPUT_SOURCE_KEYBOARD and AINPUT_SOURCE_GAMEPAD flags
-        if ((FLAG_IS_SET(source, AINPUT_SOURCE_JOYSTICK) ||
-             FLAG_IS_SET(source, AINPUT_SOURCE_GAMEPAD)) &&
-            !FLAG_IS_SET(source, AINPUT_SOURCE_KEYBOARD))
+        // Handle gamepad button presses and releases. AOSP stamps the
+        // KEYBOARD source bit on every key event from a gamepad, so
+        // discriminate on the keycode rather than gating on source bits.
+        if (FLAG_IS_SET(source, AINPUT_SOURCE_JOYSTICK) ||
+            FLAG_IS_SET(source, AINPUT_SOURCE_GAMEPAD))
         {
-            // Assuming a single gamepad, "detected" on its input event
-            CORE.Input.Gamepad.ready[0] = true;
-
             GamepadButton button = AndroidTranslateGamepadButton(keycode);
 
-            if (button == GAMEPAD_BUTTON_UNKNOWN) return 1;
-
-            if (AKeyEvent_getAction(event) == AKEY_EVENT_ACTION_DOWN)
+            if (button != GAMEPAD_BUTTON_UNKNOWN)
             {
-                CORE.Input.Gamepad.currentButtonState[0][button] = 1;
-            }
-            else CORE.Input.Gamepad.currentButtonState[0][button] = 0;  // Key up
+                // Assuming a single gamepad, "detected" on its input event
+                CORE.Input.Gamepad.ready[0] = true;
 
-            return 1; // Handled gamepad button
+                if (AKeyEvent_getAction(event) == AKEY_EVENT_ACTION_DOWN)
+                {
+                    CORE.Input.Gamepad.currentButtonState[0][button] = 1;
+                }
+                else CORE.Input.Gamepad.currentButtonState[0][button] = 0;  // Key up
+
+                return 1; // Handled gamepad button
+            }
+            // Unknown keycode: fall through to the keyboard handler below.
         }
 
         KeyboardKey key = ((keycode > 0) && (keycode < KEYCODE_MAP_SIZE))? mapKeycode[keycode] : KEY_NULL;


### PR DESCRIPTION
raylib 6.0's `rcore_android.c:1279` guard `!FLAG_IS_SET(source, AINPUT_SOURCE_KEYBOARD)` drops face-button key events that arrive with both `AINPUT_SOURCE_KEYBOARD` and `AINPUT_SOURCE_GAMEPAD` set on the source bitmask. The keyboard fallback then sees `mapKeycode[AKEYCODE_BUTTON_*] == 0` and the press is dropped. The GameSir X2 Type-C exhibits this regression: every face-button key event arrives with source `0x501` (`KEYBOARD | GAMEPAD | CLASS_BUTTON`). Reproducible on an 8BitDo Ultimate Bluetooth as well.

The combined source-bit pattern is general AOSP behaviour, not a controller quirk, and has shipped in every Android release since 3.2 (Feb 2011). [Commit `6f2fba4`](https://github.com/aosp-mirror/platform_frameworks_base/commit/6f2fba428ca5e77a26d991ad728e346cc47609ee) extended [`EventHub::openDeviceLocked`](https://android.googlesource.com/platform/frameworks/native/+/refs/heads/main/services/inputflinger/reader/EventHub.cpp) to add `InputDeviceClass::KEYBOARD` to any input device whose evdev `keyBitmask` claims gamepad buttons (`BTN_JOYSTICK..BTN_DIGI`), in addition to `InputDeviceClass::GAMEPAD`. [`InputDevice::createMappers`](https://android.googlesource.com/platform/frameworks/native/+/refs/heads/main/services/inputflinger/reader/InputDevice.cpp) then ORs both classes into the `keyboardSource` and installs a `KeyboardInputMapper`, whose [`getEventSource()`](https://android.googlesource.com/platform/frameworks/native/+/refs/heads/main/services/inputflinger/reader/mapper/KeyboardInputMapper.cpp) returns `deviceSources & (AINPUT_SOURCE_KEYBOARD | AINPUT_SOURCE_DPAD | AINPUT_SOURCE_GAMEPAD)` and stamps that on every outgoing key event. For the X2 (`deviceSources = 0x01000511`) the mask yields `0x501`.

The fix uses the keycode as the discriminator. [`AndroidTranslateGamepadButton(keycode)`](https://github.com/raysan5/raylib/blob/master/src/platforms/rcore_android.c#L1175) already enumerates exactly the keycodes raylib routes as gamepad buttons: a recognised keycode goes to the gamepad path, an unrecognised keycode falls through to the keyboard handler instead of being dropped. This mirrors [`KeyEvent.isGamepadButton(int)`](https://android.googlesource.com/platform/frameworks/base/+/refs/heads/main/core/java/android/view/KeyEvent.java#2429), a pure keycode-range test that ignores the source. Side effect: `CORE.Input.Gamepad.ready[0]` now flips to true only when a recognised gamepad keycode arrives.

Assisted-by: Claude:claude-opus-4-7
