### PR TITLE
[rcore] Fix logging format for automation event capacity warning

### DIFF
--- a/src/rcore.c
+++ b/src/rcore.c
@@ -3608,7 +3608,7 @@ AutomationEventList LoadAutomationEventList(const char *fileName)
 
                             counter++;
                         }
-                        else TRACELOG(LOG_WARNING, "AUTOMATION: Event goes beyond automated list capacity (MAX: %i): %s", buffer, list.capacity);
+                        else TRACELOG(LOG_WARNING, "AUTOMATION: Event goes beyond automated list capacity (MAX: %u): %s", list.capacity, buffer);
                     } break;
                     default: break;
                 }


### PR DESCRIPTION
The format specifiers and arguments in this log statement are mismatched:

```c
else TRACELOG(LOG_WARNING, "AUTOMATION: Event goes beyond automated list capacity (MAX: %i): %s", buffer, list.capacity);
```

The format string expects an integer followed by a string, but the arguments are passed as a string followed by an unsigned integer. If the automated event list reaches capacity, such as when 16,385 event lines are encountered, this mismatch can result in undefined behavior and potentially a crash.

This change swaps the arguments into the correct order and replaces `%i` with `%u` to match the unsigned type of `list.capacity`.
