### PR TITLE
Fix warning about unused variables

### DIFF
--- a/src/rcore.c
+++ b/src/rcore.c
@@ -2277,10 +2277,11 @@ int FileMove(const char *srcPath, const char *dstPath)
 int FileTextReplace(const char *fileName, const char *search, const char *replacement)
 {
     int result = 0;
+
+#if SUPPORT_MODULE_RTEXT
     char *fileText = NULL;
     char *fileTextUpdated = { 0 };
 
-#if SUPPORT_MODULE_RTEXT
     if (FileExists(fileName))
     {
         fileText = LoadFileText(fileName);


### PR DESCRIPTION
This fixes warnings about unused variables when raylib is built with the rtext module disabled.