### PR TITLE
[cmake] added `platform/win32` to cmake

### DIFF
--- a/CMakeOptions.txt
+++ b/CMakeOptions.txt
@@ -6,7 +6,7 @@ if(EMSCRIPTEN)
     # When configuring web builds with "emcmake cmake -B build -S .", set PLATFORM to Web by default
     SET(PLATFORM Web CACHE STRING "Platform to build for.")
 endif()
-enum_option(PLATFORM "Desktop;Web;WebRGFW;Android;Raspberry Pi;DRM;SDL;RGFW;Memory" "Platform to build for.")
+enum_option(PLATFORM "Desktop;Win32;Web;WebRGFW;Android;Raspberry Pi;DRM;SDL;RGFW;Memory" "Platform to build for.")
 
 enum_option(OPENGL_VERSION "OFF;4.3;3.3;2.1;1.1;ES 2.0;ES 3.0;Software" "Force a specific OpenGL Version?")
 

--- a/cmake/LibraryConfigurations.cmake
+++ b/cmake/LibraryConfigurations.cmake
@@ -67,6 +67,21 @@ if (${PLATFORM} STREQUAL "Desktop")
         endif ()
     endif ()
 
+elseif (${PLATFORM} STREQUAL "Win32")
+    if ((NOT WIN32) AND (NOT CMAKE_C_COMPILER MATCHES "mingw|mingw32|mingw64"))
+        message(FATAL_ERROR "Win32 platform requires Windows or a cross compiler.")
+    endif ()
+
+    set(PLATFORM_CPP "PLATFORM_DESKTOP_WIN32")
+    add_definitions(-D_CRT_SECURE_NO_WARNINGS)
+
+    if (${OPENGL_VERSION} MATCHES "Software")
+        set(GRAPHICS "GRAPHICS_API_OPENGL_SOFTWARE")
+    endif ()
+
+    find_package(OpenGL QUIET)
+    set(LIBS_PRIVATE ${OPENGL_LIBRARIES} winmm)
+
 elseif (${PLATFORM} STREQUAL "Web")
     set(PLATFORM_CPP "PLATFORM_WEB")
     if(NOT GRAPHICS)

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -20,6 +20,8 @@
 #         - Linux (X11 desktop mode)
 #         - macOS/OSX (x64, arm64 (not tested))
 #         - Others (not tested)
+#     > PLATFORM_DESKTOP_WIN32 (native Win32):
+#         - Windows (Win32, Win64)
 #     > PLATFORM_WEB_RGFW:
 #         - HTML5 (WebAssembly)
 #     > PLATFORM_WEB:
@@ -792,6 +794,23 @@ ifeq ($(TARGET_PLATFORM),PLATFORM_DESKTOP_GLFW)
     ifeq ($(PLATFORM_OS),OSX)
 		find . -type f -perm +ugo+x -delete
 		rm -f *.o
+    endif
+endif
+ifeq ($(TARGET_PLATFORM),PLATFORM_DESKTOP_WIN32)
+    ifeq ($(PLATFORM_OS),WINDOWS)
+        del *.o *.exe /s
+    endif
+    ifeq ($(PLATFORM_OS),BSD)
+        find . -type f -perm -ugo+x -delete
+        rm -fv *.o
+    endif
+    ifeq ($(PLATFORM_OS),LINUX)
+        find . -type f -executable -delete
+        rm -fv *.o
+    endif
+    ifeq ($(PLATFORM_OS),OSX)
+        find . -type f -perm +ugo+x -delete
+        rm -f *.o
     endif
 endif
 ifeq ($(TARGET_PLATFORM),PLATFORM_DRM)


### PR DESCRIPTION
I'm not a cmake user nor a windows user, so it would be great if other people could also test this

I did the following 2 tests:
```bash
mkdir build
cd build
cmake .. -DPLATFORM=Win32
# open raylib.sln
# compile core_2d_camera
# verify win32 + opengl in logs
```
```bash
mkdir build
cd build
cmake .. -DPLATFORM=Win32 -DOPENGL_VERSION=Software
# open raylib.sln
# compile core_2d_camera
# verify win32 + rlsw in logs
```