### PR TITLE
[rmodels] Enable GPU skinning for GL 3.3+,

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -322,7 +322,11 @@
 #endif
 #ifndef SUPPORT_GPU_SKINNING
     // GPU skinning disabled by default, some GPUs do not support more than 8 VBOs
-    #define SUPPORT_GPU_SKINNING        0
+    #if defined (GRAPHICS_API_OPENGL_33) || defined (GRAPHICS_API_OPENGL_43)
+        #define SUPPORT_GPU_SKINNING        1
+    #else
+        #define SUPPORT_GPU_SKINNING        0
+    #endif
 #endif
 
 //------------------------------------------------------------------------------------

--- a/src/rmodels.c
+++ b/src/rmodels.c
@@ -2487,9 +2487,12 @@ static void UpdateModelAnimationVertexBuffers(Model model)
         float boneWeight = 0.0f;
         bool bufferUpdateRequired = false; // Flag to check when anim vertex information is updated
 
+#if defined (SUPPORT_GPU_SKINNING)
+        Material material = model.materials[model.meshMaterial[m]];
         // Skip if missing bone data or missing anim buffers initialization
-        if ((mesh.boneWeights == NULL) || (mesh.boneIndices == NULL) ||
+        if ((material.shader.locs[SHADER_LOC_VERTEX_BONEIDS] != -1) && (mesh.boneWeights == NULL) || (mesh.boneIndices == NULL) ||
             (mesh.animVertices == NULL) || (mesh.animNormals == NULL)) continue;
+#endif
 
         for (int vCounter = 0; vCounter < vertexValuesCount; vCounter += 3)
         {


### PR DESCRIPTION
This PR enables GPU skinning for OpenGL 3.3 and 4.3.
It also ensures that we only do GPU animation if the model shader supports bones. Otherwise it defaults to CPU.
This allows someone to mix and GPU and CPU skinning if needed, and gives modern desktops use of GPU skinning without needing to change the default build.