### PR TITLE
[CMake] Properly remove raudio.c and rmodels.c if they're disabled modules

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,7 +31,6 @@ set(raylib_public_headers
 # Sources to be compiled
 set(raylib_sources
     rcore.c
-    rmodels.c
     rshapes.c
     rtext.c
     rtextures.c
@@ -40,6 +39,11 @@ set(raylib_sources
 # Only build raudio if it's enabled
 if (NOT DEFINED SUPPORT_MODULE_RAUDIO OR SUPPORT_MODULE_RAUDIO)
     list(APPEND raylib_sources raudio.c)
+endif()
+
+# Only build rmodels if it's enabled
+if (NOT DEFINED SUPPORT_MODULE_RMODELS OR SUPPORT_MODULE_RMODELS)
+    list(APPEND raylib_sources rmodels.c)
 endif()
 
 # <root>/cmake/GlfwImport.cmake handles the details around the inclusion of glfw

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -30,13 +30,17 @@ set(raylib_public_headers
 
 # Sources to be compiled
 set(raylib_sources
-    raudio.c
     rcore.c
     rmodels.c
     rshapes.c
     rtext.c
     rtextures.c
     )
+
+# Only build raudio if it's enabled
+if (NOT DEFINED SUPPORT_MODULE_RAUDIO OR SUPPORT_MODULE_RAUDIO)
+    list(APPEND raylib_sources raudio.c)
+endif()
 
 # <root>/cmake/GlfwImport.cmake handles the details around the inclusion of glfw
 if (NOT ${PLATFORM} MATCHES "Web")
@@ -48,10 +52,10 @@ endif ()
 # Produces a variable LIBS_PRIVATE that will be used later
 include(LibraryConfigurations)
 
-if (SUPPORT_MODULE_RAUDIO)
-    MESSAGE(STATUS "Audio Backend: miniaudio")
-else ()
+if (DEFINED SUPPORT_MODULE_RAUDIO AND NOT SUPPORT_MODULE_RAUDIO)
     MESSAGE(STATUS "Audio Backend: None (-DCUSTOMIZE_BUILD=ON -DSUPPORT_MODULE_RAUDIO=OFF)")
+else ()
+    MESSAGE(STATUS "Audio Backend: miniaudio")
 endif ()
 
 add_library(raylib ${raylib_sources} ${raylib_public_headers})


### PR DESCRIPTION
`raudio.c` and `rmodels.c` C files are still being built by raylib's CMake even if the module is disabled.

After further investigation I discovered that the Makefile (using make), already takes these removals into account.  Line 756 of src/Makefile:
```
ifeq ($(RAYLIB_MODULE_MODELS),TRUE)
    OBJS += rmodels.o
endif
```

Because of those omissions of the `.o` tasks, these C files aren't compiled when `RAYLIB_MODULE_MODELS` or `RAYLIB_MODULE_AUDIO` are set to `FALSE`.  This means CMake's behaviour doesn't line up with Make.  https://github.com/raysan5/raylib/blob/0d78f10161f9d3df38b10bd33444451b7ee11eda/src/Makefile#L867

Now, if a developer were to attempt to use the CMake version of these omissions (`SUPPORT_MODULE_RAUDIO` and `SUPPORT_MODULE_RMODELS`) and set them to `0` (`OFF`), the C files still get included.  This is because the CMake is still putting them on the project by force.  
```
# Sources to be compiled
set(raylib_sources
    raudio.c                    <<< different from Makefile
    rcore.c
    rmodels.c                 <<< different from Makefile
    rshapes.c
    rtext.c
    rtextures.c
    )
```

This PR adds logic to omit those C files if the `SUPPORT_MODULE_RAUDIO` or `SUPPORT_MODULE_RMODELS` flags on CMake configure were disabled.  This makes the logic inline with what the other Makefiles are doing.

This makes it easier on devs who want to use Raylib's CMake directly instead of writing their own CMake from scratch that rips apart C files, if it makes sense for them on their platform. 

Whilst this is not useful for debloating the libraylib.a output (gcc already strips away enough that the compile size difference is a mere few hundred bytes)...

What it is useful for is getting rid of compiler errors thrown by rmodels.c or raudio.c if you don't include certain libraries (file system related) on your platform target (such as embedded pico or esp32), even though you told CMake to not use those two files in the first place via `SUPPORT_MODULE_XXX`
