### PR TITLE
Fix DRM/EGL segfault on some NVIDIA proprietary drivers

### DIFF
--- a/src/platforms/rcore_drm.c
+++ b/src/platforms/rcore_drm.c
@@ -1446,7 +1446,8 @@ int InitPlatform(void)
         return -1;
     }
 
-    if (!eglChooseConfig(platform.device, NULL, NULL, 0, &numConfigs))
+    // Providing `framebufferAttribs` is not logically necessary, but it may prevent segfaults on some nvidia drivers
+    if (!eglChooseConfig(platform.device, framebufferAttribs, NULL, 0, &numConfigs))
     {
         TRACELOG(LOG_WARNING, "DISPLAY: Failed to get EGL config count: 0x%x", eglGetError());
         return -1;


### PR DESCRIPTION
Had a segfault on InitWindow with these conditions:

- DRM
- Nvidia GeForce RTX 3060 with void linux's proprietary `nvidia` package

It seems like nvidia's proprietary driver was ignoring the spec and dereferencing attrib_list parameter without checking. After figuring out the fix, I've updated the nvidia driver, and it seems like they fixed the issue; anyway, some versions of nvidia drivers do crash at this point, the change does not affect any existing behaviour, and it's basically an additional safeguard without any cost, so I thought maybe it would be useful.

I don't really specialize in GPU-related C code, so I apologize if it's a bad suggestion.