### PR TITLE
[cmake]: remove GLFW_BUILD warnings for when platform is SDL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ include(CompilerFlags)
 # Registers build options that are exposed to cmake
 include(CMakeOptions.txt)
 
-if (UNIX AND NOT APPLE AND NOT "${PLATFORM}" MATCHES "DRM" AND NOT "${PLATFORM}" MATCHES "Web")
+if (UNIX AND NOT APPLE AND NOT "${PLATFORM}" MATCHES "DRM" AND NOT "${PLATFORM}" MATCHES "Web" AND NOT "${PLATFORM}" MATCHES "SDL")
   if (NOT GLFW_BUILD_WAYLAND AND NOT GLFW_BUILD_X11)
     message(FATAL_ERROR "Cannot disable both Wayland and X11")
   endif()


### PR DESCRIPTION
This warning is for people who have `GLFW_BUILD_WAYLAND` and `GLFW_BUILD_X11` disabled but this only matters when you're compiling for GLFW platform