### PR TITLE
Update listed Raylib version for zig bindings

### DIFF
--- a/BINDINGS.md
+++ b/BINDINGS.md
@@ -90,7 +90,7 @@ Some people ported raylib to other languages in the form of bindings or wrappers
 | [raylib-vapi](https://github.com/lxmcf/raylib-vapi)                                      | **6.0**          | [Vala](https://vala.dev)                                             | Zlib                 |
 | [raylib-wave](https://github.com/wavefnd/raylib-wave)                                    | **auto**         |[Wave](http://wave-lang.dev)                                          | Zlib                 |
 | [raylib-wren](https://github.com/TSnake41/raylib-wren)                                   | 4.5              | [Wren](http://wren.io)                                               | ISC                  |
-| [raylib-zig](https://github.com/raylib-zig/raylib-zig)                                   | **5.6-dev**      | [Zig](https://ziglang.org)                                           | MIT                  |
+| [raylib-zig](https://github.com/raylib-zig/raylib-zig)                                   | **6.0**          | [Zig](https://ziglang.org)                                           | MIT                  |
 | [raylib.zig](https://github.com/ryupold/raylib.zig)                                      | **5.1-dev**      | [Zig](https://ziglang.org)                                           | MIT                  |
 | [raylib-zig-bindings](https://github.com/L-Briand/raylib-zig-bindings)                   | **5.0**          | [Zig](https://ziglang.org)                                           | Zlib                 |
 | [hare-raylib](https://git.sr.ht/~evantj/hare-raylib)                                     | **auto**         | [Hare](https://harelang.org)                                         | Zlib                 |


### PR DESCRIPTION
As per the README at https://github.com/raylib-zig/raylib-zig, raylib-zig now supports raylib 6.0