### PR TITLE
[rlsw] Fix alpha tracking for persistent current colors

### DIFF
--- a/src/external/rlsw.h
+++ b/src/external/rlsw.h
@@ -3909,7 +3909,6 @@ static void sw_immediate_set_color(const float color[4])
     RLSW.primitive.color[2] = color[2];
     RLSW.primitive.color[3] = color[3];
 
-    RLSW.primitive.hasColorAlpha |= (color[3] < 1.0f);
 }
 
 static void sw_immediate_set_texcoord(const float texcoord[2])
@@ -3947,6 +3946,9 @@ static void sw_immediate_push_vertex(const float position[4])
     // Copy the attributes in the current vertex
     for (int i = 0; i < 4; i++) vertex->color[i] = RLSW.primitive.color[i];
     for (int i = 0; i < 2; i++) vertex->texcoord[i] = RLSW.primitive.texcoord[i];
+
+    // Track whether any vertex in this primitive has alpha < 1.0
+    RLSW.primitive.hasColorAlpha |= (vertex->color[3] < 1.0f);
 
     // Immediate rendering of the primitive if the required number is reached
     if (RLSW.primitive.vertexCount == SW_PRIMITIVE_VERTEX_COUNT[RLSW.drawMode])


### PR DESCRIPTION
Fixes #5961.

This follows the root-cause analysis from @HurricanVD in #5961.

The issue suggested preserving `hasColorAlpha` from the persistent current color
at primitive boundaries. This PR takes a slightly narrower approach: it updates
`hasColorAlpha` when a vertex copies the current color.

That keeps the flag tied to the primitive contents themselves. A primitive is
marked as containing alpha only if one of its submitted vertices actually has
alpha below `1.0f`, while persistent translucent colors still remain correctly
tracked across multiple primitives.