### PR TITLE
[rlsw][rcore_drm] Silence warnings when using PLATFORM_DRM and GRAPHICS_API_OPENGL_SOFTWARE

### DIFF
--- a/src/external/rlsw.h
+++ b/src/external/rlsw.h
@@ -5564,9 +5564,13 @@ static void SW_RASTER_TRIANGLE(const sw_vertex_t *v0, const sw_vertex_t *v1, con
     if (v0->position[1] > v1->position[1]) { const sw_vertex_t *tmp = v0; v0 = v1; v1 = tmp; }
 
     // Extracting coordinates from the sorted vertices
-    float x0 = v0->position[0], y0 = v0->position[1];
-    float x1 = v1->position[0], y1 = v1->position[1];
-    float x2 = v2->position[0], y2 = v2->position[1];
+    // Put x away for safe keeping.  Only y is used right now.  Silences warnings.
+    //float x0 = v0->position[0];
+    float y0 = v0->position[1];
+    //float x1 = v1->position[0];
+    float y1 = v1->position[1];
+    //float x2 = v2->position[0];
+    float y2 = v2->position[1];
 
     // Compute height differences
     float h02 = y2 - y0;

--- a/src/external/rlsw.h
+++ b/src/external/rlsw.h
@@ -5517,7 +5517,9 @@ static void SW_RASTER_TRIANGLE_SPAN(const sw_vertex_t *start, const sw_vertex_t 
             }
             #endif
 
+        #ifdef SW_ENABLE_DEPTH_TEST
         discard:
+        #endif
             srcColor[0] += dSrcColordx[0];
             srcColor[1] += dSrcColordx[1];
             srcColor[2] += dSrcColordx[2];
@@ -5774,7 +5776,9 @@ static void SW_RASTER_QUAD(const sw_vertex_t *a, const sw_vertex_t *b,
             }
             #endif
 
+        #ifdef SW_ENABLE_DEPTH_TEST
         discard:
+        #endif
             color[0] += dCdx[0];
             color[1] += dCdx[1];
             color[2] += dCdx[2];
@@ -5927,7 +5931,9 @@ static void SW_RASTER_LINE(const sw_vertex_t *v0, const sw_vertex_t *v1)
         }
         #endif
 
+    #ifdef SW_ENABLE_DEPTH_TEST
     discard:
+    #endif
         x += xInc;
         y += yInc;
         #ifdef SW_ENABLE_DEPTH_TEST

--- a/src/platforms/rcore_drm.c
+++ b/src/platforms/rcore_drm.c
@@ -266,9 +266,12 @@ static void PollKeyboardEvents(void);           // Process evdev keyboard events
 static void PollGamepadEvents(void);            // Process evdev gamepad events
 static void PollMouseEvents(void);              // Process evdev mouse events
 
+// Not used by software rendering.
+#if !defined(GRAPHICS_API_OPENGL_SOFTWARE)
 static int FindMatchingConnectorMode(const drmModeConnector *connector, const drmModeModeInfo *mode);                               // Search matching DRM mode in connector's mode list
 static int FindExactConnectorMode(const drmModeConnector *connector, uint width, uint height, uint fps, bool allowInterlaced);      // Search exactly matching DRM connector mode in connector's list
 static int FindNearestConnectorMode(const drmModeConnector *connector, uint width, uint height, uint fps, bool allowInterlaced);    // Search the nearest matching DRM connector mode in connector's list
+#endif
 
 static void SetupFramebuffer(int width, int height); // Setup main framebuffer (required by InitPlatform())
 
@@ -2560,6 +2563,7 @@ static void PollMouseEvents(void)
     }
 }
 
+#if !defined(GRAPHICS_API_OPENGL_SOFTWARE)
 // Search matching DRM mode in connector's mode list
 static int FindMatchingConnectorMode(const drmModeConnector *connector, const drmModeModeInfo *mode)
 {
@@ -2648,6 +2652,7 @@ static int FindNearestConnectorMode(const drmModeConnector *connector, uint widt
 
     return nearestIndex;
 }
+#endif
 
 // Compute framebuffer size relative to screen size and display size
 // NOTE: Global variables CORE.Window.render.width/CORE.Window.render.height and CORE.Window.renderOffset.x/CORE.Window.renderOffset.y can be modified


### PR DESCRIPTION
The following commit silences three sets of warnings.

1. During SW_RASTER_TRIANGLE_SPAN, SW_RASTER_QUAD, and SW_RASTER_LINE, the inner-span for loop uses a goto to escape if z shows a tri/quad is to be discarded.  However, if SW_ENABLE_DEPTH_TEST is omitted (because of self inclusion not needing it in that cycle), the goto's label sits there unused.  

This commit just ifdef-guards those `discard` labels.

2. in SW_RASTER_TRIANGLE, both the x coordinates and the y coordinates of all vertices were cached.  But the x variables were never used.  

The definition lines were separated into separate ones for the x, and the y.  then the x ones are commented out.  If we ever need x in the future, they can be commented back in.

3. On the DRM platform C file, three specific functions are used to find the DRMModeConnector when OpenGL is hardware accelerated.  However, their callers located elsewhere are surrounded by #if !defined(GRAPHICS_API_OPENGL_SOFTWARE), leaving them unused if software rendering is enabled.

This commit adds more #if !defined checks to also leave out the definitions of those functions themselves, as they are not needed in the software renderer anyway.

Feel free to reject as you please.  I will be using this on my side for sanity sake regardless but figured you'd like to know.