### PR TITLE
[rmodels] Fix minimum rings validation in DrawCapsule and DrawCapsuleWires

### DIFF
--- a/src/rmodels.c
+++ b/src/rmodels.c
@@ -772,7 +772,7 @@ void DrawCylinderWiresEx(Vector3 startPos, Vector3 endPos, float startRadius, fl
 void DrawCapsule(Vector3 startPos, Vector3 endPos, float radius, int rings, int slices, Color color)
 {
     if (slices < 3) slices = 3;
-
+    if (rings  < 1) rings  = 1;
     Vector3 direction = { endPos.x - startPos.x, endPos.y - startPos.y, endPos.z - startPos.z };
 
     // draw a sphere if start and end points are the same
@@ -911,7 +911,7 @@ void DrawCapsule(Vector3 startPos, Vector3 endPos, float radius, int rings, int 
 void DrawCapsuleWires(Vector3 startPos, Vector3 endPos, float radius, int rings, int slices, Color color)
 {
     if (slices < 3) slices = 3;
-
+    if (rings  < 1) rings = 1;
     Vector3 direction = { endPos.x - startPos.x, endPos.y - startPos.y, endPos.z - startPos.z };
 
     // draw a sphere if start and end points are the same


### PR DESCRIPTION
## Description
This PR fixes a missing validation for the `rings` parameter in `DrawCapsule()` and `DrawCapsuleWires()`. 
Currently, `slices` has a minimum guard (`if (slices < 3) slices = 3;`), but `rings` does not, which can cause rendering artifacts or crashes if a user passes `0` or negative values.

## Changes
- Added `if (rings < 1) rings = 1;` to `DrawCapsule()` in `rmodels.c`.
- Added `if (rings < 1) rings = 1;` to `DrawCapsuleWires()` in `rmodels.c`.

## Visuals
<img width="392" height="220" alt="Info-Draw-Capsule" src="https://github.com/user-attachments/assets/67f63777-4a9a-4e82-879c-2b086aea46bb" />

## How to test / Reproduce
Passing `0` to `slices` or `rings` previously caused an issue.

```c
// Example to reproduce the issue (passing 0 to slices/rings)
DrawCapsule((Vector3){0.0f, 0.5f, 7.0f}, (Vector3){0.0f, 1.5f, 7.0f}, 0.3f, 8, 0, LIME);
DrawCapsuleWires((Vector3){7.0f, 0.5f, 7.0f}, (Vector3){7.0f, 1.5f, 7.0f}, 0.3f, 8, 0, MAGENTA);