### PR TITLE
[rlgl] Fix matrix stack overflow in rlPushMatrix()

### DIFF
--- a/src/rlgl.h
+++ b/src/rlgl.h
@@ -1237,7 +1237,11 @@ void rlMatrixMode(int mode)
 // Push the current matrix into RLGL.State.stack
 void rlPushMatrix(void)
 {
-    if (RLGL.State.stackCounter >= RL_MAX_MATRIX_STACK_SIZE) TRACELOG(RL_LOG_ERROR, "RLGL: Matrix stack overflow (RL_MAX_MATRIX_STACK_SIZE)");
+    if (RLGL.State.stackCounter >= RL_MAX_MATRIX_STACK_SIZE)
+    {
+        TRACELOG(RL_LOG_ERROR, "RLGL: Matrix stack overflow (RL_MAX_MATRIX_STACK_SIZE)");
+        return;
+    }
 
     if (RLGL.State.currentMatrixMode == RL_MODELVIEW)
     {


### PR DESCRIPTION
### Problem

`rlPushMatrix()` checks for stack overflow but does not stop on it:

```c
void rlPushMatrix(void)
{
    if (RLGL.State.stackCounter >= RL_MAX_MATRIX_STACK_SIZE) TRACELOG(RL_LOG_ERROR, "RLGL: Matrix stack overflow (RL_MAX_MATRIX_STACK_SIZE)");
    ...
    RLGL.State.stack[RLGL.State.stackCounter] = *RLGL.State.currentMatrix;
    RLGL.State.stackCounter++;
}
```

The check logs an error but has no `return`, so the assignment still runs when the stack is full. With `RLGL.State.stackCounter == RL_MAX_MATRIX_STACK_SIZE`, this writes `RLGL.State.stack[RL_MAX_MATRIX_STACK_SIZE]` — one element past `Matrix stack[RL_MAX_MATRIX_STACK_SIZE]` — corrupting the adjacent `RLGL.State` members (`stackCounter`, `currentTextureId`, …), and it grows with each further unbalanced push.

`rlPopMatrix()` already guards the symmetric underflow case (`if (RLGL.State.stackCounter > 0)`), so this is just a missing early return on the push side.

### Fix

```c
if (RLGL.State.stackCounter >= RL_MAX_MATRIX_STACK_SIZE)
{
    TRACELOG(RL_LOG_ERROR, "RLGL: Matrix stack overflow (RL_MAX_MATRIX_STACK_SIZE)");
    return;
}
```

### Reproduction

A small program mirroring the `RLGL.State` field order (`Matrix stack[RL_MAX_MATRIX_STACK_SIZE]; int stackCounter; unsigned int currentTextureId; …`) and doing 33 unbalanced `rlPushMatrix()` calls:

```
after 32 pushes: stackCounter=32, currentTextureId=0xABCD1234 (intact)
RLGL: Matrix stack overflow            <- guard fires but does NOT prevent the write
after 33rd push: stackCounter=1088421889, currentTextureId=0x40E00000   <- both clobbered
```

`0x40E00000` is the bit pattern of `7.0f`, the matrix payload — i.e. the `Matrix` bytes spilled into the neighbouring `State` members. After the fix the 33rd push is rejected and the neighbouring members stay intact. (It's an intra-object overflow, so default ASan/Valgrind do not flag it; the repro shows the member corruption directly.)

Verified to build cleanly (`make PLATFORM=PLATFORM_DESKTOP`).

---
*Disclosure: this issue was identified by a static-analysis audit and the fix was prepared with AI assistance (Anthropic Claude), then reviewed and submitted by @szarta.*
