### PR TITLE
[rcore] Fix MaximizeWindow() not resizing the screen

### DIFF
--- a/src/platforms/rcore_desktop_glfw.c
+++ b/src/platforms/rcore_desktop_glfw.c
@@ -334,11 +334,12 @@ void ToggleBorderlessWindowed(void)
 // Set window state: maximized, if resizable
 void MaximizeWindow(void)
 {
-    if (glfwGetWindowAttrib(platform.handle, GLFW_RESIZABLE) == GLFW_TRUE)
+    if (glfwGetWindowAttrib(platform.handle, GLFW_RESIZABLE) != GLFW_TRUE)
     {
-        glfwMaximizeWindow(platform.handle);
-        FLAG_SET(CORE.Window.flags, FLAG_WINDOW_MAXIMIZED);
+        glfwSetWindowAttrib(platform.handle, GLFW_RESIZABLE, GLFW_TRUE);
     }
+    glfwMaximizeWindow(platform.handle);
+    FLAG_SET(CORE.Window.flags, FLAG_WINDOW_MAXIMIZED);
 }
 
 // Set window state: minimized
@@ -2169,12 +2170,12 @@ static void MouseScrollCallback(GLFWwindow *window, double xoffset, double yoffs
 // GLFW3: Cursor ennter callback, when cursor enters the window
 static void CursorEnterCallback(GLFWwindow *window, int entered)
 {
-    if (entered) 
+    if (entered)
     {
         // NOTE: Mouse position updated by MouseCursorPosCallback()
         CORE.Input.Mouse.cursorOnScreen = true;
     }
-    else 
+    else
     {
         CORE.Input.Mouse.cursorOnScreen = false;
         CORE.Input.Mouse.currentPosition = (Vector2){ 0 };


### PR DESCRIPTION
When tinkering with raylib I noticed that MaximizeWindow() not resizing the screen. After printing the attribute value of GLFW_RESIZABLE, it printed 0.

### **Code before fix:**
<img width="568" height="200" alt="image" src="https://github.com/user-attachments/assets/5a1ad766-73d1-4edd-a067-1d06f87f7d1f" />

The solution sets the GLFW_RESIZABLE to GLFW_TRUE for cases where GLFW_RESIZABLE happens to be false. The solution was tested by running the example codes that exists in the raylib repo such as core_3d_camera_fps.c and core_input_keys.c in Windows 11

### **Code after fix:** 
<img width="568" height="201" alt="image" src="https://github.com/user-attachments/assets/a0e21b85-b588-4765-9a18-ac7f262b5721" />

