### PR TITLE
[raudio] Fix memory leak when loading .wav files

### DIFF
--- a/src/raudio.c
+++ b/src/raudio.c
@@ -1772,7 +1772,7 @@ void UnloadMusicStream(Music music)
     {
         if (false) { }
 #if SUPPORT_FILEFORMAT_WAV
-        else if (music.ctxType == MUSIC_AUDIO_WAV) drwav_uninit((drwav *)music.ctxData);
+        else if (music.ctxType == MUSIC_AUDIO_WAV) { drwav_uninit((drwav*)music.ctxData); RL_FREE(music.ctxData); }
 #endif
 #if SUPPORT_FILEFORMAT_OGG
         else if (music.ctxType == MUSIC_AUDIO_OGG) stb_vorbis_close((stb_vorbis *)music.ctxData);

--- a/src/raudio.c
+++ b/src/raudio.c
@@ -1772,7 +1772,7 @@ void UnloadMusicStream(Music music)
     {
         if (false) { }
 #if SUPPORT_FILEFORMAT_WAV
-        else if (music.ctxType == MUSIC_AUDIO_WAV) { drwav_uninit((drwav*)music.ctxData); RL_FREE(music.ctxData); }
+        else if (music.ctxType == MUSIC_AUDIO_WAV) { drwav_uninit((drwav *)music.ctxData); RL_FREE(music.ctxData); }
 #endif
 #if SUPPORT_FILEFORMAT_OGG
         else if (music.ctxType == MUSIC_AUDIO_OGG) stb_vorbis_close((stb_vorbis *)music.ctxData);


### PR DESCRIPTION
# Title

Fix memory leak in `UnloadMusicStream()` for WAV files on MSVC Debug builds

---

## Summary

This PR fixes a memory leak that occurs when unloading a WAV music stream using `UnloadMusicStream()`.

On Windows 11 with MSVC (Visual Studio 2022, x64 Debug), the Microsoft CRT Debug Heap reports a remaining allocation after the application exits, even though `UnloadMusicStream()` has been called.

The leak is caused by the decoder context (`Music.ctxData`) not being fully released.

---

## Environment

- OS: Windows 11
- Architecture: x64
- Compiler: MSVC
- IDE: Visual Studio 2022
- Configuration: Debug
- Audio file: WAV

---

## Reproduction

```cpp
#include <raylib.h>
#include <crtdbg.h>
#include <memory.h>
#include <stdlib.h>

int main(void)
{
    _CrtSetDbgFlag(_CRTDBG_ALLOC_MEM_DF | _CRTDBG_LEAK_CHECK_DF);

    const int screenWidth = 800;
    const int screenHeight = 450;

    InitWindow(screenWidth, screenHeight, "raylib leak test");

    SetTargetFPS(60);

    Music music = LoadMusicStream("./Assets/boss-round.wav");

    while (!WindowShouldClose())
    {
        BeginDrawing();

        ClearBackground(RAYWHITE);

        DrawText("Memory Leak Test", 190, 200, 20, LIGHTGRAY);

        EndDrawing();
    }

    UnloadMusicStream(music);

    CloseWindow();

    return 0;
}
```

---

## Actual Result

The Microsoft CRT Debug Heap reports the following memory leak:

```text
Detected memory leaks!
Dumping objects ->
{750} normal block at 0x00000228567A03B0, 408 bytes long.
 Data: < |              > E0 7C CF EA F7 7F 00 00 00 00 00 00 00 00 00 00
Object dump complete.
```

---

## Expected Result

`UnloadMusicStream()` should release all memory allocated by `LoadMusicStream()`.

No memory leaks should be reported after the application exits.

---

## Investigation

The leaked allocation appears to originate from the internal decoder context stored in `Music.ctxData`.

Manually releasing this pointer removes the leak:

```cpp
RL_FREE(music.ctxData);
```

However, `ctxData` is an internal implementation detail and should not need to be released by user code.

Its lifetime should be managed entirely by raylib.

---

## Fix

Release the decoder-specific context (`ctxData`) during `UnloadMusicStream()` so that all resources allocated by `LoadMusicStream()` are properly cleaned up.

This keeps ownership of internal resources inside raylib and eliminates the reported memory leak.

---

## Verification

Tested with:

- Windows 11
- Visual Studio 2022
- MSVC x64 Debug
- CRT Debug Heap (`_CrtSetDbgFlag`)
- WAV music file

After this change, no memory leaks are reported.