### PR TITLE
[rcore] Fix ``FileCopy`` doesn't copy file when directory exists

### DIFF
--- a/src/rcore.c
+++ b/src/rcore.c
@@ -2237,9 +2237,12 @@ int FileCopy(const char *srcPath, const char *dstPath)
     unsigned char *srcFileData = LoadFileData(srcPath, &srcDataSize);
 
     // Create required paths if they do not exist
-    if (DirectoryExists(GetDirectoryPath(dstPath))) {
+    if (DirectoryExists(GetDirectoryPath(dstPath))) 
+    {
         result = 0;
-    } else {
+    } 
+    else 
+    {
         result = MakeDirectory(GetDirectoryPath(dstPath));
     }
 

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -2237,8 +2237,11 @@ int FileCopy(const char *srcPath, const char *dstPath)
     unsigned char *srcFileData = LoadFileData(srcPath, &srcDataSize);
 
     // Create required paths if they do not exist
-    if (!DirectoryExists(GetDirectoryPath(dstPath)))
+    if (DirectoryExists(GetDirectoryPath(dstPath))) {
+        result = 0;
+    } else {
         result = MakeDirectory(GetDirectoryPath(dstPath));
+    }
 
     if (result == 0) // Directory created successfully (or already exists)
     {


### PR DESCRIPTION
First of all, thanks for this amazing library! I don't know how i do games if raylib doesn't exists. About bug:

Currently ``FileCopy`` doesn't copy file when directory exists because we don't do anything when directory exists, only when it doesnt exist.