### PR TITLE
[examples] Adjust call DrawCircleGradient: shapes_top_down_lights

### DIFF
--- a/examples/shapes/shapes_top_down_lights.c
+++ b/examples/shapes/shapes_top_down_lights.c
@@ -341,7 +341,7 @@ static void DrawLightMask(int slot)
         rlSetBlendMode(BLEND_CUSTOM);
 
         // If we are valid, then draw the light radius to the alpha mask
-        if (lights[slot].valid) DrawCircleGradient(lights[slot].position, lights[slot].outerRadius, ColorAlpha(WHITE, 0), WHITE);
+        if (lights[slot].valid) DrawCircleGradient(lights[slot].position.x, lights[slot].position.y, lights[slot].outerRadius, ColorAlpha(WHITE, 0), WHITE);
 
         rlDrawRenderBatchActive();
 


### PR DESCRIPTION
Small adjustment to fix compile time error

<img width="995" height="121" alt="image" src="https://github.com/user-attachments/assets/cfc4139e-8dd1-45e9-99ab-5aad05e981c2" />
