### PR TITLE
[Platform/WASIGL] new platform WIP

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -205,8 +205,9 @@ fn compileRaylib(b: *std.Build, target: std.Build.ResolvedTarget, optimize: std.
     if (options.rmodels) {
         try c_source_files.append("src/rmodels.c");
     }
-    raylib_mod.addCMacro("SUPPORT_MODULE_RAUDIO", &.{@as(u8, @intFromBool(options.raudio)) + 0x30});
-    if (options.raudio) {
+    const raudio_enabled = options.raudio and options.platform != .wasigl;
+    raylib_mod.addCMacro("SUPPORT_MODULE_RAUDIO", &.{@as(u8, @intFromBool(raudio_enabled)) + 0x30});
+    if (raudio_enabled) {
         try c_source_files.append("src/raudio.c");
     }
 
@@ -360,6 +361,12 @@ fn compileRaylib(b: *std.Build, target: std.Build.ResolvedTarget, optimize: std.
             }
             raylib_mod.addCMacro(OpenglVersion.gl_soft.toCMacroStr(), "");
             raylib_mod.addCMacro("PLATFORM_MEMORY", "");
+        },
+        .wasigl => {
+            raylib_mod.addCMacro("PLATFORM_WASIGL", "");
+            raylib_mod.addCMacro("GRAPHICS_API_OPENGL_ES2", "");
+            raylib_mod.addIncludePath(b.path("src/external/glfw/include"));
+            raylib.import_symbols = true;
         },
         .win32 => {
             if (target.result.os.tag != .windows) {
@@ -573,17 +580,7 @@ pub const LinuxDisplayBackend = enum {
     Both,
 };
 
-pub const PlatformBackend = enum {
-    glfw,
-    rgfw,
-    sdl,
-    sdl2,
-    sdl3,
-    memory,
-    win32,
-    drm,
-    android,
-};
+pub const PlatformBackend = enum { glfw, rgfw, sdl, sdl2, sdl3, memory, win32, drm, android, wasigl };
 
 fn translateCMod(
     comptime header: []const u8,
@@ -687,6 +684,7 @@ fn addExamples(
         }
         if (std.mem.eql(u8, filename, "raylib_opengl_interop")) {
             if (platform == .drm) continue;
+            if (platform == .wasigl) continue;
             if (target.result.os.tag == .macos) continue;
             exe_mod.addIncludePath(b.path("src/external"));
         }
@@ -794,4 +792,3 @@ fn waylandGenerate(
         }
     }
 }
-

--- a/src/Makefile
+++ b/src/Makefile
@@ -578,6 +578,14 @@ ifeq ($(TARGET_PLATFORM),PLATFORM_ANDROID)
     endif
 endif
 
+ifeq ($(PLATFORM),PLATFORM_WASIGL)
+    WASI_SDK ?= /opt/wasi-sdk
+    CC = $(WASI_SDK)/bin/clang
+    AR = $(WASI_SDK)/bin/llvm-ar
+    LDFLAGS += -Wl,--allow-undefined
+    CFLAGS += -DPLATFORM_WASIGL -DGRAPHICS_API_OPENGL_ES2 
+endif
+
 # Define library paths containing required libs: LDFLAGS
 # NOTE: This is only required for dynamic library generation
 #------------------------------------------------------------------------------------------------

--- a/src/external/wasigl_gles2.h
+++ b/src/external/wasigl_gles2.h
@@ -1,0 +1,307 @@
+// GLES2 header for PLATFORM_WASIGL.
+// GL functions are imported directly from the host (via @easywasm/gl), so GLAD's
+// runtime proc-address loading cannot work (imported functions have no stable WASM
+// table indices). This header reuses glad_gles2.h for types/constants, then undefines
+// the function-pointer macros and redeclares functions as plain extern so every GL
+// call compiles to a direct WASM `call` instruction against the host import.
+
+#ifndef WASIGL_GLES2_H
+#define WASIGL_GLES2_H
+
+// Pull in all types, constants, PFNGL typedefs, and extern glad_glXxx declarations
+// (no implementation — the variables are extern-declared but never referenced after
+// the macros below are replaced with direct calls).
+#include "glad_gles2.h"
+
+// Remove the function-pointer redirects added by glad_gles2.h so subsequent
+// glXxx() calls reach the extern functions declared below instead.
+#undef glActiveTexture
+#undef glAttachShader
+#undef glBindAttribLocation
+#undef glBindBuffer
+#undef glBindFramebuffer
+#undef glBindRenderbuffer
+#undef glBindTexture
+#undef glBlendColor
+#undef glBlendEquation
+#undef glBlendEquationSeparate
+#undef glBlendFunc
+#undef glBlendFuncSeparate
+#undef glBufferData
+#undef glBufferSubData
+#undef glCheckFramebufferStatus
+#undef glClear
+#undef glClearColor
+#undef glClearDepthf
+#undef glClearStencil
+#undef glColorMask
+#undef glCompileShader
+#undef glCompressedTexImage2D
+#undef glCompressedTexSubImage2D
+#undef glCopyTexImage2D
+#undef glCopyTexSubImage2D
+#undef glCreateProgram
+#undef glCreateShader
+#undef glCullFace
+#undef glDeleteBuffers
+#undef glDeleteFramebuffers
+#undef glDeleteProgram
+#undef glDeleteRenderbuffers
+#undef glDeleteShader
+#undef glDeleteTextures
+#undef glDepthFunc
+#undef glDepthMask
+#undef glDepthRangef
+#undef glDetachShader
+#undef glDisable
+#undef glDisableVertexAttribArray
+#undef glDrawArrays
+#undef glDrawElements
+#undef glEnable
+#undef glEnableVertexAttribArray
+#undef glFinish
+#undef glFlush
+#undef glFramebufferRenderbuffer
+#undef glFramebufferTexture2D
+#undef glFrontFace
+#undef glGenBuffers
+#undef glGenFramebuffers
+#undef glGenRenderbuffers
+#undef glGenTextures
+#undef glGenerateMipmap
+#undef glGetActiveAttrib
+#undef glGetActiveUniform
+#undef glGetAttachedShaders
+#undef glGetAttribLocation
+#undef glGetBooleanv
+#undef glGetBufferParameteriv
+#undef glGetError
+#undef glGetFloatv
+#undef glGetFramebufferAttachmentParameteriv
+#undef glGetIntegerv
+#undef glGetProgramInfoLog
+#undef glGetProgramiv
+#undef glGetRenderbufferParameteriv
+#undef glGetShaderInfoLog
+#undef glGetShaderPrecisionFormat
+#undef glGetShaderSource
+#undef glGetShaderiv
+#undef glGetString
+#undef glGetTexParameterfv
+#undef glGetTexParameteriv
+#undef glGetUniformLocation
+#undef glGetUniformfv
+#undef glGetUniformiv
+#undef glGetVertexAttribPointerv
+#undef glGetVertexAttribfv
+#undef glGetVertexAttribiv
+#undef glHint
+#undef glIsBuffer
+#undef glIsEnabled
+#undef glIsFramebuffer
+#undef glIsProgram
+#undef glIsRenderbuffer
+#undef glIsShader
+#undef glIsTexture
+#undef glLineWidth
+#undef glLinkProgram
+#undef glPixelStorei
+#undef glPolygonOffset
+#undef glReadPixels
+#undef glReleaseShaderCompiler
+#undef glRenderbufferStorage
+#undef glSampleCoverage
+#undef glScissor
+#undef glShaderBinary
+#undef glShaderSource
+#undef glStencilFunc
+#undef glStencilFuncSeparate
+#undef glStencilMask
+#undef glStencilMaskSeparate
+#undef glStencilOp
+#undef glStencilOpSeparate
+#undef glTexImage2D
+#undef glTexParameterf
+#undef glTexParameterfv
+#undef glTexParameteri
+#undef glTexParameteriv
+#undef glTexSubImage2D
+#undef glUniform1f
+#undef glUniform1fv
+#undef glUniform1i
+#undef glUniform1iv
+#undef glUniform2f
+#undef glUniform2fv
+#undef glUniform2i
+#undef glUniform2iv
+#undef glUniform3f
+#undef glUniform3fv
+#undef glUniform3i
+#undef glUniform3iv
+#undef glUniform4f
+#undef glUniform4fv
+#undef glUniform4i
+#undef glUniform4iv
+#undef glUniformMatrix2fv
+#undef glUniformMatrix3fv
+#undef glUniformMatrix4fv
+#undef glUseProgram
+#undef glValidateProgram
+#undef glVertexAttrib1f
+#undef glVertexAttrib1fv
+#undef glVertexAttrib2f
+#undef glVertexAttrib2fv
+#undef glVertexAttrib3f
+#undef glVertexAttrib3fv
+#undef glVertexAttrib4f
+#undef glVertexAttrib4fv
+#undef glVertexAttribPointer
+#undef glViewport
+
+// Direct extern declarations — these resolve to host imports (env.glXxx) supplied
+// by @easywasm/gl, so every call becomes a WASM `call` instruction with no
+// function-table indirection.
+extern void           glActiveTexture(GLenum texture);
+extern void           glAttachShader(GLuint program, GLuint shader);
+extern void           glBindAttribLocation(GLuint program, GLuint index, const GLchar *name);
+extern void           glBindBuffer(GLenum target, GLuint buffer);
+extern void           glBindFramebuffer(GLenum target, GLuint framebuffer);
+extern void           glBindRenderbuffer(GLenum target, GLuint renderbuffer);
+extern void           glBindTexture(GLenum target, GLuint texture);
+extern void           glBlendColor(GLfloat red, GLfloat green, GLfloat blue, GLfloat alpha);
+extern void           glBlendEquation(GLenum mode);
+extern void           glBlendEquationSeparate(GLenum modeRGB, GLenum modeAlpha);
+extern void           glBlendFunc(GLenum sfactor, GLenum dfactor);
+extern void           glBlendFuncSeparate(GLenum srcRGB, GLenum dstRGB, GLenum srcAlpha, GLenum dstAlpha);
+extern void           glBufferData(GLenum target, GLsizeiptr size, const void *data, GLenum usage);
+extern void           glBufferSubData(GLenum target, GLintptr offset, GLsizeiptr size, const void *data);
+extern GLenum         glCheckFramebufferStatus(GLenum target);
+extern void           glClear(GLbitfield mask);
+extern void           glClearColor(GLfloat red, GLfloat green, GLfloat blue, GLfloat alpha);
+extern void           glClearDepthf(GLfloat d);
+extern void           glClearStencil(GLint s);
+extern void           glColorMask(GLboolean red, GLboolean green, GLboolean blue, GLboolean alpha);
+extern void           glCompileShader(GLuint shader);
+extern void           glCompressedTexImage2D(GLenum target, GLint level, GLenum internalformat, GLsizei width, GLsizei height, GLint border, GLsizei imageSize, const void *data);
+extern void           glCompressedTexSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLsizei width, GLsizei height, GLenum format, GLsizei imageSize, const void *data);
+extern void           glCopyTexImage2D(GLenum target, GLint level, GLenum internalformat, GLint x, GLint y, GLsizei width, GLsizei height, GLint border);
+extern void           glCopyTexSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint x, GLint y, GLsizei width, GLsizei height);
+extern GLuint         glCreateProgram(void);
+extern GLuint         glCreateShader(GLenum type);
+extern void           glCullFace(GLenum mode);
+extern void           glDeleteBuffers(GLsizei n, const GLuint *buffers);
+extern void           glDeleteFramebuffers(GLsizei n, const GLuint *framebuffers);
+extern void           glDeleteProgram(GLuint program);
+extern void           glDeleteRenderbuffers(GLsizei n, const GLuint *renderbuffers);
+extern void           glDeleteShader(GLuint shader);
+extern void           glDeleteTextures(GLsizei n, const GLuint *textures);
+extern void           glDepthFunc(GLenum func);
+extern void           glDepthMask(GLboolean flag);
+extern void           glDepthRangef(GLfloat n, GLfloat f);
+extern void           glDetachShader(GLuint program, GLuint shader);
+extern void           glDisable(GLenum cap);
+extern void           glDisableVertexAttribArray(GLuint index);
+extern void           glDrawArrays(GLenum mode, GLint first, GLsizei count);
+extern void           glDrawElements(GLenum mode, GLsizei count, GLenum type, const void *indices);
+extern void           glEnable(GLenum cap);
+extern void           glEnableVertexAttribArray(GLuint index);
+extern void           glFinish(void);
+extern void           glFlush(void);
+extern void           glFramebufferRenderbuffer(GLenum target, GLenum attachment, GLenum renderbuffertarget, GLuint renderbuffer);
+extern void           glFramebufferTexture2D(GLenum target, GLenum attachment, GLenum textarget, GLuint texture, GLint level);
+extern void           glFrontFace(GLenum mode);
+extern void           glGenBuffers(GLsizei n, GLuint *buffers);
+extern void           glGenFramebuffers(GLsizei n, GLuint *framebuffers);
+extern void           glGenRenderbuffers(GLsizei n, GLuint *renderbuffers);
+extern void           glGenTextures(GLsizei n, GLuint *textures);
+extern void           glGenerateMipmap(GLenum target);
+extern void           glGetActiveAttrib(GLuint program, GLuint index, GLsizei bufSize, GLsizei *length, GLint *size, GLenum *type, GLchar *name);
+extern void           glGetActiveUniform(GLuint program, GLuint index, GLsizei bufSize, GLsizei *length, GLint *size, GLenum *type, GLchar *name);
+extern void           glGetAttachedShaders(GLuint program, GLsizei maxCount, GLsizei *count, GLuint *shaders);
+extern GLint          glGetAttribLocation(GLuint program, const GLchar *name);
+extern void           glGetBooleanv(GLenum pname, GLboolean *data);
+extern void           glGetBufferParameteriv(GLenum target, GLenum pname, GLint *params);
+extern GLenum         glGetError(void);
+extern void           glGetFloatv(GLenum pname, GLfloat *data);
+extern void           glGetFramebufferAttachmentParameteriv(GLenum target, GLenum attachment, GLenum pname, GLint *params);
+extern void           glGetIntegerv(GLenum pname, GLint *data);
+extern void           glGetProgramInfoLog(GLuint program, GLsizei bufSize, GLsizei *length, GLchar *infoLog);
+extern void           glGetProgramiv(GLuint program, GLenum pname, GLint *params);
+extern void           glGetRenderbufferParameteriv(GLenum target, GLenum pname, GLint *params);
+extern void           glGetShaderInfoLog(GLuint shader, GLsizei bufSize, GLsizei *length, GLchar *infoLog);
+extern void           glGetShaderPrecisionFormat(GLenum shadertype, GLenum precisiontype, GLint *range, GLint *precision);
+extern void           glGetShaderSource(GLuint shader, GLsizei bufSize, GLsizei *length, GLchar *source);
+extern void           glGetShaderiv(GLuint shader, GLenum pname, GLint *params);
+extern const GLubyte *glGetString(GLenum name);
+extern void           glGetTexParameterfv(GLenum target, GLenum pname, GLfloat *params);
+extern void           glGetTexParameteriv(GLenum target, GLenum pname, GLint *params);
+extern GLint          glGetUniformLocation(GLuint program, const GLchar *name);
+extern void           glGetUniformfv(GLuint program, GLint location, GLfloat *params);
+extern void           glGetUniformiv(GLuint program, GLint location, GLint *params);
+extern void           glGetVertexAttribPointerv(GLuint index, GLenum pname, void **pointer);
+extern void           glGetVertexAttribfv(GLuint index, GLenum pname, GLfloat *params);
+extern void           glGetVertexAttribiv(GLuint index, GLenum pname, GLint *params);
+extern void           glHint(GLenum target, GLenum mode);
+extern GLboolean      glIsBuffer(GLuint buffer);
+extern GLboolean      glIsEnabled(GLenum cap);
+extern GLboolean      glIsFramebuffer(GLuint framebuffer);
+extern GLboolean      glIsProgram(GLuint program);
+extern GLboolean      glIsRenderbuffer(GLuint renderbuffer);
+extern GLboolean      glIsShader(GLuint shader);
+extern GLboolean      glIsTexture(GLuint texture);
+extern void           glLineWidth(GLfloat width);
+extern void           glLinkProgram(GLuint program);
+extern void           glPixelStorei(GLenum pname, GLint param);
+extern void           glPolygonOffset(GLfloat factor, GLfloat units);
+extern void           glReadPixels(GLint x, GLint y, GLsizei width, GLsizei height, GLenum format, GLenum type, void *pixels);
+extern void           glReleaseShaderCompiler(void);
+extern void           glRenderbufferStorage(GLenum target, GLenum internalformat, GLsizei width, GLsizei height);
+extern void           glSampleCoverage(GLfloat value, GLboolean invert);
+extern void           glScissor(GLint x, GLint y, GLsizei width, GLsizei height);
+extern void           glShaderBinary(GLsizei count, const GLuint *shaders, GLenum binaryFormat, const void *binary, GLsizei length);
+extern void           glShaderSource(GLuint shader, GLsizei count, const GLchar *const *string, const GLint *length);
+extern void           glStencilFunc(GLenum func, GLint ref, GLuint mask);
+extern void           glStencilFuncSeparate(GLenum face, GLenum func, GLint ref, GLuint mask);
+extern void           glStencilMask(GLuint mask);
+extern void           glStencilMaskSeparate(GLenum face, GLuint mask);
+extern void           glStencilOp(GLenum fail, GLenum zfail, GLenum zpass);
+extern void           glStencilOpSeparate(GLenum face, GLenum sfail, GLenum dpfail, GLenum dppass);
+extern void           glTexImage2D(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height, GLint border, GLenum format, GLenum type, const void *pixels);
+extern void           glTexParameterf(GLenum target, GLenum pname, GLfloat param);
+extern void           glTexParameterfv(GLenum target, GLenum pname, const GLfloat *params);
+extern void           glTexParameteri(GLenum target, GLenum pname, GLint param);
+extern void           glTexParameteriv(GLenum target, GLenum pname, const GLint *params);
+extern void           glTexSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLsizei width, GLsizei height, GLenum format, GLenum type, const void *pixels);
+extern void           glUniform1f(GLint location, GLfloat v0);
+extern void           glUniform1fv(GLint location, GLsizei count, const GLfloat *value);
+extern void           glUniform1i(GLint location, GLint v0);
+extern void           glUniform1iv(GLint location, GLsizei count, const GLint *value);
+extern void           glUniform2f(GLint location, GLfloat v0, GLfloat v1);
+extern void           glUniform2fv(GLint location, GLsizei count, const GLfloat *value);
+extern void           glUniform2i(GLint location, GLint v0, GLint v1);
+extern void           glUniform2iv(GLint location, GLsizei count, const GLint *value);
+extern void           glUniform3f(GLint location, GLfloat v0, GLfloat v1, GLfloat v2);
+extern void           glUniform3fv(GLint location, GLsizei count, const GLfloat *value);
+extern void           glUniform3i(GLint location, GLint v0, GLint v1, GLint v2);
+extern void           glUniform3iv(GLint location, GLsizei count, const GLint *value);
+extern void           glUniform4f(GLint location, GLfloat v0, GLfloat v1, GLfloat v2, GLfloat v3);
+extern void           glUniform4fv(GLint location, GLsizei count, const GLfloat *value);
+extern void           glUniform4i(GLint location, GLint v0, GLint v1, GLint v2, GLint w);
+extern void           glUniform4iv(GLint location, GLsizei count, const GLint *value);
+extern void           glUniformMatrix2fv(GLint location, GLsizei count, GLboolean transpose, const GLfloat *value);
+extern void           glUniformMatrix3fv(GLint location, GLsizei count, GLboolean transpose, const GLfloat *value);
+extern void           glUniformMatrix4fv(GLint location, GLsizei count, GLboolean transpose, const GLfloat *value);
+extern void           glUseProgram(GLuint program);
+extern void           glValidateProgram(GLuint program);
+extern void           glVertexAttrib1f(GLuint index, GLfloat x);
+extern void           glVertexAttrib1fv(GLuint index, const GLfloat *v);
+extern void           glVertexAttrib2f(GLuint index, GLfloat x, GLfloat y);
+extern void           glVertexAttrib2fv(GLuint index, const GLfloat *v);
+extern void           glVertexAttrib3f(GLuint index, GLfloat x, GLfloat y, GLfloat z);
+extern void           glVertexAttrib3fv(GLuint index, const GLfloat *v);
+extern void           glVertexAttrib4f(GLuint index, GLfloat x, GLfloat y, GLfloat z, GLfloat w);
+extern void           glVertexAttrib4fv(GLuint index, const GLfloat *v);
+extern void           glVertexAttribPointer(GLuint index, GLint size, GLenum type, GLboolean normalized, GLsizei stride, const void *pointer);
+extern void           glViewport(GLint x, GLint y, GLsizei width, GLsizei height);
+
+#endif // WASIGL_GLES2_H

