### PR TITLE
Fix compilation for -DPLATFORM=RGFW

### DIFF
--- a/examples/others/raylib_opengl_interop.c
+++ b/examples/others/raylib_opengl_interop.c
@@ -28,7 +28,7 @@
 
 #include "raylib.h"
 
-#if defined(PLATFORM_DESKTOP) || defined(PLATFORM_DESKTOP_SDL)
+#if defined(PLATFORM_DESKTOP) || defined(PLATFORM_DESKTOP_SDL) || defined(PLATFORM_DESKTOP_RGFW)
     #if defined(GRAPHICS_API_OPENGL_ES2)
         #include "glad_gles2.h"       // Required for: OpenGL functionality
         #define glGenVertexArrays glGenVertexArraysOES


### PR DESCRIPTION
When compiling with
cmake -S . -B build-desktop-rgfw -DPLATFORM=RGFW -DCMAKE_BUILD_TYPE=Release 
cmake --build build-desktop-rgfw

these errors appeared:
raylib/examples/others/raylib_opengl_interop.c:100:5: error: unknown type name ‘GLuint’
  100 |     GLuint vao = 0;
[etc]