### PR TITLE
[rlsw] Fix out of bounds on raster quad

### DIFF
--- a/src/external/rlsw.h
+++ b/src/external/rlsw.h
@@ -2483,6 +2483,7 @@ static inline void sw_texture_sample_nearest(float *SW_RESTRICT color, const sw_
     {
         u = (tex->sWrap == SW_REPEAT)? sw_fract(u) : sw_saturate(u);
         x = (int)(u*tex->width);
+        x = sw_clamp_int(x, 0, tex->wMinus1);
     }
 
 #ifdef SW_TEXTURE_REPEAT_POT_FAST
@@ -2495,6 +2496,7 @@ static inline void sw_texture_sample_nearest(float *SW_RESTRICT color, const sw_
     {
         v = (tex->tWrap == SW_REPEAT)? sw_fract(v) : sw_saturate(v);
         y = (int)(v*tex->height);
+        y = sw_clamp_int(y, 0, tex->hMinus1);
     }
 
     tex->readColor(color, tex->pixels, y*tex->width + x);
@@ -3484,6 +3486,11 @@ static void sw_triangle_clip_and_project(void)
 
             // Transformation to screen space
             sw_project_ndc_to_screen(v->position);
+
+            // NDC +1.0 projects to exactly (width + 0.5f), which truncates out of bounds
+            // Clamp screen-space coordinates to valid pixel centers.
+            v->position[0] = sw_clamp(v->position[0], 0.0f, (float)(RLSW.colorBuffer->width  - 1) + 0.5f);
+            v->position[1] = sw_clamp(v->position[1], 0.0f, (float)(RLSW.colorBuffer->height - 1) + 0.5f);
         }
     }
 }
@@ -3599,6 +3606,11 @@ static void sw_quad_clip_and_project(void)
 
             // Transformation to screen space
             sw_project_ndc_to_screen(v->position);
+
+            // NDC +1.0 projects to exactly (width + 0.5f), which truncates out of bounds
+            // Clamp screen-space coordinates to valid pixel centers.
+            v->position[0] = sw_clamp(v->position[0], 0.0f, (float)(RLSW.colorBuffer->width  - 1) + 0.5f);
+            v->position[1] = sw_clamp(v->position[1], 0.0f, (float)(RLSW.colorBuffer->height - 1) + 0.5f);
         }
     }
 }


### PR DESCRIPTION
Fixes #5838 

These possible out of bounds problems were pinned specifically by Grok Code initially.  However its commits have been entirely replaced by human written code.

However, the code was tested with me, a human, and reimplemented on my pi2 and pi5 as a double-test.  This code review was also written by me.

## It is worth noting that the nature of this out of bounds may result in similar segfaults on other platforms, but those haven't been tested.

`textures_bunnymark` and `models_waving_cubes` started working after these changes were applied.  

# Confirmed out of bounds on Clip and Project methods.

This is what causes the segfault reported in the issue.  

When a triangle is trying to raster its pixel onto the color buffer, only certain examples such as `textures_bunnymark` or `models_waving_cubes` were attempting to draw triangles on or past the border of the screen.  

Other examples such as `shapes_basic_shapes`, never touched the far edges.

From @ZX41R
> The `gdb` trace is a good clue that this is earlier than `sw_color_to_color8()` itself. `sw_pixel_write_color_R8G8B8A8()` is called with `offset=0`, so the bad address has already become the framebuffer pointer passed down from the raster path.
> 
> In the quad path, `SW_RASTER_QUAD` derives `xMin/yMin/xMax/yMax` directly from the projected corners and then computes:
> 
> baseOffset = y * stride + xMin;
> cPtr = cPixels + baseOffset * SW_FRAMEBUFFER_COLOR_SIZE;
> without the clamp that the clear paths use. A negative `xMin`/`yMin`, or a projected quad extending outside the target, can therefore move `cPtr` before the color buffer before the inner loop even starts. On 32-bit ARM that underflow can plausibly land on a mapped ELF page, which matches `dst=... "\177ELF"` in the trace.


This commit clamps the screen space coordinates of each triangle in the raster stage so that only valid pixel centers are collected before coloring.

# Verify please

I would like to express that I don't actually know if these two clamp methods placed where they are is the solution, beyond the fact it indeed stopped the segfaulting.  I'm also worried that it could cause pixel inconsistency with triangles at an edge of the buffer.

Beyond that is there anything I'm missing in the code's architecture that could lead to these clamps just causing more problems than fixes?  