### PR TITLE
[rtext] add warning for loadfontex/loadfontfrommemory

### DIFF
--- a/src/rtext.c
+++ b/src/rtext.c
@@ -580,8 +580,13 @@ Font LoadFontFromMemory(const char *fileType, const unsigned char *fileData, int
 
         TRACELOG(LOG_INFO, "FONT: Data loaded successfully (%i pixel size | %i glyphs)", font.baseSize, font.glyphCount);
     }
-    else font = GetFontDefault();
+    else 
+    {
+        TRACELOG(LOG_WARNING, "FONT: Font is not supported by LoadFontEx/LoadFontFromMemory or no glyphs found, reverted to default font");
+        font = GetFontDefault();
+    }
 #else
+    TRACELOG(LOG_WARNING, "FONT: Font is not supported by LoadFontEx/LoadFontFromMemory or no glyphs found, reverted to default font");
     font = GetFontDefault();
 #endif
 


### PR DESCRIPTION
Added warning to `LoadFontEx`/`LoadFontFromMemory`, brought up from https://github.com/raysan5/raylib/issues/5856 where some font formats are unavailable to load from memory

the easiest way to see this is to make a small change to `text/text_unicode_emojis`
```c
Font fontDefault = LoadFont("resources/dejavu.fnt");
// =>
Font fontDefault = LoadFontEx("resources/dejavu.fnt", 32, NULL, 95);
```
```
INFO: FILEIO: [resources/dejavu.fnt] File loaded successfully
WARNING: FONT: Font is not supported by LoadFontEx/LoadFontFromMemory or no glyphs found, reverted to default font
```