### PR TITLE
[raudio] Support basic capture streaming to speakers

### DIFF
--- a/src/raudio.c
+++ b/src/raudio.c
@@ -282,7 +282,7 @@ typedef struct tagBITMAPINFOHEADER {
 // Defines and Macros
 //----------------------------------------------------------------------------------
 #ifndef AUDIO_DEVICE_FORMAT
-    #define AUDIO_DEVICE_FORMAT    ma_format_f32    // Device output format (float-32bit)
+    #define AUDIO_DEVICE_FORMAT    ma_format_s32    // Device output format (signed-32bit)
 #endif
 #ifndef AUDIO_DEVICE_CHANNELS
     #define AUDIO_DEVICE_CHANNELS              2    // Device output channels: stereo
@@ -395,6 +395,9 @@ typedef struct AudioData {
         AudioBuffer *last;          // Pointer to last AudioBuffer in the list
         int defaultSize;            // Default audio buffer size for audio streams
     } Buffer;
+    struct {
+        bool isStreaming;
+    } Capture;
     rAudioProcessor *mixedProcessor;
 } AudioData;
 
@@ -408,7 +411,8 @@ static AudioData AUDIO = {          // Global AUDIO context
     // standard double-buffering system, a 4096 samples buffer has been chosen, it should be enough
     // In case of music-stalls, increase this number
     .Buffer.defaultSize = 0,
-    .mixedProcessor = NULL
+    .mixedProcessor = NULL,
+    .Capture.isStreaming = false
 };
 
 //----------------------------------------------------------------------------------
@@ -477,10 +481,13 @@ void InitAudioDevice(void)
 
     // Init audio device
     // NOTE: Using the default device. Format is floating point because it simplifies mixing
-    ma_device_config config = ma_device_config_init(ma_device_type_playback);
+    ma_device_config config = ma_device_config_init(ma_device_type_duplex);
     config.playback.pDeviceID = NULL;  // NULL for the default playback AUDIO.System.device
     config.playback.format = AUDIO_DEVICE_FORMAT;
     config.playback.channels = AUDIO_DEVICE_CHANNELS;
+    config.capture.pDeviceID = NULL;
+    config.capture.format = AUDIO_DEVICE_FORMAT;
+    config.capture.channels = AUDIO_DEVICE_CHANNELS;
     config.sampleRate = AUDIO_DEVICE_SAMPLE_RATE;
     config.periodSizeInFrames = AUDIO_DEVICE_PERIOD_SIZE_IN_FRAMES;
     config.dataCallback = OnSendAudioDataToDevice;
@@ -2370,6 +2377,21 @@ void DetachAudioMixedProcessor(AudioCallback process)
 }
 
 //----------------------------------------------------------------------------------
+// Module Functions Definition - Capture streaming
+//----------------------------------------------------------------------------------
+// Start streaming capture device (e.g. microphone) to speakers
+void StartCaptureStream(void)
+{
+    AUDIO.Capture.isStreaming = true;
+}
+
+// Stop streaming caputre device (e.g. microphone) to speakers
+void StopCaptureStream(void)
+{
+    AUDIO.Capture.isStreaming = false;
+}
+
+//----------------------------------------------------------------------------------
 // Module Internal Functions Definition
 //----------------------------------------------------------------------------------
 // Log callback function
@@ -2648,6 +2670,11 @@ static void OnSendAudioDataToDevice(ma_device *pDevice, void *pFramesOut, const 
     {
         processor->process(pFramesOut, frameCount);
         processor = processor->next;
+    }
+
+    if(AUDIO.Capture.isStreaming)
+    {
+        memcpy(pFramesOut, pFramesInput, frameCount * ma_get_bytes_per_frame(pDevice->capture.format, pDevice->capture.channels));
     }
 
     ma_mutex_unlock(&AUDIO.System.lock);

--- a/src/raudio.c
+++ b/src/raudio.c
@@ -282,7 +282,7 @@ typedef struct tagBITMAPINFOHEADER {
 // Defines and Macros
 //----------------------------------------------------------------------------------
 #ifndef AUDIO_DEVICE_FORMAT
-    #define AUDIO_DEVICE_FORMAT    ma_format_s32    // Device output format (signed-32bit)
+    #define AUDIO_DEVICE_FORMAT    ma_format_f32    // Device output format (float-32bit)
 #endif
 #ifndef AUDIO_DEVICE_CHANNELS
     #define AUDIO_DEVICE_CHANNELS              2    // Device output channels: stereo

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1740,6 +1740,10 @@ RLAPI void DetachAudioStreamProcessor(AudioStream stream, AudioCallback processo
 RLAPI void AttachAudioMixedProcessor(AudioCallback processor); // Attach audio stream processor to the entire audio pipeline, receives frames x 2 samples as 'float' (stereo)
 RLAPI void DetachAudioMixedProcessor(AudioCallback processor); // Detach audio stream processor from the entire audio pipeline
 
+// Capture streaming functions
+RLAPI void StartCaptureStream(void);                                  // Start streaming capture device (e.g. microphone) to speakers
+RLAPI void StopCaptureStream(void);                                   // Stop streaming caputre device (e.g. microphone) to speakers
+
 #if defined(__cplusplus)
 }
 #endif


### PR DESCRIPTION
This commit introduces basic streaming from a capture source (e.g. a microphone) to the device speakers. The playback format was changed from ma_format_f32 to ma_format_s32 to support capturing audio.

Hopefully this commit can be a basis for future capture-related functionality

Note: I have tested this on Windows, macOS, and Linux.