### PR TITLE
[rshapes] Fix auto segment rounded-corner math and rounding

### DIFF
--- a/src/rshapes.c
+++ b/src/rshapes.c
@@ -361,7 +361,7 @@ void DrawCircleSector(Vector2 center, float radius, float startAngle, float endA
     {
         // Calculate the maximum angle between segments based on the error rate (usually 0.5f)
         float th = acosf(2*powf(1 - SMOOTH_CIRCLE_ERROR_RATE/radius, 2) - 1);
-        segments = (int)((endAngle - startAngle)*ceilf(2*PI/th)/360);
+        segments = (int)ceilf((endAngle - startAngle)*(2*PI/th)/360.0f);
 
         if (segments <= 0) segments = minSegments;
     }
@@ -453,7 +453,7 @@ void DrawCircleSectorLines(Vector2 center, float radius, float startAngle, float
     {
         // Calculate the maximum angle between segments based on the error rate (usually 0.5f)
         float th = acosf(2*powf(1 - SMOOTH_CIRCLE_ERROR_RATE/radius, 2) - 1);
-        segments = (int)((endAngle - startAngle)*ceilf(2*PI/th)/360);
+        segments = (int)ceilf((endAngle - startAngle)*(2*PI/th)/360.0f);
 
         if (segments <= 0) segments = minSegments;
     }
@@ -579,7 +579,7 @@ void DrawRing(Vector2 center, float innerRadius, float outerRadius, float startA
     {
         // Calculate the maximum angle between segments based on the error rate (usually 0.5f)
         float th = acosf(2*powf(1 - SMOOTH_CIRCLE_ERROR_RATE/outerRadius, 2) - 1);
-        segments = (int)((endAngle - startAngle)*ceilf(2*PI/th)/360);
+        segments = (int)ceilf((endAngle - startAngle)*(2*PI/th)/360.0f);
 
         if (segments <= 0) segments = minSegments;
     }
@@ -670,7 +670,7 @@ void DrawRingLines(Vector2 center, float innerRadius, float outerRadius, float s
     {
         // Calculate the maximum angle between segments based on the error rate (usually 0.5f)
         float th = acosf(2*powf(1 - SMOOTH_CIRCLE_ERROR_RATE/outerRadius, 2) - 1);
-        segments = (int)((endAngle - startAngle)*ceilf(2*PI/th)/360);
+        segments = (int)ceilf((endAngle - startAngle)*(2*PI/th)/360.0f);
 
         if (segments <= 0) segments = minSegments;
     }
@@ -960,7 +960,7 @@ void DrawRectangleRounded(Rectangle rec, float roundness, int segments, Color co
     {
         // Calculate the maximum angle between segments based on the error rate (usually 0.5f)
         float th = acosf(2*powf(1 - SMOOTH_CIRCLE_ERROR_RATE/radius, 2) - 1);
-        segments = (int)(ceilf(2*PI/th)/2.0f);
+        segments = (int)ceilf((2*PI/th)/4.0f);
         if (segments <= 0) segments = 4;
     }
 
@@ -1195,7 +1195,7 @@ void DrawRectangleRoundedLinesEx(Rectangle rec, float roundness, int segments, f
     {
         // Calculate the maximum angle between segments based on the error rate (usually 0.5f)
         float th = acosf(2*powf(1 - SMOOTH_CIRCLE_ERROR_RATE/radius, 2) - 1);
-        segments = (int)(ceilf(2*PI/th)/2.0f);
+        segments = (int)ceilf((2*PI/th)/4.0f);
         if (segments <= 0) segments = 4;
     }
 


### PR DESCRIPTION
As follow-up to #5875, this PR fixes the auto- segmentation math used by the rounded rectangle path and applies the same rounding correction to the related rshapes helpers.

`DrawRectangleRounded()` and `DrawRectangleRoundedLinesEx()` use segments as the subdivision count for a single 90° corner: `float stepLength = 90.0f/(float)segments;`. Because of that, the correct automatic segment count is based on a quarter circle: `ceil((PI/2)/th)` or equivalently `ceil((2*PI/th)/4)`.

Using `/2` instead computes the subdivision count for a half-circle, which does not match how rounded rectangle corners are actually rendered.

This is also consistent with the other auto-segmentation formulas in rshapes, which scale the full-circle segment count by the portion of arc being rendered, e.g. `ceilf((endAngle - startAngle)*(2*PI/th)/360.0f)`. Rounded rectangle corners are the 90° case of the same logic, which simplifies to `/4`.
 
This PR also moves `ceilf()` to the outside in the affected formulas, so rounding is applied to the final computed segment count rather than to an intermediate full-circle value. That makes the result mathematically consistent for sectors, rings, and rounded rectangle corners.