### PR TITLE
guard slices<3 in par_shapes_create_disk, fixed compiler warning -Wal…

### DIFF
--- a/src/external/par_shapes.h
+++ b/src/external/par_shapes.h
@@ -715,6 +715,12 @@ void par_shapes_merge(par_shapes_mesh* dst, par_shapes_mesh const* src)
 par_shapes_mesh* par_shapes_create_disk(float radius, int slices,
     float const* center, float const* normal)
 {
+    // Guard against degenerate and invalid tessellation counts
+    // fixes compiler warning -Walloc-size-larger-than
+    // and a heap-buffer-overflow
+    if (slices < 3) {
+        return 0;
+    }
     par_shapes_mesh* mesh = PAR_CALLOC(par_shapes_mesh, 1);
     mesh->npoints = slices + 1;
     mesh->points = PAR_MALLOC(float, 3 * mesh->npoints);


### PR DESCRIPTION
This PR fixes a -Walloc-size-larger-than compiler warning when compiling rmodels.c traced to par_shapes_create_disk in par_shapes.h not validating if slices>=3

Negative slices cause heap-buffer-overflow crash. The same guard is already implemented in the GenMesh* functions that call par_shapes_create_disk. Fixing it anyway since it's the actual root cause
of the warning and a real bug in the function on its own( since par_shapes_create_disk isn't a static function, anyone call it and might potentially lead to a crash)

tested:
- ASan repro on par_shapes_create_disk directly: crashes on negative
  slices before the fix, clean after, valid slice counts unaffected
- rebuilt rmodels.c, warning's gone
- GenMeshCone w/ slices=2 still hits the same guard + behavior as
  before (no change to already-guarded path), verified the resulting
  empty mesh survives UploadMesh/DrawModel/UnloadModel under ASan too