### PR TITLE
[raudio] remove extra drflac_free

### DIFF
--- a/src/raudio.c
+++ b/src/raudio.c
@@ -1784,7 +1784,7 @@ void UnloadMusicStream(Music music)
         else if (music.ctxType == MUSIC_AUDIO_QOA) qoaplay_close((qoaplay_desc *)music.ctxData);
 #endif
 #if SUPPORT_FILEFORMAT_FLAC
-        else if (music.ctxType == MUSIC_AUDIO_FLAC) { drflac_close((drflac *)music.ctxData); drflac_free((drflac *)music.ctxData, NULL); }
+        else if (music.ctxType == MUSIC_AUDIO_FLAC) { drflac_close((drflac *)music.ctxData); }
 #endif
 #if SUPPORT_FILEFORMAT_XM
         else if (music.ctxType == MUSIC_MODULE_XM) jar_xm_free_context((jar_xm_context_t *)music.ctxData);


### PR DESCRIPTION
a user made a bug report while using flac files. @mackron said this free should be removed, as it is handled in `drflac_close` now. this was discussed in discord: https://discord.com/channels/426912293134270465/1513529965214437616

to reproduce you just load any flac file and close the window (with flac enabled)
