### PR TITLE
[rcore][GLFW] Update window position in `WindowMaximizeCallback()`

### DIFF
--- a/src/platforms/rcore_desktop_glfw.c
+++ b/src/platforms/rcore_desktop_glfw.c
@@ -2012,6 +2012,8 @@ static void WindowMaximizeCallback(GLFWwindow *window, int maximized)
 {
     if (maximized) FLAG_SET(CORE.Window.flags, FLAG_WINDOW_MAXIMIZED);  // The window was maximized
     else FLAG_CLEAR(CORE.Window.flags, FLAG_WINDOW_MAXIMIZED);          // The window was restored
+    // Update current window position 
+    glfwGetWindowPos(platform.handle, &CORE.Window.position.x, &CORE.Window.position.y);
 }
 
 // GLFW3: Window focus callback, runs when window get/lose focus


### PR DESCRIPTION
Update window position in WindowMaximizeCallback, since maximization does not appear to trigger WindowPosCallback on some platforms, such as MacOS.

Fixes #5931.