--- a/src/platforms/rcore_wasigl.c
+++ b/src/platforms/rcore_wasigl.c
@@ -1,0 +1,1 @@
+#include "./rcore_desktop_glfw.c"

--- a/src/platforms/rcore_wasigl.c
+++ b/src/platforms/rcore_wasigl.c
@@ -1,1 +1,16 @@
+// WASM imported functions can't be used as indirect call targets (function pointers).
+// Wrap glfwGetProcAddress in a C-defined function so it lives in the WASM table.
+// glfw3.h (included inside rcore_desktop_glfw.c) declares wasigl_proc_loader via
+// the macro — no forward declaration needed here to avoid a type conflict.
+#define glfwGetProcAddress wasigl_proc_loader
 #include "./rcore_desktop_glfw.c"
+#undef glfwGetProcAddress
+
+// After the undef, glfwGetProcAddress names the real host import again.
+// Re-declare it so the wrapper body below can call it.
+extern GLFWglproc glfwGetProcAddress(const char *procname);
+
+// Definition matches the GLFWAPI GLFWglproc declaration glfw3.h produced via macro.
+GLFWglproc wasigl_proc_loader(const char *procname) {
+    return glfwGetProcAddress(procname);
+}

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -33,6 +33,8 @@
 *           - Android (ARM, ARM64)
 *       > PLATFORM_MEMORY
 *           - Memory framebuffer output, using software renderer, no OS required
