### PR TITLE
[rcore] Fix for stale mouse position on web platform

### DIFF
--- a/src/platforms/rcore_web_emscripten.c
+++ b/src/platforms/rcore_web_emscripten.c
@@ -1507,8 +1507,16 @@ static EM_BOOL EmscriptenMouseCallback(int eventType, const EmscriptenMouseEvent
 {
     switch (eventType)
     {
-        case EMSCRIPTEN_EVENT_MOUSEENTER: CORE.Input.Mouse.cursorOnScreen = true; break;
-        case EMSCRIPTEN_EVENT_MOUSELEAVE: CORE.Input.Mouse.cursorOnScreen = false; break;
+        case EMSCRIPTEN_EVENT_MOUSEENTER: {
+            // NOTE: Mouse position updated by EmscriptenMouseMoveCallback(),
+            // EmscriptenPointerlockCallback(), and EmscriptenTouchCallback()
+            CORE.Input.Mouse.cursorOnScreen = true;
+        } break;
+        case EMSCRIPTEN_EVENT_MOUSELEAVE:
+        {
+            CORE.Input.Mouse.cursorOnScreen = false;
+            CORE.Input.Mouse.currentPosition = (Vector2){ 0 };
+        } break;
         case EMSCRIPTEN_EVENT_MOUSEDOWN:
         {
             // NOTE: Emscripten and raylib buttons indices are not aligned


### PR DESCRIPTION
This is a follow up to [issue 5945](https://github.com/raysan5/raylib/issues/5945) that applies a fix for web.
> When moving the mouse cursor outside of the window, GetMousePosition returns stale values, and no other window function seems to notice


This fix is similar to [commit 5e37421](https://github.com/raysan5/raylib/commit/5e374218eec7f137fb8f28c75fd97a639628efa1) to solve the same bug on another platform. I am using this platform's cursor enter/leave callback to zero the stored position the same way.

## Checks
- The wasm and windows build pipelines still work
- Follows the same conventions as similar fix
- No similar pr has been opened recently.
- Solves the bug in a test project
- Synchronized with the latest commit of the main branch.