### PR TITLE
[rtext] Fix buffer overflow in TextReplaceBetween()

### DIFF
--- a/src/rtext.c
+++ b/src/rtext.c
@@ -1919,9 +1919,13 @@ char *TextReplaceBetween(const char *text, const char *begin, const char *end, c
                 int replaceLen = (replacement == NULL)? 0 : TextLength(replacement);
                 //int toreplaceLen = endIndex - beginIndex - beginLen;
 
-                strncpy(buffer, text, beginIndex + beginLen); // Copy first text part
-                if (replacement != NULL) strncpy(buffer + beginIndex + beginLen, replacement, replaceLen); // Copy replacement (if provided)
-                strncpy(buffer + beginIndex + beginLen + replaceLen, text + endIndex, textLen - endIndex); // Copy end text part
+                if ((beginIndex + beginLen + replaceLen + (textLen - endIndex)) < (MAX_TEXT_BUFFER_LENGTH - 1))
+                {
+                    strncpy(buffer, text, beginIndex + beginLen); // Copy first text part
+                    if (replacement != NULL) strncpy(buffer + beginIndex + beginLen, replacement, replaceLen); // Copy replacement (if provided)
+                    strncpy(buffer + beginIndex + beginLen + replaceLen, text + endIndex, textLen - endIndex); // Copy end text part
+                }
+                else TRACELOG(LOG_WARNING, "TEXT: Text with replaced string is longer than internal buffer (MAX_TEXT_BUFFER_LENGTH)");
             }
         }
     }


### PR DESCRIPTION
### Problem

`TextReplaceBetween()` copies into the 1024-byte `static char buffer[MAX_TEXT_BUFFER_LENGTH]` with three `strncpy()` calls whose combined length is driven by the input lengths and is never clamped to the buffer size:

```c
strncpy(buffer, text, beginIndex + beginLen);
if (replacement != NULL) strncpy(buffer + beginIndex + beginLen, replacement, replaceLen);
strncpy(buffer + beginIndex + beginLen + replaceLen, text + endIndex, textLen - endIndex);
```

For a long enough `text`/`replacement` this writes past `buffer`. The sibling functions `TextReplace()` and `TextInsert()` already guard against `MAX_TEXT_BUFFER_LENGTH`; this one is missing the check.

### Fix

Guard the total output length against the buffer size before copying, matching `TextInsert()`/`TextReplace()`:

```c
if ((beginIndex + beginLen + replaceLen + (textLen - endIndex)) < (MAX_TEXT_BUFFER_LENGTH - 1))
{
    strncpy(buffer, text, beginIndex + beginLen);
    if (replacement != NULL) strncpy(buffer + beginIndex + beginLen, replacement, replaceLen);
    strncpy(buffer + beginIndex + beginLen + replaceLen, text + endIndex, textLen - endIndex);
}
else TRACELOG(LOG_WARNING, "TEXT: Text with replaced string is longer than internal buffer (MAX_TEXT_BUFFER_LENGTH)");
```

### Reproduction

AddressSanitizer on a call with a long input (e.g. `"BE" + 2000×'x'`, begin `"B"`, end `"E"`):

```
==ERROR: AddressSanitizer: global-buffer-overflow ... WRITE of size 2001
  #1 TextReplaceBetween rtext.c  (third strncpy)
  ... 0 bytes to the right of global variable 'buffer' ... of size 1024
```

After the fix the over-long input is rejected (warning logged) and normal inputs are unchanged (`"hello[X]world"`, `"["`, `"]"`, `"_"` → `"hello[_]world"`). Verified to build cleanly (`make PLATFORM=PLATFORM_DESKTOP`).

---
*Disclosure: this issue was identified by a static-analysis audit and the fix was prepared with AI assistance (Anthropic Claude), then reviewed and submitted by @szarta.*
