### PR TITLE
[rshapes] Fix `DrawRectangleRounded` automatic segments count to be consistent with `DrawRectangleRoundedLinesEx`

### DIFF
--- a/src/rshapes.c
+++ b/src/rshapes.c
@@ -960,7 +960,7 @@ void DrawRectangleRounded(Rectangle rec, float roundness, int segments, Color co
     {
         // Calculate the maximum angle between segments based on the error rate (usually 0.5f)
         float th = acosf(2*powf(1 - SMOOTH_CIRCLE_ERROR_RATE/radius, 2) - 1);
-        segments = (int)(ceilf(2*PI/th)/4.0f);
+        segments = (int)(ceilf(2*PI/th)/2.0f);
         if (segments <= 0) segments = 4;
     }
 


### PR DESCRIPTION
The `DrawRectangleRounded` when set segments count < 4 automatically calculates number of segments needed to draw smoother corners, but it divides the count by 4 instead of 2 which `DrawRectangleRoundedLinesEx` does. This fix makes `DrawRectangleRounded` use the same math as `DrawRectangleRoundedLinesEx`.

Before fix:
<img width="135" height="117" alt="image" src="https://github.com/user-attachments/assets/0855b590-8f54-4964-a5df-74ba852180e4" />

Notice fewer segments for the `DrawRectangleRounded` (gray colored box) compared to the `DrawRectangleRoundedLinesEx` (black colored outline) with same rectangle.

After fix:
<img width="135" height="117" alt="image" src="https://github.com/user-attachments/assets/bc738bc5-6b19-4a02-a492-a9fa07e56544" />