+*       > PLATFORM_WASIGL
+*           - WASM that imports GL/GLFW from host
 *
 *   CONFIGURATION:
 *       #define SUPPORT_CAMERA_SYSTEM       1
@@ -528,6 +530,8 @@ const char *TextFormat(const char *text, ...); // Formatting of text with variab
     #include "platforms/rcore_android.c"
 #elif defined(PLATFORM_MEMORY)
     #include "platforms/rcore_memory.c"
+#elif defined(PLATFORM_WASIGL)
+    #include "platforms/rcore_wasigl.c"
 #else
     // TODO: Include your custom platform backend!
     // i.e software rendering backend or console backend!

--- a/src/rlgl.h
+++ b/src/rlgl.h
@@ -883,7 +883,7 @@ RLAPI void rlLoadDrawQuad(void);     // Load and draw a quad
     // NOTE: OpenGL ES 2.0 can be enabled on Desktop platforms,
     // in that case, functions are loaded from a custom glad for OpenGL ES 2.0
     // TODO: OpenGL ES 2.0 support shouldn't be platform-dependent, neither require GLAD
-    #if defined(PLATFORM_DESKTOP_GLFW) || defined(PLATFORM_DESKTOP_SDL)
+    #if defined(PLATFORM_DESKTOP_GLFW) || defined(PLATFORM_DESKTOP_SDL) || defined(PLATFORM_WASIGL)
         #define GLAD_GLES2_IMPLEMENTATION
         #include "external/glad_gles2.h"
     #else
