### PR TITLE
[rmodels] Fix glTF skinning when joints have non-joint parent nodes

### DIFF
--- a/src/rmodels.c
+++ b/src/rmodels.c
@@ -6517,8 +6517,6 @@ static ModelAnimation *LoadModelAnimationsGLTF(const char *fileName, int *animCo
         if (data->skins_count > 0)
         {
             cgltf_skin skin = data->skins[0];
-            *animCount = (int)data->animations_count;
-            animations = (ModelAnimation *)RL_CALLOC(data->animations_count, sizeof(ModelAnimation));
 
             // Precompute, per joint, the static transform contributed by any
             // intermediate non-joint nodes between the joint and its nearest
@@ -6527,23 +6525,47 @@ static ModelAnimation *LoadModelAnimationsGLTF(const char *fileName, int *animCo
             // joints themselves. Depends only on the skin, not the animation.
             int jointCount = (int)skin.joints_count;
             Matrix *extOffset = (Matrix *)RL_MALLOC(jointCount*sizeof(Matrix));
+
+            if (extOffset == NULL)
+            {
+                // Allocation failed: abort animation loading at the source rather than
+                // propagating a NULL pointer into the per-frame transform loop below
+                TRACELOG(LOG_WARNING, "MODEL: [%s] Failed to allocate joint offset buffer", fileName);
+                cgltf_free(data);
+                UnloadFileData(fileData);
+                *animCount = 0;
+                return NULL;
+            }
+
+            *animCount = (int)data->animations_count;
+            animations = (ModelAnimation *)RL_CALLOC(data->animations_count, sizeof(ModelAnimation));
+
             for (int k = 0; k < jointCount; k++)
             {
                 extOffset[k] = MatrixIdentity();
                 cgltf_node *n = skin.joints[k]->parent;
+
                 while (n != NULL)
                 {
                     bool isJoint = false;
                     for (int jj = 0; jj < jointCount; jj++)
                     {
-                        if (skin.joints[jj] == n) { isJoint = true; break; }
+                        if (skin.joints[jj] == n)
+                        {
+                            isJoint = true;
+                            break;
+                        }
                     }
+
                     if (isJoint) break;
-                    Matrix nm = MatrixMultiply(MatrixMultiply(
-                        MatrixScale(n->scale[0], n->scale[1], n->scale[2]),
-                        QuaternionToMatrix((Quaternion){ n->rotation[0], n->rotation[1], n->rotation[2], n->rotation[3] })),
-                        MatrixTranslate(n->translation[0], n->translation[1], n->translation[2]));
-                    extOffset[k] = MatrixMultiply(extOffset[k], nm);
+
+                    // Compose the intermediate node's local TRS (scale, then rotation, then translation)
+                    Matrix nodeScale = MatrixScale(n->scale[0], n->scale[1], n->scale[2]);
+                    Matrix nodeRotation = QuaternionToMatrix((Quaternion){ n->rotation[0], n->rotation[1], n->rotation[2], n->rotation[3] });
+                    Matrix nodeTranslation = MatrixTranslate(n->translation[0], n->translation[1], n->translation[2]);
+                    Matrix nodeTransform = MatrixMultiply(MatrixMultiply(nodeScale, nodeRotation), nodeTranslation);
+
+                    extOffset[k] = MatrixMultiply(extOffset[k], nodeTransform);
                     n = n->parent;
                 }
             }

--- a/src/rmodels.c
+++ b/src/rmodels.c
@@ -5375,16 +5375,18 @@ static BoneInfo *LoadBoneInfoGLTF(cgltf_skin skin, int *boneCount)
         cgltf_node node = *skin.joints[i];
         if (node.name != NULL) strncpy(bones[i].name, node.name, sizeof(bones[i].name) - 1);
 
-        // Find parent bone index
+        // Find parent bone index by walking up the node tree past any
+        // non-joint ancestors (intermediate transform nodes used by some
+        // DCC exporters), until we hit a node that is also in skin.joints.
         int parentIndex = -1;
-
-        for (unsigned int j = 0; j < skin.joints_count; j++)
+        cgltf_node *ancestor = node.parent;
+        while (ancestor != NULL && parentIndex == -1)
         {
-            if (skin.joints[j] == node.parent)
+            for (unsigned int j = 0; j < skin.joints_count; j++)
             {
-                parentIndex = (int)j;
-                break;
+                if (skin.joints[j] == ancestor) { parentIndex = (int)j; break; }
             }
+            if (parentIndex == -1) ancestor = ancestor->parent;
         }
 
         bones[i].parent = parentIndex;
@@ -6518,17 +6520,33 @@ static ModelAnimation *LoadModelAnimationsGLTF(const char *fileName, int *animCo
             *animCount = (int)data->animations_count;
             animations = (ModelAnimation *)RL_CALLOC(data->animations_count, sizeof(ModelAnimation));
 
-            Transform worldTransform = { 0 };
-            cgltf_float cgltf_worldTransform[16] = { 0 };
-            cgltf_node *node = skin.joints[0];
-            cgltf_node_transform_world(node->parent, cgltf_worldTransform);
-            Matrix worldMatrix = {
-                cgltf_worldTransform[0], cgltf_worldTransform[4], cgltf_worldTransform[8], cgltf_worldTransform[12],
-                cgltf_worldTransform[1], cgltf_worldTransform[5], cgltf_worldTransform[9], cgltf_worldTransform[13],
-                cgltf_worldTransform[2], cgltf_worldTransform[6], cgltf_worldTransform[10], cgltf_worldTransform[14],
-                cgltf_worldTransform[3], cgltf_worldTransform[7], cgltf_worldTransform[11], cgltf_worldTransform[15]
-            };
-            MatrixDecompose(worldMatrix, &worldTransform.translation, &worldTransform.rotation, &worldTransform.scale);
+            // Precompute, per joint, the static transform contributed by any
+            // intermediate non-joint nodes between the joint and its nearest
+            // joint ancestor. This handles exporters (e.g. wow.export) that
+            // store bone offsets on dummy parent nodes rather than on the
+            // joints themselves. Depends only on the skin, not the animation.
+            int jointCount = (int)skin.joints_count;
+            Matrix *extOffset = (Matrix *)RL_MALLOC(jointCount*sizeof(Matrix));
+            for (int k = 0; k < jointCount; k++)
+            {
+                extOffset[k] = MatrixIdentity();
+                cgltf_node *n = skin.joints[k]->parent;
+                while (n != NULL)
+                {
+                    bool isJoint = false;
+                    for (int jj = 0; jj < jointCount; jj++)
+                    {
+                        if (skin.joints[jj] == n) { isJoint = true; break; }
+                    }
+                    if (isJoint) break;
+                    Matrix nm = MatrixMultiply(MatrixMultiply(
+                        MatrixScale(n->scale[0], n->scale[1], n->scale[2]),
+                        QuaternionToMatrix((Quaternion){ n->rotation[0], n->rotation[1], n->rotation[2], n->rotation[3] })),
+                        MatrixTranslate(n->translation[0], n->translation[1], n->translation[2]));
+                    extOffset[k] = MatrixMultiply(extOffset[k], nm);
+                    n = n->parent;
+                }
+            }
 
             for (unsigned int a = 0; a < data->animations_count; a++)
             {
@@ -6637,19 +6655,19 @@ static ModelAnimation *LoadModelAnimationsGLTF(const char *fileName, int *animCo
                             }
                         }
 
-                        animations[a].keyframePoses[j][k] = (Transform){
-                            .translation = translation,
-                            .rotation = rotation,
-                            .scale = scale
-                        };
-                    }
+                        // Compose joint local TRS, then prepend the static
+                        // intermediate non-joint offsets so the final TRS is
+                        // expressed relative to the joint's skeleton parent.
+                        Matrix S = MatrixScale(scale.x, scale.y, scale.z);
+                        Matrix R = QuaternionToMatrix(rotation);
+                        Matrix T = MatrixTranslate(translation.x, translation.y, translation.z);
+                        Matrix jointLocal = MatrixMultiply(MatrixMultiply(S, R), T);
+                        Matrix combined = MatrixMultiply(jointLocal, extOffset[k]);
 
-                    Transform *root = &animations[a].keyframePoses[j][0];
-                    root->rotation = QuaternionMultiply(worldTransform.rotation, root->rotation);
-                    root->scale = Vector3Multiply(root->scale, worldTransform.scale);
-                    root->translation = Vector3Multiply(root->translation, worldTransform.scale);
-                    root->translation = Vector3RotateByQuaternion(root->translation, worldTransform.rotation);
-                    root->translation = Vector3Add(root->translation, worldTransform.translation);
+                        Transform tr;
+                        MatrixDecompose(combined, &tr.translation, &tr.rotation, &tr.scale);
+                        animations[a].keyframePoses[j][k] = tr;
+                    }
 
                     BuildPoseFromParentJoints(bones, animations[a].boneCount, animations[a].keyframePoses[j]);
                 }
@@ -6658,6 +6676,8 @@ static ModelAnimation *LoadModelAnimationsGLTF(const char *fileName, int *animCo
                 RL_FREE(boneChannels);
                 RL_FREE(bones);
             }
+
+            RL_FREE(extOffset);
         }
 
         if (data->skins_count > 1)


