### PR TITLE
[rcore][GLFW] Fix `GetClipboardImage()` creating new connection under X11

### DIFF
--- a/src/platforms/rcore_desktop_glfw.c
+++ b/src/platforms/rcore_desktop_glfw.c
@@ -112,13 +112,6 @@
 typedef struct {
     GLFWwindow *handle;                 // GLFW window handle (graphic device)
 #if defined(__linux__) && defined(_GLFW_X11)
-#if SUPPORT_CLIPBOARD_IMAGE && SUPPORT_MODULE_RTEXTURES
-    // Clipboard specific
-    Display *cbDisplay;
-    XID cbWindow;
-    Atom cbAtom, cbTargetAtom, cbPropertyAtom;
-#endif
-
     // Local storage for the window handle returned by glfwGetX11Window
     // This is needed as X11 handles are integers and may not fit inside a pointer depending on platform
     // Storing the handle locally and returning a pointer in GetWindowHandle allows the code to work regardless of pointer width
@@ -1068,34 +1061,31 @@ Image GetClipboardImage(void)
     else image = LoadImageFromMemory(".bmp", (const unsigned char *)bmpData, (int)dataSize);
 
 #elif defined(__linux__) && defined(_GLFW_X11)
-
     // REF: https://github.com/ColleagueRiley/Clipboard-Copy-Paste/blob/main/x11.c
-    if(!platform.cbDisplay)
+
+    static Atom clipboard = 0;
+    static Atom targetType = 0;
+    static Atom property = 0;
+
+    Display *display = glfwGetX11Display();
+    XID window = glfwGetX11Window(platform.handle);
+
+    // Lazy-load X11 atoms
+    if(clipboard == 0)
     {
-        platform.cbDisplay = XOpenDisplay(NULL);
-        if (!platform.cbDisplay) return image;
-
-        platform.cbWindow = XCreateSimpleWindow(
-            platform.cbDisplay,                    // The connection to the X Server
-            DefaultRootWindow(platform.cbDisplay), // The 'Parent' window (usually the desktop/root)
-            0, 0,                                         // X and Y position on the screen
-            1, 1,                                         // Width and Height (1x1 pixel)
-            0,                                            // Border width
-            0,                                            // Border color
-            0                                             // Background color
-        );
-
-        platform.cbAtom = XInternAtom(platform.cbDisplay, "CLIPBOARD", False);
-        platform.cbTargetAtom = XInternAtom(platform.cbDisplay, "image/png", False); // Ask for PNG
-        platform.cbPropertyAtom = XInternAtom(platform.cbDisplay, "RAYLIB_CLIPBOARD_MANAGER", False);
+        clipboard = XInternAtom(display, "CLIPBOARD", False);
+        targetType = XInternAtom(display, "image/png", False);
+        property = XInternAtom(display, "RAYLIB_CLIPBOARD_MANAGER", False);
     }
 
-    // Request the data: "Convert whatever is in CLIPBOARD to image/png and put it in RAYLIB_CLIPBOARD_MANAGER"
-    XConvertSelection(platform.cbDisplay, platform.cbAtom, platform.cbTargetAtom, platform.cbPropertyAtom, platform.cbWindow, CurrentTime);
+    XConvertSelection(display, clipboard, targetType, property, window, CurrentTime);
+    XSync(display, 0);
 
-    // Wait for the SelectionNotify event
     XEvent ev = { 0 };
-    XNextEvent(platform.cbDisplay, &ev);
+    bool eventFound;
+
+    // Keep calling until we get SelectionNotify
+    do { eventFound = XCheckTypedEvent(display, SelectionNotify, &ev); } while(!eventFound);
 
     Atom actualType = { 0 };
     int actualFormat = 0;
@@ -1103,15 +1093,15 @@ Image GetClipboardImage(void)
     unsigned long bytesAfter = 0;
     unsigned char *data = NULL;
 
-    // Read the data from our ghost window's property
-    XGetWindowProperty(platform.cbDisplay, platform.cbWindow, platform.cbPropertyAtom, 0, ~0L, False, AnyPropertyType,
-        &actualType, &actualFormat, &nitems, &bytesAfter, &data);
+    XGetWindowProperty(display, window, property, 0, ~0L, False, AnyPropertyType,
+                       &actualType, &actualFormat, &nitems, &bytesAfter, &data);
 
     if (data != NULL)
     {
         image = LoadImageFromMemory(".png", data, (int)nitems);
         XFree(data);
     }
+
 #else
     TRACELOG(LOG_WARNING, "GetClipboardImage() not implemented on target platform");
 #endif // _WIN32
@@ -1877,13 +1867,6 @@ void ClosePlatform(void)
 
 #if defined(_WIN32) && SUPPORT_WINMM_HIGHRES_TIMER && !SUPPORT_BUSY_WAIT_LOOP
     timeEndPeriod(1);           // Restore time period
-#elif defined(__linux__) && defined(_GLFW_X11) && SUPPORT_CLIPBOARD_IMAGE && SUPPORT_MODULE_RTEXTURES
-    if(platform.cbDisplay)     // Unload clipboard connection
-    {
-        XDestroyWindow(platform.cbDisplay, platform.cbWindow);
-        XCloseDisplay(platform.cbDisplay);
-        platform.cbDisplay = NULL;
-    }
 #endif
 }
 

