### PR TITLE
[rcore][glfw] Fix initial macOS window size

### DIFF
--- a/src/platforms/rcore_desktop_glfw.c
+++ b/src/platforms/rcore_desktop_glfw.c
@@ -1693,6 +1693,14 @@ int InitPlatform(void)
             return -1;
         }
 
+#if defined(__APPLE__)
+        // AppKit can constrain the requested window size to the visible work area during creation
+        int windowWidth = 0;
+        int windowHeight = 0;
+        glfwGetWindowSize(platform.handle, &windowWidth, &windowHeight);
+        if ((windowWidth > 0) && (windowHeight > 0)) CORE.Window.screen = (Size){ windowWidth, windowHeight };
+#endif
+
         // NOTE: Not considering scale factor now, considered below
         CORE.Window.render.width = CORE.Window.screen.width;
         CORE.Window.render.height = CORE.Window.screen.height;


### PR DESCRIPTION
While developing a game on macOS, I found that requesting a window taller than the visible work area caused the top of the framebuffer to be clipped and mouse input to be vertically offset. AppKit constrains the window during creation before raylib installs its resize callbacks, so raylib keeps the requested dimensions instead of the actual Cocoa content size and initializes an oversized screen and render area. This change reads the window size back from GLFW after creation on macOS and before render dimensions are initialized, keeping raylib's screen and framebuffer sizes synchronized with the window AppKit created.