### PR DESCRIPTION
# [rmodels] Fix glTF skinning when joints have non-joint parent nodes

## Summary

Two surgical fixes in `src/rmodels.c` that correct glTF skinning for files
where the skin's joints are nested under intermediate non-joint transform
nodes that carry part of the bind-pose offset. Common in exports from
wow.export, and seen in some Blender/Maya/Houdini pipelines that wrap an
armature in a parent "rig" or "offset" empty.

Both spec-compliant files (every skeletal `.glb` shipped with raylib's
examples) and previously broken files now render correctly.

## The bug

A glTF skin lists which nodes are joints. The skeleton hierarchy that
raylib reconstructs from that list assumes each joint's parent in
`skin.joints[]` equals its node-tree parent. Many real-world files
violate this: a joint can have a non-joint ancestor (a plain transform
node) sitting between it and the next joint up the chain. That
intermediate node's TRS is part of the model's bind pose and must be
applied to the joint's animation frames; otherwise the per-frame world
transform diverges from the bind world transform, the inverse-bind
multiplication in `UpdateModelAnimationBoneMatrices` produces
non-identity skin matrices at rest, and the mesh explodes.

`LoadGLTF` already handles this correctly when building `bindPose`
because it calls `cgltf_node_transform_world(joint)` per joint, which
walks the full ancestor chain. The two animation-side functions did not.