--- a/src/platforms/rcore_desktop_glfw.c
+++ b/src/platforms/rcore_desktop_glfw.c
@@ -1082,10 +1082,9 @@ Image GetClipboardImage(void)
     XSync(display, 0);
 
     XEvent ev = { 0 };
-    bool eventFound;
 
     // Keep calling until we get SelectionNotify
-    do { eventFound = XCheckTypedEvent(display, SelectionNotify, &ev); } while(!eventFound);
+    while (XCheckTypedEvent(display, SelectionNotify, &ev) == False);
 
     Atom actualType = { 0 };
     int actualFormat = 0;

--- a/src/platforms/rcore_desktop_glfw.c
+++ b/src/platforms/rcore_desktop_glfw.c
@@ -112,6 +112,13 @@
 typedef struct {
     GLFWwindow *handle;                 // GLFW window handle (graphic device)
 #if defined(__linux__) && defined(_GLFW_X11)
+#if SUPPORT_CLIPBOARD_IMAGE && SUPPORT_MODULE_RTEXTURES
+    // Clipboard specific
+    Display *cbDisplay;
+    XID cbWindow;
+    Atom cbAtom, cbTargetAtom, cbPropertyAtom;
+#endif
+
     // Local storage for the window handle returned by glfwGetX11Window
     // This is needed as X11 handles are integers and may not fit inside a pointer depending on platform
     // Storing the handle locally and returning a pointer in GetWindowHandle allows the code to work regardless of pointer width
@@ -1042,11 +1049,6 @@ const char *GetClipboardText(void)
     return glfwGetClipboardString(platform.handle);
 }
 
