### PR TITLE
[rcore][RGFW] Add fullscreen behaviour on size 0 window creation

### DIFF
--- a/src/platforms/rcore_desktop_rgfw.c
+++ b/src/platforms/rcore_desktop_rgfw.c
@@ -1674,8 +1674,12 @@ void PollInputEvents(void)
 // Initialize platform: graphics, inputs and more
 int InitPlatform(void)
 {
+    int result = RGFW_init();
+    if (result != 0) { TRACELOG(LOG_WARNING, "RGFW: Failed to initialize RGFW"); return -1; }
     // Initialize RGFW internal global state, only required systems
     unsigned int flags = RGFW_windowCenter | RGFW_windowAllowDND;
+
+    if ((CORE.Window.screen.width == 0) || (CORE.Window.screen.height == 0)) FLAG_SET(CORE.Window.flags, FLAG_FULLSCREEN_MODE);
 
     // Check window creation flags
     if (FLAG_IS_SET(CORE.Window.flags, FLAG_FULLSCREEN_MODE))
@@ -1691,7 +1695,40 @@ int InitPlatform(void)
     if (FLAG_IS_SET(CORE.Window.flags, FLAG_WINDOW_UNDECORATED)) FLAG_SET(flags, RGFW_windowNoBorder);
     if (!FLAG_IS_SET(CORE.Window.flags, FLAG_WINDOW_RESIZABLE)) FLAG_SET(flags, RGFW_windowNoResize);
     if (FLAG_IS_SET(CORE.Window.flags, FLAG_WINDOW_TRANSPARENT)) FLAG_SET(flags, RGFW_windowTransparent);
-    if (FLAG_IS_SET(CORE.Window.flags, FLAG_FULLSCREEN_MODE)) FLAG_SET(flags, RGFW_windowFullscreen);
+    // Init window in fullscreen mode if requested
+    // NOTE: Keeping original screen size for toggle
+    if (FLAG_IS_SET(CORE.Window.flags, FLAG_FULLSCREEN_MODE)) {
+        FLAG_SET(flags, RGFW_windowFullscreen);
+        // NOTE: Fullscreen applications default to the primary monitor
+        RGFW_monitor *monitor = RGFW_getPrimaryMonitor();
+        if (!monitor)
+        {
+            TRACELOG(LOG_WARNING, "RGFW: Failed to get primary monitor");
+            return -1;
+        }
+        // Default display resolution to that of the current mode
+        CORE.Window.display.width = monitor->mode.w;
+        CORE.Window.display.height = monitor->mode.h;
+
+        // Check if user requested some screen size
+        if ((CORE.Window.screen.width == 0) || (CORE.Window.screen.height == 0))
+        {
+            // Set some default screen size in case user decides to exit fullscreen mode
+            CORE.Window.previousScreen.width = 800;
+            CORE.Window.previousScreen.height = 450;
+            CORE.Window.previousPosition.x = CORE.Window.display.width/2 - 800/2;
+            CORE.Window.previousPosition.y = CORE.Window.display.height/2 - 450/2;
+
+            // Set screen width/height to the display width/height
+            if (CORE.Window.screen.width == 0) CORE.Window.screen.width = CORE.Window.display.width;
+            if (CORE.Window.screen.height == 0) CORE.Window.screen.height = CORE.Window.display.height;
+        }
+        else
+        {
+            CORE.Window.previousScreen = CORE.Window.screen;
+            CORE.Window.screen = CORE.Window.display;
+        }
+    }
     if (FLAG_IS_SET(CORE.Window.flags, FLAG_WINDOW_HIDDEN)) FLAG_SET(flags, RGFW_windowHide);
     if (FLAG_IS_SET(CORE.Window.flags, FLAG_WINDOW_MAXIMIZED)) FLAG_SET(flags, RGFW_windowMaximize);
 

--- a/src/platforms/rcore_desktop_rgfw.c
+++ b/src/platforms/rcore_desktop_rgfw.c
@@ -1674,12 +1674,20 @@ void PollInputEvents(void)
 // Initialize platform: graphics, inputs and more
 int InitPlatform(void)
 {
-    int result = RGFW_init();
-    if (result != 0) { TRACELOG(LOG_WARNING, "RGFW: Failed to initialize RGFW"); return -1; }
     // Initialize RGFW internal global state, only required systems
     unsigned int flags = RGFW_windowCenter | RGFW_windowAllowDND;
 
-    if ((CORE.Window.screen.width == 0) || (CORE.Window.screen.height == 0)) FLAG_SET(CORE.Window.flags, FLAG_FULLSCREEN_MODE);
+    if (FLAG_IS_SET(CORE.Window.flags, FLAG_WINDOW_UNDECORATED)) FLAG_SET(flags, RGFW_windowNoBorder);
+    if (!FLAG_IS_SET(CORE.Window.flags, FLAG_WINDOW_RESIZABLE)) FLAG_SET(flags, RGFW_windowNoResize);
+    if (FLAG_IS_SET(CORE.Window.flags, FLAG_WINDOW_TRANSPARENT)) FLAG_SET(flags, RGFW_windowTransparent);
+    if (FLAG_IS_SET(CORE.Window.flags, FLAG_WINDOW_HIDDEN)) FLAG_SET(flags, RGFW_windowHide);
+    if (FLAG_IS_SET(CORE.Window.flags, FLAG_WINDOW_MAXIMIZED)) FLAG_SET(flags, RGFW_windowMaximize);
+    if (!FLAG_IS_SET(CORE.Window.flags, FLAG_WINDOW_UNFOCUSED)) FLAG_SET(flags, RGFW_windowFocusOnShow | RGFW_windowFocus);
+
+    if ((CORE.Window.screen.width == 0) || (CORE.Window.screen.height == 0))
+    {
+        FLAG_SET(CORE.Window.flags, FLAG_FULLSCREEN_MODE);
+    }
 
     // Check window creation flags
     if (FLAG_IS_SET(CORE.Window.flags, FLAG_FULLSCREEN_MODE))
@@ -1692,13 +1700,17 @@ int InitPlatform(void)
         FLAG_SET(flags, RGFW_windowedFullscreen);
     }
 
-    if (FLAG_IS_SET(CORE.Window.flags, FLAG_WINDOW_UNDECORATED)) FLAG_SET(flags, RGFW_windowNoBorder);
-    if (!FLAG_IS_SET(CORE.Window.flags, FLAG_WINDOW_RESIZABLE)) FLAG_SET(flags, RGFW_windowNoResize);
-    if (FLAG_IS_SET(CORE.Window.flags, FLAG_WINDOW_TRANSPARENT)) FLAG_SET(flags, RGFW_windowTransparent);
     // Init window in fullscreen mode if requested
     // NOTE: Keeping original screen size for toggle
-    if (FLAG_IS_SET(CORE.Window.flags, FLAG_FULLSCREEN_MODE)) {
-        FLAG_SET(flags, RGFW_windowFullscreen);
+    if (FLAG_IS_SET(CORE.Window.flags, FLAG_FULLSCREEN_MODE))
+    {
+        int result = RGFW_init();
+        if (result != 0)
+        {
+            TRACELOG(LOG_WARNING, "RGFW: Failed to initialize RGFW");
+            return -1;
+        }
+
         // NOTE: Fullscreen applications default to the primary monitor
         RGFW_monitor *monitor = RGFW_getPrimaryMonitor();
         if (!monitor)
@@ -1706,6 +1718,7 @@ int InitPlatform(void)
             TRACELOG(LOG_WARNING, "RGFW: Failed to get primary monitor");
             return -1;
         }
+
         // Default display resolution to that of the current mode
         CORE.Window.display.width = monitor->mode.w;
         CORE.Window.display.height = monitor->mode.h;
@@ -1716,8 +1729,8 @@ int InitPlatform(void)
             // Set some default screen size in case user decides to exit fullscreen mode
             CORE.Window.previousScreen.width = 800;
             CORE.Window.previousScreen.height = 450;
-            CORE.Window.previousPosition.x = CORE.Window.display.width/2 - 800/2;
-            CORE.Window.previousPosition.y = CORE.Window.display.height/2 - 450/2;
+            CORE.Window.previousPosition.x = (CORE.Window.display.width - CORE.Window.previousScreen.width)/2;
+            CORE.Window.previousPosition.y = (CORE.Window.display.height - CORE.Window.previousScreen.height)/2;
 
             // Set screen width/height to the display width/height
             if (CORE.Window.screen.width == 0) CORE.Window.screen.width = CORE.Window.display.width;
@@ -1729,12 +1742,17 @@ int InitPlatform(void)
             CORE.Window.screen = CORE.Window.display;
         }
     }