Repro file: babyoctopus.gltf from a wow.export of a World of Warcraft
model. Stock raylib renders a stretched/inverted mesh; f3d, the Khronos
sample viewer, and three.js all render it correctly. Screenshots
attached.

## The fix

### 1. `LoadBoneInfoGLTF`

Replace the single-step parent comparison with a loop that walks
`node.parent->parent->parent...` until it either hits a node listed in
`skin.joints[]` or runs off the scene root. Joints whose direct parent
is a non-joint were previously assigned `parent = -1` (treated as
skeleton roots), corrupting the chain used by `BuildPoseFromParentJoints`.

### 2. `LoadModelAnimationsGLTF`

Precompute once per skin a `Matrix extOffset[k]` per joint that bakes in
the composed TRS of every intermediate non-joint node between joint `k`
and its nearest joint ancestor. Then, in the per-frame loop, compose the
joint's local TRS into a matrix, multiply by `extOffset[k]`, and
`MatrixDecompose` back to TRS before storing in `keyframePoses`. The
result is the joint's transform expressed relative to its skeleton
parent, which is what `BuildPoseFromParentJoints` expects.

This also subsumes the previous root-only `worldTransform` adjustment
block — the new `extOffset[0]` covers it for the root joint and
correctly extends the same logic to every joint. The dead variables and
the root patch-up are removed.

## Diff size

+49 / -29 lines in one file. No new files, no API changes, no behaviour
changes for files that don't have intermediate non-joint nodes.

## Validation

Built on Linux with cmake + gcc, no warnings.

Regression sweep across every skeletal `.glb` in raylib's examples
(`robot.glb`, `greenman.glb`, `raylib_logo_3d.glb`, `old_car_new.glb`,
`plane.glb`, `shaders/robot.glb`): pixel-identical output before/after
under fixed-camera screenshot comparison. Any noise was sub-0.0002 and
traced to HUD framerate-counter antialiasing, not 3D output.

Visual verification of the broken file (babyoctopus.gltf): now matches
f3d, the Khronos sample viewer, and three.js.

## Known limitation (pre-existing, not addressed by this PR)

If a non-joint ancestor uses a 4×4 `matrix` instead of TRS
(`node->has_matrix == 1` in cgltf), this patch's `extOffset` builder
reads `n->scale`/`n->rotation`/`n->translation` directly and ignores
`matrix`. This matches the rest of `rmodels.c` (no `has_matrix`
references; joint TRS reader behaves the same way). Properly handling
matrix-form nodes would be a separate, file-wide change.

## Checklist

- [x] Fixes a real bug observed in third-party files
- [x] Two existing functions changed; no new APIs
- [x] No behavioural change for files that previously rendered correctly
- [x] Builds clean (Linux, gcc, no new warnings)
- [x] Code style matches surrounding `rmodels.c`
<img width="1280" height="800" alt="babyoctopus gltf_stock" src="https://github.com/user-attachments/assets/d4befc46-b174-4591-83c9-a2e9335c9559" />
<img width="1280" height="800" alt="babyoctopus gltf_patch" src="https://github.com/user-attachments/assets/3d078c94-b057-464b-bec7-5b301323fedf" />