@@ -2484,7 +2484,7 @@ void rlLoadExtensions(void *loader)
 
 #elif defined(GRAPHICS_API_OPENGL_ES2)
 
-    #if defined(PLATFORM_DESKTOP_GLFW) || defined(PLATFORM_DESKTOP_SDL)
+    #if defined(PLATFORM_DESKTOP_GLFW) || defined(PLATFORM_DESKTOP_SDL) || defined(PLATFORM_WASIGL)
     // TODO: Support GLAD loader for OpenGL ES 3.0
     if (gladLoadGLES2((GLADloadfunc)loader) == 0) TRACELOG(RL_LOG_WARNING, "GLAD: Cannot load OpenGL ES2.0 functions");
     else TRACELOG(RL_LOG_INFO, "GLAD: OpenGL ES 2.0 loaded successfully");

--- a/src/rlgl.h
+++ b/src/rlgl.h
@@ -883,7 +883,11 @@ RLAPI void rlLoadDrawQuad(void);     // Load and draw a quad
     // NOTE: OpenGL ES 2.0 can be enabled on Desktop platforms,
     // in that case, functions are loaded from a custom glad for OpenGL ES 2.0
     // TODO: OpenGL ES 2.0 support shouldn't be platform-dependent, neither require GLAD
-    #if defined(PLATFORM_DESKTOP_GLFW) || defined(PLATFORM_DESKTOP_SDL) || defined(PLATFORM_WASIGL)
+    #if defined(PLATFORM_WASIGL)
+        // GL functions are host imports — GLAD proc-address loading cannot work in WASM
+        // (imported functions have no stable table indices). Use direct extern calls instead.
+        #include "external/wasigl_gles2.h"
+    #elif defined(PLATFORM_DESKTOP_GLFW) || defined(PLATFORM_DESKTOP_SDL)
         #define GLAD_GLES2_IMPLEMENTATION
         #include "external/glad_gles2.h"
     #else
