### PR TITLE
fix UB in ComputeSHA-1

### DIFF
--- a/src/rcore.c
+++ b/src/rcore.c
@@ -3379,10 +3379,10 @@ unsigned int *ComputeSHA1(const unsigned char *data, int dataSize)
         unsigned int w[80] = { 0 };
         for (int i = 0; i < 16; i++)
         {
-            w[i] = (msg[offset + (i*4) + 0] << 24) |
-                   (msg[offset + (i*4) + 1] << 16) |
-                   (msg[offset + (i*4) + 2] << 8) |
-                   (msg[offset + (i*4) + 3]);
+            w[i] = ((unsigned int)msg[offset + (i*4) + 0] << 24) |
+                   ((unsigned int)msg[offset + (i*4) + 1] << 16) |
+                   ((unsigned int)msg[offset + (i*4) + 2] << 8) |
+                   ((unsigned int)msg[offset + (i*4) + 3]);
         }
 
         // Message schedule: extend the sixteen 32-bit words into eighty 32-bit words:


### PR DESCRIPTION
Fixes UB related to integer promotion in `ComputeSHA1`.

When compiling with UBSans on (like the zig compiler does) unsigned chars are promoted to integers, so any value in `msg` > 128 will cause the 32nd bit to be set and technically triggering a signed integer overflow. This shouldn't cause issues in most compilers but it is techincally UB. explicitly casing the msg to an unsigned int fixes the problem

the fastest way to replicate the above issue to run `zig build core_compute_hash` and press the `compute input data hashes button`