### PR TITLE
Fix: ImageFromImage rectangle validation uses strict comparisons

### DIFF
--- a/src/rtextures.c
+++ b/src/rtextures.c
@@ -1231,9 +1231,9 @@ Image ImageFromImage(Image image, Rectangle rec)
     Image result = { 0 };
 
     // Basic rectangle validation: size smaller than image size
-    if ((rec.x > 0) && (rec.y > 0) && (rec.width > 0) && (rec.height > 0) &&
-        (((int)rec.x + (int)rec.width) < image.width) &&
-        (((int)rec.y + (int)rec.height) < image.height))
+    if ((rec.x >= 0) && (rec.y >= 0) && (rec.width > 0) && (rec.height > 0) &&
+        (((int)rec.x + (int)rec.width) <= image.width) &&
+        (((int)rec.y + (int)rec.height) <= image.height))
     {
         int bytesPerPixel = GetPixelDataSize(1, 1, image.format);
 


### PR DESCRIPTION
The conditions `rec.x > 0` and `rec.y > 0` should be `rec.x >= 0` and `rec.y >= 0`, otherwise cropping from the top-left corner (0,0) is incorrectly rejected.

Similarly, `(int)rec.x + (int)rec.width < image.width` should be `<=` (and same for height), otherwise cropping the full image is also rejected.

This bug affects every call to `ImageFromImage` where the rectangle starts at the origin or spans the full image, causing the warnings:

```
WARNING: IMAGE: Rectangle provided for ImageToImage not valid
WARNING: IMAGE: Data is not valid to load texture
```

### Example
For a 16×16 image cropped with `{0, 0, 16, 16}`:
- `0 > 0` → **false** ❌
- `0 + 16 < 16` → **false** ❌
