### PR TITLE
Fix TextSubtext() returning empty string when position is 0

### DIFF
--- a/src/rtext.c
+++ b/src/rtext.c
@@ -1699,7 +1699,7 @@ const char *TextSubtext(const char *text, int position, int length)
     static char buffer[MAX_TEXT_BUFFER_LENGTH] = { 0 };
     memset(buffer, 0, MAX_TEXT_BUFFER_LENGTH);
 
-    if ((text != NULL) && (position > 0) && (length > 0))
+    if ((text != NULL) && (position >= 0) && (length > 0))
     {
         int textLength = TextLength(text);
 


### PR DESCRIPTION
### Description
This PR fixes a bug in `TextSubtext()` where passing a `position` of `0` (the start of the string) would incorrectly return an empty string. The recent API hardening introduced a strict `position > 0` check, which broke valid use cases like the `text_writing_anim` example. Changing the guard to `position >= 0` fixes the issue

Closes #5973

_Thanks to @HurricanVD for finding the root cause and providing the logic fix in the issue description!_