### PR TITLE
[build] Fix static CMake link dependencies

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -107,6 +107,20 @@ endif ()
 target_link_libraries(raylib PRIVATE $<BUILD_INTERFACE:${LIBS_PRIVATE}>)
 target_link_libraries(raylib PUBLIC ${LIBS_PUBLIC})
 
+# Static libraries must export their private link dependencies for installed consumers.
+# LINK_ONLY keeps those dependencies out of the compile interface.
+if (NOT BUILD_SHARED_LIBS)
+    set(raylib_install_private_libs ${LIBS_PRIVATE})
+
+    if (NOT glfw3_FOUND)
+        list(REMOVE_ITEM raylib_install_private_libs glfw)
+    endif()
+
+    foreach(lib IN LISTS raylib_install_private_libs)
+        target_link_libraries(raylib INTERFACE $<INSTALL_INTERFACE:$<LINK_ONLY:${lib}>>)
+    endforeach()
+endif()
+
 # Sets some compile time definitions for the pre-processor
 # If CUSTOMIZE_BUILD option is on you will not use config.h by default
 # and you will be able to select more build options


### PR DESCRIPTION
Fixes #5926.

When raylib is installed as a static library, downstream CMake consumers need raylib's private platform/link dependencies to be present in the exported target metadata. Those dependencies were previously wrapped in "BUILD_INTERFACE", so the installed "raylib-targets.cmake" did not carry them forward.

This caused projects using "find_package(raylib)" to configure successfully but fail at link time with unresolved OpenGL/GLES symbols when raylib was built with "PLATFORM=Desktop" and 'OPENGL_VERSION="ES 2.0"'.

This keeps the existing build-only private link behavior, but adds install-only "LINK_ONLY" entries for static-library consumers. Bundled GLFW is excluded from the install interface when it is built as raylib object sources, because it is not an exported target.

I tested on Linux (WSL):

- I built and installed static raylib with "PLATFORM=Desktop", 'OPENGL_VERSION="ES 2.0"', "BUILD_SHARED_LIBS=OFF"
- I also built projects/CMake against the installed package
- Before (issue reproduced): consumer link failed with unresolved GL symbols such as "glViewport" and "glClear"
- After (with fix): consumer linked successfully