@@ -2484,7 +2488,7 @@ void rlLoadExtensions(void *loader)
 
 #elif defined(GRAPHICS_API_OPENGL_ES2)
 
-    #if defined(PLATFORM_DESKTOP_GLFW) || defined(PLATFORM_DESKTOP_SDL) || defined(PLATFORM_WASIGL)
+    #if defined(PLATFORM_DESKTOP_GLFW) || defined(PLATFORM_DESKTOP_SDL)
     // TODO: Support GLAD loader for OpenGL ES 3.0
     if (gladLoadGLES2((GLADloadfunc)loader) == 0) TRACELOG(RL_LOG_WARNING, "GLAD: Cannot load OpenGL ES2.0 functions");
     else TRACELOG(RL_LOG_INFO, "GLAD: OpenGL ES 2.0 loaded successfully");


### PR DESCRIPTION
This is related to [this discussion](https://github.com/raysan5/raylib/discussions/3626).

It adds a new platform that just imports the functions it needs (GLFW and GL) from the wasm-host.

A user should be able to use it on the web with [easywasm/gl](https://github.com/easywasm/gl/), but also can expose the same functions on native wasm hosts, just using GLFW directly.

*why is this better than emscripten?* All functions that are needed are imported from host, so instead of bloating it up with JS and extra code to bind the JS to wasm, it makes it way lighter. The imported functions are mandatory, but can be implemented however the host wants to.

The change itself is fairly trivial. it's essentially just glfw, then `-Wl,--allow-undefined` is added to import anything that is not linked. Additionally, it should be built with wasi-sdk, which presets some flags, and has many stdlib headers implemented to use WASI.

I'm not totally sure if I modified enough files. I messed with build.zig and Makefile. Are there more?

Also, not really sure what the `ubsan_handle` functions are, but it might be worth tracking down why they are not defined (and being imported.)

for illustration core_basic_window.wasm is all wasi and glfw/gl:

```
Import[82]:
 - func[0] sig=0 <__ubsan_handle_nonnull_arg> <- env.__ubsan_handle_nonnull_arg
 - func[1] sig=1 <__ubsan_handle_out_of_bounds> <- env.__ubsan_handle_out_of_bounds
 - func[2] sig=2 <__ubsan_handle_pointer_overflow> <- env.__ubsan_handle_pointer_overflow
 - func[3] sig=3 <fd_close|wasi_snapshot_preview1> <- wasi_snapshot_preview1.fd_close
 - func[4] sig=4 <__imported_wasi_snapshot_preview1_fd_write> <- wasi_snapshot_preview1.fd_write
 - func[5] sig=5 <__imported_wasi_snapshot_preview1_fd_fdstat_get> <- wasi_snapshot_preview1.fd_fdstat_get
 - func[6] sig=6 <__imported_wasi_snapshot_preview1_fd_seek> <- wasi_snapshot_preview1.fd_seek
 - func[7] sig=0 <__imported_wasi_snapshot_preview1_proc_exit> <- wasi_snapshot_preview1.proc_exit
 - func[8] sig=0 <__ubsan_handle_builtin_unreachable> <- env.__ubsan_handle_builtin_unreachable
 - func[9] sig=1 <__ubsan_handle_type_mismatch_v1> <- env.__ubsan_handle_type_mismatch_v1
 - func[10] sig=3 <glfwSetErrorCallback> <- env.glfwSetErrorCallback
 - func[11] sig=0 <glfwInitAllocator> <- env.glfwInitAllocator
 - func[12] sig=7 <glfwInit> <- env.glfwInit
 - func[13] sig=8 <glfwDefaultWindowHints> <- env.glfwDefaultWindowHints
 - func[14] sig=1 <glfwWindowHint> <- env.glfwWindowHint
 - func[15] sig=3 <glfwSetJoystickCallback> <- env.glfwSetJoystickCallback
 - func[16] sig=7 <glfwGetPrimaryMonitor> <- env.glfwGetPrimaryMonitor
 - func[17] sig=3 <glfwGetVideoMode> <- env.glfwGetVideoMode
 - func[18] sig=2 <__ubsan_handle_divrem_overflow> <- env.__ubsan_handle_divrem_overflow
 - func[19] sig=9 <glfwCreateWindow> <- env.glfwCreateWindow
 - func[20] sig=8 <glfwTerminate> <- env.glfwTerminate
 - func[21] sig=3 <glfwGetMonitors> <- env.glfwGetMonitors
 - func[22] sig=3 <glfwGetWindowMonitor> <- env.glfwGetWindowMonitor
 - func[23] sig=2 <__ubsan_handle_add_overflow> <- env.__ubsan_handle_add_overflow
 - func[24] sig=2 <glfwGetWindowPos> <- env.glfwGetWindowPos
 - func[25] sig=2 <glfwGetMonitorPos> <- env.glfwGetMonitorPos
 - func[26] sig=2 <__ubsan_handle_sub_overflow> <- env.__ubsan_handle_sub_overflow
 - func[27] sig=2 <__ubsan_handle_mul_overflow> <- env.__ubsan_handle_mul_overflow
 - func[28] sig=2 <glfwSetWindowSize> <- env.glfwSetWindowSize
 - func[29] sig=0 <glfwMakeContextCurrent> <- env.glfwMakeContextCurrent
 - func[30] sig=3 <glfwGetError> <- env.glfwGetError
 - func[31] sig=1 <__ubsan_handle_load_invalid_value> <- env.__ubsan_handle_load_invalid_value
 - func[32] sig=0 <glfwSwapInterval> <- env.glfwSwapInterval
 - func[33] sig=2 <glfwGetWindowContentScale> <- env.glfwGetWindowContentScale
 - func[34] sig=1 <__ubsan_handle_float_cast_overflow> <- env.__ubsan_handle_float_cast_overflow
 - func[35] sig=7 <glfwGetPlatform> <- env.glfwGetPlatform
 - func[36] sig=2 <glfwGetFramebufferSize> <- env.glfwGetFramebufferSize
 - func[37] sig=10 <glfwGetMonitorWorkarea> <- env.glfwGetMonitorWorkarea
 - func[38] sig=2 <glfwSetWindowPos> <- env.glfwSetWindowPos
 - func[39] sig=0 <glfwIconifyWindow> <- env.glfwIconifyWindow
 - func[40] sig=11 <glfwSetWindowMonitor> <- env.glfwSetWindowMonitor
 - func[41] sig=2 <glfwSetWindowAttrib> <- env.glfwSetWindowAttrib
 - func[42] sig=0 <glfwFocusWindow> <- env.glfwFocusWindow
 - func[43] sig=0 <glfwHideWindow> <- env.glfwHideWindow
 - func[44] sig=5 <glfwGetWindowAttrib> <- env.glfwGetWindowAttrib
 - func[45] sig=0 <glfwMaximizeWindow> <- env.glfwMaximizeWindow
 - func[46] sig=3 <glfwGetProcAddress> <- env.glfwGetProcAddress
 - func[47] sig=5 <glfwSetWindowSizeCallback> <- env.glfwSetWindowSizeCallback
 - func[48] sig=5 <glfwSetFramebufferSizeCallback> <- env.glfwSetFramebufferSizeCallback
 - func[49] sig=5 <glfwSetWindowPosCallback> <- env.glfwSetWindowPosCallback
 - func[50] sig=5 <glfwSetWindowMaximizeCallback> <- env.glfwSetWindowMaximizeCallback
 - func[51] sig=5 <glfwSetWindowIconifyCallback> <- env.glfwSetWindowIconifyCallback
 - func[52] sig=5 <glfwSetWindowFocusCallback> <- env.glfwSetWindowFocusCallback
 - func[53] sig=5 <glfwSetDropCallback> <- env.glfwSetDropCallback
 - func[54] sig=5 <glfwSetWindowContentScaleCallback> <- env.glfwSetWindowContentScaleCallback
 - func[55] sig=1 <glfwSetWindowShouldClose> <- env.glfwSetWindowShouldClose
 - func[56] sig=5 <glfwSetKeyCallback> <- env.glfwSetKeyCallback
 - func[57] sig=5 <glfwSetCharCallback> <- env.glfwSetCharCallback
 - func[58] sig=12 <glfwGetTime> <- env.glfwGetTime
 - func[59] sig=5 <glfwSetMouseButtonCallback> <- env.glfwSetMouseButtonCallback
 - func[60] sig=5 <glfwSetCursorPosCallback> <- env.glfwSetCursorPosCallback
 - func[61] sig=5 <glfwSetScrollCallback> <- env.glfwSetScrollCallback
 - func[62] sig=5 <glfwSetCursorEnterCallback> <- env.glfwSetCursorEnterCallback
 - func[63] sig=3 <glfwGetJoystickName> <- env.glfwGetJoystickName
 - func[64] sig=2 <glfwSetInputMode> <- env.glfwSetInputMode
 - func[65] sig=3 <glfwJoystickPresent> <- env.glfwJoystickPresent
 - func[66] sig=2 <__ubsan_handle_shift_out_of_bounds> <- env.__ubsan_handle_shift_out_of_bounds
 - func[67] sig=13 <__imported_wasi_snapshot_preview1_clock_time_get> <- wasi_snapshot_preview1.clock_time_get
 - func[68] sig=0 <glfwSwapBuffers> <- env.glfwSwapBuffers
 - func[69] sig=5 <glfwGetGamepadState> <- env.glfwGetGamepadState
 - func[70] sig=8 <glfwWaitEvents> <- env.glfwWaitEvents
 - func[71] sig=8 <glfwPollEvents> <- env.glfwPollEvents
 - func[72] sig=3 <glfwWindowShouldClose> <- env.glfwWindowShouldClose
 - func[73] sig=1 <__ubsan_handle_negate_overflow> <- env.__ubsan_handle_negate_overflow
 - func[74] sig=5 <__imported_wasi_snapshot_preview1_fd_prestat_get> <- wasi_snapshot_preview1.fd_prestat_get
 - func[75] sig=14 <__imported_wasi_snapshot_preview1_fd_prestat_dir_name> <- wasi_snapshot_preview1.fd_prestat_dir_name
 - func[76] sig=15 <__imported_wasi_snapshot_preview1_path_open> <- wasi_snapshot_preview1.path_open
 - func[77] sig=5 <__imported_wasi_snapshot_preview1_fd_fdstat_set_flags> <- wasi_snapshot_preview1.fd_fdstat_set_flags
 - func[78] sig=4 <__imported_wasi_snapshot_preview1_fd_read> <- wasi_snapshot_preview1.fd_read
 - func[79] sig=9 <__imported_wasi_snapshot_preview1_path_filestat_get> <- wasi_snapshot_preview1.path_filestat_get
 - func[80] sig=0 <glfwDestroyWindow> <- env.glfwDestroyWindow
 - func[81] sig=5 <__imported_wasi_snapshot_preview1_random_get> <- wasi_snapshot_preview1.random_get
```