### PR TITLE
[rcore] `GetCurrentMonitor()`, fix for integer overflow in distance calculation

### DIFF
--- a/src/platforms/rcore_desktop_glfw.c
+++ b/src/platforms/rcore_desktop_glfw.c
@@ -839,7 +839,7 @@ int GetCurrentMonitor(void)
             // this is probably an overengineered solution for a side case
             // trying to match SDL behaviour
 
-            long long closestDist = 0x7FFFFFFFFFFFFFFFLL;
+            int closestDist = 0x7FFFFFFF;
 
             // Window center position
             int wcx = 0;
@@ -883,7 +883,7 @@ int GetCurrentMonitor(void)
 
                     int dx = wcx - xclosest;
                     int dy = wcy - yclosest;
-                    long long dist = (long long)dx*dx + (long long)dy*dy;
+                    int dist = (dx*dx) + (dy*dy);
                     if (dist < closestDist)
                     {
                         index = i;

--- a/src/platforms/rcore_desktop_glfw.c
+++ b/src/platforms/rcore_desktop_glfw.c
@@ -839,7 +839,7 @@ int GetCurrentMonitor(void)
             // this is probably an overengineered solution for a side case
             // trying to match SDL behaviour
 
-            int closestDist = 0x7FFFFFFF;
+            long long closestDist = 0x7FFFFFFFFFFFFFFFLL;
 
             // Window center position
             int wcx = 0;
@@ -883,7 +883,7 @@ int GetCurrentMonitor(void)
 
                     int dx = wcx - xclosest;
                     int dy = wcy - yclosest;
-                    int dist = (dx*dx) + (dy*dy);
+                    long long dist = (long long)dx*dx + (long long)dy*dy;
                     if (dist < closestDist)
                     {
                         index = i;

--- a/src/platforms/rcore_desktop_glfw.c
+++ b/src/platforms/rcore_desktop_glfw.c
@@ -883,7 +883,14 @@ int GetCurrentMonitor(void)
 
                     int dx = wcx - xclosest;
                     int dy = wcy - yclosest;
-                    int dist = (dx*dx) + (dy*dy);
+
+                    // Use unsigned int to avoid signed integer overflow UB.
+                    // Note: (-x)^2 == x^2 (mod 2^32), so sign of dx/dy does not matter
+                    unsigned int ux = (unsigned int)dx;
+                    unsigned int uy = (unsigned int)dy;
+                    unsigned int udist = ux*ux + uy*uy;
+                    int dist = (int)udist;
+
                     if (dist < closestDist)
                     {
                         index = i;

--- a/src/platforms/rcore_desktop_glfw.c
+++ b/src/platforms/rcore_desktop_glfw.c
@@ -839,7 +839,7 @@ int GetCurrentMonitor(void)
             // this is probably an overengineered solution for a side case
             // trying to match SDL behaviour
 
-            int closestDist = 0x7FFFFFFF;
+            unsigned int closestDist = 0xFFFFFFFFu;
 
             // Window center position
             int wcx = 0;
@@ -884,12 +884,12 @@ int GetCurrentMonitor(void)
                     int dx = wcx - xclosest;
                     int dy = wcy - yclosest;
 
-                    // Use unsigned int to avoid signed integer overflow UB.
-                    // Note: (-x)^2 == x^2 (mod 2^32), so sign of dx/dy does not matter
+                    // Unsigned to dodge signed overflow UB; (-x)^2 == x^2 mod 2^32 so sign drops out.
+                    // If |dx| or |dy| >= 65536, dist wraps and the wrong monitor may win.
+                    // Not a concern for realistic monitor layouts.
                     unsigned int ux = (unsigned int)dx;
                     unsigned int uy = (unsigned int)dy;
-                    unsigned int udist = ux*ux + uy*uy;
-                    int dist = (int)udist;
+                    unsigned int dist = ux*ux + uy*uy;
 
                     if (dist < closestDist)
                     {


### PR DESCRIPTION
## Problem
`GetCurrentMonitor()` in `rcore_desktop_glfw.c` computes `int dist = dx*dx + dy*dy` where `dx`, `dy` are pixel offsets from window centre to monitor corner. On my setup (multi-monitor WSL2 through Windows 11) the squared sum exceeds `INT_MAX`, causing signed integer overflow UB. Today GCC wraps silently, but UBSan-instrumented builds (eg. Zig or clang with `-fsanitize=undefined`) fail. 

## Environment
- OS: Ubuntu 24.04.1 on WSL2 (Windows 11 host), X11 via WSLg
- Compiler: gcc 13.3.0
- Display 1920x1200
- Detected on: Zig 0.16 bundling raylib 6.0

## Repro
Originally caught by Zig 0.16's UBSan trapping on the bundled raylib build:

    thread panic: signed integer overflow: 1173062500 + 1050343281 cannot be represented in type 'int'
    rcore_desktop_glfw.c:887

Reproduced standalone by adding a `printf` next to the overflow site and running `examples/core/core_basic_window`:

    REPRO i=0 dx=-34250 dy=-32484 prod=2228272756 INT_MAX=2147483647 overflow=1
    REPRO i=1 dx=-32330 dy=-32484 prod=2100439156 INT_MAX=2147483647 overflow=0

`prod` (computed as `(long long)dx*dx + (long long)dy*dy`) exceeds `INT_MAX`, confirming the truncation.

## Fix
Promote `dist` and `closestDist` to `long long`. No behavior change for monitors within `INT_MAX` distance and correctly handles cases beyond it without UB.