### PR TITLE
Add "UpdateModelPose" to API for manual posing support

### DIFF
--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1642,6 +1642,7 @@ RLAPI void SetModelMeshMaterial(Model *model, int meshId, int materialId);      
 
 // Model animations loading/unloading functions
 RLAPI ModelAnimation *LoadModelAnimations(const char *fileName, int *animCount);            // Load model animations from file
+RLAPI void UpdateModelPose(Model model);                                                    // Update model current pose (vertex buffers and bone matrices)
 RLAPI void UpdateModelAnimation(Model model, ModelAnimation anim, float frame);             // Update model animation pose (vertex buffers and bone matrices)
 RLAPI void UpdateModelAnimationEx(Model model, ModelAnimation animA, float frameA, ModelAnimation animB, float frameB, float blend); // Update model animation pose, blending two animations
 RLAPI void UnloadModelAnimations(ModelAnimation *animations, int animCount);                // Unload animation array data

--- a/src/rmodels.c
+++ b/src/rmodels.c
@@ -2293,6 +2293,35 @@ ModelAnimation *LoadModelAnimations(const char *fileName, int *animCount)
     return animations;
 }
 
+// Update model current pose (vertex buffers and bone matrices)
+void UpdateModelPose(Model model)
+{
+    if ((model.boneMatrices == NULL) || (model.currentPose == NULL) || (model.skeleton.bindPose == NULL) || (model.skeleton.boneCount < 1)) return;
+
+    Matrix bindPoseMatrix = { 0 };
+    Matrix currentPoseMatrix = { 0 };
+
+    // Compute bone matrix from model current pose
+    for (int boneIndex = 0; boneIndex < model.skeleton.boneCount; boneIndex++)
+    {
+        Transform *bindPoseTransform = &model.skeleton.bindPose[boneIndex];
+        bindPoseMatrix = MatrixMultiply(
+            MatrixMultiply(MatrixScale(bindPoseTransform->scale.x, bindPoseTransform->scale.y, bindPoseTransform->scale.z),
+                QuaternionToMatrix(bindPoseTransform->rotation)),
+            MatrixTranslate(bindPoseTransform->translation.x, bindPoseTransform->translation.y, bindPoseTransform->translation.z));
+
+        Transform *currentPoseTransform = &model.currentPose[boneIndex];
+        currentPoseMatrix = MatrixMultiply(
+            MatrixMultiply(MatrixScale(currentPoseTransform->scale.x, currentPoseTransform->scale.y, currentPoseTransform->scale.z),
+                QuaternionToMatrix(currentPoseTransform->rotation)),
+            MatrixTranslate(currentPoseTransform->translation.x, currentPoseTransform->translation.y, currentPoseTransform->translation.z));
+
+        model.boneMatrices[boneIndex] = MatrixMultiply(MatrixInvert(bindPoseMatrix), currentPoseMatrix);
+    }
+
+    UpdateModelAnimationVertexBuffers(model);
+}
+
 // Update model animation data (vertex buffers / bone matrices) for a specific pose
 // NOTE 1: Request frame could be fractional, using a lerp interpolation between two frames
 // NOTE 2: Updated vertex animation data is uploaded to GPU in case of CPU skinning,


### PR DESCRIPTION
I was trying to work on procedural animations and noticed there was no interface to update the matrices of a skinned mesh based on manually posed bone transforms (currentPose).
Ended up writing this simple patch with the intention of allowing procedural animations, custom ragdoll-driven skinning or any sort of posing that doesn't work by traditional animations, while trying to minimize the amount of code that had to be added to the project.
The added function allows for a clean way of manually posing the bones of a skinned mesh, without changing the existing animation API.

I have confirmed it works and builds correctly on Windows using MSVC.