-    if (FLAG_IS_SET(CORE.Window.flags, FLAG_WINDOW_HIDDEN)) FLAG_SET(flags, RGFW_windowHide);
-    if (FLAG_IS_SET(CORE.Window.flags, FLAG_WINDOW_MAXIMIZED)) FLAG_SET(flags, RGFW_windowMaximize);
+
+    if (FLAG_IS_SET(CORE.Window.flags, FLAG_WINDOW_HIGHDPI))
+    {
+        #if !defined(__APPLE__)
+            CORE.Window.screen.width = CORE.Window.screen.width * GetWindowScaleDPI().x;
+            CORE.Window.screen.height = CORE.Window.screen.height * GetWindowScaleDPI().y;
+        #endif
+    }
 
     // NOTE: Some OpenGL context attributes must be set before window creation
     // Check selection OpenGL version
-
     RGFW_glHints* hints = RGFW_getGlobalHints_OpenGL();
     if (rlGetVersion() == RL_OPENGL_21)
     {
@@ -1757,20 +1775,9 @@ int InitPlatform(void)
         hints->minor = 1;
         hints->renderer = RGFW_glSoftware;
     }
-
     if (FLAG_IS_SET(CORE.Window.flags, FLAG_MSAA_4X_HINT)) hints->samples = 4;
