### PR TITLE
[rcore][desktop] Fix clipboard image memory leak

### DIFF
--- a/src/platforms/rcore_desktop_sdl.c
+++ b/src/platforms/rcore_desktop_sdl.c
@@ -1261,6 +1261,9 @@ Image GetClipboardImage(void)
         if (fileData)
         {
             image = LoadImageFromMemory(imageExtensions[i], fileData, (int)dataSize);
+
+            SDL_free(fileData);
+
             if (IsImageValid(image))
             {
                 TRACELOG(LOG_INFO, "Clipboard: Got image from clipboard successfully: %s", imageExtensions[i]);

--- a/src/platforms/rcore_desktop_sdl.c
+++ b/src/platforms/rcore_desktop_sdl.c
@@ -1255,7 +1255,6 @@ Image GetClipboardImage(void)
 
     for (int i = 0; i < SDL_arraysize(imageFormats); i++)
     {
-        // NOTE: This pointer should be free with SDL_free() at some point
         fileData = SDL_GetClipboardData(imageFormats[i], &dataSize);
 
         if (fileData)


### PR DESCRIPTION
# PR Title

Fix memory leak in `GetClipboardImage()`

---

# Summary

This PR fixes a memory leak in `GetClipboardImage()`.

`SDL_GetClipboardData()` returns a heap-allocated buffer that must be released with `SDL_free()`. The current implementation loads the image from the returned buffer but never frees it, resulting in a memory leak.

This PR simply calls `SDL_free(fileData)` immediately after `LoadImageFromMemory()`.

The goal of this PR is to keep the change as small as possible and consistent with raylib's design philosophy.

---

# Environment

- Windows 11
- x64
- MSVC
- Visual Studio 2022

---

# Reproduction

The following sample reproduces the issue.

```cpp
#include <raylib.h>
#include <crtdbg.h>

int main(void)
{
    _CrtSetDbgFlag(_CRTDBG_ALLOC_MEM_DF | _CRTDBG_LEAK_CHECK_DF);

    const int screenWidth = 800;
    const int screenHeight = 450;

    InitWindow(screenWidth, screenHeight, "raylib - clipboard image memory leak");

    SetTargetFPS(60);

    Texture2D clipboardTexture = { 0 };
    bool hasClipboardTexture = false;

    while (!WindowShouldClose())
    {
        const bool controlPressed =
            IsKeyDown(KEY_LEFT_CONTROL) ||
            IsKeyDown(KEY_RIGHT_CONTROL);

        if (controlPressed && IsKeyPressed(KEY_V))
        {
            Image clipboardImage = GetClipboardImage();

            if (IsImageValid(clipboardImage))
            {
                if (hasClipboardTexture)
                {
                    UnloadTexture(clipboardTexture);
                }

                clipboardTexture = LoadTextureFromImage(clipboardImage);
                hasClipboardTexture = IsTextureValid(clipboardTexture);

                UnloadImage(clipboardImage);
            }
        }

        BeginDrawing();

        ClearBackground(RAYWHITE);

        DrawText("Copy an image, then press Ctrl + V", 20, 20, 20, DARKGRAY);

        if (hasClipboardTexture)
        {
            DrawTexture(clipboardTexture, 20, 60, WHITE);
        }

        EndDrawing();
    }

    if (hasClipboardTexture)
    {
        UnloadTexture(clipboardTexture);
    }

    CloseWindow();

    return 0;
}
```

---

# Reproduction Images

## Example 1

Copy this image:

https://images.unsplash.com/photo-1657632843433-e6a8b7451ac6?fm=jpg&q=60&w=3000&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxzZWFyY2h8MTd8fDRrJUU1JUEzJTgxJUU3JUI0JTk5fGVufDB8fDB8fHww

CRT reports:

```text
Detected memory leaks!
Dumping objects ->
{756} normal block at 0x0000025669A4F070, 50784054 bytes long.
 Data: <BM6       6   ( > 42 4D 36 E7 06 03 00 00 00 00 36 00 00 00 28 00
Object dump complete.
```

---

## Example 2

Copy the raylib logo:

https://upload.wikimedia.org/wikipedia/commons/f/f4/Raylib_logo.png

CRT reports:

```text
Detected memory leaks!
Dumping objects ->
{756} normal block at 0x000002A77C0B4CB0, 262198 bytes long.
 Data: <BM6       6   ( > 42 4D 36 00 04 00 00 00 00 00 36 00 00 00 28 00
Object dump complete.
```

The leaked allocation size roughly matches the clipboard image data size.

---

# Fix

The only change is adding

```c
SDL_free(fileData);
```

after

```c
LoadImageFromMemory(...)
```

This ensures the temporary clipboard buffer returned by SDL is released after the image has been decoded.

---

# Notes

I intentionally kept this PR as small as possible to match raylib's design philosophy.

I noticed there are a few other places where additional validation or guards could potentially be added, but those are outside the scope of this fix, so I did not include them in this PR.

I'd appreciate your opinion:

- Does this minimal fix align with raylib's preferred design/style?
- If there are other safeguards you would like to see for this API in the future, I'd be happy to work on them in a separate PR.