### PR TITLE
[rlsw][SEGFAULT] Fix triangle and quad spans applying pixels out of bounds

### DIFF
--- a/src/external/rlsw.h
+++ b/src/external/rlsw.h
@@ -5389,6 +5389,11 @@ static void SW_RASTER_TRIANGLE_SPAN(const sw_vertex_t *start, const sw_vertex_t 
     int xEnd = (int)end->position[0];
     if (xStart == xEnd) return;
 
+    // Get the current row and skip if outside the framebuffer.
+    // Maybe this check is better suited elsewhere? 
+    int y = (int)start->position[1];
+    if (y < 0 || y >= RLSW.colorBuffer->height) return;
+
     // Compute the inverse horizontal distance along the X axis
     float dxRcp = sw_rcp(end->position[0] - start->position[0]);
 
@@ -5411,25 +5416,30 @@ static void SW_RASTER_TRIANGLE_SPAN(const sw_vertex_t *start, const sw_vertex_t 
     // Compute the subpixel distance to traverse before the first pixel
     float xSubstep = 1.0f - sw_fract(start->position[0]);
 
-    // Initializing the interpolation starting values
-    float w = start->position[3] + dWdx*xSubstep;
+    // Intercept the span bounds to ensure we don't write before the framebuffer.
+    int xLoopStart = sw_clamp_int(xStart, 0, RLSW.colorBuffer->width - 1);
+    int dxStart = xLoopStart - xStart;
+
+    // Initializing the interpolation starting values.
+    // Also step further into them to move away from the colorbuffer edge.
+    float w = start->position[3] + dWdx*xSubstep + dWdx*dxStart;
     float color[4] = {
-        start->color[0] + dCdx[0]*xSubstep,
-        start->color[1] + dCdx[1]*xSubstep,
-        start->color[2] + dCdx[2]*xSubstep,
-        start->color[3] + dCdx[3]*xSubstep
+        start->color[0] + dCdx[0]*xSubstep + dCdx[0]*dxStart,
+        start->color[1] + dCdx[1]*xSubstep + dCdx[1]*dxStart,
+        start->color[2] + dCdx[2]*xSubstep + dCdx[2]*dxStart,
+        start->color[3] + dCdx[3]*xSubstep + dCdx[3]*dxStart
     };
 #ifdef SW_ENABLE_DEPTH_TEST
-    float z = start->position[2] + dZdx*xSubstep;
+    float z = start->position[2] + dZdx*xSubstep + dZdx*dxStart;
 #endif
 #ifdef SW_ENABLE_TEXTURE
-    float u = start->texcoord[0] + dUdx*xSubstep;
-    float v = start->texcoord[1] + dVdx*xSubstep;
+    float u = start->texcoord[0] + dUdx*xSubstep + dUdx*dxStart;
+    float v = start->texcoord[1] + dVdx*xSubstep + dVdx*dxStart;
 #endif
 
     // Pre-calculate the starting pointers for the framebuffer row
-    int y = (int)start->position[1];
-    int baseOffset = y*RLSW.colorBuffer->width + xStart;
+    // Don't allow a y value outside the buffer.
+    int baseOffset = y*RLSW.colorBuffer->width + xLoopStart;
     uint8_t *cPtr = (uint8_t *)(RLSW.colorBuffer->pixels) + baseOffset*SW_FRAMEBUFFER_COLOR_SIZE;
 #ifdef SW_ENABLE_DEPTH_TEST
     uint8_t *dPtr = (uint8_t *)(RLSW.depthBuffer->pixels) + baseOffset*SW_FRAMEBUFFER_DEPTH_SIZE;
@@ -5437,12 +5447,14 @@ static void SW_RASTER_TRIANGLE_SPAN(const sw_vertex_t *start, const sw_vertex_t 
 
 #define SW_AFFINE_BLOCK 16
 
-    int x = xStart;
-    while (x < xEnd)
+    int x = xLoopStart;
+    // Prevent pixels from beyond the buffer from processing.
+    int xLoopEnd = sw_clamp_int(xEnd, 0, RLSW.colorBuffer->width - 1);
+    while (x < xLoopEnd)
     {
         // Clamp last block to remaining pixels
         int blockEnd = x + SW_AFFINE_BLOCK;
-        if (blockEnd > xEnd) blockEnd = xEnd;
+        if (blockEnd > xLoopEnd) blockEnd = xLoopEnd;
         float blockLenF = (float)(blockEnd - x);
         float blockLenRcp = sw_rcp(blockLenF);
 
@@ -5730,21 +5742,38 @@ static void SW_RASTER_QUAD(const sw_vertex_t *a, const sw_vertex_t *b,
     uint8_t *dPixels = RLSW.depthBuffer->pixels;
 #endif
 
-    for (int y = yMin; y < yMax; y++)
+    // Intercept the boundaries to stay within the framebuffer.
+    int yLoopMin = sw_clamp_int(yMin, 0, RLSW.colorBuffer->height - 1);
+    int yLoopMax = sw_clamp_int(yMax, 0, RLSW.colorBuffer->height - 1);
+    int xLoopMin = sw_clamp_int(xMin, 0, RLSW.colorBuffer->width - 1);
+    int xLoopMax = sw_clamp_int(xMax, 0, RLSW.colorBuffer->width - 1);
+    int dxMin = xLoopMin - xMin;
+    #if defined(SW_ENABLE_DEPTH_TEST) || defined(SW_ENABLE_TEXTURE)
+    int dyMin = yLoopMin - yMin;
+    #endif
+
+    for (int y = yLoopMin; y < yLoopMax; y++)
     {
-        int baseOffset = y*stride + xMin;
+        int baseOffset = y*stride + xLoopMin;
         uint8_t *cPtr = cPixels + baseOffset*SW_FRAMEBUFFER_COLOR_SIZE;
     #ifdef SW_ENABLE_DEPTH_TEST
         uint8_t *dPtr = dPixels + baseOffset*SW_FRAMEBUFFER_DEPTH_SIZE;
-        float z = zRow;
+        // Correct our start by how far we clipped outside the framebuffer.
+        float z = zRow + dZdy*dyMin;
     #endif
     #ifdef SW_ENABLE_TEXTURE
-        float u = uRow;
-        float v = vRow;
+        // Correct our start by how far we clipped outside the framebuffer.
+        float u = uRow + dUdy*dyMin;
+        float v = vRow + dVdy*dyMin;
     #endif
-        float color[4] = { cRow[0], cRow[1], cRow[2], cRow[3] };
+        float color[4] = {
+            cRow[0] + dCdx[0]*dxMin,
+            cRow[1] + dCdx[1]*dxMin,
+            cRow[2] + dCdx[2]*dxMin,
+            cRow[3] + dCdx[3]*dxMin
+        };
 
-        for (int x = xMin; x < xMax; x++)
+        for (int x = xLoopMin; x < xLoopMax; x++)
         {
             float srcColor[4] = { color[0], color[1], color[2], color[3] };
 

--- a/src/external/rlsw.h
+++ b/src/external/rlsw.h
@@ -5752,25 +5752,36 @@ static void SW_RASTER_QUAD(const sw_vertex_t *a, const sw_vertex_t *b,
     int dyMin = yLoopMin - yMin;
     #endif
 
+    // Correct our start by how far we clipped outside the framebuffer.
+    cRow[0] += dCdx[0]*dxMin + dCdy[0]*dyMin;
+    cRow[1] += dCdx[1]*dxMin + dCdy[1]*dyMin;
+    cRow[2] += dCdx[2]*dxMin + dCdy[2]*dyMin;
+    cRow[3] += dCdx[3]*dxMin + dCdy[3]*dyMin;
+    #ifdef SW_ENABLE_DEPTH_TEST
+    zRow += dZdy*dyMin + dZdx*dxMin;
+    #ifdef SW_ENABLE_TEXTURE
+    uRow += dUdy*dyMin + dUdx*dxMin;
+    vRow += dVdy*dyMin + dVdx*dxMin;
+    #endif
+
     for (int y = yLoopMin; y < yLoopMax; y++)
     {
         int baseOffset = y*stride + xLoopMin;
         uint8_t *cPtr = cPixels + baseOffset*SW_FRAMEBUFFER_COLOR_SIZE;
     #ifdef SW_ENABLE_DEPTH_TEST
         uint8_t *dPtr = dPixels + baseOffset*SW_FRAMEBUFFER_DEPTH_SIZE;
-        // Correct our start by how far we clipped outside the framebuffer.
-        float z = zRow + dZdy*dyMin;
+        // Copy the cursors so we increment them ourselves without destroying the offset maths.
+        float z = zRow;
     #endif
     #ifdef SW_ENABLE_TEXTURE
-        // Correct our start by how far we clipped outside the framebuffer.
-        float u = uRow + dUdy*dyMin;
-        float v = vRow + dVdy*dyMin;
+        float u = uRow;
+        float v = vRow;
     #endif
         float color[4] = {
-            cRow[0] + dCdx[0]*dxMin,
-            cRow[1] + dCdx[1]*dxMin,
-            cRow[2] + dCdx[2]*dxMin,
-            cRow[3] + dCdx[3]*dxMin
+            cRow[0],
+            cRow[1],
+            cRow[2],
+            cRow[3]
         };
 
         for (int x = xLoopMin; x < xLoopMax; x++)
@@ -5812,6 +5823,7 @@ static void SW_RASTER_QUAD(const sw_vertex_t *a, const sw_vertex_t *b,
         #ifdef SW_ENABLE_DEPTH_TEST
         discard:
         #endif
+            // We move one pixel over without touching the original "start offset"
             color[0] += dCdx[0];
             color[1] += dCdx[1];
             color[2] += dCdx[2];
@@ -5834,6 +5846,9 @@ static void SW_RASTER_QUAD(const sw_vertex_t *a, const sw_vertex_t *b,
             cPtr += SW_FRAMEBUFFER_COLOR_SIZE;
         }
 
+        // The for loop is clamped to the right side of the screen.
+        // However, these cursor start vars are still on the left.
+        // That's fine.  We just need to advance to the next row.
         cRow[0] += dCdy[0];
         cRow[1] += dCdy[1];
         cRow[2] += dCdy[2];

--- a/src/external/rlsw.h
+++ b/src/external/rlsw.h
@@ -5748,9 +5748,7 @@ static void SW_RASTER_QUAD(const sw_vertex_t *a, const sw_vertex_t *b,
     int xLoopMin = sw_clamp_int(xMin, 0, RLSW.colorBuffer->width - 1);
     int xLoopMax = sw_clamp_int(xMax, 0, RLSW.colorBuffer->width);
     int dxMin = xLoopMin - xMin;
-    #if defined(SW_ENABLE_DEPTH_TEST) || defined(SW_ENABLE_TEXTURE)
     int dyMin = yLoopMin - yMin;
-    #endif
 
     // Correct our start by how far we clipped outside the framebuffer.
     cRow[0] += dCdx[0]*dxMin + dCdy[0]*dyMin;

--- a/src/external/rlsw.h
+++ b/src/external/rlsw.h
@@ -5759,6 +5759,7 @@ static void SW_RASTER_QUAD(const sw_vertex_t *a, const sw_vertex_t *b,
     cRow[3] += dCdx[3]*dxMin + dCdy[3]*dyMin;
     #ifdef SW_ENABLE_DEPTH_TEST
     zRow += dZdy*dyMin + dZdx*dxMin;
+    #endif
     #ifdef SW_ENABLE_TEXTURE
     uRow += dUdy*dyMin + dUdx*dxMin;
     vRow += dVdy*dyMin + dVdx*dxMin;

--- a/src/external/rlsw.h
+++ b/src/external/rlsw.h
@@ -5692,6 +5692,14 @@ static void SW_RASTER_QUAD(const sw_vertex_t *a, const sw_vertex_t *b,
     int xMax = (int)br->position[0];
     int yMax = (int)br->position[1];
 
+    // Exit early if no pixels to draw.  Use these later for loop boundaries
+    int yLoopMin = (yMin >= 0)? yMin : 0;
+    int xLoopMin = (xMin >= 0)? xMin : 0;
+    int yLoopMax = (yMax <= RLSW.colorBuffer->height)? yMax : RLSW.colorBuffer->height;
+    int xLoopMax = (xMax <= RLSW.colorBuffer->width)?  xMax : RLSW.colorBuffer->width;
+
+    if (yLoopMin >= yLoopMax || xLoopMin >= xLoopMax) return;
+
     float w = (float)(xMax - xMin);
     float h = (float)(yMax - yMin);
     if ((w <= 0) || (h <= 0)) return;
@@ -5745,13 +5753,9 @@ static void SW_RASTER_QUAD(const sw_vertex_t *a, const sw_vertex_t *b,
     uint8_t *dPixels = RLSW.depthBuffer->pixels;
 #endif
 
-    // Intercept the boundaries to stay within the framebuffer.
-    int yLoopMin = sw_clamp_int(yMin, 0, RLSW.colorBuffer->height - 1);
-    int yLoopMax = sw_clamp_int(yMax, 0, RLSW.colorBuffer->height);
-    int xLoopMin = sw_clamp_int(xMin, 0, RLSW.colorBuffer->width - 1);
-    int xLoopMax = sw_clamp_int(xMax, 0, RLSW.colorBuffer->width);
-    int dxMin = xLoopMin - xMin;
-    int dyMin = yLoopMin - yMin;
+    // Calculate the distance the in-bounds boundary is from the quad's edges, only on the left and top.
+    float dxMin = (float)(xLoopMin - xMin);
+    float dyMin = (float)(yLoopMin - yMin);
 
     // Correct our start by how far we clipped outside the framebuffer.
     cRow[0] += dCdx[0]*dxMin + dCdy[0]*dyMin;

--- a/src/external/rlsw.h
+++ b/src/external/rlsw.h
@@ -5389,6 +5389,12 @@ static void SW_RASTER_TRIANGLE_SPAN(const sw_vertex_t *start, const sw_vertex_t 
     int xEnd = (int)end->position[0];
     if (xStart == xEnd) return;
 
+    // Intercept the span bounds to ensure we don't write before the framebuffer.
+    int xLoopStart = (xStart >= 0)? xStart : 0;
+    int xLoopEnd = (xEnd <= RLSW.colorBuffer->width)? xEnd : RLSW.colorBuffer->width;
+    // Nothing to draw.
+    if (xLoopStart >= xLoopEnd) return;
+
     // Get the current row and skip if outside the framebuffer.
     // Maybe this check is better suited elsewhere? 
     int y = (int)start->position[1];
@@ -5415,10 +5421,6 @@ static void SW_RASTER_TRIANGLE_SPAN(const sw_vertex_t *start, const sw_vertex_t 
 
     // Compute the subpixel distance to traverse before the first pixel
     float xSubstep = 1.0f - sw_fract(start->position[0]);
-
-    // Intercept the span bounds to ensure we don't write before the framebuffer.
-    int xLoopStart = sw_clamp_int(xStart, 0, RLSW.colorBuffer->width - 1);
-    int dxStart = xLoopStart - xStart;
 
     // Initializing the interpolation starting values.
     // Also step further into them to move away from the colorbuffer edge.

--- a/src/external/rlsw.h
+++ b/src/external/rlsw.h
@@ -5449,7 +5449,7 @@ static void SW_RASTER_TRIANGLE_SPAN(const sw_vertex_t *start, const sw_vertex_t 
 
     int x = xLoopStart;
     // Prevent pixels from beyond the buffer from processing.
-    int xLoopEnd = sw_clamp_int(xEnd, 0, RLSW.colorBuffer->width - 1);
+    int xLoopEnd = sw_clamp_int(xEnd, 0, RLSW.colorBuffer->width);
     while (x < xLoopEnd)
     {
         // Clamp last block to remaining pixels
@@ -5744,9 +5744,9 @@ static void SW_RASTER_QUAD(const sw_vertex_t *a, const sw_vertex_t *b,
 
     // Intercept the boundaries to stay within the framebuffer.
     int yLoopMin = sw_clamp_int(yMin, 0, RLSW.colorBuffer->height - 1);
-    int yLoopMax = sw_clamp_int(yMax, 0, RLSW.colorBuffer->height - 1);
+    int yLoopMax = sw_clamp_int(yMax, 0, RLSW.colorBuffer->height);
     int xLoopMin = sw_clamp_int(xMin, 0, RLSW.colorBuffer->width - 1);
-    int xLoopMax = sw_clamp_int(xMax, 0, RLSW.colorBuffer->width - 1);
+    int xLoopMax = sw_clamp_int(xMax, 0, RLSW.colorBuffer->width);
     int dxMin = xLoopMin - xMin;
     #if defined(SW_ENABLE_DEPTH_TEST) || defined(SW_ENABLE_TEXTURE)
     int dyMin = yLoopMin - yMin;

--- a/src/external/rlsw.h
+++ b/src/external/rlsw.h
@@ -5420,23 +5420,25 @@ static void SW_RASTER_TRIANGLE_SPAN(const sw_vertex_t *start, const sw_vertex_t 
 #endif
 
     // Compute the subpixel distance to traverse before the first pixel
+    // Also step further into them to move away from the colorbuffer edge.
     float xSubstep = 1.0f - sw_fract(start->position[0]);
+    float dxStart = (float)(xLoopStart - xStart);
+    float xOffset = xSubstep + dxStart;
 
     // Initializing the interpolation starting values.
-    // Also step further into them to move away from the colorbuffer edge.
-    float w = start->position[3] + dWdx*xSubstep + dWdx*dxStart;
+    float w = start->position[3] + dWdx*xOffset;
     float color[4] = {
-        start->color[0] + dCdx[0]*xSubstep + dCdx[0]*dxStart,
-        start->color[1] + dCdx[1]*xSubstep + dCdx[1]*dxStart,
-        start->color[2] + dCdx[2]*xSubstep + dCdx[2]*dxStart,
-        start->color[3] + dCdx[3]*xSubstep + dCdx[3]*dxStart
+        start->color[0] + dCdx[0]*xOffset,
+        start->color[1] + dCdx[1]*xOffset,
+        start->color[2] + dCdx[2]*xOffset,
+        start->color[3] + dCdx[3]*xOffset
     };
 #ifdef SW_ENABLE_DEPTH_TEST
-    float z = start->position[2] + dZdx*xSubstep + dZdx*dxStart;
+    float z = start->position[2] + dZdx*xOffset;
 #endif
 #ifdef SW_ENABLE_TEXTURE
-    float u = start->texcoord[0] + dUdx*xSubstep + dUdx*dxStart;
-    float v = start->texcoord[1] + dVdx*xSubstep + dVdx*dxStart;
+    float u = start->texcoord[0] + dUdx*xOffset;
+    float v = start->texcoord[1] + dVdx*xOffset;
 #endif
 
     // Pre-calculate the starting pointers for the framebuffer row

--- a/src/external/rlsw.h
+++ b/src/external/rlsw.h
@@ -5451,8 +5451,6 @@ static void SW_RASTER_TRIANGLE_SPAN(const sw_vertex_t *start, const sw_vertex_t 
 #define SW_AFFINE_BLOCK 16
 
     int x = xLoopStart;
-    // Prevent pixels from beyond the buffer from processing.
-    int xLoopEnd = sw_clamp_int(xEnd, 0, RLSW.colorBuffer->width);
     while (x < xLoopEnd)
     {
         // Clamp last block to remaining pixels

--- a/src/external/rlsw.h
+++ b/src/external/rlsw.h
@@ -5442,7 +5442,6 @@ static void SW_RASTER_TRIANGLE_SPAN(const sw_vertex_t *start, const sw_vertex_t 
 #endif
 
     // Pre-calculate the starting pointers for the framebuffer row
-    // Don't allow a y value outside the buffer.
     int baseOffset = y*RLSW.colorBuffer->width + xLoopStart;
     uint8_t *cPtr = (uint8_t *)(RLSW.colorBuffer->pixels) + baseOffset*SW_FRAMEBUFFER_COLOR_SIZE;
 #ifdef SW_ENABLE_DEPTH_TEST


### PR DESCRIPTION
Fixes https://github.com/raysan5/raylib/issues/5838

The code in this commit and text in this PR are entirely human written.  

It has been tested on a Raspberry Pi 2, the same board the original issue was found on.  

Then it was tested on a Raspberry Pi 5 to verify texture and triangle warping wasn't present, using `models_first_person_maze`

# Fixes RLSW Rastering buffer boundary out of bounds

In the raster routine `SW_RASTER_QUAD`, there was the following problem spotted by @ZX41R

> In the quad path, `SW_RASTER_QUAD` derives `xMin/yMin/xMax/yMax` directly from the projected corners and then computes:
> 
> baseOffset = y * stride + xMin;
> cPtr = cPixels + baseOffset * SW_FRAMEBUFFER_COLOR_SIZE;
> without the clamp that the clear paths use. A negative `xMin`/`yMin`, or a projected quad extending outside the target, can therefore move `cPtr` before the color buffer before the inner loop even starts. On 32-bit ARM that underflow can plausibly land on a mapped ELF page, which matches `dst=... "\177ELF"` in the trace.

Additionally, in `TRIANGLE_SPAN`, the issue is much simpler.  It only has an `xMin` that calculates into `baseOffset`, there is no `yMin` involved on that method.  However it is the same boundary crossing bug.

This commit applies some fixes they suggested by ensuring to clamp the loop min and max to inside of `RLSW.colorBuffer`.

Then it moves the start of each interpolation for spans, textures, depths and vertex colours, to compensate for the new clamps so that only the correct colours are grabbed.

This fixes the segfault discovered on the issue and avoids the triangle warping that was previously discussed in the deleted fork on  https://github.com/raysan5/raylib/pull/5843

It should be much safer than the previous PR I self-rejected.