-#if SUPPORT_CLIPBOARD_IMAGE && defined(__linux__) && defined(_GLFW_X11)
-    #include <X11/Xlib.h>
-    #include <X11/Xatom.h>
-#endif
-
 // Get clipboard image
 Image GetClipboardImage(void)
 {
@@ -1068,30 +1070,32 @@ Image GetClipboardImage(void)
 #elif defined(__linux__) && defined(_GLFW_X11)
 
     // REF: https://github.com/ColleagueRiley/Clipboard-Copy-Paste/blob/main/x11.c
-    Display *dpy = XOpenDisplay(NULL);
-    if (!dpy) return image;
+    if(!platform.cbDisplay)
+    {
+        platform.cbDisplay = XOpenDisplay(NULL);
+        if (!platform.cbDisplay) return image;
 
-    Window root = DefaultRootWindow(dpy);
-    Window win = XCreateSimpleWindow(
-        dpy,      // The connection to the X Server
-        root,     // The 'Parent' window (usually the desktop/root)
-        0, 0,     // X and Y position on the screen
-        1, 1,     // Width and Height (1x1 pixel)
-        0,        // Border width
-        0,        // Border color
-        0         // Background color
-    );
+        platform.cbWindow = XCreateSimpleWindow(
+            platform.cbDisplay,                    // The connection to the X Server
+            DefaultRootWindow(platform.cbDisplay), // The 'Parent' window (usually the desktop/root)
+            0, 0,                                         // X and Y position on the screen
+            1, 1,                                         // Width and Height (1x1 pixel)
+            0,                                            // Border width
+            0,                                            // Border color
+            0                                             // Background color
+        );
 
-    Atom clipboard = XInternAtom(dpy, "CLIPBOARD", False);
-    Atom targetType = XInternAtom(dpy, "image/png", False); // Ask for PNG
-    Atom property = XInternAtom(dpy, "RAYLIB_CLIPBOARD_MANAGER", False);
+        platform.cbAtom = XInternAtom(platform.cbDisplay, "CLIPBOARD", False);
+        platform.cbTargetAtom = XInternAtom(platform.cbDisplay, "image/png", False); // Ask for PNG
+        platform.cbPropertyAtom = XInternAtom(platform.cbDisplay, "RAYLIB_CLIPBOARD_MANAGER", False);
+    }
 
     // Request the data: "Convert whatever is in CLIPBOARD to image/png and put it in RAYLIB_CLIPBOARD_MANAGER"
-    XConvertSelection(dpy, clipboard, targetType, property, win, CurrentTime);
+    XConvertSelection(platform.cbDisplay, platform.cbAtom, platform.cbTargetAtom, platform.cbPropertyAtom, platform.cbWindow, CurrentTime);
 
     // Wait for the SelectionNotify event
     XEvent ev = { 0 };
-    XNextEvent(dpy, &ev);
+    XNextEvent(platform.cbDisplay, &ev);
 
     Atom actualType = { 0 };
     int actualFormat = 0;
@@ -1100,7 +1104,7 @@ Image GetClipboardImage(void)
     unsigned char *data = NULL;
 
     // Read the data from our ghost window's property
-    XGetWindowProperty(dpy, win, property, 0, ~0L, False, AnyPropertyType,
+    XGetWindowProperty(platform.cbDisplay, platform.cbWindow, platform.cbPropertyAtom, 0, ~0L, False, AnyPropertyType,
         &actualType, &actualFormat, &nitems, &bytesAfter, &data);
 
     if (data != NULL)
@@ -1108,9 +1112,6 @@ Image GetClipboardImage(void)
         image = LoadImageFromMemory(".png", data, (int)nitems);
         XFree(data);
     }
-
-    XDestroyWindow(dpy, win);
-    XCloseDisplay(dpy);
 #else
     TRACELOG(LOG_WARNING, "GetClipboardImage() not implemented on target platform");
 #endif // _WIN32
@@ -1876,6 +1877,13 @@ void ClosePlatform(void)
 
 #if defined(_WIN32) && SUPPORT_WINMM_HIGHRES_TIMER && !SUPPORT_BUSY_WAIT_LOOP
     timeEndPeriod(1);           // Restore time period
+#elif defined(__linux__) && defined(_GLFW_X11) && SUPPORT_CLIPBOARD_IMAGE && SUPPORT_MODULE_RTEXTURES
+    if(platform.cbDisplay)     // Unload clipboard connection
+    {
+        XDestroyWindow(platform.cbDisplay, platform.cbWindow);
+        XCloseDisplay(platform.cbDisplay);
+        platform.cbDisplay = NULL;
+    }
 #endif
 }
 


### PR DESCRIPTION
As of now, GetClipboardImage creates a new connection and a ghost window to retrieve image data and then unloads it all. This adds unnecessary overhead for this function caused by establishing and terminating connection.

This PR ~~stores this clipboard connection and other related data in the global platform struct but is also lazy loaded (so a first call would have the overhead and subsequent ones would not). The clipboard handling data is unloaded upon ClosePlatform.~~

**Update 18/05/26**: Now this PR makes the use of the main raylib connection without creating new ones at all.  

Tested with ubench:

```c

UBENCH_EX(raylib, clipboard_image) {
    Image images[10];

    UBENCH_DO_BENCHMARK() {
        for(int i = 0; i < 10; ++i)
            images[i] = GetClipboardImage();
    }

    for(int i = 0; i < 10; ++i)
        UnloadImage(images[i]);
}

```

Without the fix, the result is: 

```
[       OK ] raylib.clipboard_image (mean 4.350ms, confidence interval +- 1.332339%)
```

With the fix:

```
[       OK ] raylib.clipboard_image (mean 499.261us, confidence interval +- 1.124542%)
```

