### PR TITLE
[rtextures][rlgl] Fix pixel data size regressions

### DIFF
--- a/src/rlgl.h
+++ b/src/rlgl.h
@@ -5237,7 +5237,7 @@ static int rlGetPixelDataSize(int width, int height, int format)
         {
             int blockWidth = (width + 3)/4;
             int blockHeight = (height + 3)/4;
-            unsigned long long dataSizeBytes = blockWidth*blockHeight*8;
+            unsigned long long dataSizeBytes = (unsigned long long)blockWidth*blockHeight*8;
             if (dataSizeBytes < INT_MAX) dataSize = (int)dataSizeBytes;
             
         } break;
@@ -5248,7 +5248,7 @@ static int rlGetPixelDataSize(int width, int height, int format)
         {
             int blockWidth = (width + 3)/4;
             int blockHeight = (height + 3)/4;
-            unsigned long long dataSizeBytes = blockWidth*blockHeight*16;
+            unsigned long long dataSizeBytes = (unsigned long long)blockWidth*blockHeight*16;
             if (dataSizeBytes < INT_MAX) dataSize = (int)dataSizeBytes;
             
         } break;
@@ -5256,7 +5256,7 @@ static int rlGetPixelDataSize(int width, int height, int format)
         {
             int blockWidth = (width + 3)/4;
             int blockHeight = (height + 3)/4;
-            unsigned long long dataSizeBytes = blockWidth*blockHeight*4;
+            unsigned long long dataSizeBytes = (unsigned long long)blockWidth*blockHeight*4;
             if (dataSizeBytes < INT_MAX) dataSize = (int)dataSizeBytes;
             
         } break;
@@ -5267,7 +5267,7 @@ static int rlGetPixelDataSize(int width, int height, int format)
     if ((format >= RL_PIXELFORMAT_UNCOMPRESSED_GRAYSCALE) &&
         (format <= RL_PIXELFORMAT_UNCOMPRESSED_R16G16B16A16))
     {
-        unsigned long long dataSizeBytes = (width*height*bpp) >> 3;  // Get size in bytes (dividing by 8)
+        unsigned long long dataSizeBytes = ((unsigned long long)width*height*bpp) >> 3;  // Get size in bytes (dividing by 8)
         if (dataSizeBytes < INT_MAX) dataSize = (int)dataSizeBytes;
     }
     

--- a/src/rtextures.c
+++ b/src/rtextures.c
@@ -2693,8 +2693,9 @@ void ImageRotate(Image *image, int degrees)
         int width = (int)(fabsf(image->width*cosRadius) + fabsf(image->height*sinRadius));
         int height = (int)(fabsf(image->height*cosRadius) + fabsf(image->width*sinRadius));
 
-        int bytesPerPixel = GetPixelDataSize(width, height, image->format);
-        unsigned char *rotatedData = (unsigned char *)RL_CALLOC(bytesPerPixel, 1);
+        int dataSize = GetPixelDataSize(width, height, image->format);
+        int bytesPerPixel = GetPixelDataSize(1, 1, image->format);
+        unsigned char *rotatedData = (unsigned char *)RL_CALLOC(dataSize, 1);
 
         if (rotatedData != NULL)
         {
@@ -5514,7 +5515,7 @@ int GetPixelDataSize(int width, int height, int format)
         default: break;
     }
     
-    unsigned long long dataSizeBytes = (width*height*bpp) >> 3;  // Get size in bytes (dividing by 8)
+    unsigned long long dataSizeBytes = ((unsigned long long)width*height*bpp) >> 3;  // Get size in bytes (dividing by 8)
 
     if (dataSizeBytes < INT_MAX)
     {


### PR DESCRIPTION
### Problem
Recent pixel-size hardening added 64-bit variables to safely check image data sizes before converting them to `int`. Some multiplication operands remain `int`, so the intermediate calculation may still occur at 32-bit width before assignment.

Explicitly promoting the first operand ensures the calculation consistently uses 64-bit arithmetic across compilers.

`ImageRotate()` used the total destination image size as its per-pixel stride, causing out-of-bounds access for images larger than one pixel.

### Fix

- Promote pixel-size multiplication operands before evaluation in both `GetPixelDataSize()` and `rlGetPixelDataSize()`.
- Keep `ImageRotate()` allocation size and per-pixel stride as separate values.

### Validation

- Reproduced the `ImageRotate()` overflow with MSVC AddressSanitizer.
- Verified large valid and over-limit pixel-size calculations.
- Verified zero-degree RGBA8 image rotation preserves dimensions and data.
- Built raylib and all examples with MSVC x64 Release.