### PR TITLE
[rmodels] Par malloc size fix

### DIFF
--- a/src/external/par_shapes.h
+++ b/src/external/par_shapes.h
@@ -737,8 +737,8 @@ par_shapes_mesh* par_shapes_create_disk(float radius, int slices,
         *norms++ = nnormal[1];
         *norms++ = nnormal[2];
     }
-    mesh->ntriangles = (unsigned int) slices;
-    mesh->triangles = PAR_MALLOC(PAR_SHAPES_T, 3 * mesh->ntriangles);
+    mesh->ntriangles = slices;
+    mesh->triangles = PAR_MALLOC(PAR_SHAPES_T, 3 * (unsigned int) mesh->ntriangles);
     PAR_SHAPES_T* triangles = mesh->triangles;
     for (int i = 0; i < slices; i++) {
         *triangles++ = 0;

--- a/src/external/par_shapes.h
+++ b/src/external/par_shapes.h
@@ -737,8 +737,8 @@ par_shapes_mesh* par_shapes_create_disk(float radius, int slices,
         *norms++ = nnormal[1];
         *norms++ = nnormal[2];
     }
-    mesh->ntriangles = slices;
-    mesh->triangles = PAR_MALLOC(PAR_SHAPES_T, 3 * (uint32_t) mesh->ntriangles);
+    mesh->ntriangles = (unsigned int) slices;
+    mesh->triangles = PAR_MALLOC(PAR_SHAPES_T, 3 * mesh->ntriangles);
     PAR_SHAPES_T* triangles = mesh->triangles;
     for (int i = 0; i < slices; i++) {
         *triangles++ = 0;

--- a/src/external/par_shapes.h
+++ b/src/external/par_shapes.h
@@ -738,7 +738,7 @@ par_shapes_mesh* par_shapes_create_disk(float radius, int slices,
         *norms++ = nnormal[2];
     }
     mesh->ntriangles = slices;
-    mesh->triangles = PAR_MALLOC(PAR_SHAPES_T, 3 * mesh->ntriangles);
+    mesh->triangles = PAR_MALLOC(PAR_SHAPES_T, 3 * (uint32_t) mesh->ntriangles);
     PAR_SHAPES_T* triangles = mesh->triangles;
     for (int i = 0; i < slices; i++) {
         *triangles++ = 0;


### PR DESCRIPTION
Casting ntriangles to an unsigned int appears to stop the warning from triggering. This solution feels hacky, I did try to do:

```c
mesh->ntriangles = (unsigned int) slices;
```

but that still triggered the warning discussed in #5891.

`mesh->ntriangles` could be stored as an unsigned integer? Alternatively the makefile could include [`-Wno-alloc-size-larger-than`](https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wno-alloc-size-larger-than-1)?

Closes #5891 