-
-    if (!FLAG_IS_SET(CORE.Window.flags, FLAG_WINDOW_UNFOCUSED)) FLAG_SET(flags, RGFW_windowFocusOnShow | RGFW_windowFocus);
-
-    if (FLAG_IS_SET(CORE.Window.flags, FLAG_WINDOW_HIGHDPI))
-    {
-        #if !defined(__APPLE__)
-            CORE.Window.screen.width = CORE.Window.screen.width * GetWindowScaleDPI().x;
-            CORE.Window.screen.height = CORE.Window.screen.height * GetWindowScaleDPI().y;
-        #endif
-    }
-
     RGFW_setGlobalHints_OpenGL(hints);
+
     platform.window = RGFW_createWindow((CORE.Window.title != 0)? CORE.Window.title : " ", 0, 0, CORE.Window.screen.width, CORE.Window.screen.height, flags | RGFW_windowOpenGL);
 
 #ifndef PLATFORM_WEB_RGFW

--- a/src/platforms/rcore_desktop_rgfw.c
+++ b/src/platforms/rcore_desktop_rgfw.c
@@ -1690,20 +1690,12 @@ int InitPlatform(void)
     }
 
     // Check window creation flags
-    if (FLAG_IS_SET(CORE.Window.flags, FLAG_FULLSCREEN_MODE))
-    {
-        FLAG_SET(flags, RGFW_windowFullscreen);
-    }
-
-    if (FLAG_IS_SET(CORE.Window.flags, FLAG_BORDERLESS_WINDOWED_MODE))
-    {
-        FLAG_SET(flags, RGFW_windowedFullscreen);
-    }
 
     // Init window in fullscreen mode if requested
     // NOTE: Keeping original screen size for toggle
     if (FLAG_IS_SET(CORE.Window.flags, FLAG_FULLSCREEN_MODE))
     {
+        FLAG_SET(flags, RGFW_windowFullscreen);
         int result = RGFW_init();
         if (result != 0)
         {
@@ -1741,6 +1733,11 @@ int InitPlatform(void)
             CORE.Window.previousScreen = CORE.Window.screen;
             CORE.Window.screen = CORE.Window.display;
         }
+    }
+
+    if (FLAG_IS_SET(CORE.Window.flags, FLAG_BORDERLESS_WINDOWED_MODE))
+    {
+        FLAG_SET(flags, RGFW_windowedFullscreen);
     }
 
     if (FLAG_IS_SET(CORE.Window.flags, FLAG_WINDOW_HIGHDPI))


### PR DESCRIPTION
rcore_desktop_glfw has a nice feature of automatically creating a fullscreen window if you InitWindow(0,0,"title")
but on rgfw it instead just got stuck saying "failed to create drawable"
so I mostly just copied the logic, including the comments, from the glfw backend to handle this case
it does mean we now need to call RGFW_init ahead of time, to be able to get the primary monitor in the case of a size zero window