### PR TITLE
[rtext] Fix TextInsertAlloc buffer overflow

### DIFF
--- a/src/rtext.c
+++ b/src/rtext.c
@@ -2014,7 +2014,7 @@ char *TextInsertAlloc(const char *text, const char *insert, int position)
 
         for (int i = 0; i < position; i++) result[i] = text[i];
         for (int i = position; i < (insertLen + position); i++) result[i] = insert[i - position];
-        for (int i = (insertLen + position); i < (textLen + insertLen + position); i++) result[i] = text[i - insertLen];
+        for (int i = (insertLen + position); i < (textLen + insertLen); i++) result[i] = text[i - insertLen];
 
         result[textLen + insertLen] = '\0'; // Add EOL
     }


### PR DESCRIPTION
### Problem

`TextInsertAlloc()` allocates `textLen + insertLen + 1` bytes, but its suffix-copy loop iterates until `textLen + insertLen + position`.

For any insertion position greater than zero, this reads beyond the source string and writes beyond the allocated result buffer.

### Fix

Remove the duplicated `position` term from the suffix-copy loop bound.

### Validation

- Reproduced the original overflow with MSVC AddressSanitizer