### PR TITLE
[makefile] ANDROID_ARCH check

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -240,6 +240,9 @@ ifeq ($(TARGET_PLATFORM),PLATFORM_ANDROID)
     ifeq ($(ANDROID_ARCH),x86_64)
         ANDROID_COMPILER_ARCH = x86_64
     endif
+    ifndef ANDROID_COMPILER_ARCH
+        $(error ANDROID_COMPILER_ARCH: Unknown ANDROID_ARCH=$(ANDROID_ARCH))
+    endif
 endif
 
 # Define raylib graphics api depending on selected platform


### PR DESCRIPTION
While I was trying to setup Android build pipeline, I encountered a problem, that Makefile didn't print any useful error message on unknown ANDROID_ARCH. It was using default `gcc` for building and printed many errors that weren't informative. I added simple check during `ANDROID_COMPILER_ARCH` identification, because it's probably doesn't make sense to allow arbitrary `ANDROID_ARCH`  when `TARGET_PLATFORM=PLATFORM_ANDROID`