### PR TITLE
[rmodels] Fix memory leak in UnloadModel()

### DIFF
--- a/src/rmodels.c
+++ b/src/rmodels.c
@@ -1222,6 +1222,8 @@ void UnloadModel(Model model)
     // Unload animation data
     RL_FREE(model.skeleton.bones);
     RL_FREE(model.skeleton.bindPose);
+    RL_FREE(model.currentPose);
+    RL_FREE(model.boneMatrices);
 
     TRACELOG(LOG_INFO, "MODEL: Unloaded model (and meshes) from RAM and VRAM");
 }


### PR DESCRIPTION
## Description
There is a memory leak in `UnloadModel()` when loading and unloading 3D models with bones (skinned models). 
`LoadModel()` allocates memory for `model.currentPose` and `model.boneMatrices`, but `UnloadModel()` does not free them.

## Scope of leak
Tested with a GLB model containing 43 bones on raylib 6.0 (Windows / Visual Studio).
Leak sizes reported by Visual Studio exactly match the bone allocations:
- 43 * sizeof(Transform) = 1720 bytes
- 43 * sizeof(Matrix) = 2752 bytes

## Solution
Added `RL_FREE(model.currentPose);` and `RL_FREE(model.boneMatrices);` inside `UnloadModel()` right before the TRACELOG.

The `RL_FREE` macro safely checks for `NULL`, so this will not cause any issues or crashes for non-animated models (models without bones).