### PR TITLE
[build][Zig] 0.17 migration 

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -69,7 +69,7 @@ pub const emsdk = struct {
         raylib.root_module.addIncludePath(emsdk_dep.path("upstream/emscripten/cache/sysroot/include"));
         wasm.root_module.addIncludePath(emsdk_dep.path("upstream/emscripten/cache/sysroot/include"));
 
-        const emcc_step = zemscripten.emccStep(b, wasm, options);
+        const emcc_step = zemscripten.emccStep(b, &.{}, &.{wasm}, options);
         emcc_step.dependOn(activate_emsdk_step);
 
         return emcc_step;
@@ -77,7 +77,7 @@ pub const emsdk = struct {
 
     pub fn emrunStep(
         b: *std.Build,
-        html_path: []const u8,
+        html_path: std.Build.LazyPath,
         extra_args: []const []const u8,
     ) *std.Build.Step {
         return zemscripten.emrunStep(b, html_path, extra_args);
@@ -718,13 +718,16 @@ fn addExamples(
                 .preload_paths = emcc_examples_preloads_map.get(filename) orelse &.{},
                 .shell_file_path = b.path("src/shell.html"),
                 .install_dir = install_dir,
+                .out_file_name = wasm.name,
             });
             b.getInstallStep().dependOn(emcc_step);
 
-            const html_filename = try std.fmt.allocPrint(b.allocator, "{s}.html", .{wasm.name});
+            const install_file = b.addInstallFile(.{ .cwd_relative = b.fmt("{s}/{s}/{s}.html", .{ module, filename, wasm.name }) }, "web");
+            b.getInstallStep().dependOn(&install_file.step);
+
             const emrun_step = emsdk.emrunStep(
                 b,
-                b.getInstallPath(install_dir, html_filename),
+                install_file.source,
                 &.{},
             );
 

--- a/build.zig
+++ b/build.zig
@@ -92,7 +92,7 @@ pub fn linkWindows(mod: *std.Build.Module, opengl: bool, comptime shcore: bool) 
 }
 
 fn findWaylandScanner(b: *std.Build) void {
-    _ = b.findProgram(&.{"wayland-scanner"}, &.{}) catch {
+    _ = b.findProgram(.{ .names = &.{"wayland-scanner"} }) orelse {
         std.log.err(
             \\ `wayland-scanner` may not be installed on the system.
             \\ You can switch to X11 in your `build.zig` by changing `Options.linux_display_backend`
@@ -648,7 +648,7 @@ fn addExamples(
     const all = b.step(module, "All " ++ module ++ " examples");
     const module_subpath = b.pathJoin(&.{ "examples", module });
 
-    var dir = try b.build_root.handle.openDir(b.graph.io, module_subpath, .{ .iterate = true });
+    var dir = try b.root.openDir(b.graph.io, module_subpath, .{ .iterate = true });
     defer dir.close(b.graph.io);
 
     var iter = dir.iterate();
@@ -706,9 +706,10 @@ fn addExamples(
             const emcc_flags = emsdk.emccDefaultFlags(b.allocator, .{ .optimize = optimize });
             const emcc_settings = emsdk.emccDefaultSettings(b.allocator, .{ .optimize = optimize });
 
-            const EmccExamplesPreloadMap = std.static_string_map.StaticStringMap([]const emsdk.zemscripten.EmccFilePath);
-            const EmccExamplesPreloadKV = struct { []const u8, []const emsdk.zemscripten.EmccFilePath };
-            const emcc_examples_preloads: []const EmccExamplesPreloadKV = @import("examples/example_resources.zon");
+            const EmccExamplesPreloadMap = std.static_string_map.StaticStringMap([]const emsdk.zemscripten.ResourceFile);
+            const EmccExamplesPreloadKV = struct { []const u8, []const emsdk.zemscripten.ResourceFile };
+            const emcc_examples_preloads_ = @import("examples/example_resources.zon");
+            const emcc_examples_preloads: []const EmccExamplesPreloadKV = @ptrCast(@alignCast(&emcc_examples_preloads_));
             const emcc_examples_preloads_map = EmccExamplesPreloadMap.initComptime(emcc_examples_preloads);
 
             const emcc_step = emsdk.emccStep(b, raylib, wasm, .{
@@ -762,7 +763,7 @@ fn waylandGenerate(
     comptime waylandDir: []const u8,
     comptime source: bool,
 ) !void {
-    const dir = try b.build_root.handle.openDir(b.graph.io, waylandDir, .{ .iterate = true });
+    const dir = try b.root.openDir(b.graph.io, waylandDir, .{ .iterate = true });
     defer dir.close(b.graph.io);
 
     var iter = dir.iterate();

--- a/build.zig
+++ b/build.zig
@@ -63,14 +63,11 @@ pub const emsdk = struct {
     }
 
     pub fn emccStep(b: *std.Build, raylib: *std.Build.Step.Compile, wasm: *std.Build.Step.Compile, options: zemscripten.StepOptions) *std.Build.Step {
-        const activate_emsdk_step = zemscripten.activateEmsdkStep(b);
-
         const emsdk_dep = b.dependency("emsdk", .{});
         raylib.root_module.addIncludePath(emsdk_dep.path("upstream/emscripten/cache/sysroot/include"));
         wasm.root_module.addIncludePath(emsdk_dep.path("upstream/emscripten/cache/sysroot/include"));
 
         const emcc_step = zemscripten.emccStep(b, &.{}, &.{wasm}, options);
-        emcc_step.dependOn(activate_emsdk_step);
 
         return emcc_step;
     }
@@ -797,4 +794,3 @@ fn waylandGenerate(
         }
     }
 }
-

--- a/build.zig
+++ b/build.zig
@@ -695,7 +695,7 @@ fn addExamples(
             exe_mod.addCMacro("PLATFORM_WEB", "");
 
             const wasm = b.addLibrary(.{
-                .name = filename,
+                .name = b.fmt("{s}.html", .{filename}),
                 .root_module = exe_mod,
             });
 

--- a/build.zig
+++ b/build.zig
@@ -721,7 +721,7 @@ fn addExamples(
 
             const emrun_step = emsdk.emrunStep(
                 b,
-                b.graph.path(.install_prefix, b.fmt("{s}/{s}.html", .{ filename, wasm.name })),
+                b.graph.path(.install_prefix, b.fmt("web/{s}/{s}.html", .{ filename, wasm.name })),
                 &.{},
             );
 

--- a/build.zig
+++ b/build.zig
@@ -718,7 +718,6 @@ fn addExamples(
                 .install_dir = install_dir,
                 .out_file_name = wasm.name,
             });
-            b.getInstallStep().dependOn(emcc_step);
 
             const emrun_step = emsdk.emrunStep(
                 b,

--- a/build.zig
+++ b/build.zig
@@ -721,7 +721,10 @@ fn addExamples(
 
             const emrun_step = emsdk.emrunStep(
                 b,
-                b.graph.path(.install_prefix, b.fmt("web/{s}/{s}.html", .{ filename, wasm.name })),
+                b.graph.path(.install_prefix, b.fmt(
+                    "web/{s}/{s}/{s}",
+                    .{ module, filename, wasm.name },
+                )),
                 &.{},
             );
 

--- a/build.zig
+++ b/build.zig
@@ -720,12 +720,9 @@ fn addExamples(
             });
             b.getInstallStep().dependOn(emcc_step);
 
-            const install_file = b.addInstallFile(.{ .cwd_relative = b.fmt("{s}/{s}/{s}.html", .{ module, filename, wasm.name }) }, "web");
-            b.getInstallStep().dependOn(&install_file.step);
-
             const emrun_step = emsdk.emrunStep(
                 b,
-                install_file.source,
+                b.graph.path(.install_prefix, b.fmt("{s}/{s}.html", .{ filename, wasm.name })),
                 &.{},
             );
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .name = .raylib,
     .version = "6.0.0",
-    .minimum_zig_version = "0.17.0-dev.1158+1d1193aa7",
+    .minimum_zig_version = "0.17.0-dev.1426+58a94eaae",
 
     .fingerprint = 0x13035e5cb8bc1ac2, // Changing this has security and trust implications.
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .name = .raylib,
     .version = "6.0.0",
-    .minimum_zig_version = "0.16.0",
+    .minimum_zig_version = "0.17.0-dev.1158+1d1193aa7",
 
     .fingerprint = 0x13035e5cb8bc1ac2, // Changing this has security and trust implications.
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -21,8 +21,8 @@
             .hash = "N-V-__8AAJl1DwBezhYo_VE6f53mPVm00R-Fk28NPW7P14EQ",
         },
         .zemscripten = .{
-            .url = "git+https://github.com/zig-gamedev/zemscripten#3fa4b778852226c7346bdcc3c1486e875a9a6d02",
-            .hash = "zemscripten-0.2.0-dev-sRlDqApRAACspTbAZnuNKWIzfWzSYgYkb2nWAXZ-tqqt",
+            .url = "git+https://github.com/Yinameah/zemscripten#06d49243789d638ba10d4af004c46df4da83579c",
+            .hash = "zemscripten-0.2.0-dev-sRlDqKFRAAAXl8aICu541O6PiY70v4HIr3FTmCg--WqM",
         },
     },
 


### PR DESCRIPTION
Zig 0.17 is not out yet, but it (supposedly) will be soon.  There was recently some [breaking changes to the build system](https://codeberg.org/ziglang/zig/pulls/35428), causing nightly zig to not work with raylib's `build.zig`.  

Because the aforementioned changes are not in a major release yet, this probably should not be merged yet.  But it doesn't seem like there will be many further breaking changes before the major release, so this can be considered a tentative PR for when it happens.  One further consideration here is that this branch uses an [unmerged branch of zemscripten](https://github.com/zig-gamedev/zemscripten/pull/23) which updates it for 0.17.  So, hopefully that can be merged before this should be!