### PR TITLE
Fix build.zig building examples all the time

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -739,7 +739,6 @@ fn addExamples(
                 .root_module = exe_mod,
                 .use_lld = target.result.os.tag == .windows,
             });
-            b.installArtifact(exe);
 
             const install_cmd = b.addInstallArtifact(exe, .{ .dest_sub_path = b.fmt("{s}/{s}", .{ module, filename }) });
 


### PR DESCRIPTION
The `installArtifact` was adding the examples to be built and installed when building the raylib even when not asking to build the examples.

The `addInstallArtifact` already adds it to be built and installed in the correct folder when asked to build the examples.