### PR TITLE
[CMake] Reduce minimum CMake version from 3.25 to 3.22

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.25)
+cmake_minimum_required(VERSION 3.22)
 #this change avoid the warning that appear when we include raylib using Cmake fatch content 
 project(raylib)
 


### PR DESCRIPTION
There isn't anything in 3.25 that we actually need, so we can reduce the minimum requirement. 3.22 is commonly available across many package managers, while it seems like 3.25 isn't quite there.

For a list of the changes in `FetchContent`, see:
https://cmake.org/cmake/help/latest/module/FetchContent.html

cc @elite0OG
