### PR TITLE
[rcore][GLFW] Prevent GLFW fullscreen from always being on top

### DIFF
--- a/src/external/glfw/src/win32_window.c
+++ b/src/external/glfw/src/win32_window.c
@@ -1901,7 +1901,7 @@ void _glfwSetWindowMonitorWin32(_GLFWwindow* window,
         acquireMonitorWin32(window);
 
         GetMonitorInfoW(window->monitor->win32.handle, &mi);
-        SetWindowPos(window->win32.handle, HWND_TOPMOST,
+        SetWindowPos(window->win32.handle, HWND_TOP,
                      mi.rcMonitor.left,
                      mi.rcMonitor.top,
                      mi.rcMonitor.right - mi.rcMonitor.left,


### PR DESCRIPTION
fixes this issue https://github.com/raysan5/raylib/issues/5854

Seems to be as simple as changing a flag from "TOPMOST" to "TOP" :)