### PR TITLE
[rcore] Fix SDL3 backend using wrong joystick functions

### DIFF
--- a/src/platforms/rcore_desktop_sdl.c
+++ b/src/platforms/rcore_desktop_sdl.c
@@ -2197,17 +2197,6 @@ int InitPlatform(void)
         else TRACELOG(LOG_WARNING, "PLATFORM: Unable to open game controller [ERROR: %s]", SDL_GetError());
     }
 
-    if (numJoysticks > 0) {
-        TRACELOG(LOG_INFO, "PLATFORM: Available joysticks:");
-    }
-
-    for (int i = 0; (i < numJoysticks) && (i < MAX_GAMEPADS); i++) {
-        if (CORE.Input.Gamepad.ready[i] == false) {
-            continue;
-        }
-        TRACELOG(LOG_INFO, " - [ID %d] %s", i, CORE.Input.Gamepad.name[i]);
-    }
-
     // Disable mouse events being interpreted as touch events
     // NOTE: This is wanted because there are SDL_FINGER* events available which provide unique data
     // Due to the way PollInputEvents() and rgestures.h are currently implemented, setting this won't break SUPPORT_MOUSE_GESTURES

--- a/src/platforms/rcore_desktop_sdl.c
+++ b/src/platforms/rcore_desktop_sdl.c
@@ -2164,11 +2164,20 @@ int InitPlatform(void)
         platform.gamepadId[i] = -1; // Set all gamepad initial instance ids as invalid to not conflict with instance id zero
     }
 
+#if defined(USING_VERSION_SDL3)
+    int numJoysticks;
+    SDL_JoystickID *joysticks = SDL_GetJoysticks(&numJoysticks);
+#else
     int numJoysticks = SDL_NumJoysticks();
+#endif
 
     for (int i = 0; (i < numJoysticks) && (i < MAX_GAMEPADS); i++)
     {
+#if defined(USING_VERSION_SDL3)
+        platform.gamepad[i] = SDL_OpenGamepad(joysticks[i]);
+#else
         platform.gamepad[i] = SDL_GameControllerOpen(i);
+#endif
         platform.gamepadId[i] = SDL_JoystickInstanceID(SDL_GameControllerGetJoystick(platform.gamepad[i]));
 
         if (platform.gamepad[i])
@@ -2177,10 +2186,26 @@ int InitPlatform(void)
             CORE.Input.Gamepad.axisCount[i] = SDL_JoystickNumAxes(SDL_GameControllerGetJoystick(platform.gamepad[i]));
             CORE.Input.Gamepad.axisState[i][GAMEPAD_AXIS_LEFT_TRIGGER] = -1.0f;
             CORE.Input.Gamepad.axisState[i][GAMEPAD_AXIS_RIGHT_TRIGGER] = -1.0f;
-            strncpy(CORE.Input.Gamepad.name[i], SDL_GameControllerNameForIndex(i), MAX_GAMEPAD_NAME_LENGTH - 1);
+#if defined(USING_VERSION_SDL3)
+            const char *joystickName = SDL_GetJoystickNameForID(joysticks[i]);
+#else
+            const char *joystickName = SDL_GameControllerNameForIndex(i);
+#endif
+            strncpy(CORE.Input.Gamepad.name[i], joystickName, MAX_GAMEPAD_NAME_LENGTH - 1);
             CORE.Input.Gamepad.name[i][MAX_GAMEPAD_NAME_LENGTH - 1] = '\0';
         }
         else TRACELOG(LOG_WARNING, "PLATFORM: Unable to open game controller [ERROR: %s]", SDL_GetError());
+    }
+
+    if (numJoysticks > 0) {
+        TRACELOG(LOG_INFO, "PLATFORM: Available joysticks:");
+    }
+
+    for (int i = 0; (i < numJoysticks) && (i < MAX_GAMEPADS); i++) {
+        if (CORE.Input.Gamepad.ready[i] == false) {
+            continue;
+        }
+        TRACELOG(LOG_INFO, " - [ID %d] %s", i, CORE.Input.Gamepad.name[i]);
     }
 
     // Disable mouse events being interpreted as touch events


### PR DESCRIPTION
Fixes what was discussed in #5946

This works well on both SDL2 and SDL3 backends. Works for both hot-plugging and starting raylib with joystick already attached. But keep in my mind that's on my machine just with one controller.

Thanks.