### PR TITLE
[rlsw] Variant dispatch refactor + bunch of improvements

### DIFF
--- a/src/external/rlsw.h
+++ b/src/external/rlsw.h
@@ -3783,7 +3783,6 @@ static void sw_immediate_set_color(const float color[4])
     RLSW.primitive.color[1] = color[1];
     RLSW.primitive.color[2] = color[2];
     RLSW.primitive.color[3] = color[3];
-
 }
 
 static void sw_immediate_set_texcoord(const float texcoord[2])
@@ -3837,6 +3836,18 @@ static void sw_immediate_push_vertex(const float position[4])
             else if ((RLSW.blendFlags & SW_BLEND_FLAG_NEEDS_ALPHA) && (!RLSW.primitive.hasColorAlpha))
             {
                 if (!(state & SW_STATE_TEXTURE_2D) || (RLSW.boundTexture->alpha == SW_PIXEL_ALPHA_NONE)) state &= ~SW_STATE_BLEND;
+            }
+        }
+
+        // Determine whether colors should be interpolated
+        const float *ref = RLSW.primitive.buffer[0].color;
+        for (int i = 1; i < RLSW.primitive.vertexCount; ++i)
+        {
+            const float *c = RLSW.primitive.buffer[i].color;
+            if (c[0] != ref[0] || c[1] != ref[1] || c[2] != ref[2] || c[3] != ref[3])
+            {
+                state |= SW_STATE_COLOR_INTERP;
+                break;
             }
         }
 

--- a/src/external/rlsw.h
+++ b/src/external/rlsw.h
@@ -5405,49 +5405,40 @@ static void SW_RASTER_TRIANGLE_SPAN(const sw_vertex_t *start, const sw_vertex_t 
         // Inner span pixel loop
         for (; x < blockEnd; x++)
         {
-            #if (SW_RASTER_TRIANGLE_FLAGS) & SW_STATE_DEPTH_TEST
+        #if (SW_RASTER_TRIANGLE_FLAGS) & SW_STATE_DEPTH_TEST
+            float depth = SW_FRAMEBUFFER_DEPTH_GET(dPtr, 0);
+            if (z <= depth)
             {
-                float depth = SW_FRAMEBUFFER_DEPTH_GET(dPtr, 0);
-                if (z > depth) goto discard;
                 SW_FRAMEBUFFER_DEPTH_SET(dPtr, z, 0);
-            }
-            #endif
+        #endif
 
             #if (SW_RASTER_TRIANGLE_FLAGS) & SW_STATE_TEXTURE_2D
-            {
                 float finalColor[4];
                 ctx->sample(finalColor, RLSW.boundTexture, tcAffine[0], tcAffine[1]);
                 SW_VEC_OP(finalColor[i] *= srcColor[i], i, 4);
-
-                #if (SW_RASTER_TRIANGLE_FLAGS) & SW_STATE_BLEND
-                {
-                    float dstColor[4];
-                    SW_FRAMEBUFFER_COLOR_GET(dstColor, cPtr, 0);
-                    RLSW.blendFunc(dstColor, finalColor);
-                    SW_FRAMEBUFFER_COLOR_SET(cPtr, dstColor, 0);
-                }
-                #else
-                    SW_FRAMEBUFFER_COLOR_SET(cPtr, finalColor, 0);
-                #endif
-            }
+                #define SW_FINAL_COLOR finalColor
             #else
-            {
-                #if (SW_RASTER_TRIANGLE_FLAGS) & SW_STATE_BLEND
-                {
-                    float dstColor[4];
-                    SW_FRAMEBUFFER_COLOR_GET(dstColor, cPtr, 0);
-                    RLSW.blendFunc(dstColor, srcColor);
-                    SW_FRAMEBUFFER_COLOR_SET(cPtr, dstColor, 0);
-                }
-                #else
-                    SW_FRAMEBUFFER_COLOR_SET(cPtr, srcColor, 0);
-                #endif
-            }
+                #define SW_FINAL_COLOR srcColor
             #endif
 
+            #if (SW_RASTER_TRIANGLE_FLAGS) & SW_STATE_BLEND
+            {
+                float dstColor[4];
+                SW_FRAMEBUFFER_COLOR_GET(dstColor, cPtr, 0);
+                RLSW.blendFunc(dstColor, SW_FINAL_COLOR);
+                SW_FRAMEBUFFER_COLOR_SET(cPtr, dstColor, 0);
+            }
+            #else
+                SW_FRAMEBUFFER_COLOR_SET(cPtr, SW_FINAL_COLOR, 0);
+            #endif
+
+            #undef SW_FINAL_COLOR
+
         #if (SW_RASTER_TRIANGLE_FLAGS) & SW_STATE_DEPTH_TEST
-        discard:
+            }
         #endif
+
+            // Advance unconditionally: depth test only guards the write above
             cPtr += SW_FRAMEBUFFER_COLOR_SIZE;
         #if (SW_RASTER_TRIANGLE_FLAGS) & SW_STATE_DEPTH_TEST
             dPtr += SW_FRAMEBUFFER_DEPTH_SIZE;
@@ -5710,38 +5701,32 @@ static void SW_RASTER_QUAD(const sw_vertex_t *a, const sw_vertex_t *b,
             const float *srcColor = SW_QUAD_BASE_COLOR;
         #endif
 
-            #if (SW_RASTER_QUAD_FLAGS) & SW_STATE_DEPTH_TEST
+        #if (SW_RASTER_QUAD_FLAGS) & SW_STATE_DEPTH_TEST
+            float depth = SW_FRAMEBUFFER_DEPTH_GET(dPtr, 0);
+            if (z <= depth)
             {
-                float depth = SW_FRAMEBUFFER_DEPTH_GET(dPtr, 0);
-                if (z > depth) goto discard;
                 SW_FRAMEBUFFER_DEPTH_SET(dPtr, z, 0);
-            }
-            #endif
+        #endif
 
             #if (SW_RASTER_QUAD_FLAGS) & SW_STATE_TEXTURE_2D
-            {
                 float texColor[4];
                 sample(texColor, RLSW.boundTexture, tc[0], tc[1]);
                 SW_VEC_OP(srcColor[i] *= texColor[i], i, 4);
-            }
             #endif
 
             #if (SW_RASTER_QUAD_FLAGS) & SW_STATE_BLEND
-            {
                 float dstColor[4];
                 SW_FRAMEBUFFER_COLOR_GET(dstColor, cPtr, 0);
                 RLSW.blendFunc(dstColor, srcColor);
                 SW_FRAMEBUFFER_COLOR_SET(cPtr, dstColor, 0);
-            }
             #else
-            {
                 SW_FRAMEBUFFER_COLOR_SET(cPtr, srcColor, 0);
-            }
             #endif
 
         #if (SW_RASTER_QUAD_FLAGS) & SW_STATE_DEPTH_TEST
-        discard:
+            }
         #endif
+
             // Move one pixel over without touching the original "start offset"
         #if (SW_RASTER_QUAD_FLAGS) & SW_STATE_COLOR_INTERP
             SW_VEC_OP(color[i] += dCdx[i], i, 4);

--- a/src/external/rlsw.h
+++ b/src/external/rlsw.h
@@ -906,6 +906,7 @@ SWAPI void swGetFramebufferAttachmentParameteriv(SWattachment attachment, SWatta
 #define SW_FRAMEBUFFER_COLOR_SIZE           SW_PIXELFORMAT_SIZE[SW_FRAMEBUFFER_COLOR_FORMAT]
 #define SW_FRAMEBUFFER_DEPTH_SIZE           SW_PIXELFORMAT_SIZE[SW_FRAMEBUFFER_DEPTH_FORMAT]
 
+#define SW_STATE_NONE                             0     /* Pseudo state used for the rasterizer variant with no pipeline state enabled */
 #define SW_STATE_SCISSOR_TEST               (1 << 0)
 #define SW_STATE_TEXTURE_2D                 (1 << 1)
 #define SW_STATE_DEPTH_TEST                 (1 << 2)
@@ -3061,314 +3062,200 @@ static bool sw_polygon_clip(sw_vertex_t polygon[SW_MAX_CLIPPED_POLYGON_VERTICES]
     return (n >= 3);
 }
 
+// Rasterizer variant generation macros
+//-------------------------------------------------------------------------------------------
+// Argument count (1-4)
+#define SW_NARGS_(_1,_2,_3,_4,N,...) N
+#define SW_NARGS(...) SW_NARGS_(__VA_ARGS__,4,3,2,1)
+
+// State tokens -> OR'd SW_STATE_xxx flags
+#define SW_OR1(a)       (SW_STATE_##a)
+#define SW_OR2(a,b)     (SW_STATE_##a | SW_STATE_##b)
+#define SW_OR3(a,b,c)   (SW_STATE_##a | SW_STATE_##b | SW_STATE_##c)
+#define SW_OR4(a,b,c,d) (SW_STATE_##a | SW_STATE_##b | SW_STATE_##c | SW_STATE_##d)
+#define SW_FLAGS_(N, ...) SW_CONCATX(SW_OR, N)(__VA_ARGS__)
+#define SW_FLAGS(...)     SW_FLAGS_(SW_NARGS(__VA_ARGS__), __VA_ARGS__)
+
+// State tokens -> function name suffix
+#define SW_CAT1(a)       a
+#define SW_CAT2(a,b)     a##_##b
+#define SW_CAT3(a,b,c)   a##_##b##_##c
+#define SW_CAT4(a,b,c,d) a##_##b##_##c##_##d
+#define SW_NAME_(N, ...) SW_CONCATX(SW_CAT, N)(__VA_ARGS__)
+#define SW_NAME(...)     SW_NAME_(SW_NARGS(__VA_ARGS__), __VA_ARGS__)
+
+// Forward decl for one variant; SIG is a parenthesized param list
+#define SW_RASTER_FWD(PREFIX, SIG, ...) \
+    static void SW_CONCATX(PREFIX, SW_NAME(__VA_ARGS__)) SIG;
+
+// Dispatch table entry for one variant
+#define SW_RASTER_ENTRY(PREFIX, ...) \
+    [SW_FLAGS(__VA_ARGS__)] = SW_CONCATX(PREFIX, SW_NAME(__VA_ARGS__)),
+
+// Variant lists: X(STATES...) invoked once per specialization
+// Triangle/quad: TEXTURE_2D, DEPTH_TEST, BLEND
+#define SW_RASTER_VARIANTS_3(X, ...)                \
+    X(__VA_ARGS__, NONE)                            \
+    X(__VA_ARGS__, TEXTURE_2D)                      \
+    X(__VA_ARGS__, DEPTH_TEST)                      \
+    X(__VA_ARGS__, BLEND)                           \
+    X(__VA_ARGS__, TEXTURE_2D, DEPTH_TEST)          \
+    X(__VA_ARGS__, TEXTURE_2D, BLEND)               \
+    X(__VA_ARGS__, DEPTH_TEST, BLEND)               \
+    X(__VA_ARGS__, TEXTURE_2D, DEPTH_TEST, BLEND)
+
+// Line/point: DEPTH_TEST, BLEND
+#define SW_RASTER_VARIANTS_2(X, ...)    \
+    X(__VA_ARGS__, NONE)                \
+    X(__VA_ARGS__, DEPTH_TEST)          \
+    X(__VA_ARGS__, BLEND)               \
+    X(__VA_ARGS__, DEPTH_TEST, BLEND)
+//-------------------------------------------------------------------------------------------
+
 // Triangle rasterizer variant dispatch
 //-------------------------------------------------------------------------------------------
-#ifndef RLSW_TEMPLATE_RASTER_TRIANGLE_EXPANDING
-#define RLSW_TEMPLATE_RASTER_TRIANGLE_EXPANDING
+#define SW_RASTER_TRIANGLE_STATE_MASK SW_FLAGS(TEXTURE_2D, DEPTH_TEST, BLEND)
 
-    // State mask to apply before indexing the dispatch table
-    #define SW_RASTER_TRIANGLE_STATE_MASK \
-        (SW_STATE_TEXTURE_2D | SW_STATE_DEPTH_TEST | SW_STATE_BLEND)
+#define SW_RASTER_TRIANGLE_STATES NONE
+#include __FILE__ // IWYU pragma: keep
+#undef SW_RASTER_TRIANGLE_STATES
 
-    // Single source of truth for all rasterizer specializations
-    // X(NAME, STATE_FLAGS)
-    #define SW_RASTER_VARIANTS(X)                                                       \
-        X(BASE,            0)                                                           \
-        X(TEX,             SW_STATE_TEXTURE_2D)                                         \
-        X(DEPTH,           SW_STATE_DEPTH_TEST)                                         \
-        X(BLEND,           SW_STATE_BLEND)                                              \
-        X(TEX_DEPTH,       SW_STATE_TEXTURE_2D | SW_STATE_DEPTH_TEST)                   \
-        X(TEX_BLEND,       SW_STATE_TEXTURE_2D | SW_STATE_BLEND)                        \
-        X(DEPTH_BLEND,     SW_STATE_DEPTH_TEST | SW_STATE_BLEND)                        \
-        X(TEX_DEPTH_BLEND, SW_STATE_TEXTURE_2D | SW_STATE_DEPTH_TEST | SW_STATE_BLEND)
+#define SW_RASTER_TRIANGLE_STATES TEXTURE_2D
+#include __FILE__
+#undef SW_RASTER_TRIANGLE_STATES
 
-    // Forward declarations because clangd does not follow #include __FILE__ to avoid infinite recursion
-    // These declarations make all variants visible to static analysis tools without affecting compilation
-    #define SW_FWD_DECL(NAME, _FLAGS) \
-        static void sw_raster_triangle_##NAME(const sw_vertex_t*, const sw_vertex_t*, const sw_vertex_t*);
-    SW_RASTER_VARIANTS(SW_FWD_DECL) // NOLINT
-    #undef SW_FWD_DECL
+#define SW_RASTER_TRIANGLE_STATES DEPTH_TEST
+#include __FILE__
+#undef SW_RASTER_TRIANGLE_STATES
 
-    // Specialization generation via self-inclusion
+#define SW_RASTER_TRIANGLE_STATES BLEND
+#include __FILE__
+#undef SW_RASTER_TRIANGLE_STATES
 
-    #define RLSW_TEMPLATE_RASTER_TRIANGLE BASE
-    #define RLSW_RASTER_FLAGS (0)
-    #include __FILE__ // IWYU pragma: keep
-    #undef RLSW_RASTER_FLAGS
-    #undef RLSW_TEMPLATE_RASTER_TRIANGLE
+#define SW_RASTER_TRIANGLE_STATES TEXTURE_2D, DEPTH_TEST
+#include __FILE__
+#undef SW_RASTER_TRIANGLE_STATES
 
-    #define RLSW_TEMPLATE_RASTER_TRIANGLE TEX
-    #define RLSW_RASTER_FLAGS (SW_STATE_TEXTURE_2D)
-    #include __FILE__
-    #undef RLSW_RASTER_FLAGS
-    #undef RLSW_TEMPLATE_RASTER_TRIANGLE
+#define SW_RASTER_TRIANGLE_STATES TEXTURE_2D, BLEND
+#include __FILE__
+#undef SW_RASTER_TRIANGLE_STATES
 
-    #define RLSW_TEMPLATE_RASTER_TRIANGLE DEPTH
-    #define RLSW_RASTER_FLAGS (SW_STATE_DEPTH_TEST)
-    #include __FILE__
-    #undef RLSW_RASTER_FLAGS
-    #undef RLSW_TEMPLATE_RASTER_TRIANGLE
+#define SW_RASTER_TRIANGLE_STATES DEPTH_TEST, BLEND
+#include __FILE__
+#undef SW_RASTER_TRIANGLE_STATES
 
-    #define RLSW_TEMPLATE_RASTER_TRIANGLE BLEND
-    #define RLSW_RASTER_FLAGS (SW_STATE_BLEND)
-    #include __FILE__
-    #undef RLSW_RASTER_FLAGS
-    #undef RLSW_TEMPLATE_RASTER_TRIANGLE
+#define SW_RASTER_TRIANGLE_STATES TEXTURE_2D, DEPTH_TEST, BLEND
+#include __FILE__
+#undef SW_RASTER_TRIANGLE_STATES
 
-    #define RLSW_TEMPLATE_RASTER_TRIANGLE TEX_DEPTH
-    #define RLSW_RASTER_FLAGS (SW_STATE_TEXTURE_2D | SW_STATE_DEPTH_TEST)
-    #include __FILE__
-    #undef RLSW_RASTER_FLAGS
-    #undef RLSW_TEMPLATE_RASTER_TRIANGLE
+// Forward declarations because clangd does not follow #include __FILE__ to avoid infinite recursion
+// These declarations make all variants visible to static analysis tools without affecting compilation
+SW_RASTER_VARIANTS_3(SW_RASTER_FWD, sw_raster_triangle_, (const sw_vertex_t*, const sw_vertex_t*, const sw_vertex_t*)) // NOLINT
 
-    #define RLSW_TEMPLATE_RASTER_TRIANGLE TEX_BLEND
-    #define RLSW_RASTER_FLAGS (SW_STATE_TEXTURE_2D | SW_STATE_BLEND)
-    #include __FILE__
-    #undef RLSW_RASTER_FLAGS
-    #undef RLSW_TEMPLATE_RASTER_TRIANGLE
-
-    #define RLSW_TEMPLATE_RASTER_TRIANGLE DEPTH_BLEND
-    #define RLSW_RASTER_FLAGS (SW_STATE_DEPTH_TEST | SW_STATE_BLEND)
-    #include __FILE__
-    #undef RLSW_RASTER_FLAGS
-    #undef RLSW_TEMPLATE_RASTER_TRIANGLE
-
-    #define RLSW_TEMPLATE_RASTER_TRIANGLE TEX_DEPTH_BLEND
-    #define RLSW_RASTER_FLAGS (SW_STATE_TEXTURE_2D | SW_STATE_DEPTH_TEST | SW_STATE_BLEND)
-    #include __FILE__
-    #undef RLSW_RASTER_FLAGS
-    #undef RLSW_TEMPLATE_RASTER_TRIANGLE
-
-    // Dispatch table (auto-generated from SW_RASTER_VARIANTS)
-    #define SW_TABLE_ENTRY(NAME, FLAGS) [FLAGS] = sw_raster_triangle_##NAME,
-    static const sw_raster_triangle_f SW_RASTER_TRIANGLE_TABLE[] = {
-        SW_RASTER_VARIANTS(SW_TABLE_ENTRY)
-    };
-    #undef SW_TABLE_ENTRY
-
-#undef SW_RASTER_VARIANTS
-#undef RLSW_TEMPLATE_RASTER_TRIANGLE_EXPANDING
-
-#endif // RLSW_TEMPLATE_RASTER_TRIANGLE_EXPANDING
+static const sw_raster_triangle_f SW_RASTER_TRIANGLE_TABLE[] = {
+    SW_RASTER_VARIANTS_3(SW_RASTER_ENTRY, sw_raster_triangle_)
+};
 //-------------------------------------------------------------------------------------------
 
 // Quad rasterizer variant dispatch
 //-------------------------------------------------------------------------------------------
-#ifndef RLSW_TEMPLATE_RASTER_QUAD_EXPANDING
-#define RLSW_TEMPLATE_RASTER_QUAD_EXPANDING
+#define SW_RASTER_QUAD_STATE_MASK SW_FLAGS(TEXTURE_2D, DEPTH_TEST, BLEND)
 
-    // State mask to apply before indexing the dispatch table
-    #define SW_RASTER_QUAD_STATE_MASK \
-        (SW_STATE_TEXTURE_2D | SW_STATE_DEPTH_TEST | SW_STATE_BLEND)
+#define SW_RASTER_QUAD_STATES NONE
+#include __FILE__ // IWYU pragma: keep
+#undef SW_RASTER_QUAD_STATES
 
-    // Single source of truth for all rasterizer specializations
-    // X(NAME, STATE_FLAGS)
-    #define SW_RASTER_VARIANTS(X)                                                       \
-        X(BASE,            0)                                                           \
-        X(TEX,             SW_STATE_TEXTURE_2D)                                         \
-        X(DEPTH,           SW_STATE_DEPTH_TEST)                                         \
-        X(BLEND,           SW_STATE_BLEND)                                              \
-        X(TEX_DEPTH,       SW_STATE_TEXTURE_2D | SW_STATE_DEPTH_TEST)                   \
-        X(TEX_BLEND,       SW_STATE_TEXTURE_2D | SW_STATE_BLEND)                        \
-        X(DEPTH_BLEND,     SW_STATE_DEPTH_TEST | SW_STATE_BLEND)                        \
-        X(TEX_DEPTH_BLEND, SW_STATE_TEXTURE_2D | SW_STATE_DEPTH_TEST | SW_STATE_BLEND)
+#define SW_RASTER_QUAD_STATES TEXTURE_2D
+#include __FILE__
+#undef SW_RASTER_QUAD_STATES
 
-    // Forward declarations because clangd does not follow #include __FILE__ to avoid infinite recursion
-    // These declarations make all variants visible to static analysis tools without affecting compilation
-    #define SW_FWD_DECL(NAME, _FLAGS) \
-        static void sw_raster_quad_##NAME(const sw_vertex_t *v0, const sw_vertex_t *v1, const sw_vertex_t *v2, const sw_vertex_t *v3);
-    SW_RASTER_VARIANTS(SW_FWD_DECL) // NOLINT
-    #undef SW_FWD_DECL
+#define SW_RASTER_QUAD_STATES DEPTH_TEST
+#include __FILE__
+#undef SW_RASTER_QUAD_STATES
 
-    // Specialization generation via self-inclusion
+#define SW_RASTER_QUAD_STATES BLEND
+#include __FILE__
+#undef SW_RASTER_QUAD_STATES
 
-    #define RLSW_TEMPLATE_RASTER_QUAD BASE
-    #define RLSW_RASTER_FLAGS (0)
-    #include __FILE__ // IWYU pragma: keep
-    #undef RLSW_RASTER_FLAGS
-    #undef RLSW_TEMPLATE_RASTER_QUAD
+#define SW_RASTER_QUAD_STATES TEXTURE_2D, DEPTH_TEST
+#include __FILE__
+#undef SW_RASTER_QUAD_STATES
 
-    #define RLSW_TEMPLATE_RASTER_QUAD TEX
-    #define RLSW_RASTER_FLAGS (SW_STATE_TEXTURE_2D)
-    #include __FILE__
-    #undef RLSW_RASTER_FLAGS
-    #undef RLSW_TEMPLATE_RASTER_QUAD
+#define SW_RASTER_QUAD_STATES TEXTURE_2D, BLEND
+#include __FILE__
+#undef SW_RASTER_QUAD_STATES
 
-    #define RLSW_TEMPLATE_RASTER_QUAD DEPTH
-    #define RLSW_RASTER_FLAGS (SW_STATE_DEPTH_TEST)
-    #include __FILE__
-    #undef RLSW_RASTER_FLAGS
-    #undef RLSW_TEMPLATE_RASTER_QUAD
+#define SW_RASTER_QUAD_STATES DEPTH_TEST, BLEND
+#include __FILE__
+#undef SW_RASTER_QUAD_STATES
 
-    #define RLSW_TEMPLATE_RASTER_QUAD BLEND
-    #define RLSW_RASTER_FLAGS (SW_STATE_BLEND)
-    #include __FILE__
-    #undef RLSW_RASTER_FLAGS
-    #undef RLSW_TEMPLATE_RASTER_QUAD
+#define SW_RASTER_QUAD_STATES TEXTURE_2D, DEPTH_TEST, BLEND
+#include __FILE__
+#undef SW_RASTER_QUAD_STATES
 
-    #define RLSW_TEMPLATE_RASTER_QUAD TEX_DEPTH
-    #define RLSW_RASTER_FLAGS (SW_STATE_TEXTURE_2D | SW_STATE_DEPTH_TEST)
-    #include __FILE__
-    #undef RLSW_RASTER_FLAGS
-    #undef RLSW_TEMPLATE_RASTER_QUAD
+SW_RASTER_VARIANTS_3(SW_RASTER_FWD, sw_raster_quad_, (const sw_vertex_t*, const sw_vertex_t*, const sw_vertex_t*, const sw_vertex_t*)) // NOLINT
 
-    #define RLSW_TEMPLATE_RASTER_QUAD TEX_BLEND
-    #define RLSW_RASTER_FLAGS (SW_STATE_TEXTURE_2D | SW_STATE_BLEND)
-    #include __FILE__
-    #undef RLSW_RASTER_FLAGS
-    #undef RLSW_TEMPLATE_RASTER_QUAD
-
-    #define RLSW_TEMPLATE_RASTER_QUAD DEPTH_BLEND
-    #define RLSW_RASTER_FLAGS (SW_STATE_DEPTH_TEST | SW_STATE_BLEND)
-    #include __FILE__
-    #undef RLSW_RASTER_FLAGS
-    #undef RLSW_TEMPLATE_RASTER_QUAD
-
-    #define RLSW_TEMPLATE_RASTER_QUAD TEX_DEPTH_BLEND
-    #define RLSW_RASTER_FLAGS (SW_STATE_TEXTURE_2D | SW_STATE_DEPTH_TEST | SW_STATE_BLEND)
-    #include __FILE__
-    #undef RLSW_RASTER_FLAGS
-    #undef RLSW_TEMPLATE_RASTER_QUAD
-
-    // Dispatch table (auto-generated from SW_RASTER_VARIANTS)
-    #define SW_TABLE_ENTRY(NAME, FLAGS) [FLAGS] = sw_raster_quad_##NAME,
-    static const sw_raster_quad_f SW_RASTER_QUAD_TABLE[] = {
-        SW_RASTER_VARIANTS(SW_TABLE_ENTRY)
-    };
-    #undef SW_TABLE_ENTRY
-
-#undef SW_RASTER_VARIANTS
-#undef RLSW_TEMPLATE_RASTER_QUAD_EXPANDING
-
-#endif // RLSW_TEMPLATE_RASTER_QUAD_EXPANDING
+static const sw_raster_quad_f SW_RASTER_QUAD_TABLE[] = {
+    SW_RASTER_VARIANTS_3(SW_RASTER_ENTRY, sw_raster_quad_)
+};
 //-------------------------------------------------------------------------------------------
 
 // Line rasterizer variant dispatch
 //-------------------------------------------------------------------------------------------
-#ifndef RLSW_TEMPLATE_RASTER_LINE_EXPANDING
-#define RLSW_TEMPLATE_RASTER_LINE_EXPANDING
+#define SW_RASTER_LINE_STATE_MASK SW_FLAGS(DEPTH_TEST, BLEND)
 
-    // State mask to apply before indexing the dispatch table
-    #define SW_RASTER_LINE_STATE_MASK \
-        (SW_STATE_DEPTH_TEST | SW_STATE_BLEND)
+#define SW_RASTER_LINE_STATES NONE
+#include __FILE__ // IWYU pragma: keep
+#undef SW_RASTER_LINE_STATES
 
-    // Single source of truth for all rasterizer specializations
-    // X(NAME, STATE_FLAGS)
-    #define SW_RASTER_VARIANTS(X)                                                       \
-        X(BASE,            0)                                                           \
-        X(DEPTH,           SW_STATE_DEPTH_TEST)                                         \
-        X(BLEND,           SW_STATE_BLEND)                                              \
-        X(DEPTH_BLEND,     SW_STATE_DEPTH_TEST | SW_STATE_BLEND)
+#define SW_RASTER_LINE_STATES DEPTH_TEST
+#include __FILE__
+#undef SW_RASTER_LINE_STATES
 
-    // Forward declarations because clangd does not follow #include __FILE__ to avoid infinite recursion
-    // These declarations make all variants visible to static analysis tools without affecting compilation
-    #define SW_FWD_DECL(NAME, _FLAGS)                                                       \
-        static void sw_raster_line_##NAME(const sw_vertex_t *v0, const sw_vertex_t *v1);    \
-        static void sw_raster_line_thick_##NAME(const sw_vertex_t *v0, const sw_vertex_t *v1);
-    SW_RASTER_VARIANTS(SW_FWD_DECL) // NOLINT
-    #undef SW_FWD_DECL
+#define SW_RASTER_LINE_STATES BLEND
+#include __FILE__
+#undef SW_RASTER_LINE_STATES
 
-    // Specialization generation via self-inclusion
+#define SW_RASTER_LINE_STATES DEPTH_TEST, BLEND
+#include __FILE__
+#undef SW_RASTER_LINE_STATES
 
-    #define RLSW_TEMPLATE_RASTER_LINE BASE
-    #define RLSW_RASTER_FLAGS (0)
-    #include __FILE__ // IWYU pragma: keep
-    #undef RLSW_RASTER_FLAGS
-    #undef RLSW_TEMPLATE_RASTER_LINE
+SW_RASTER_VARIANTS_3(SW_RASTER_FWD, sw_raster_line_, (const sw_vertex_t*, const sw_vertex_t*)) // NOLINT
+SW_RASTER_VARIANTS_3(SW_RASTER_FWD, sw_raster_line_thick_, (const sw_vertex_t*, const sw_vertex_t*)) // NOLINT
 
-    #define RLSW_TEMPLATE_RASTER_LINE DEPTH
-    #define RLSW_RASTER_FLAGS (SW_STATE_DEPTH_TEST)
-    #include __FILE__
-    #undef RLSW_RASTER_FLAGS
-    #undef RLSW_TEMPLATE_RASTER_LINE
-
-    #define RLSW_TEMPLATE_RASTER_LINE BLEND
-    #define RLSW_RASTER_FLAGS (SW_STATE_BLEND)
-    #include __FILE__
-    #undef RLSW_RASTER_FLAGS
-    #undef RLSW_TEMPLATE_RASTER_LINE
-
-    #define RLSW_TEMPLATE_RASTER_LINE DEPTH_BLEND
-    #define RLSW_RASTER_FLAGS (SW_STATE_DEPTH_TEST | SW_STATE_BLEND)
-    #include __FILE__
-    #undef RLSW_RASTER_FLAGS
-    #undef RLSW_TEMPLATE_RASTER_LINE
-
-    // Dispatch table (auto-generated from SW_RASTER_VARIANTS)
-    #define SW_TABLE_ENTRY0(NAME, FLAGS) [FLAGS] = sw_raster_line_##NAME,
-    #define SW_TABLE_ENTRY1(NAME, FLAGS) [FLAGS] = sw_raster_line_thick_##NAME,
-    static const sw_raster_line_f SW_RASTER_LINE_TABLE[] = {  SW_RASTER_VARIANTS(SW_TABLE_ENTRY0) };
-    static const sw_raster_line_f SW_RASTER_LINE_THICK_TABLE[] = { SW_RASTER_VARIANTS(SW_TABLE_ENTRY1) };
-    #undef SW_TABLE_ENTRY0
-    #undef SW_TABLE_ENTRY1
-
-#undef SW_RASTER_VARIANTS
-#undef RLSW_TEMPLATE_RASTER_LINE_EXPANDING
-
-#endif // RLSW_TEMPLATE_RASTER_LINE_EXPANDING
+static const sw_raster_line_f SW_RASTER_LINE_TABLE[] = {
+    SW_RASTER_VARIANTS_2(SW_RASTER_ENTRY, sw_raster_line_)
+};
+static const sw_raster_line_f SW_RASTER_LINE_THICK_TABLE[] = {
+    SW_RASTER_VARIANTS_2(SW_RASTER_ENTRY, sw_raster_line_thick_)
+};
 //-------------------------------------------------------------------------------------------
 
 // Point rasterizer variant dispatch
 //-------------------------------------------------------------------------------------------
-#ifndef RLSW_TEMPLATE_RASTER_POINT_EXPANDING
-#define RLSW_TEMPLATE_RASTER_POINT_EXPANDING
+#define SW_RASTER_POINT_STATE_MASK SW_FLAGS(DEPTH_TEST, BLEND)
 
-    // State mask to apply before indexing the dispatch table
-    #define SW_RASTER_POINT_STATE_MASK \
-        (SW_STATE_DEPTH_TEST | SW_STATE_BLEND)
+#define SW_RASTER_POINT_STATES NONE
+#include __FILE__ // IWYU pragma: keep
+#undef SW_RASTER_POINT_STATES
 
-    // Single source of truth for all rasterizer specializations
-    // X(NAME, STATE_FLAGS)
-    #define SW_RASTER_VARIANTS(X)                                                       \
-        X(BASE,            0)                                                           \
-        X(DEPTH,           SW_STATE_DEPTH_TEST)                                         \
-        X(BLEND,           SW_STATE_BLEND)                                              \
-        X(DEPTH_BLEND,     SW_STATE_DEPTH_TEST | SW_STATE_BLEND)
+#define SW_RASTER_POINT_STATES DEPTH_TEST
+#include __FILE__
+#undef SW_RASTER_POINT_STATES
 
-    // Forward declarations because clangd does not follow #include __FILE__ to avoid infinite recursion
-    // These declarations make all variants visible to static analysis tools without affecting compilation
-    #define SW_FWD_DECL(NAME, _FLAGS) \
-        static void sw_raster_point_##NAME(const sw_vertex_t *v);
-    SW_RASTER_VARIANTS(SW_FWD_DECL) // NOLINT
-    #undef SW_FWD_DECL
+#define SW_RASTER_POINT_STATES BLEND
+#include __FILE__
+#undef SW_RASTER_POINT_STATES
 
-    // Specialization generation via self-inclusion
+#define SW_RASTER_POINT_STATES DEPTH_TEST, BLEND
+#include __FILE__
+#undef SW_RASTER_POINT_STATES
 
-    #define RLSW_TEMPLATE_RASTER_POINT BASE
-    #define RLSW_RASTER_FLAGS (0)
-    #include __FILE__ // IWYU pragma: keep
-    #undef RLSW_RASTER_FLAGS
-    #undef RLSW_TEMPLATE_RASTER_POINT
+SW_RASTER_VARIANTS_2(SW_RASTER_FWD, sw_raster_point_, (const sw_vertex_t*)) // NOLINT
 
-    #define RLSW_TEMPLATE_RASTER_POINT DEPTH
-    #define RLSW_RASTER_FLAGS (SW_STATE_DEPTH_TEST)
-    #include __FILE__
-    #undef RLSW_RASTER_FLAGS
-    #undef RLSW_TEMPLATE_RASTER_POINT
-
-    #define RLSW_TEMPLATE_RASTER_POINT BLEND
-    #define RLSW_RASTER_FLAGS (SW_STATE_BLEND)
-    #include __FILE__
-    #undef RLSW_RASTER_FLAGS
-    #undef RLSW_TEMPLATE_RASTER_POINT
-
-    #define RLSW_TEMPLATE_RASTER_POINT DEPTH_BLEND
-    #define RLSW_RASTER_FLAGS (SW_STATE_DEPTH_TEST | SW_STATE_BLEND)
-    #include __FILE__
-    #undef RLSW_RASTER_FLAGS
-    #undef RLSW_TEMPLATE_RASTER_POINT
-
-    // Dispatch table (auto-generated from SW_RASTER_VARIANTS)
-    #define SW_TABLE_ENTRY(NAME, FLAGS) [FLAGS] = sw_raster_point_##NAME,
-    static const sw_raster_point_f SW_RASTER_POINT_TABLE[] = {
-        SW_RASTER_VARIANTS(SW_TABLE_ENTRY)
-    };
-    #undef SW_TABLE_ENTRY
-
-#undef SW_RASTER_VARIANTS
-#undef RLSW_TEMPLATE_RASTER_POINT_EXPANDING
-
-#endif // RLSW_TEMPLATE_RASTER_POINT_EXPANDING
+static const sw_raster_point_f SW_RASTER_POINT_TABLE[] = {
+    SW_RASTER_VARIANTS_2(SW_RASTER_ENTRY, sw_raster_point_)
+};
 //-------------------------------------------------------------------------------------------
 
 // Triangle rendering logic
@@ -5345,12 +5232,13 @@ void swGetFramebufferAttachmentParameteriv(SWattachment attachment, SWattachget 
 
 // Triangle rasterization functions
 //-------------------------------------------------------------------------------------------
-#ifdef RLSW_TEMPLATE_RASTER_TRIANGLE
+#ifdef SW_RASTER_TRIANGLE_STATES
 
-#define SW_RASTER_TRIANGLE_SPAN SW_CONCATX(sw_raster_triangle_span_, RLSW_TEMPLATE_RASTER_TRIANGLE)
-#define SW_RASTER_TRIANGLE      SW_CONCATX(sw_raster_triangle_, RLSW_TEMPLATE_RASTER_TRIANGLE)
+#define SW_RASTER_TRIANGLE_FLAGS SW_FLAGS(SW_RASTER_TRIANGLE_STATES)
+#define SW_RASTER_TRIANGLE_SPAN  SW_CONCATX(sw_raster_triangle_span_, SW_NAME(SW_RASTER_TRIANGLE_STATES))
+#define SW_RASTER_TRIANGLE       SW_CONCATX(sw_raster_triangle_, SW_NAME(SW_RASTER_TRIANGLE_STATES))
 
-#if (RLSW_RASTER_FLAGS) & SW_STATE_TEXTURE_2D
+#if (SW_RASTER_TRIANGLE_FLAGS) & SW_STATE_TEXTURE_2D
     #define SW_GET_GRAD         sw_get_vertex_grad_PCT
     #define SW_ADD_GRAD         sw_add_vertex_grad_PCT
     #define SW_ADD_GRAD_SCALED  sw_add_vertex_grad_scaled_PCT
@@ -5388,10 +5276,10 @@ static void SW_RASTER_TRIANGLE_SPAN(const sw_vertex_t *start, const sw_vertex_t 
         (end->color[2] - start->color[2])*dxRcp,
         (end->color[3] - start->color[3])*dxRcp
     };
-#if (RLSW_RASTER_FLAGS) & SW_STATE_DEPTH_TEST
+#if (SW_RASTER_TRIANGLE_FLAGS) & SW_STATE_DEPTH_TEST
     float dZdx = (end->position[2] - start->position[2])*dxRcp;
 #endif
-#if (RLSW_RASTER_FLAGS) & SW_STATE_TEXTURE_2D
+#if (SW_RASTER_TRIANGLE_FLAGS) & SW_STATE_TEXTURE_2D
     float dUdx = (end->texcoord[0] - start->texcoord[0])*dxRcp;
     float dVdx = (end->texcoord[1] - start->texcoord[1])*dxRcp;
 #endif
@@ -5410,10 +5298,10 @@ static void SW_RASTER_TRIANGLE_SPAN(const sw_vertex_t *start, const sw_vertex_t 
         start->color[2] + dCdx[2]*xOffset,
         start->color[3] + dCdx[3]*xOffset
     };
-#if (RLSW_RASTER_FLAGS) & SW_STATE_DEPTH_TEST
+#if (SW_RASTER_TRIANGLE_FLAGS) & SW_STATE_DEPTH_TEST
     float z = start->position[2] + dZdx*xOffset;
 #endif
-#if (RLSW_RASTER_FLAGS) & SW_STATE_TEXTURE_2D
+#if (SW_RASTER_TRIANGLE_FLAGS) & SW_STATE_TEXTURE_2D
     float u = start->texcoord[0] + dUdx*xOffset;
     float v = start->texcoord[1] + dVdx*xOffset;
 #endif
@@ -5421,7 +5309,7 @@ static void SW_RASTER_TRIANGLE_SPAN(const sw_vertex_t *start, const sw_vertex_t 
     // Pre-calculate the starting pointers for the framebuffer row
     int baseOffset = y*RLSW.colorBuffer->width + xLoopStart;
     uint8_t *cPtr = (uint8_t *)(RLSW.colorBuffer->pixels) + baseOffset*SW_FRAMEBUFFER_COLOR_SIZE;
-#if (RLSW_RASTER_FLAGS) & SW_STATE_DEPTH_TEST
+#if (SW_RASTER_TRIANGLE_FLAGS) & SW_STATE_DEPTH_TEST
     uint8_t *dPtr = (uint8_t *)(RLSW.depthBuffer->pixels) + baseOffset*SW_FRAMEBUFFER_DEPTH_SIZE;
 #endif
 
@@ -5455,7 +5343,7 @@ static void SW_RASTER_TRIANGLE_SPAN(const sw_vertex_t *start, const sw_vertex_t 
             ((color[3] + dCdx[3]*blockLenF)*wRcpB - srcColor[3])*blockLenRcp
         };
 
-    #if (RLSW_RASTER_FLAGS) & SW_STATE_TEXTURE_2D
+    #if (SW_RASTER_TRIANGLE_FLAGS) & SW_STATE_TEXTURE_2D
         // Perspective-correct UVs at both endpoints, then affine gradient
         float uAffine  = u*wRcpA;
         float vAffine  = v*wRcpA;
@@ -5466,7 +5354,7 @@ static void SW_RASTER_TRIANGLE_SPAN(const sw_vertex_t *start, const sw_vertex_t 
         // Inner span pixel loop
         for (; x < blockEnd; x++)
         {
-            #if (RLSW_RASTER_FLAGS) & SW_STATE_DEPTH_TEST
+            #if (SW_RASTER_TRIANGLE_FLAGS) & SW_STATE_DEPTH_TEST
             {
                 float depth = SW_FRAMEBUFFER_DEPTH_GET(dPtr, 0);
                 if (z > depth) goto discard;
@@ -5474,7 +5362,7 @@ static void SW_RASTER_TRIANGLE_SPAN(const sw_vertex_t *start, const sw_vertex_t 
             }
             #endif
 
-            #if (RLSW_RASTER_FLAGS) & SW_STATE_TEXTURE_2D
+            #if (SW_RASTER_TRIANGLE_FLAGS) & SW_STATE_TEXTURE_2D
             {
                 float texColor[4];
                 sw_texture_sample(texColor, RLSW.boundTexture, uAffine, vAffine, dUdx, dUdy, dVdx, dVdy);
@@ -5484,7 +5372,7 @@ static void SW_RASTER_TRIANGLE_SPAN(const sw_vertex_t *start, const sw_vertex_t 
                     srcColor[2]*texColor[2],
                     srcColor[3]*texColor[3]
                 };
-                #if (RLSW_RASTER_FLAGS) & SW_STATE_BLEND
+                #if (SW_RASTER_TRIANGLE_FLAGS) & SW_STATE_BLEND
                 {
                     float dstColor[4];
                     SW_FRAMEBUFFER_COLOR_GET(dstColor, cPtr, 0);
@@ -5497,7 +5385,7 @@ static void SW_RASTER_TRIANGLE_SPAN(const sw_vertex_t *start, const sw_vertex_t 
             }
             #else
             {
-                #if (RLSW_RASTER_FLAGS) & SW_STATE_BLEND
+                #if (SW_RASTER_TRIANGLE_FLAGS) & SW_STATE_BLEND
                 {
                     float dstColor[4];
                     SW_FRAMEBUFFER_COLOR_GET(dstColor, cPtr, 0);
@@ -5510,7 +5398,7 @@ static void SW_RASTER_TRIANGLE_SPAN(const sw_vertex_t *start, const sw_vertex_t 
             }
             #endif
 
-        #if (RLSW_RASTER_FLAGS) & SW_STATE_DEPTH_TEST
+        #if (SW_RASTER_TRIANGLE_FLAGS) & SW_STATE_DEPTH_TEST
         discard:
         #endif
             srcColor[0] += dSrcColordx[0];
@@ -5519,14 +5407,14 @@ static void SW_RASTER_TRIANGLE_SPAN(const sw_vertex_t *start, const sw_vertex_t 
             srcColor[3] += dSrcColordx[3];
             cPtr += SW_FRAMEBUFFER_COLOR_SIZE;
 
-            #if (RLSW_RASTER_FLAGS) & SW_STATE_DEPTH_TEST
+            #if (SW_RASTER_TRIANGLE_FLAGS) & SW_STATE_DEPTH_TEST
             {
                 z += dZdx;
                 dPtr += SW_FRAMEBUFFER_DEPTH_SIZE;
             }
             #endif
 
-            #if (RLSW_RASTER_FLAGS) & SW_STATE_TEXTURE_2D
+            #if (SW_RASTER_TRIANGLE_FLAGS) & SW_STATE_TEXTURE_2D
             {
                 uAffine += dUaffine;
                 vAffine += dVaffine;
@@ -5540,7 +5428,7 @@ static void SW_RASTER_TRIANGLE_SPAN(const sw_vertex_t *start, const sw_vertex_t 
         color[1] += dCdx[1]*blockLenF;
         color[2] += dCdx[2]*blockLenF;
         color[3] += dCdx[3]*blockLenF;
-        #if (RLSW_RASTER_FLAGS) & SW_STATE_TEXTURE_2D
+        #if (SW_RASTER_TRIANGLE_FLAGS) & SW_STATE_TEXTURE_2D
         u += dUdx*blockLenF;
         v += dVdx*blockLenF;
         #endif
@@ -5626,14 +5514,15 @@ static void SW_RASTER_TRIANGLE(const sw_vertex_t *v0, const sw_vertex_t *v1, con
 #undef SW_ADD_GRAD
 #undef SW_ADD_GRAD_SCALED
 
-#endif // RLSW_TEMPLATE_RASTER_TRIANGLE
+#endif // SW_RASTER_TRIANGLE_STATES
 //-------------------------------------------------------------------------------------------
 
 // Quad rasterization functions
 //-------------------------------------------------------------------------------------------
-#ifdef RLSW_TEMPLATE_RASTER_QUAD
+#ifdef SW_RASTER_QUAD_STATES
 
-#define SW_RASTER_QUAD SW_CONCATX(sw_raster_quad_, RLSW_TEMPLATE_RASTER_QUAD)
+#define SW_RASTER_QUAD_FLAGS SW_FLAGS(SW_RASTER_QUAD_STATES)
+#define SW_RASTER_QUAD       SW_CONCATX(sw_raster_quad_, SW_NAME(SW_RASTER_QUAD_STATES))
 
 // NOTE: This function should only render affine axis-aligned quads
 //       No perspective divide is applied after interpolation
@@ -5693,13 +5582,13 @@ static void SW_RASTER_QUAD(const sw_vertex_t *a, const sw_vertex_t *b,
         (bl->color[3] - tl->color[3])*hRcp,
     };
 
-#if (RLSW_RASTER_FLAGS) & SW_STATE_DEPTH_TEST
+#if (SW_RASTER_QUAD_FLAGS) & SW_STATE_DEPTH_TEST
     float dZdx = (tr->position[2] - tl->position[2])*wRcp;
     float dZdy = (bl->position[2] - tl->position[2])*hRcp;
     float zRow = tl->position[2] + dZdx*xSubstep + dZdy*ySubstep;
 #endif
 
-#if (RLSW_RASTER_FLAGS) & SW_STATE_TEXTURE_2D
+#if (SW_RASTER_QUAD_FLAGS) & SW_STATE_TEXTURE_2D
     float dUdx = (tr->texcoord[0] - tl->texcoord[0])*wRcp;
     float dVdx = (tr->texcoord[1] - tl->texcoord[1])*wRcp;
     float dUdy = (bl->texcoord[0] - tl->texcoord[0])*hRcp;
@@ -5717,7 +5606,7 @@ static void SW_RASTER_QUAD(const sw_vertex_t *a, const sw_vertex_t *b,
 
     int stride = RLSW.colorBuffer->width;
     uint8_t *cPixels = RLSW.colorBuffer->pixels;
-#if (RLSW_RASTER_FLAGS) & SW_STATE_DEPTH_TEST
+#if (SW_RASTER_QUAD_FLAGS) & SW_STATE_DEPTH_TEST
     uint8_t *dPixels = RLSW.depthBuffer->pixels;
 #endif
 
@@ -5730,10 +5619,10 @@ static void SW_RASTER_QUAD(const sw_vertex_t *a, const sw_vertex_t *b,
     cRow[1] += dCdx[1]*dxMin + dCdy[1]*dyMin;
     cRow[2] += dCdx[2]*dxMin + dCdy[2]*dyMin;
     cRow[3] += dCdx[3]*dxMin + dCdy[3]*dyMin;
-    #if (RLSW_RASTER_FLAGS) & SW_STATE_DEPTH_TEST
+    #if (SW_RASTER_QUAD_FLAGS) & SW_STATE_DEPTH_TEST
     zRow += dZdy*dyMin + dZdx*dxMin;
     #endif
-    #if (RLSW_RASTER_FLAGS) & SW_STATE_TEXTURE_2D
+    #if (SW_RASTER_QUAD_FLAGS) & SW_STATE_TEXTURE_2D
     uRow += dUdy*dyMin + dUdx*dxMin;
     vRow += dVdy*dyMin + dVdx*dxMin;
     #endif
@@ -5742,12 +5631,12 @@ static void SW_RASTER_QUAD(const sw_vertex_t *a, const sw_vertex_t *b,
     {
         int baseOffset = y*stride + xLoopMin;
         uint8_t *cPtr = cPixels + baseOffset*SW_FRAMEBUFFER_COLOR_SIZE;
-    #if (RLSW_RASTER_FLAGS) & SW_STATE_DEPTH_TEST
+    #if (SW_RASTER_QUAD_FLAGS) & SW_STATE_DEPTH_TEST
         uint8_t *dPtr = dPixels + baseOffset*SW_FRAMEBUFFER_DEPTH_SIZE;
         // Copy the cursors without destroying the offset maths
         float z = zRow;
     #endif
-    #if (RLSW_RASTER_FLAGS) & SW_STATE_TEXTURE_2D
+    #if (SW_RASTER_QUAD_FLAGS) & SW_STATE_TEXTURE_2D
         float u = uRow;
         float v = vRow;
     #endif
@@ -5762,7 +5651,7 @@ static void SW_RASTER_QUAD(const sw_vertex_t *a, const sw_vertex_t *b,
         {
             float srcColor[4] = { color[0], color[1], color[2], color[3] };
 
-            #if (RLSW_RASTER_FLAGS) & SW_STATE_DEPTH_TEST
+            #if (SW_RASTER_QUAD_FLAGS) & SW_STATE_DEPTH_TEST
             {
                 float depth = SW_FRAMEBUFFER_DEPTH_GET(dPtr, 0);
                 if (z > depth) goto discard;
@@ -5770,7 +5659,7 @@ static void SW_RASTER_QUAD(const sw_vertex_t *a, const sw_vertex_t *b,
             }
             #endif
 
-            #if (RLSW_RASTER_FLAGS) & SW_STATE_TEXTURE_2D
+            #if (SW_RASTER_QUAD_FLAGS) & SW_STATE_TEXTURE_2D
             {
                 float texColor[4];
                 sw_texture_sample(texColor, RLSW.boundTexture, u, v, dUdx, dUdy, dVdx, dVdy);
@@ -5781,7 +5670,7 @@ static void SW_RASTER_QUAD(const sw_vertex_t *a, const sw_vertex_t *b,
             }
             #endif
 
-            #if (RLSW_RASTER_FLAGS) & SW_STATE_BLEND
+            #if (SW_RASTER_QUAD_FLAGS) & SW_STATE_BLEND
             {
                 float dstColor[4];
                 SW_FRAMEBUFFER_COLOR_GET(dstColor, cPtr, 0);
@@ -5794,7 +5683,7 @@ static void SW_RASTER_QUAD(const sw_vertex_t *a, const sw_vertex_t *b,
             }
             #endif
 
-        #if (RLSW_RASTER_FLAGS) & SW_STATE_DEPTH_TEST
+        #if (SW_RASTER_QUAD_FLAGS) & SW_STATE_DEPTH_TEST
         discard:
         #endif
             // Move one pixel over without touching the original "start offset"
@@ -5803,14 +5692,14 @@ static void SW_RASTER_QUAD(const sw_vertex_t *a, const sw_vertex_t *b,
             color[2] += dCdx[2];
             color[3] += dCdx[3];
 
-            #if (RLSW_RASTER_FLAGS) & SW_STATE_DEPTH_TEST
+            #if (SW_RASTER_QUAD_FLAGS) & SW_STATE_DEPTH_TEST
             {
                 z += dZdx;
                 dPtr += SW_FRAMEBUFFER_DEPTH_SIZE;
             }
             #endif
 
-            #if (RLSW_RASTER_FLAGS) & SW_STATE_TEXTURE_2D
+            #if (SW_RASTER_QUAD_FLAGS) & SW_STATE_TEXTURE_2D
             {
                 u += dUdx;
                 v += dVdx;
@@ -5828,13 +5717,13 @@ static void SW_RASTER_QUAD(const sw_vertex_t *a, const sw_vertex_t *b,
         cRow[2] += dCdy[2];
         cRow[3] += dCdy[3];
 
-        #if (RLSW_RASTER_FLAGS) & SW_STATE_DEPTH_TEST
+        #if (SW_RASTER_QUAD_FLAGS) & SW_STATE_DEPTH_TEST
         {
             zRow += dZdy;
         }
         #endif
 
-        #if (RLSW_RASTER_FLAGS) & SW_STATE_TEXTURE_2D
+        #if (SW_RASTER_QUAD_FLAGS) & SW_STATE_TEXTURE_2D
         {
             uRow += dUdy;
             vRow += dVdy;
@@ -5843,15 +5732,16 @@ static void SW_RASTER_QUAD(const sw_vertex_t *a, const sw_vertex_t *b,
     }
 }
 
-#endif // RLSW_TEMPLATE_RASTER_QUAD
+#endif // SW_RASTER_QUAD_STATES
 //-------------------------------------------------------------------------------------------
 
 // Quad rasterization functions
 //-------------------------------------------------------------------------------------------
-#ifdef RLSW_TEMPLATE_RASTER_LINE
+#ifdef SW_RASTER_LINE_STATES
 
-#define SW_RASTER_LINE       SW_CONCATX(sw_raster_line_, RLSW_TEMPLATE_RASTER_LINE)
-#define SW_RASTER_LINE_THICK SW_CONCATX(sw_raster_line_thick_, RLSW_TEMPLATE_RASTER_LINE)
+#define SW_RASTER_LINE_FLAGS SW_FLAGS(SW_RASTER_LINE_STATES)
+#define SW_RASTER_LINE       SW_CONCATX(sw_raster_line_, SW_NAME(SW_RASTER_LINE_STATES))
+#define SW_RASTER_LINE_THICK SW_CONCATX(sw_raster_line_thick_, SW_NAME(SW_RASTER_LINE_STATES))
 
 static void SW_RASTER_LINE(const sw_vertex_t *v0, const sw_vertex_t *v1)
 {
@@ -5883,7 +5773,7 @@ static void SW_RASTER_LINE(const sw_vertex_t *v0, const sw_vertex_t *v1)
     float xInc = dx/steps;
     float yInc = dy/steps;
     float stepRcp = sw_rcp(steps);
-#if (RLSW_RASTER_FLAGS) & SW_STATE_DEPTH_TEST
+#if (SW_RASTER_LINE_FLAGS) & SW_STATE_DEPTH_TEST
     float zInc = (v1->position[2] - v0->position[2])*stepRcp;
 #endif
     float rInc = (v1->color[0] - v0->color[0])*stepRcp;
@@ -5894,7 +5784,7 @@ static void SW_RASTER_LINE(const sw_vertex_t *v0, const sw_vertex_t *v1)
     // Initializing the interpolation starting values
     float x = x0 + xInc*substep;
     float y = y0 + yInc*substep;
-#if (RLSW_RASTER_FLAGS) & SW_STATE_DEPTH_TEST
+#if (SW_RASTER_LINE_FLAGS) & SW_STATE_DEPTH_TEST
     float z = v0->position[2] + zInc*substep;
 #endif
     float r = v0->color[0] + rInc*substep;
@@ -5905,7 +5795,7 @@ static void SW_RASTER_LINE(const sw_vertex_t *v0, const sw_vertex_t *v1)
     // Start line rasterization
     const int fbWidth = RLSW.colorBuffer->width;
     uint8_t *cPixels = RLSW.colorBuffer->pixels;
-#if (RLSW_RASTER_FLAGS) & SW_STATE_DEPTH_TEST
+#if (SW_RASTER_LINE_FLAGS) & SW_STATE_DEPTH_TEST
     uint8_t *dPixels = RLSW.depthBuffer->pixels;
 #endif
 
@@ -5918,11 +5808,11 @@ static void SW_RASTER_LINE(const sw_vertex_t *v0, const sw_vertex_t *v1)
 
         int baseOffset = py*fbWidth + px;
         uint8_t *cPtr = cPixels + baseOffset*SW_FRAMEBUFFER_COLOR_SIZE;
-    #if (RLSW_RASTER_FLAGS) & SW_STATE_DEPTH_TEST
+    #if (SW_RASTER_LINE_FLAGS) & SW_STATE_DEPTH_TEST
         uint8_t *dPtr = dPixels + baseOffset*SW_FRAMEBUFFER_DEPTH_SIZE;
     #endif
 
-        #if (RLSW_RASTER_FLAGS) & SW_STATE_DEPTH_TEST
+        #if (SW_RASTER_LINE_FLAGS) & SW_STATE_DEPTH_TEST
         {
             // TODO: Implement different depth funcs?
             float depth = SW_FRAMEBUFFER_DEPTH_GET(dPtr, 0);
@@ -5935,7 +5825,7 @@ static void SW_RASTER_LINE(const sw_vertex_t *v0, const sw_vertex_t *v1)
 
         float srcColor[4] = {r, g, b, a};
 
-        #if (RLSW_RASTER_FLAGS) & SW_STATE_BLEND
+        #if (SW_RASTER_LINE_FLAGS) & SW_STATE_BLEND
         {
             float dstColor[4];
             SW_FRAMEBUFFER_COLOR_GET(dstColor, cPtr, 0);
@@ -5948,12 +5838,12 @@ static void SW_RASTER_LINE(const sw_vertex_t *v0, const sw_vertex_t *v1)
         }
         #endif
 
-    #if (RLSW_RASTER_FLAGS) & SW_STATE_DEPTH_TEST
+    #if (SW_RASTER_LINE_FLAGS) & SW_STATE_DEPTH_TEST
     discard:
     #endif
         x += xInc;
         y += yInc;
-        #if (RLSW_RASTER_FLAGS) & SW_STATE_DEPTH_TEST
+        #if (SW_RASTER_LINE_FLAGS) & SW_STATE_DEPTH_TEST
         {
             z += zInc;
         }
@@ -6013,21 +5903,22 @@ static void SW_RASTER_LINE_THICK(const sw_vertex_t *v0, const sw_vertex_t *v1)
     }
 }
 
-#endif // RLSW_TEMPLATE_RASTER_LINE
+#endif // SW_RASTER_LINE_STATES
 //-------------------------------------------------------------------------------------------
 
 // Point rasterization functions
 //-------------------------------------------------------------------------------------------
-#ifdef RLSW_TEMPLATE_RASTER_POINT
+#ifdef SW_RASTER_POINT_STATES
 
-#define SW_RASTER_POINT_PIXEL SW_CONCATX(sw_raster_point_pixel_, RLSW_TEMPLATE_RASTER_POINT)
-#define SW_RASTER_POINT       SW_CONCATX(sw_raster_point_, RLSW_TEMPLATE_RASTER_POINT)
+#define SW_RASTER_POINT_FLAGS SW_FLAGS(SW_RASTER_POINT_STATES)
+#define SW_RASTER_POINT_PIXEL SW_CONCATX(sw_raster_point_pixel_, SW_NAME(SW_RASTER_POINT_STATES))
+#define SW_RASTER_POINT       SW_CONCATX(sw_raster_point_, SW_NAME(SW_RASTER_POINT_STATES))
 
 static void SW_RASTER_POINT_PIXEL(int x, int y, float z, const float color[4])
 {
     int offset = y*RLSW.colorBuffer->width + x;
 
-    #if (RLSW_RASTER_FLAGS) & SW_STATE_DEPTH_TEST
+    #if (SW_RASTER_POINT_FLAGS) & SW_STATE_DEPTH_TEST
     {
         uint8_t *dPtr = (uint8_t *)(RLSW.depthBuffer->pixels) + offset*SW_FRAMEBUFFER_DEPTH_SIZE;
 
@@ -6042,7 +5933,7 @@ static void SW_RASTER_POINT_PIXEL(int x, int y, float z, const float color[4])
 
     uint8_t *cPtr = (uint8_t *)(RLSW.colorBuffer->pixels) + offset*SW_FRAMEBUFFER_COLOR_SIZE;
 
-    #if (RLSW_RASTER_FLAGS) & SW_STATE_BLEND
+    #if (SW_RASTER_POINT_FLAGS) & SW_STATE_BLEND
     {
         float dstColor[4];
         SW_FRAMEBUFFER_COLOR_GET(dstColor, cPtr, 0);
@@ -6073,5 +5964,5 @@ static void SW_RASTER_POINT(const sw_vertex_t *v)
     }
 }
 
-#endif // RLSW_TEMPLATE_RASTER_POINT
+#endif // SW_RASTER_POINT_STATES
 //-------------------------------------------------------------------------------------------

--- a/src/external/rlsw.h
+++ b/src/external/rlsw.h
@@ -3092,59 +3092,51 @@ static bool sw_polygon_clip(sw_vertex_t polygon[SW_MAX_CLIPPED_POLYGON_VERTICES]
     // Specialization generation via self-inclusion
 
     #define RLSW_TEMPLATE_RASTER_TRIANGLE BASE
+    #define RLSW_RASTER_FLAGS (0)
     #include __FILE__ // IWYU pragma: keep
+    #undef RLSW_RASTER_FLAGS
     #undef RLSW_TEMPLATE_RASTER_TRIANGLE
 
     #define RLSW_TEMPLATE_RASTER_TRIANGLE TEX
-    #define SW_ENABLE_TEXTURE
+    #define RLSW_RASTER_FLAGS (SW_STATE_TEXTURE_2D)
     #include __FILE__
-    #undef SW_ENABLE_TEXTURE
+    #undef RLSW_RASTER_FLAGS
     #undef RLSW_TEMPLATE_RASTER_TRIANGLE
 
     #define RLSW_TEMPLATE_RASTER_TRIANGLE DEPTH
-    #define SW_ENABLE_DEPTH_TEST
+    #define RLSW_RASTER_FLAGS (SW_STATE_DEPTH_TEST)
     #include __FILE__
-    #undef SW_ENABLE_DEPTH_TEST
+    #undef RLSW_RASTER_FLAGS
     #undef RLSW_TEMPLATE_RASTER_TRIANGLE
 
     #define RLSW_TEMPLATE_RASTER_TRIANGLE BLEND
-    #define SW_ENABLE_BLEND
+    #define RLSW_RASTER_FLAGS (SW_STATE_BLEND)
     #include __FILE__
-    #undef SW_ENABLE_BLEND
+    #undef RLSW_RASTER_FLAGS
     #undef RLSW_TEMPLATE_RASTER_TRIANGLE
 
     #define RLSW_TEMPLATE_RASTER_TRIANGLE TEX_DEPTH
-    #define SW_ENABLE_TEXTURE
-    #define SW_ENABLE_DEPTH_TEST
+    #define RLSW_RASTER_FLAGS (SW_STATE_TEXTURE_2D | SW_STATE_DEPTH_TEST)
     #include __FILE__
-    #undef SW_ENABLE_DEPTH_TEST
-    #undef SW_ENABLE_TEXTURE
+    #undef RLSW_RASTER_FLAGS
     #undef RLSW_TEMPLATE_RASTER_TRIANGLE
 
     #define RLSW_TEMPLATE_RASTER_TRIANGLE TEX_BLEND
-    #define SW_ENABLE_TEXTURE
-    #define SW_ENABLE_BLEND
+    #define RLSW_RASTER_FLAGS (SW_STATE_TEXTURE_2D | SW_STATE_BLEND)
     #include __FILE__
-    #undef SW_ENABLE_BLEND
-    #undef SW_ENABLE_TEXTURE
+    #undef RLSW_RASTER_FLAGS
     #undef RLSW_TEMPLATE_RASTER_TRIANGLE
 
     #define RLSW_TEMPLATE_RASTER_TRIANGLE DEPTH_BLEND
-    #define SW_ENABLE_DEPTH_TEST
-    #define SW_ENABLE_BLEND
+    #define RLSW_RASTER_FLAGS (SW_STATE_DEPTH_TEST | SW_STATE_BLEND)
     #include __FILE__
-    #undef SW_ENABLE_BLEND
-    #undef SW_ENABLE_DEPTH_TEST
+    #undef RLSW_RASTER_FLAGS
     #undef RLSW_TEMPLATE_RASTER_TRIANGLE
 
     #define RLSW_TEMPLATE_RASTER_TRIANGLE TEX_DEPTH_BLEND
-    #define SW_ENABLE_TEXTURE
-    #define SW_ENABLE_DEPTH_TEST
-    #define SW_ENABLE_BLEND
+    #define RLSW_RASTER_FLAGS (SW_STATE_TEXTURE_2D | SW_STATE_DEPTH_TEST | SW_STATE_BLEND)
     #include __FILE__
-    #undef SW_ENABLE_BLEND
-    #undef SW_ENABLE_DEPTH_TEST
-    #undef SW_ENABLE_TEXTURE
+    #undef RLSW_RASTER_FLAGS
     #undef RLSW_TEMPLATE_RASTER_TRIANGLE
 
     // Dispatch table (auto-generated from SW_RASTER_VARIANTS)
@@ -3191,59 +3183,51 @@ static bool sw_polygon_clip(sw_vertex_t polygon[SW_MAX_CLIPPED_POLYGON_VERTICES]
     // Specialization generation via self-inclusion
 
     #define RLSW_TEMPLATE_RASTER_QUAD BASE
+    #define RLSW_RASTER_FLAGS (0)
     #include __FILE__ // IWYU pragma: keep
+    #undef RLSW_RASTER_FLAGS
     #undef RLSW_TEMPLATE_RASTER_QUAD
 
     #define RLSW_TEMPLATE_RASTER_QUAD TEX
-    #define SW_ENABLE_TEXTURE
+    #define RLSW_RASTER_FLAGS (SW_STATE_TEXTURE_2D)
     #include __FILE__
-    #undef SW_ENABLE_TEXTURE
+    #undef RLSW_RASTER_FLAGS
     #undef RLSW_TEMPLATE_RASTER_QUAD
 
     #define RLSW_TEMPLATE_RASTER_QUAD DEPTH
-    #define SW_ENABLE_DEPTH_TEST
+    #define RLSW_RASTER_FLAGS (SW_STATE_DEPTH_TEST)
     #include __FILE__
-    #undef SW_ENABLE_DEPTH_TEST
+    #undef RLSW_RASTER_FLAGS
     #undef RLSW_TEMPLATE_RASTER_QUAD
 
     #define RLSW_TEMPLATE_RASTER_QUAD BLEND
-    #define SW_ENABLE_BLEND
+    #define RLSW_RASTER_FLAGS (SW_STATE_BLEND)
     #include __FILE__
-    #undef SW_ENABLE_BLEND
+    #undef RLSW_RASTER_FLAGS
     #undef RLSW_TEMPLATE_RASTER_QUAD
 
     #define RLSW_TEMPLATE_RASTER_QUAD TEX_DEPTH
-    #define SW_ENABLE_TEXTURE
-    #define SW_ENABLE_DEPTH_TEST
+    #define RLSW_RASTER_FLAGS (SW_STATE_TEXTURE_2D | SW_STATE_DEPTH_TEST)
     #include __FILE__
-    #undef SW_ENABLE_DEPTH_TEST
-    #undef SW_ENABLE_TEXTURE
+    #undef RLSW_RASTER_FLAGS
     #undef RLSW_TEMPLATE_RASTER_QUAD
 
     #define RLSW_TEMPLATE_RASTER_QUAD TEX_BLEND
-    #define SW_ENABLE_TEXTURE
-    #define SW_ENABLE_BLEND
+    #define RLSW_RASTER_FLAGS (SW_STATE_TEXTURE_2D | SW_STATE_BLEND)
     #include __FILE__
-    #undef SW_ENABLE_BLEND
-    #undef SW_ENABLE_TEXTURE
+    #undef RLSW_RASTER_FLAGS
     #undef RLSW_TEMPLATE_RASTER_QUAD
 
     #define RLSW_TEMPLATE_RASTER_QUAD DEPTH_BLEND
-    #define SW_ENABLE_DEPTH_TEST
-    #define SW_ENABLE_BLEND
+    #define RLSW_RASTER_FLAGS (SW_STATE_DEPTH_TEST | SW_STATE_BLEND)
     #include __FILE__
-    #undef SW_ENABLE_BLEND
-    #undef SW_ENABLE_DEPTH_TEST
+    #undef RLSW_RASTER_FLAGS
     #undef RLSW_TEMPLATE_RASTER_QUAD
 
     #define RLSW_TEMPLATE_RASTER_QUAD TEX_DEPTH_BLEND
-    #define SW_ENABLE_TEXTURE
-    #define SW_ENABLE_DEPTH_TEST
-    #define SW_ENABLE_BLEND
+    #define RLSW_RASTER_FLAGS (SW_STATE_TEXTURE_2D | SW_STATE_DEPTH_TEST | SW_STATE_BLEND)
     #include __FILE__
-    #undef SW_ENABLE_BLEND
-    #undef SW_ENABLE_DEPTH_TEST
-    #undef SW_ENABLE_TEXTURE
+    #undef RLSW_RASTER_FLAGS
     #undef RLSW_TEMPLATE_RASTER_QUAD
 
     // Dispatch table (auto-generated from SW_RASTER_VARIANTS)
@@ -3287,27 +3271,27 @@ static bool sw_polygon_clip(sw_vertex_t polygon[SW_MAX_CLIPPED_POLYGON_VERTICES]
     // Specialization generation via self-inclusion
 
     #define RLSW_TEMPLATE_RASTER_LINE BASE
+    #define RLSW_RASTER_FLAGS (0)
     #include __FILE__ // IWYU pragma: keep
+    #undef RLSW_RASTER_FLAGS
     #undef RLSW_TEMPLATE_RASTER_LINE
 
     #define RLSW_TEMPLATE_RASTER_LINE DEPTH
-    #define SW_ENABLE_DEPTH_TEST
+    #define RLSW_RASTER_FLAGS (SW_STATE_DEPTH_TEST)
     #include __FILE__
-    #undef SW_ENABLE_DEPTH_TEST
+    #undef RLSW_RASTER_FLAGS
     #undef RLSW_TEMPLATE_RASTER_LINE
 
     #define RLSW_TEMPLATE_RASTER_LINE BLEND
-    #define SW_ENABLE_BLEND
+    #define RLSW_RASTER_FLAGS (SW_STATE_BLEND)
     #include __FILE__
-    #undef SW_ENABLE_BLEND
+    #undef RLSW_RASTER_FLAGS
     #undef RLSW_TEMPLATE_RASTER_LINE
 
     #define RLSW_TEMPLATE_RASTER_LINE DEPTH_BLEND
-    #define SW_ENABLE_DEPTH_TEST
-    #define SW_ENABLE_BLEND
+    #define RLSW_RASTER_FLAGS (SW_STATE_DEPTH_TEST | SW_STATE_BLEND)
     #include __FILE__
-    #undef SW_ENABLE_BLEND
-    #undef SW_ENABLE_DEPTH_TEST
+    #undef RLSW_RASTER_FLAGS
     #undef RLSW_TEMPLATE_RASTER_LINE
 
     // Dispatch table (auto-generated from SW_RASTER_VARIANTS)
@@ -3351,27 +3335,27 @@ static bool sw_polygon_clip(sw_vertex_t polygon[SW_MAX_CLIPPED_POLYGON_VERTICES]
     // Specialization generation via self-inclusion
 
     #define RLSW_TEMPLATE_RASTER_POINT BASE
+    #define RLSW_RASTER_FLAGS (0)
     #include __FILE__ // IWYU pragma: keep
+    #undef RLSW_RASTER_FLAGS
     #undef RLSW_TEMPLATE_RASTER_POINT
 
     #define RLSW_TEMPLATE_RASTER_POINT DEPTH
-    #define SW_ENABLE_DEPTH_TEST
+    #define RLSW_RASTER_FLAGS (SW_STATE_DEPTH_TEST)
     #include __FILE__
-    #undef SW_ENABLE_DEPTH_TEST
+    #undef RLSW_RASTER_FLAGS
     #undef RLSW_TEMPLATE_RASTER_POINT
 
     #define RLSW_TEMPLATE_RASTER_POINT BLEND
-    #define SW_ENABLE_BLEND
+    #define RLSW_RASTER_FLAGS (SW_STATE_BLEND)
     #include __FILE__
-    #undef SW_ENABLE_BLEND
+    #undef RLSW_RASTER_FLAGS
     #undef RLSW_TEMPLATE_RASTER_POINT
 
     #define RLSW_TEMPLATE_RASTER_POINT DEPTH_BLEND
-    #define SW_ENABLE_DEPTH_TEST
-    #define SW_ENABLE_BLEND
+    #define RLSW_RASTER_FLAGS (SW_STATE_DEPTH_TEST | SW_STATE_BLEND)
     #include __FILE__
-    #undef SW_ENABLE_BLEND
-    #undef SW_ENABLE_DEPTH_TEST
+    #undef RLSW_RASTER_FLAGS
     #undef RLSW_TEMPLATE_RASTER_POINT
 
     // Dispatch table (auto-generated from SW_RASTER_VARIANTS)
@@ -5363,16 +5347,10 @@ void swGetFramebufferAttachmentParameteriv(SWattachment attachment, SWattachget 
 //-------------------------------------------------------------------------------------------
 #ifdef RLSW_TEMPLATE_RASTER_TRIANGLE
 
-// Options:
-//  - RLSW_TEMPLATE_RASTER_TRIANGLE     -> Contains the suffix name
-//  - SW_ENABLE_DEPTH_TEST
-//  - SW_ENABLE_TEXTURE
-//  - SW_ENABLE_BLEND
-
 #define SW_RASTER_TRIANGLE_SPAN SW_CONCATX(sw_raster_triangle_span_, RLSW_TEMPLATE_RASTER_TRIANGLE)
 #define SW_RASTER_TRIANGLE      SW_CONCATX(sw_raster_triangle_, RLSW_TEMPLATE_RASTER_TRIANGLE)
 
-#ifdef SW_ENABLE_TEXTURE
+#if (RLSW_RASTER_FLAGS) & SW_STATE_TEXTURE_2D
     #define SW_GET_GRAD         sw_get_vertex_grad_PCT
     #define SW_ADD_GRAD         sw_add_vertex_grad_PCT
     #define SW_ADD_GRAD_SCALED  sw_add_vertex_grad_scaled_PCT
@@ -5410,10 +5388,10 @@ static void SW_RASTER_TRIANGLE_SPAN(const sw_vertex_t *start, const sw_vertex_t 
         (end->color[2] - start->color[2])*dxRcp,
         (end->color[3] - start->color[3])*dxRcp
     };
-#ifdef SW_ENABLE_DEPTH_TEST
+#if (RLSW_RASTER_FLAGS) & SW_STATE_DEPTH_TEST
     float dZdx = (end->position[2] - start->position[2])*dxRcp;
 #endif
-#ifdef SW_ENABLE_TEXTURE
+#if (RLSW_RASTER_FLAGS) & SW_STATE_TEXTURE_2D
     float dUdx = (end->texcoord[0] - start->texcoord[0])*dxRcp;
     float dVdx = (end->texcoord[1] - start->texcoord[1])*dxRcp;
 #endif
@@ -5432,10 +5410,10 @@ static void SW_RASTER_TRIANGLE_SPAN(const sw_vertex_t *start, const sw_vertex_t 
         start->color[2] + dCdx[2]*xOffset,
         start->color[3] + dCdx[3]*xOffset
     };
-#ifdef SW_ENABLE_DEPTH_TEST
+#if (RLSW_RASTER_FLAGS) & SW_STATE_DEPTH_TEST
     float z = start->position[2] + dZdx*xOffset;
 #endif
-#ifdef SW_ENABLE_TEXTURE
+#if (RLSW_RASTER_FLAGS) & SW_STATE_TEXTURE_2D
     float u = start->texcoord[0] + dUdx*xOffset;
     float v = start->texcoord[1] + dVdx*xOffset;
 #endif
@@ -5443,7 +5421,7 @@ static void SW_RASTER_TRIANGLE_SPAN(const sw_vertex_t *start, const sw_vertex_t 
     // Pre-calculate the starting pointers for the framebuffer row
     int baseOffset = y*RLSW.colorBuffer->width + xLoopStart;
     uint8_t *cPtr = (uint8_t *)(RLSW.colorBuffer->pixels) + baseOffset*SW_FRAMEBUFFER_COLOR_SIZE;
-#ifdef SW_ENABLE_DEPTH_TEST
+#if (RLSW_RASTER_FLAGS) & SW_STATE_DEPTH_TEST
     uint8_t *dPtr = (uint8_t *)(RLSW.depthBuffer->pixels) + baseOffset*SW_FRAMEBUFFER_DEPTH_SIZE;
 #endif
 
@@ -5477,7 +5455,7 @@ static void SW_RASTER_TRIANGLE_SPAN(const sw_vertex_t *start, const sw_vertex_t 
             ((color[3] + dCdx[3]*blockLenF)*wRcpB - srcColor[3])*blockLenRcp
         };
 
-    #ifdef SW_ENABLE_TEXTURE
+    #if (RLSW_RASTER_FLAGS) & SW_STATE_TEXTURE_2D
         // Perspective-correct UVs at both endpoints, then affine gradient
         float uAffine  = u*wRcpA;
         float vAffine  = v*wRcpA;
@@ -5488,7 +5466,7 @@ static void SW_RASTER_TRIANGLE_SPAN(const sw_vertex_t *start, const sw_vertex_t 
         // Inner span pixel loop
         for (; x < blockEnd; x++)
         {
-            #ifdef SW_ENABLE_DEPTH_TEST
+            #if (RLSW_RASTER_FLAGS) & SW_STATE_DEPTH_TEST
             {
                 float depth = SW_FRAMEBUFFER_DEPTH_GET(dPtr, 0);
                 if (z > depth) goto discard;
@@ -5496,7 +5474,7 @@ static void SW_RASTER_TRIANGLE_SPAN(const sw_vertex_t *start, const sw_vertex_t 
             }
             #endif
 
-            #ifdef SW_ENABLE_TEXTURE
+            #if (RLSW_RASTER_FLAGS) & SW_STATE_TEXTURE_2D
             {
                 float texColor[4];
                 sw_texture_sample(texColor, RLSW.boundTexture, uAffine, vAffine, dUdx, dUdy, dVdx, dVdy);
@@ -5506,7 +5484,7 @@ static void SW_RASTER_TRIANGLE_SPAN(const sw_vertex_t *start, const sw_vertex_t 
                     srcColor[2]*texColor[2],
                     srcColor[3]*texColor[3]
                 };
-                #ifdef SW_ENABLE_BLEND
+                #if (RLSW_RASTER_FLAGS) & SW_STATE_BLEND
                 {
                     float dstColor[4];
                     SW_FRAMEBUFFER_COLOR_GET(dstColor, cPtr, 0);
@@ -5519,7 +5497,7 @@ static void SW_RASTER_TRIANGLE_SPAN(const sw_vertex_t *start, const sw_vertex_t 
             }
             #else
             {
-                #ifdef SW_ENABLE_BLEND
+                #if (RLSW_RASTER_FLAGS) & SW_STATE_BLEND
                 {
                     float dstColor[4];
                     SW_FRAMEBUFFER_COLOR_GET(dstColor, cPtr, 0);
@@ -5532,7 +5510,7 @@ static void SW_RASTER_TRIANGLE_SPAN(const sw_vertex_t *start, const sw_vertex_t 
             }
             #endif
 
-        #ifdef SW_ENABLE_DEPTH_TEST
+        #if (RLSW_RASTER_FLAGS) & SW_STATE_DEPTH_TEST
         discard:
         #endif
             srcColor[0] += dSrcColordx[0];
@@ -5541,14 +5519,14 @@ static void SW_RASTER_TRIANGLE_SPAN(const sw_vertex_t *start, const sw_vertex_t 
             srcColor[3] += dSrcColordx[3];
             cPtr += SW_FRAMEBUFFER_COLOR_SIZE;
 
-            #ifdef SW_ENABLE_DEPTH_TEST
+            #if (RLSW_RASTER_FLAGS) & SW_STATE_DEPTH_TEST
             {
                 z += dZdx;
                 dPtr += SW_FRAMEBUFFER_DEPTH_SIZE;
             }
             #endif
 
-            #ifdef SW_ENABLE_TEXTURE
+            #if (RLSW_RASTER_FLAGS) & SW_STATE_TEXTURE_2D
             {
                 uAffine += dUaffine;
                 vAffine += dVaffine;
@@ -5562,7 +5540,7 @@ static void SW_RASTER_TRIANGLE_SPAN(const sw_vertex_t *start, const sw_vertex_t 
         color[1] += dCdx[1]*blockLenF;
         color[2] += dCdx[2]*blockLenF;
         color[3] += dCdx[3]*blockLenF;
-        #ifdef SW_ENABLE_TEXTURE
+        #if (RLSW_RASTER_FLAGS) & SW_STATE_TEXTURE_2D
         u += dUdx*blockLenF;
         v += dVdx*blockLenF;
         #endif
@@ -5655,12 +5633,6 @@ static void SW_RASTER_TRIANGLE(const sw_vertex_t *v0, const sw_vertex_t *v1, con
 //-------------------------------------------------------------------------------------------
 #ifdef RLSW_TEMPLATE_RASTER_QUAD
 
-// Options:
-//  - RLSW_TEMPLATE_RASTER_QUAD     -> Contains the suffix name
-//  - SW_ENABLE_DEPTH_TEST
-//  - SW_ENABLE_TEXTURE
-//  - SW_ENABLE_BLEND
-
 #define SW_RASTER_QUAD SW_CONCATX(sw_raster_quad_, RLSW_TEMPLATE_RASTER_QUAD)
 
 // NOTE: This function should only render affine axis-aligned quads
@@ -5721,13 +5693,13 @@ static void SW_RASTER_QUAD(const sw_vertex_t *a, const sw_vertex_t *b,
         (bl->color[3] - tl->color[3])*hRcp,
     };
 
-#ifdef SW_ENABLE_DEPTH_TEST
+#if (RLSW_RASTER_FLAGS) & SW_STATE_DEPTH_TEST
     float dZdx = (tr->position[2] - tl->position[2])*wRcp;
     float dZdy = (bl->position[2] - tl->position[2])*hRcp;
     float zRow = tl->position[2] + dZdx*xSubstep + dZdy*ySubstep;
 #endif
 
-#ifdef SW_ENABLE_TEXTURE
+#if (RLSW_RASTER_FLAGS) & SW_STATE_TEXTURE_2D
     float dUdx = (tr->texcoord[0] - tl->texcoord[0])*wRcp;
     float dVdx = (tr->texcoord[1] - tl->texcoord[1])*wRcp;
     float dUdy = (bl->texcoord[0] - tl->texcoord[0])*hRcp;
@@ -5745,7 +5717,7 @@ static void SW_RASTER_QUAD(const sw_vertex_t *a, const sw_vertex_t *b,
 
     int stride = RLSW.colorBuffer->width;
     uint8_t *cPixels = RLSW.colorBuffer->pixels;
-#ifdef SW_ENABLE_DEPTH_TEST
+#if (RLSW_RASTER_FLAGS) & SW_STATE_DEPTH_TEST
     uint8_t *dPixels = RLSW.depthBuffer->pixels;
 #endif
 
@@ -5758,10 +5730,10 @@ static void SW_RASTER_QUAD(const sw_vertex_t *a, const sw_vertex_t *b,
     cRow[1] += dCdx[1]*dxMin + dCdy[1]*dyMin;
     cRow[2] += dCdx[2]*dxMin + dCdy[2]*dyMin;
     cRow[3] += dCdx[3]*dxMin + dCdy[3]*dyMin;
-    #ifdef SW_ENABLE_DEPTH_TEST
+    #if (RLSW_RASTER_FLAGS) & SW_STATE_DEPTH_TEST
     zRow += dZdy*dyMin + dZdx*dxMin;
     #endif
-    #ifdef SW_ENABLE_TEXTURE
+    #if (RLSW_RASTER_FLAGS) & SW_STATE_TEXTURE_2D
     uRow += dUdy*dyMin + dUdx*dxMin;
     vRow += dVdy*dyMin + dVdx*dxMin;
     #endif
@@ -5770,12 +5742,12 @@ static void SW_RASTER_QUAD(const sw_vertex_t *a, const sw_vertex_t *b,
     {
         int baseOffset = y*stride + xLoopMin;
         uint8_t *cPtr = cPixels + baseOffset*SW_FRAMEBUFFER_COLOR_SIZE;
-    #ifdef SW_ENABLE_DEPTH_TEST
+    #if (RLSW_RASTER_FLAGS) & SW_STATE_DEPTH_TEST
         uint8_t *dPtr = dPixels + baseOffset*SW_FRAMEBUFFER_DEPTH_SIZE;
         // Copy the cursors without destroying the offset maths
         float z = zRow;
     #endif
-    #ifdef SW_ENABLE_TEXTURE
+    #if (RLSW_RASTER_FLAGS) & SW_STATE_TEXTURE_2D
         float u = uRow;
         float v = vRow;
     #endif
@@ -5790,7 +5762,7 @@ static void SW_RASTER_QUAD(const sw_vertex_t *a, const sw_vertex_t *b,
         {
             float srcColor[4] = { color[0], color[1], color[2], color[3] };
 
-            #ifdef SW_ENABLE_DEPTH_TEST
+            #if (RLSW_RASTER_FLAGS) & SW_STATE_DEPTH_TEST
             {
                 float depth = SW_FRAMEBUFFER_DEPTH_GET(dPtr, 0);
                 if (z > depth) goto discard;
@@ -5798,7 +5770,7 @@ static void SW_RASTER_QUAD(const sw_vertex_t *a, const sw_vertex_t *b,
             }
             #endif
 
-            #ifdef SW_ENABLE_TEXTURE
+            #if (RLSW_RASTER_FLAGS) & SW_STATE_TEXTURE_2D
             {
                 float texColor[4];
                 sw_texture_sample(texColor, RLSW.boundTexture, u, v, dUdx, dUdy, dVdx, dVdy);
@@ -5809,7 +5781,7 @@ static void SW_RASTER_QUAD(const sw_vertex_t *a, const sw_vertex_t *b,
             }
             #endif
 
-            #ifdef SW_ENABLE_BLEND
+            #if (RLSW_RASTER_FLAGS) & SW_STATE_BLEND
             {
                 float dstColor[4];
                 SW_FRAMEBUFFER_COLOR_GET(dstColor, cPtr, 0);
@@ -5822,7 +5794,7 @@ static void SW_RASTER_QUAD(const sw_vertex_t *a, const sw_vertex_t *b,
             }
             #endif
 
-        #ifdef SW_ENABLE_DEPTH_TEST
+        #if (RLSW_RASTER_FLAGS) & SW_STATE_DEPTH_TEST
         discard:
         #endif
             // Move one pixel over without touching the original "start offset"
@@ -5831,14 +5803,14 @@ static void SW_RASTER_QUAD(const sw_vertex_t *a, const sw_vertex_t *b,
             color[2] += dCdx[2];
             color[3] += dCdx[3];
 
-            #ifdef SW_ENABLE_DEPTH_TEST
+            #if (RLSW_RASTER_FLAGS) & SW_STATE_DEPTH_TEST
             {
                 z += dZdx;
                 dPtr += SW_FRAMEBUFFER_DEPTH_SIZE;
             }
             #endif
 
-            #ifdef SW_ENABLE_TEXTURE
+            #if (RLSW_RASTER_FLAGS) & SW_STATE_TEXTURE_2D
             {
                 u += dUdx;
                 v += dVdx;
@@ -5856,13 +5828,13 @@ static void SW_RASTER_QUAD(const sw_vertex_t *a, const sw_vertex_t *b,
         cRow[2] += dCdy[2];
         cRow[3] += dCdy[3];
 
-        #ifdef SW_ENABLE_DEPTH_TEST
+        #if (RLSW_RASTER_FLAGS) & SW_STATE_DEPTH_TEST
         {
             zRow += dZdy;
         }
         #endif
 
-        #ifdef SW_ENABLE_TEXTURE
+        #if (RLSW_RASTER_FLAGS) & SW_STATE_TEXTURE_2D
         {
             uRow += dUdy;
             vRow += dVdy;
@@ -5877,11 +5849,6 @@ static void SW_RASTER_QUAD(const sw_vertex_t *a, const sw_vertex_t *b,
 // Quad rasterization functions
 //-------------------------------------------------------------------------------------------
 #ifdef RLSW_TEMPLATE_RASTER_LINE
-
-// Options:
-//  - RLSW_TEMPLATE_RASTER_LINE     -> Contains the suffix name
-//  - SW_ENABLE_DEPTH_TEST
-//  - SW_ENABLE_BLEND
 
 #define SW_RASTER_LINE       SW_CONCATX(sw_raster_line_, RLSW_TEMPLATE_RASTER_LINE)
 #define SW_RASTER_LINE_THICK SW_CONCATX(sw_raster_line_thick_, RLSW_TEMPLATE_RASTER_LINE)
@@ -5916,7 +5883,7 @@ static void SW_RASTER_LINE(const sw_vertex_t *v0, const sw_vertex_t *v1)
     float xInc = dx/steps;
     float yInc = dy/steps;
     float stepRcp = sw_rcp(steps);
-#ifdef SW_ENABLE_DEPTH_TEST
+#if (RLSW_RASTER_FLAGS) & SW_STATE_DEPTH_TEST
     float zInc = (v1->position[2] - v0->position[2])*stepRcp;
 #endif
     float rInc = (v1->color[0] - v0->color[0])*stepRcp;
@@ -5927,7 +5894,7 @@ static void SW_RASTER_LINE(const sw_vertex_t *v0, const sw_vertex_t *v1)
     // Initializing the interpolation starting values
     float x = x0 + xInc*substep;
     float y = y0 + yInc*substep;
-#ifdef SW_ENABLE_DEPTH_TEST
+#if (RLSW_RASTER_FLAGS) & SW_STATE_DEPTH_TEST
     float z = v0->position[2] + zInc*substep;
 #endif
     float r = v0->color[0] + rInc*substep;
@@ -5938,7 +5905,7 @@ static void SW_RASTER_LINE(const sw_vertex_t *v0, const sw_vertex_t *v1)
     // Start line rasterization
     const int fbWidth = RLSW.colorBuffer->width;
     uint8_t *cPixels = RLSW.colorBuffer->pixels;
-#ifdef SW_ENABLE_DEPTH_TEST
+#if (RLSW_RASTER_FLAGS) & SW_STATE_DEPTH_TEST
     uint8_t *dPixels = RLSW.depthBuffer->pixels;
 #endif
 
@@ -5951,11 +5918,11 @@ static void SW_RASTER_LINE(const sw_vertex_t *v0, const sw_vertex_t *v1)
 
         int baseOffset = py*fbWidth + px;
         uint8_t *cPtr = cPixels + baseOffset*SW_FRAMEBUFFER_COLOR_SIZE;
-    #ifdef SW_ENABLE_DEPTH_TEST
+    #if (RLSW_RASTER_FLAGS) & SW_STATE_DEPTH_TEST
         uint8_t *dPtr = dPixels + baseOffset*SW_FRAMEBUFFER_DEPTH_SIZE;
     #endif
 
-        #ifdef SW_ENABLE_DEPTH_TEST
+        #if (RLSW_RASTER_FLAGS) & SW_STATE_DEPTH_TEST
         {
             // TODO: Implement different depth funcs?
             float depth = SW_FRAMEBUFFER_DEPTH_GET(dPtr, 0);
@@ -5968,7 +5935,7 @@ static void SW_RASTER_LINE(const sw_vertex_t *v0, const sw_vertex_t *v1)
 
         float srcColor[4] = {r, g, b, a};
 
-        #ifdef SW_ENABLE_BLEND
+        #if (RLSW_RASTER_FLAGS) & SW_STATE_BLEND
         {
             float dstColor[4];
             SW_FRAMEBUFFER_COLOR_GET(dstColor, cPtr, 0);
@@ -5981,12 +5948,12 @@ static void SW_RASTER_LINE(const sw_vertex_t *v0, const sw_vertex_t *v1)
         }
         #endif
 
-    #ifdef SW_ENABLE_DEPTH_TEST
+    #if (RLSW_RASTER_FLAGS) & SW_STATE_DEPTH_TEST
     discard:
     #endif
         x += xInc;
         y += yInc;
-        #ifdef SW_ENABLE_DEPTH_TEST
+        #if (RLSW_RASTER_FLAGS) & SW_STATE_DEPTH_TEST
         {
             z += zInc;
         }
@@ -6053,11 +6020,6 @@ static void SW_RASTER_LINE_THICK(const sw_vertex_t *v0, const sw_vertex_t *v1)
 //-------------------------------------------------------------------------------------------
 #ifdef RLSW_TEMPLATE_RASTER_POINT
 
-// Options:
-//  - RLSW_TEMPLATE_RASTER_POINT    -> Contains the suffix name
-//  - SW_ENABLE_DEPTH_TEST
-//  - SW_ENABLE_BLEND
-
 #define SW_RASTER_POINT_PIXEL SW_CONCATX(sw_raster_point_pixel_, RLSW_TEMPLATE_RASTER_POINT)
 #define SW_RASTER_POINT       SW_CONCATX(sw_raster_point_, RLSW_TEMPLATE_RASTER_POINT)
 
@@ -6065,7 +6027,7 @@ static void SW_RASTER_POINT_PIXEL(int x, int y, float z, const float color[4])
 {
     int offset = y*RLSW.colorBuffer->width + x;
 
-    #ifdef SW_ENABLE_DEPTH_TEST
+    #if (RLSW_RASTER_FLAGS) & SW_STATE_DEPTH_TEST
     {
         uint8_t *dPtr = (uint8_t *)(RLSW.depthBuffer->pixels) + offset*SW_FRAMEBUFFER_DEPTH_SIZE;
 
@@ -6080,7 +6042,7 @@ static void SW_RASTER_POINT_PIXEL(int x, int y, float z, const float color[4])
 
     uint8_t *cPtr = (uint8_t *)(RLSW.colorBuffer->pixels) + offset*SW_FRAMEBUFFER_COLOR_SIZE;
 
-    #ifdef SW_ENABLE_BLEND
+    #if (RLSW_RASTER_FLAGS) & SW_STATE_BLEND
     {
         float dstColor[4];
         SW_FRAMEBUFFER_COLOR_GET(dstColor, cPtr, 0);

--- a/src/external/rlsw.h
+++ b/src/external/rlsw.h
@@ -793,14 +793,14 @@ SWAPI void swGetFramebufferAttachmentParameteriv(SWattachment attachment, SWatta
 
 #if defined(NDEBUG)
     #if defined(_MSC_VER)
-        #define SW_FORCE_INLINE __forceinline
+        #define SW_INLINE __forceinline
     #elif defined(__GNUC__) || defined(__clang__)
-        #define SW_FORCE_INLINE inline __attribute__((always_inline))
+        #define SW_INLINE inline __attribute__((always_inline))
     #else
-        #define SW_FORCE_INLINE inline
+        #define SW_INLINE inline
     #endif
 #else
-    #define SW_FORCE_INLINE inline
+    #define SW_INLINE inline
 #endif
 
 #if defined(_M_X64) || defined(__x86_64__)
@@ -966,6 +966,7 @@ typedef enum {
 } sw_pixel_alpha_t;
 
 // Forward declarations
+typedef struct sw_texture sw_texture_t;
 typedef struct sw_vertex sw_vertex_t;
 
 // Pixel getter functions
@@ -975,6 +976,9 @@ typedef void (*sw_pixel_read_color_f)(float *SW_RESTRICT, const void *SW_RESTRIC
 // Pixel setter functions
 typedef void (*sw_pixel_write_color8_f)(void *SW_RESTRICT, const uint8_t *SW_RESTRICT, uint32_t);
 typedef void (*sw_pixel_write_color_f)(void *SW_RESTRICT, const float *SW_RESTRICT, uint32_t);
+
+// Texture sampler function
+typedef void (*sw_texture_sampler_f)(float *SW_RESTRICT, const sw_texture_t *SW_RESTRICT, float, float);
 
 // Color blending function
 typedef void (*sw_blend_f)(float *SW_RESTRICT, const float *SW_RESTRICT);
@@ -993,7 +997,7 @@ typedef struct sw_vertex {
     float texcoord[2];          // Texture coordinates
 } sw_vertex_t;
 
-typedef struct {
+typedef struct sw_texture {
     void *pixels;                       // Texture pixels
     sw_pixel_read_color8_f readColor8;  // Texel read RGBA8
     sw_pixel_read_color_f readColor;    // Texel read RGBA32F
@@ -1167,6 +1171,13 @@ static const int SW_PRIMITIVE_VERTEX_COUNT[] =
 // Internal Functions Definitions
 //----------------------------------------------------------------------------------
 
+// Common helper macros
+//----------------------------------------------------------------------------------
+#define SW_VEC_OP(expr, i_name, count) do {                 \
+    for (int i_name = 0; i_name < (count); i_name++) expr;  \
+} while (0)
+//----------------------------------------------------------------------------------
+
 // Math helper functions
 //----------------------------------------------------------------------------------
 static inline void sw_matrix_id(sw_matrix_t dst)
@@ -1257,7 +1268,7 @@ static inline float sw_fract(float x)
     return (x - floorf(x));
 }
 
-static SW_FORCE_INLINE float sw_rcp(float x)
+static SW_INLINE float sw_rcp(float x)
 {
 #if defined(__XTENSA__)
     // Xtensa architecture optimization
@@ -2464,8 +2475,8 @@ static inline void sw_texture_sample_linear(float *SW_RESTRICT color, const sw_t
     }
 }
 
-static inline void sw_texture_sample(float *SW_RESTRICT color, const sw_texture_t *SW_RESTRICT tex,
-                                     float u, float v, float dUdx, float dUdy, float dVdx, float dVdy)
+// Resolves which sample function to use from the texel-to-pixel derivative magnitude
+static inline sw_texture_sampler_f sw_texture_pick_sampler(const sw_texture_t *tex, const float dTdx[2], const float dTdy[2])
 {
     // NOTE: Commented there is the previous method used
     // There was no need to compute the square root because
@@ -2474,19 +2485,12 @@ static inline void sw_texture_sample(float *SW_RESTRICT color, const sw_texture_
     //float dv = sqrtf(dVdx*dVdx + dVdy*dVdy);
     //float L = (du > dv)? du : dv;
 
-    // Calculate the derivatives for each axis
-    float dU2 = dUdx*dUdx + dUdy*dUdy;
-    float dV2 = dVdx*dVdx + dVdy*dVdy;
+    float dU2 = dTdx[0]*dTdx[0] + dTdy[0]*dTdy[0];
+    float dV2 = dTdx[1]*dTdx[1] + dTdy[1]*dTdy[1];
     float L2 = (dU2 > dV2)? dU2 : dV2;
 
     SWfilter filter = (L2 > 1.0f)? tex->minFilter : tex->magFilter;
-
-    switch (filter)
-    {
-        case SW_NEAREST: sw_texture_sample_nearest(color, tex, u, v); break;
-        case SW_LINEAR: sw_texture_sample_linear(color, tex, u, v); break;
-        default: break;
-    }
+    return (filter == SW_LINEAR)? sw_texture_sample_linear : sw_texture_sample_nearest;
 }
 //-------------------------------------------------------------------------------------------
 
@@ -5247,82 +5251,80 @@ void swGetFramebufferAttachmentParameteriv(SWattachment attachment, SWattachget 
 #define SW_RASTER_TRIANGLE_FLAGS SW_FLAGS(SW_RASTER_TRIANGLE_STATES)
 #define SW_RASTER_TRIANGLE_SPAN  SW_CONCATX(sw_raster_triangle_span_, SW_NAME(SW_RASTER_TRIANGLE_STATES))
 #define SW_RASTER_TRIANGLE       SW_CONCATX(sw_raster_triangle_, SW_NAME(SW_RASTER_TRIANGLE_STATES))
+#define SW_SPAN_CTX              SW_CONCATX(sw_span_ctx_, SW_NAME(SW_RASTER_TRIANGLE_STATES))
 
-#if (SW_RASTER_TRIANGLE_FLAGS) & SW_STATE_COLOR_INTERP
-    #define SW_SPAN_FLAT_COLOR_PARAM
-    #define SW_SPAN_FLAT_COLOR_ARG
-#else
-    #define SW_SPAN_FLAT_COLOR_PARAM , const float flatColor[4]
-    #define SW_SPAN_FLAT_COLOR_ARG   , flatColor
-#endif
+// True when a perspective-correct interpolation pass is needed (color or UVs);
+// lets SPAN skip all w-tracking and block subdivision otherwise
+#define SW_RASTER_TRIANGLE_NEEDS_PERSPECTIVE \
+    (((SW_RASTER_TRIANGLE_FLAGS) & SW_STATE_COLOR_INTERP) || ((SW_RASTER_TRIANGLE_FLAGS) & SW_STATE_TEXTURE_2D))
 
 #define SW_GRAD SW_CONCATX(sw_grad_, SW_NAME(SW_RASTER_TRIANGLE_STATES))
 #define SW_VADD SW_CONCATX(sw_vadd_, SW_NAME(SW_RASTER_TRIANGLE_STATES))
-#define SW_VFMA SW_CONCATX(sw_vfma_, SW_NAME(SW_RASTER_TRIANGLE_STATES))
+#define SW_VMAD SW_CONCATX(sw_vmad_, SW_NAME(SW_RASTER_TRIANGLE_STATES))
 
-static SW_FORCE_INLINE void SW_GRAD(sw_vertex_t *SW_RESTRICT out, const sw_vertex_t *SW_RESTRICT a, const sw_vertex_t *SW_RESTRICT b, float scale)
+// Per-triangle constants reused by every scanline: attribute x-derivatives
+// (constant across a planar triangle) plus whatever is fixed once and for
+// all when its interpolation is disabled (flat color, resolved sampler)
+typedef struct
 {
-    out->position[0] = (b->position[0] - a->position[0])*scale;
-    out->position[1] = (b->position[1] - a->position[1])*scale;
-    out->position[2] = (b->position[2] - a->position[2])*scale;
-    out->position[3] = (b->position[3] - a->position[3])*scale;
-
-#if (SW_RASTER_TRIANGLE_FLAGS) & SW_STATE_COLOR_INTERP
-    out->color[0] = (b->color[0] - a->color[0])*scale;
-    out->color[1] = (b->color[1] - a->color[1])*scale;
-    out->color[2] = (b->color[2] - a->color[2])*scale;
-    out->color[3] = (b->color[3] - a->color[3])*scale;
+#if SW_RASTER_TRIANGLE_NEEDS_PERSPECTIVE
+    float dWdx;
 #endif
-
+#if (SW_RASTER_TRIANGLE_FLAGS) & SW_STATE_DEPTH_TEST
+    float dZdx;
+#endif
+#if (SW_RASTER_TRIANGLE_FLAGS) & SW_STATE_COLOR_INTERP
+    float dCdx[4];
+#else
+    float flatColor[4];
+#endif
 #if (SW_RASTER_TRIANGLE_FLAGS) & SW_STATE_TEXTURE_2D
-    out->texcoord[0] = (b->texcoord[0] - a->texcoord[0])*scale;
-    out->texcoord[1] = (b->texcoord[1] - a->texcoord[1])*scale;
+    float dTdx[2];
+    float dTdy[2];
+    sw_texture_sampler_f sample;
+#endif
+} SW_SPAN_CTX;
+
+static inline void SW_GRAD(sw_vertex_t *SW_RESTRICT out, const sw_vertex_t *SW_RESTRICT a, const sw_vertex_t *SW_RESTRICT b, float scale)
+{
+    SW_VEC_OP(out->position[i] = (b->position[i] - a->position[i])*scale, i, 4);
+#if (SW_RASTER_TRIANGLE_FLAGS) & SW_STATE_COLOR_INTERP
+    SW_VEC_OP(out->color[i] = (b->color[i] - a->color[i])*scale, i, 4);
+#endif
+#if (SW_RASTER_TRIANGLE_FLAGS) & SW_STATE_TEXTURE_2D
+    SW_VEC_OP(out->texcoord[i] = (b->texcoord[i] - a->texcoord[i])*scale, i, 2);
 #endif
 }
 
-static SW_FORCE_INLINE void SW_VADD(sw_vertex_t *SW_RESTRICT out, const sw_vertex_t *SW_RESTRICT gradients)
+static inline void SW_VADD(sw_vertex_t *SW_RESTRICT out, const sw_vertex_t *SW_RESTRICT inc)
 {
-    out->position[0] += gradients->position[0];
-    out->position[1] += gradients->position[1];
-    out->position[2] += gradients->position[2];
-    out->position[3] += gradients->position[3];
-
+    SW_VEC_OP(out->position[i] += inc->position[i], i, 4);
 #if (SW_RASTER_TRIANGLE_FLAGS) & SW_STATE_COLOR_INTERP
-    out->color[0] += gradients->color[0];
-    out->color[1] += gradients->color[1];
-    out->color[2] += gradients->color[2];
-    out->color[3] += gradients->color[3];
+    SW_VEC_OP(out->color[i] += inc->color[i], i, 4);
 #endif
-
 #if (SW_RASTER_TRIANGLE_FLAGS) & SW_STATE_TEXTURE_2D
-    out->texcoord[0] += gradients->texcoord[0];
-    out->texcoord[1] += gradients->texcoord[1];
+    SW_VEC_OP(out->texcoord[i] += inc->texcoord[i], i, 2);
 #endif
 }
 
-static SW_FORCE_INLINE void SW_VFMA(sw_vertex_t *SW_RESTRICT out, const sw_vertex_t *SW_RESTRICT gradients, float scale)
+static inline void SW_VMAD(sw_vertex_t *SW_RESTRICT out, const sw_vertex_t *SW_RESTRICT inc, float scale)
 {
-    out->position[0] += gradients->position[0]*scale;
-    out->position[1] += gradients->position[1]*scale;
-    out->position[2] += gradients->position[2]*scale;
-    out->position[3] += gradients->position[3]*scale;
-
+    SW_VEC_OP(out->position[i] += inc->position[i]*scale, i, 4);
 #if (SW_RASTER_TRIANGLE_FLAGS) & SW_STATE_COLOR_INTERP
-    out->color[0] += gradients->color[0]*scale;
-    out->color[1] += gradients->color[1]*scale;
-    out->color[2] += gradients->color[2]*scale;
-    out->color[3] += gradients->color[3]*scale;
+    SW_VEC_OP(out->color[i] += inc->color[i]*scale, i, 4);
 #endif
-
 #if (SW_RASTER_TRIANGLE_FLAGS) & SW_STATE_TEXTURE_2D
-    out->texcoord[0] += gradients->texcoord[0]*scale;
-    out->texcoord[1] += gradients->texcoord[1]*scale;
+    SW_VEC_OP(out->texcoord[i] += inc->texcoord[i]*scale, i, 2);
 #endif
 }
 
-static void SW_RASTER_TRIANGLE_SPAN(const sw_vertex_t *start, const sw_vertex_t *end,
-                                    float dUdy, float dVdy SW_SPAN_FLAT_COLOR_PARAM)
+static void SW_RASTER_TRIANGLE_SPAN(const sw_vertex_t *start, const sw_vertex_t *end, const SW_SPAN_CTX *ctx)
 {
+    // Skip rows outside the framebuffer; can only trigger on FP rounding at
+    // clip boundaries since triangles are already clipped to the viewport
+    int y = (int)start->position[1];
+    if (y < 0 || y >= RLSW.colorBuffer->height) return;
+
     // Gets the start/end coordinates and skip empty lines
     int xStart = (int)start->position[0];
     int xEnd = (int)end->position[0];
@@ -5333,33 +5335,6 @@ static void SW_RASTER_TRIANGLE_SPAN(const sw_vertex_t *start, const sw_vertex_t 
     int xLoopEnd = (xEnd <= RLSW.colorBuffer->width)? xEnd : RLSW.colorBuffer->width;
     if (xLoopStart >= xLoopEnd) return; // Nothing to draw
 
-    // Get the current row and skip if outside the framebuffer
-    // Maybe this check is better suited elsewhere?
-    int y = (int)start->position[1];
-    if (y < 0 || y >= RLSW.colorBuffer->height) return;
-
-    // Compute the inverse horizontal distance along the X axis
-    float dxRcp = sw_rcp(end->position[0] - start->position[0]);
-
-    // Compute the interpolation steps along the X axis
-#if (SW_RASTER_TRIANGLE_FLAGS) & SW_STATE_DEPTH_TEST
-    float dZdx = (end->position[2] - start->position[2])*dxRcp;
-#endif
-    float dWdx = (end->position[3] - start->position[3])*dxRcp;
-
-#if (SW_RASTER_TRIANGLE_FLAGS) & SW_STATE_COLOR_INTERP
-    float dCdx[4] = {
-        (end->color[0] - start->color[0])*dxRcp,
-        (end->color[1] - start->color[1])*dxRcp,
-        (end->color[2] - start->color[2])*dxRcp,
-        (end->color[3] - start->color[3])*dxRcp
-    };
-#endif
-#if (SW_RASTER_TRIANGLE_FLAGS) & SW_STATE_TEXTURE_2D
-    float dUdx = (end->texcoord[0] - start->texcoord[0])*dxRcp;
-    float dVdx = (end->texcoord[1] - start->texcoord[1])*dxRcp;
-#endif
-
     // Compute the subpixel distance to traverse before the first pixel
     // Also step further into them to move away from the colorbuffer edge
     float xSubstep = 1.0f - sw_fract(start->position[0]);
@@ -5368,21 +5343,21 @@ static void SW_RASTER_TRIANGLE_SPAN(const sw_vertex_t *start, const sw_vertex_t 
 
     // Initializing the interpolation starting values
 #if (SW_RASTER_TRIANGLE_FLAGS) & SW_STATE_DEPTH_TEST
-    float z = start->position[2] + dZdx*xOffset;
+    float z = start->position[2] + ctx->dZdx*xOffset;
 #endif
-    float w = start->position[3] + dWdx*xOffset;
-
+#if SW_RASTER_TRIANGLE_NEEDS_PERSPECTIVE
+    float w = start->position[3] + ctx->dWdx*xOffset;
+#endif
 #if (SW_RASTER_TRIANGLE_FLAGS) & SW_STATE_COLOR_INTERP
-    float color[4] = {
-        start->color[0] + dCdx[0]*xOffset,
-        start->color[1] + dCdx[1]*xOffset,
-        start->color[2] + dCdx[2]*xOffset,
-        start->color[3] + dCdx[3]*xOffset
-    };
+    float color[4];
+    SW_VEC_OP(color[i] = start->color[i] + ctx->dCdx[i]*xOffset, i, 4);
+#else
+    // Flat: constant across the whole triangle, computed once for the whole span
+    const float *srcColor = ctx->flatColor;
 #endif
 #if (SW_RASTER_TRIANGLE_FLAGS) & SW_STATE_TEXTURE_2D
-    float u = start->texcoord[0] + dUdx*xOffset;
-    float v = start->texcoord[1] + dVdx*xOffset;
+    float texcoord[2];
+    SW_VEC_OP(texcoord[i] = start->texcoord[i] + ctx->dTdx[i]*xOffset, i, 2);
 #endif
 
     // Pre-calculate the starting pointers for the framebuffer row
@@ -5397,6 +5372,7 @@ static void SW_RASTER_TRIANGLE_SPAN(const sw_vertex_t *start, const sw_vertex_t 
     int x = xLoopStart;
     while (x < xLoopEnd)
     {
+    #if SW_RASTER_TRIANGLE_NEEDS_PERSPECTIVE
         // Clamp last block to remaining pixels
         int blockEnd = x + SW_AFFINE_BLOCK;
         if (blockEnd > xLoopEnd) blockEnd = xLoopEnd;
@@ -5405,31 +5381,25 @@ static void SW_RASTER_TRIANGLE_SPAN(const sw_vertex_t *start, const sw_vertex_t 
 
         // Only 2 '1/w' here; none inside the pixel loop
         float wRcpA = sw_rcp(w);
-        float wB = w + dWdx*blockLenF;
+        float wB = w + ctx->dWdx*blockLenF;
         float wRcpB = sw_rcp(wB);
+    #else
+        // Nothing perspective-correct to interpolate: one block covers the whole span
+        int blockEnd = xLoopEnd;
+    #endif
 
     #if (SW_RASTER_TRIANGLE_FLAGS) & SW_STATE_COLOR_INTERP
         // Perspective-correct color at both block endpoints, then affine gradient
-        float srcColor[4] = {
-            color[0]*wRcpA, color[1]*wRcpA, color[2]*wRcpA, color[3]*wRcpA
-        };
-        float dSrcColordx[4] = {
-            ((color[0] + dCdx[0]*blockLenF)*wRcpB - srcColor[0])*blockLenRcp,
-            ((color[1] + dCdx[1]*blockLenF)*wRcpB - srcColor[1])*blockLenRcp,
-            ((color[2] + dCdx[2]*blockLenF)*wRcpB - srcColor[2])*blockLenRcp,
-            ((color[3] + dCdx[3]*blockLenF)*wRcpB - srcColor[3])*blockLenRcp
-        };
-    #else
-        // Flat: constant across the whole triangle, no perspective correction needed
-        const float *srcColor = flatColor;
+        float srcColor[4], dSrcColor[4];
+        SW_VEC_OP(srcColor[i] = color[i]*wRcpA, i, 4);
+        SW_VEC_OP(dSrcColor[i] = ((color[i] + ctx->dCdx[i]*blockLenF)*wRcpB - srcColor[i])*blockLenRcp, i, 4);
     #endif
 
     #if (SW_RASTER_TRIANGLE_FLAGS) & SW_STATE_TEXTURE_2D
         // Perspective-correct UVs at both endpoints, then affine gradient
-        float uAffine  = u*wRcpA;
-        float vAffine  = v*wRcpA;
-        float dUaffine = ((u + dUdx*blockLenF)*wRcpB - uAffine)*blockLenRcp;
-        float dVaffine = ((v + dVdx*blockLenF)*wRcpB - vAffine)*blockLenRcp;
+        float tcAffine[2], dTcAffine[2];
+        SW_VEC_OP(tcAffine[i] = texcoord[i]*wRcpA, i, 2);
+        SW_VEC_OP(dTcAffine[i] = ((texcoord[i] + ctx->dTdx[i]*blockLenF)*wRcpB - tcAffine[i])*blockLenRcp, i, 2);
     #endif
 
         // Inner span pixel loop
@@ -5445,14 +5415,10 @@ static void SW_RASTER_TRIANGLE_SPAN(const sw_vertex_t *start, const sw_vertex_t 
 
             #if (SW_RASTER_TRIANGLE_FLAGS) & SW_STATE_TEXTURE_2D
             {
-                float texColor[4];
-                sw_texture_sample(texColor, RLSW.boundTexture, uAffine, vAffine, dUdx, dUdy, dVdx, dVdy);
-                float finalColor[4] = {
-                    srcColor[0]*texColor[0],
-                    srcColor[1]*texColor[1],
-                    srcColor[2]*texColor[2],
-                    srcColor[3]*texColor[3]
-                };
+                float finalColor[4];
+                ctx->sample(finalColor, RLSW.boundTexture, tcAffine[0], tcAffine[1]);
+                SW_VEC_OP(finalColor[i] *= srcColor[i], i, 4);
+
                 #if (SW_RASTER_TRIANGLE_FLAGS) & SW_STATE_BLEND
                 {
                     float dstColor[4];
@@ -5482,41 +5448,29 @@ static void SW_RASTER_TRIANGLE_SPAN(const sw_vertex_t *start, const sw_vertex_t 
         #if (SW_RASTER_TRIANGLE_FLAGS) & SW_STATE_DEPTH_TEST
         discard:
         #endif
-        #if (SW_RASTER_TRIANGLE_FLAGS) & SW_STATE_COLOR_INTERP
-            srcColor[0] += dSrcColordx[0];
-            srcColor[1] += dSrcColordx[1];
-            srcColor[2] += dSrcColordx[2];
-            srcColor[3] += dSrcColordx[3];
-        #endif
             cPtr += SW_FRAMEBUFFER_COLOR_SIZE;
-
-            #if (SW_RASTER_TRIANGLE_FLAGS) & SW_STATE_DEPTH_TEST
-            {
-                z += dZdx;
-                dPtr += SW_FRAMEBUFFER_DEPTH_SIZE;
-            }
-            #endif
-
-            #if (SW_RASTER_TRIANGLE_FLAGS) & SW_STATE_TEXTURE_2D
-            {
-                uAffine += dUaffine;
-                vAffine += dVaffine;
-            }
-            #endif
-        }
-
-        // Advance perspective-space accumulators by the full block width
-        w = wB;
+        #if (SW_RASTER_TRIANGLE_FLAGS) & SW_STATE_DEPTH_TEST
+            dPtr += SW_FRAMEBUFFER_DEPTH_SIZE;
+            z += ctx->dZdx;
+        #endif
         #if (SW_RASTER_TRIANGLE_FLAGS) & SW_STATE_COLOR_INTERP
-        color[0] += dCdx[0]*blockLenF;
-        color[1] += dCdx[1]*blockLenF;
-        color[2] += dCdx[2]*blockLenF;
-        color[3] += dCdx[3]*blockLenF;
+            SW_VEC_OP(srcColor[i] += dSrcColor[i], i, 4);
         #endif
         #if (SW_RASTER_TRIANGLE_FLAGS) & SW_STATE_TEXTURE_2D
-        u += dUdx*blockLenF;
-        v += dVdx*blockLenF;
+            SW_VEC_OP(tcAffine[i] += dTcAffine[i], i, 2);
         #endif
+        }
+
+#if SW_RASTER_TRIANGLE_NEEDS_PERSPECTIVE
+        // Advance perspective-space accumulators by the full block width
+        w = wB;
+    #if (SW_RASTER_TRIANGLE_FLAGS) & SW_STATE_COLOR_INTERP
+        SW_VEC_OP(color[i] += ctx->dCdx[i]*blockLenF, i, 4);
+    #endif
+    #if (SW_RASTER_TRIANGLE_FLAGS) & SW_STATE_TEXTURE_2D
+        SW_VEC_OP(texcoord[i] += ctx->dTdx[i]*blockLenF, i, 2);
+    #endif
+#endif
     }
 
 #undef SW_AFFINE_BLOCK
@@ -5539,12 +5493,46 @@ static void SW_RASTER_TRIANGLE(const sw_vertex_t *v0, const sw_vertex_t *v1, con
     float h01 = y1 - y0;
     float h12 = y2 - y1;
 
-    if (h02 < 1e-6f) return;
+    if (h02 < 1e-6f) return; // Degenerate (zero screen height): nothing to rasterize
 
     // Inverse edge dy for per-edge dV/dy (scanline interpolation)
     float h02Rcp = sw_rcp(h02);
     float h01Rcp = (h01 > 1e-6f)? sw_rcp(h01) : 0.0f;
     float h12Rcp = (h12 > 1e-6f)? sw_rcp(h12) : 0.0f;
+
+    // D = twice the signed screen area; also the shared denominator of the
+    // barycentric plane solve used below for whole-triangle x/y derivatives
+    float e1x = v1->position[0] - v0->position[0];
+    float e2x = v2->position[0] - v0->position[0];
+    float D = e1x*h02 - e2x*h01;
+    if (fabsf(D) < 1e-9f) return; // Degenerate (zero screen area): nothing to rasterize
+    float DRcp = sw_rcp(D);
+
+    // Whole-triangle xy-derivatives of an affine attribute (constant for every scanline)
+    #define SW_DADX(A0, A1, A2) ((((A1)-(A0))*h02 - ((A2)-(A0))*h01)*DRcp)
+    #define SW_DADY(A0, A1, A2) ((((A2)-(A0))*e1x - ((A1)-(A0))*e2x)*DRcp)
+
+    SW_SPAN_CTX ctx;
+#if SW_RASTER_TRIANGLE_NEEDS_PERSPECTIVE
+    ctx.dWdx = SW_DADX(v0->position[3], v1->position[3], v2->position[3]);
+#endif
+#if (SW_RASTER_TRIANGLE_FLAGS) & SW_STATE_DEPTH_TEST
+    ctx.dZdx = SW_DADX(v0->position[2], v1->position[2], v2->position[2]);
+#endif
+#if (SW_RASTER_TRIANGLE_FLAGS) & SW_STATE_COLOR_INTERP
+    SW_VEC_OP(ctx.dCdx[i] = SW_DADX(v0->color[i], v1->color[i], v2->color[i]), i, 4);
+#else
+    float flatWRcp = sw_rcp(v0->position[3]);
+    SW_VEC_OP(ctx.flatColor[i] = v0->color[i]*flatWRcp, i, 4);
+#endif
+#if (SW_RASTER_TRIANGLE_FLAGS) & SW_STATE_TEXTURE_2D
+    SW_VEC_OP(ctx.dTdx[i] = SW_DADX(v0->texcoord[i], v1->texcoord[i], v2->texcoord[i]), i, 2);
+    SW_VEC_OP(ctx.dTdy[i] = SW_DADY(v0->texcoord[i], v1->texcoord[i], v2->texcoord[i]), i, 2);
+    ctx.sample = sw_texture_pick_sampler(RLSW.boundTexture, ctx.dTdx, ctx.dTdy);
+#endif
+
+    #undef SW_DADX
+    #undef SW_DADY
 
     // Compute gradients for each side of the triangle
     sw_vertex_t dVXdy02, dVXdy01, dVXdy12;
@@ -5558,18 +5546,8 @@ static void SW_RASTER_TRIANGLE(const sw_vertex_t *v0, const sw_vertex_t *v1, con
 
     // Get a copy of vertices for interpolation and apply substep correction
     sw_vertex_t lVert = *v0, rVert = *v0;
-    SW_VFMA(&lVert, &dVXdy02, y0Substep);
-    SW_VFMA(&rVert, &dVXdy01, y0Substep);
-
-#if !((SW_RASTER_TRIANGLE_FLAGS) & SW_STATE_COLOR_INTERP)
-    float invW = 1.0f / v0->position[3];
-    float flatColor[4] = {
-        v0->color[0]*invW,
-        v0->color[1]*invW,
-        v0->color[2]*invW,
-        v0->color[3]*invW
-    };
-#endif
+    SW_VMAD(&lVert, &dVXdy02, y0Substep);
+    SW_VMAD(&rVert, &dVXdy01, y0Substep);
 
     // Y bounds (vertical clipping)
     int yTop = (int)y0;
@@ -5583,14 +5561,14 @@ static void SW_RASTER_TRIANGLE(const sw_vertex_t *v0, const sw_vertex_t *v1, con
         bool longSideIsLeft = (lVert.position[0] < rVert.position[0]);
         const sw_vertex_t *a = longSideIsLeft? &lVert : &rVert;
         const sw_vertex_t *b = longSideIsLeft? &rVert : &lVert;
-        SW_RASTER_TRIANGLE_SPAN(a, b, dVXdy02.texcoord[0], dVXdy02.texcoord[1] SW_SPAN_FLAT_COLOR_ARG);
+        SW_RASTER_TRIANGLE_SPAN(a, b, &ctx);
         SW_VADD(&lVert, &dVXdy02);
         SW_VADD(&rVert, &dVXdy01);
     }
 
     // Get a copy of next right for interpolation and apply substep correction
     rVert = *v1;
-    SW_VFMA(&rVert, &dVXdy12, y1Substep);
+    SW_VMAD(&rVert, &dVXdy12, y1Substep);
 
     // Scanline for the lower part of the triangle
     for (int y = yMid; y < yBot; y++)
@@ -5599,14 +5577,11 @@ static void SW_RASTER_TRIANGLE(const sw_vertex_t *v0, const sw_vertex_t *v1, con
         bool longSideIsLeft = (lVert.position[0] < rVert.position[0]);
         const sw_vertex_t *a = longSideIsLeft? &lVert : &rVert;
         const sw_vertex_t *b = longSideIsLeft? &rVert : &lVert;
-        SW_RASTER_TRIANGLE_SPAN(a, b, dVXdy02.texcoord[0], dVXdy02.texcoord[1] SW_SPAN_FLAT_COLOR_ARG);
+        SW_RASTER_TRIANGLE_SPAN(a, b, &ctx);
         SW_VADD(&lVert, &dVXdy02);
         SW_VADD(&rVert, &dVXdy12);
     }
 }
-
-#undef SW_SPAN_FLAT_COLOR_PARAM
-#undef SW_SPAN_FLAT_COLOR_ARG
 
 #endif // SW_RASTER_TRIANGLE_STATES
 //-------------------------------------------------------------------------------------------
@@ -5662,46 +5637,30 @@ static void SW_RASTER_QUAD(const sw_vertex_t *a, const sw_vertex_t *b,
     float xSubstep = 1.0f - sw_fract(tl->position[0]);
     float ySubstep = 1.0f - sw_fract(tl->position[1]);
 
-#if (SW_RASTER_QUAD_FLAGS) & SW_STATE_COLOR_INTERP
-    // Gradients along X (tl->tr) and Y (tl->bl)
-    float dCdx[4] = {
-        (tr->color[0] - tl->color[0])*wRcp,
-        (tr->color[1] - tl->color[1])*wRcp,
-        (tr->color[2] - tl->color[2])*wRcp,
-        (tr->color[3] - tl->color[3])*wRcp,
-    };
-    float dCdy[4] = {
-        (bl->color[0] - tl->color[0])*hRcp,
-        (bl->color[1] - tl->color[1])*hRcp,
-        (bl->color[2] - tl->color[2])*hRcp,
-        (bl->color[3] - tl->color[3])*hRcp,
-    };
-#else
-    const float *flatColor = tl->color;
-#endif
-
 #if (SW_RASTER_QUAD_FLAGS) & SW_STATE_DEPTH_TEST
+    // Gradients along X (tl->tr) and Y (tl->bl)
     float dZdx = (tr->position[2] - tl->position[2])*wRcp;
     float dZdy = (bl->position[2] - tl->position[2])*hRcp;
     float zRow = tl->position[2] + dZdx*xSubstep + dZdy*ySubstep;
 #endif
 
-#if (SW_RASTER_QUAD_FLAGS) & SW_STATE_TEXTURE_2D
-    float dUdx = (tr->texcoord[0] - tl->texcoord[0])*wRcp;
-    float dVdx = (tr->texcoord[1] - tl->texcoord[1])*wRcp;
-    float dUdy = (bl->texcoord[0] - tl->texcoord[0])*hRcp;
-    float dVdy = (bl->texcoord[1] - tl->texcoord[1])*hRcp;
-    float uRow = tl->texcoord[0] + dUdx*xSubstep + dUdy*ySubstep;
-    float vRow = tl->texcoord[1] + dVdx*xSubstep + dVdy*ySubstep;
+#if (SW_RASTER_QUAD_FLAGS) & SW_STATE_COLOR_INTERP
+    float dCdx[4], dCdy[4], cRow[4];
+    SW_VEC_OP(dCdx[i] = (tr->color[i] - tl->color[i])*wRcp, i, 4);
+    SW_VEC_OP(dCdy[i] = (bl->color[i] - tl->color[i])*hRcp, i, 4);
+    SW_VEC_OP(cRow[i] = tl->color[i] + dCdx[i]*xSubstep + dCdy[i]*ySubstep, i, 4);
+#else
+    const float *flatColor = tl->color;
 #endif
 
-#if (SW_RASTER_QUAD_FLAGS) & SW_STATE_COLOR_INTERP
-    float cRow[4] = {
-        tl->color[0] + dCdx[0]*xSubstep + dCdy[0]*ySubstep,
-        tl->color[1] + dCdx[1]*xSubstep + dCdy[1]*ySubstep,
-        tl->color[2] + dCdx[2]*xSubstep + dCdy[2]*ySubstep,
-        tl->color[3] + dCdx[3]*xSubstep + dCdy[3]*ySubstep,
-    };
+#if (SW_RASTER_QUAD_FLAGS) & SW_STATE_TEXTURE_2D
+    float dTdx[2], dTdy[2], tcRow[2];
+    SW_VEC_OP(dTdx[i] = (tr->texcoord[i] - tl->texcoord[i])*wRcp, i, 2);
+    SW_VEC_OP(dTdy[i] = (bl->texcoord[i] - tl->texcoord[i])*hRcp, i, 2);
+    SW_VEC_OP(tcRow[i] = tl->texcoord[i] + dTdx[i]*xSubstep + dTdy[i]*ySubstep, i, 2);
+
+    // Constant across the whole quad: resolved once, called directly per pixel
+    sw_texture_sampler_f sample = sw_texture_pick_sampler(RLSW.boundTexture, dTdx, dTdy);
 #endif
 
     int stride = RLSW.colorBuffer->width;
@@ -5715,19 +5674,15 @@ static void SW_RASTER_QUAD(const sw_vertex_t *a, const sw_vertex_t *b,
     float dyMin = (float)(yLoopMin - yMin);
 
     // Correct our start by how far it's clipped outside the framebuffer
-#if (SW_RASTER_QUAD_FLAGS) & SW_STATE_COLOR_INTERP
-    cRow[0] += dCdx[0]*dxMin + dCdy[0]*dyMin;
-    cRow[1] += dCdx[1]*dxMin + dCdy[1]*dyMin;
-    cRow[2] += dCdx[2]*dxMin + dCdy[2]*dyMin;
-    cRow[3] += dCdx[3]*dxMin + dCdy[3]*dyMin;
-#endif
-    #if (SW_RASTER_QUAD_FLAGS) & SW_STATE_DEPTH_TEST
+#if (SW_RASTER_QUAD_FLAGS) & SW_STATE_DEPTH_TEST
     zRow += dZdy*dyMin + dZdx*dxMin;
-    #endif
-    #if (SW_RASTER_QUAD_FLAGS) & SW_STATE_TEXTURE_2D
-    uRow += dUdy*dyMin + dUdx*dxMin;
-    vRow += dVdy*dyMin + dVdx*dxMin;
-    #endif
+#endif
+#if (SW_RASTER_QUAD_FLAGS) & SW_STATE_COLOR_INTERP
+    SW_VEC_OP(cRow[i] += dCdx[i]*dxMin + dCdy[i]*dyMin, i, 4);
+#endif
+#if (SW_RASTER_QUAD_FLAGS) & SW_STATE_TEXTURE_2D
+    SW_VEC_OP(tcRow[i] += dTdy[i]*dyMin + dTdx[i]*dxMin, i, 2);
+#endif
 
     for (int y = yLoopMin; y < yLoopMax; y++)
     {
@@ -5735,12 +5690,10 @@ static void SW_RASTER_QUAD(const sw_vertex_t *a, const sw_vertex_t *b,
         uint8_t *cPtr = cPixels + baseOffset*SW_FRAMEBUFFER_COLOR_SIZE;
     #if (SW_RASTER_QUAD_FLAGS) & SW_STATE_DEPTH_TEST
         uint8_t *dPtr = dPixels + baseOffset*SW_FRAMEBUFFER_DEPTH_SIZE;
-        // Copy the cursors without destroying the offset maths
         float z = zRow;
     #endif
     #if (SW_RASTER_QUAD_FLAGS) & SW_STATE_TEXTURE_2D
-        float u = uRow;
-        float v = vRow;
+        float tc[2] = { tcRow[0], tcRow[1] };
     #endif
     #if (SW_RASTER_QUAD_FLAGS) & SW_STATE_COLOR_INTERP
         float color[4] = { cRow[0], cRow[1], cRow[2], cRow[3] };
@@ -5749,9 +5702,18 @@ static void SW_RASTER_QUAD(const sw_vertex_t *a, const sw_vertex_t *b,
         for (int x = xLoopMin; x < xLoopMax; x++)
         {
         #if (SW_RASTER_QUAD_FLAGS) & SW_STATE_COLOR_INTERP
-            float srcColor[4] = { color[0], color[1], color[2], color[3] };
+            #define SW_QUAD_BASE_COLOR color
         #else
-            float srcColor[4] = { flatColor[0], flatColor[1], flatColor[2], flatColor[3] };
+            #define SW_QUAD_BASE_COLOR flatColor
+        #endif
+
+        #if (SW_RASTER_QUAD_FLAGS) & SW_STATE_TEXTURE_2D
+            // Mutable copy: about to be modulated by the sampled texel below
+            float srcColor[4];
+            SW_VEC_OP(srcColor[i] = SW_QUAD_BASE_COLOR[i], i, 4);
+        #else
+            // Never mutated past this point: alias directly, no copy needed
+            const float *srcColor = SW_QUAD_BASE_COLOR;
         #endif
 
             #if (SW_RASTER_QUAD_FLAGS) & SW_STATE_DEPTH_TEST
@@ -5765,11 +5727,8 @@ static void SW_RASTER_QUAD(const sw_vertex_t *a, const sw_vertex_t *b,
             #if (SW_RASTER_QUAD_FLAGS) & SW_STATE_TEXTURE_2D
             {
                 float texColor[4];
-                sw_texture_sample(texColor, RLSW.boundTexture, u, v, dUdx, dUdy, dVdx, dVdy);
-                srcColor[0] *= texColor[0];
-                srcColor[1] *= texColor[1];
-                srcColor[2] *= texColor[2];
-                srcColor[3] *= texColor[3];
+                sample(texColor, RLSW.boundTexture, tc[0], tc[1]);
+                SW_VEC_OP(srcColor[i] *= texColor[i], i, 4);
             }
             #endif
 
@@ -5791,25 +5750,17 @@ static void SW_RASTER_QUAD(const sw_vertex_t *a, const sw_vertex_t *b,
         #endif
             // Move one pixel over without touching the original "start offset"
         #if (SW_RASTER_QUAD_FLAGS) & SW_STATE_COLOR_INTERP
-            color[0] += dCdx[0];
-            color[1] += dCdx[1];
-            color[2] += dCdx[2];
-            color[3] += dCdx[3];
+            SW_VEC_OP(color[i] += dCdx[i], i, 4);
         #endif
 
-            #if (SW_RASTER_QUAD_FLAGS) & SW_STATE_DEPTH_TEST
-            {
-                z += dZdx;
-                dPtr += SW_FRAMEBUFFER_DEPTH_SIZE;
-            }
-            #endif
+        #if (SW_RASTER_QUAD_FLAGS) & SW_STATE_DEPTH_TEST
+            z += dZdx;
+            dPtr += SW_FRAMEBUFFER_DEPTH_SIZE;
+        #endif
 
-            #if (SW_RASTER_QUAD_FLAGS) & SW_STATE_TEXTURE_2D
-            {
-                u += dUdx;
-                v += dVdx;
-            }
-            #endif
+        #if (SW_RASTER_QUAD_FLAGS) & SW_STATE_TEXTURE_2D
+            SW_VEC_OP(tc[i] += dTdx[i], i, 2);
+        #endif
 
             cPtr += SW_FRAMEBUFFER_COLOR_SIZE;
         }
@@ -5817,26 +5768,18 @@ static void SW_RASTER_QUAD(const sw_vertex_t *a, const sw_vertex_t *b,
         // The for loop is clamped to the right side of the screen
         // However, these cursor start vars are still on the left
         // That's fine, advancing to the next row
-    #if (SW_RASTER_QUAD_FLAGS) & SW_STATE_COLOR_INTERP
-        cRow[0] += dCdy[0];
-        cRow[1] += dCdy[1];
-        cRow[2] += dCdy[2];
-        cRow[3] += dCdy[3];
+    #if (SW_RASTER_QUAD_FLAGS) & SW_STATE_DEPTH_TEST
+        zRow += dZdy;
     #endif
-
-        #if (SW_RASTER_QUAD_FLAGS) & SW_STATE_DEPTH_TEST
-        {
-            zRow += dZdy;
-        }
-        #endif
-
-        #if (SW_RASTER_QUAD_FLAGS) & SW_STATE_TEXTURE_2D
-        {
-            uRow += dUdy;
-            vRow += dVdy;
-        }
-        #endif
+    #if (SW_RASTER_QUAD_FLAGS) & SW_STATE_COLOR_INTERP
+        SW_VEC_OP(cRow[i] += dCdy[i], i, 4);
+    #endif
+    #if (SW_RASTER_QUAD_FLAGS) & SW_STATE_TEXTURE_2D
+        SW_VEC_OP(tcRow[i] += dTdy[i], i, 2);
+    #endif
     }
+
+#undef SW_QUAD_BASE_COLOR
 }
 
 #endif // SW_RASTER_QUAD_STATES

--- a/src/external/rlsw.h
+++ b/src/external/rlsw.h
@@ -93,34 +93,8 @@
 #include <stdint.h>
 
 //----------------------------------------------------------------------------------
-// Defines and Macros
+// RLSW Configuration
 //----------------------------------------------------------------------------------
-// Function specifiers definition
-#ifndef SWAPI
-    #define SWAPI       // Functions defined as 'extern' by default (implicit specifiers)
-#endif
-
-#ifndef SW_MALLOC
-    #define SW_MALLOC(sz) malloc(sz)
-#endif
-#ifndef SW_CALLOC
-    #define SW_CALLOC(n,sz) calloc(n,sz)
-#endif
-#ifndef SW_REALLOC
-    #define SW_REALLOC(ptr, newSz) realloc(ptr, newSz)
-#endif
-#ifndef SW_FREE
-    #define SW_FREE(ptr) free(ptr)
-#endif
-
-#ifndef SW_RESTRICT
-    #ifdef _MSC_VER
-        #define SW_RESTRICT __restrict
-    #else
-        #define SW_RESTRICT restrict
-    #endif
-#endif
-
 #ifndef SW_FRAMEBUFFER_OUTPUT_BGRA
     #define SW_FRAMEBUFFER_OUTPUT_BGRA      true
 #endif
@@ -167,7 +141,38 @@
 // Full NPOT texture support (enabled by default)
 // When disabled, SW_REPEAT requires POT on its axis (fast bitmask wrap)
 // SW_CLAMP remains supported for any dimension, per-axis
-#define SW_SUPPORT_NPOT_TEXTURE true
+#ifndef SW_SUPPORT_NPOT_TEXTURE
+#   define SW_SUPPORT_NPOT_TEXTURE true
+#endif
+
+//----------------------------------------------------------------------------------
+// Defines and Macros
+//----------------------------------------------------------------------------------
+// Function specifiers definition
+#ifndef SWAPI
+    #define SWAPI       // Functions defined as 'extern' by default (implicit specifiers)
+#endif
+
+#ifndef SW_MALLOC
+    #define SW_MALLOC(sz) malloc(sz)
+#endif
+#ifndef SW_CALLOC
+    #define SW_CALLOC(n,sz) calloc(n,sz)
+#endif
+#ifndef SW_REALLOC
+    #define SW_REALLOC(ptr, newSz) realloc(ptr, newSz)
+#endif
+#ifndef SW_FREE
+    #define SW_FREE(ptr) free(ptr)
+#endif
+
+#ifndef SW_RESTRICT
+    #ifdef _MSC_VER
+        #define SW_RESTRICT __restrict
+    #else
+        #define SW_RESTRICT restrict
+    #endif
+#endif
 
 //----------------------------------------------------------------------------------
 // OpenGL Compatibility Types

--- a/src/external/rlsw.h
+++ b/src/external/rlsw.h
@@ -791,6 +791,18 @@ SWAPI void swGetFramebufferAttachmentParameteriv(SWattachment attachment, SWatta
     #define SW_ALIGN(x) // Do nothing if not available
 #endif
 
+#if defined(NDEBUG)
+    #if defined(_MSC_VER)
+        #define SW_FORCE_INLINE __forceinline
+    #elif defined(__GNUC__) || defined(__clang__)
+        #define SW_FORCE_INLINE inline __attribute__((always_inline))
+    #else
+        #define SW_FORCE_INLINE inline
+    #endif
+#else
+    #define SW_FORCE_INLINE inline
+#endif
+
 #if defined(_M_X64) || defined(__x86_64__)
     #define SW_ARCH_X86_64
 #elif defined(_M_IX86) || defined(__i386__)
@@ -908,10 +920,11 @@ SWAPI void swGetFramebufferAttachmentParameteriv(SWattachment attachment, SWatta
 
 #define SW_STATE_NONE                             0     /* Pseudo state used for the rasterizer variant with no pipeline state enabled */
 #define SW_STATE_SCISSOR_TEST               (1 << 0)
-#define SW_STATE_TEXTURE_2D                 (1 << 1)
-#define SW_STATE_DEPTH_TEST                 (1 << 2)
-#define SW_STATE_CULL_FACE                  (1 << 3)
-#define SW_STATE_BLEND                      (1 << 4)
+#define SW_STATE_COLOR_INTERP               (1 << 1)
+#define SW_STATE_TEXTURE_2D                 (1 << 2)
+#define SW_STATE_DEPTH_TEST                 (1 << 3)
+#define SW_STATE_CULL_FACE                  (1 << 4)
+#define SW_STATE_BLEND                      (1 << 5)
 
 #define SW_BLEND_FLAG_NOOP                  (1 << 0)
 #define SW_BLEND_FLAG_NEEDS_ALPHA           (1 << 1)
@@ -1244,16 +1257,15 @@ static inline float sw_fract(float x)
     return (x - floorf(x));
 }
 
-// Xtensa architecture optimization
-// Fast reciprocal: 1-ULP accurate in ~7 instructions using the
-// hardware `recip0.s` seed + two Newton-Raphson refinement steps
-// All work stays in FPU registers — no `__divsf3` software call
-// Hot-path divisions in the rasterizer (span/triangle setup, perspective divide, etc.) call this
-// On non-Xtensa targets it transparently expands to `1.0f / x`, so generated code is identical to before
-#if defined(__XTENSA__)
-__attribute__((always_inline))
-static inline float sw_rcp(float x)
+static SW_FORCE_INLINE float sw_rcp(float x)
 {
+#if defined(__XTENSA__)
+    // Xtensa architecture optimization
+    // Fast reciprocal: 1-ULP accurate in ~7 instructions using the
+    // hardware `recip0.s` seed + two Newton-Raphson refinement steps
+    // All work stays in FPU registers — no `__divsf3` software call
+    // Hot-path divisions in the rasterizer (span/triangle setup, perspective divide, etc.) call this
+    // On non-Xtensa targets it transparently expands to `1.0f / x`, so generated code is identical to before
     float result, temp;
     __asm__(
         "recip0.s %0, %2\n"
@@ -1266,10 +1278,10 @@ static inline float sw_rcp(float x)
         : "=&f"(result), "=&f"(temp) : "f"(x)
     );
     return result;
-}
 #else
-static inline float sw_rcp(float x) { return 1.0f/x; }
+    return 1.0f/x;
 #endif
+}
 
 static inline uint8_t sw_luminance8(const uint8_t *color)
 {
@@ -1300,108 +1312,6 @@ static inline void sw_lerp_vertex_PCT(sw_vertex_t *SW_RESTRICT out, const sw_ver
     // Texture coordinate interpolation (2 components)
     out->texcoord[0] = a->texcoord[0]*tInv + b->texcoord[0]*t;
     out->texcoord[1] = a->texcoord[1]*tInv + b->texcoord[1]*t;
-}
-
-static inline void sw_get_vertex_grad_PCT(sw_vertex_t *SW_RESTRICT out, const sw_vertex_t *SW_RESTRICT a, const sw_vertex_t *SW_RESTRICT b, float scale)
-{
-    // Calculate gradients for Position
-    out->position[0] = (b->position[0] - a->position[0])*scale;
-    out->position[1] = (b->position[1] - a->position[1])*scale;
-    out->position[2] = (b->position[2] - a->position[2])*scale;
-    out->position[3] = (b->position[3] - a->position[3])*scale;
-
-    // Calculate gradients for Color
-    out->color[0] = (b->color[0] - a->color[0])*scale;
-    out->color[1] = (b->color[1] - a->color[1])*scale;
-    out->color[2] = (b->color[2] - a->color[2])*scale;
-    out->color[3] = (b->color[3] - a->color[3])*scale;
-
-    // Calculate gradients for Texture coordinates
-    out->texcoord[0] = (b->texcoord[0] - a->texcoord[0])*scale;
-    out->texcoord[1] = (b->texcoord[1] - a->texcoord[1])*scale;
-}
-
-static inline void sw_add_vertex_grad_PCT(sw_vertex_t *SW_RESTRICT out, const sw_vertex_t *SW_RESTRICT gradients)
-{
-    // Add gradients to Position
-    out->position[0] += gradients->position[0];
-    out->position[1] += gradients->position[1];
-    out->position[2] += gradients->position[2];
-    out->position[3] += gradients->position[3];
-
-    // Add gradients to Color
-    out->color[0] += gradients->color[0];
-    out->color[1] += gradients->color[1];
-    out->color[2] += gradients->color[2];
-    out->color[3] += gradients->color[3];
-
-    // Add gradients to Texture coordinates
-    out->texcoord[0] += gradients->texcoord[0];
-    out->texcoord[1] += gradients->texcoord[1];
-}
-
-static inline void sw_add_vertex_grad_scaled_PCT(sw_vertex_t *SW_RESTRICT out, const sw_vertex_t *SW_RESTRICT gradients, float scale)
-{
-    // Add gradients to Position
-    out->position[0] += gradients->position[0]*scale;
-    out->position[1] += gradients->position[1]*scale;
-    out->position[2] += gradients->position[2]*scale;
-    out->position[3] += gradients->position[3]*scale;
-
-    // Add gradients to Color
-    out->color[0] += gradients->color[0]*scale;
-    out->color[1] += gradients->color[1]*scale;
-    out->color[2] += gradients->color[2]*scale;
-    out->color[3] += gradients->color[3]*scale;
-
-    // Add gradients to Texture coordinates
-    out->texcoord[0] += gradients->texcoord[0]*scale;
-    out->texcoord[1] += gradients->texcoord[1]*scale;
-}
-
-static inline void sw_get_vertex_grad_PC(sw_vertex_t *SW_RESTRICT out, const sw_vertex_t *SW_RESTRICT a, const sw_vertex_t *SW_RESTRICT b, float scale)
-{
-    // Calculate gradients for Position
-    out->position[0] = (b->position[0] - a->position[0])*scale;
-    out->position[1] = (b->position[1] - a->position[1])*scale;
-    out->position[2] = (b->position[2] - a->position[2])*scale;
-    out->position[3] = (b->position[3] - a->position[3])*scale;
-
-    // Calculate gradients for Color
-    out->color[0] = (b->color[0] - a->color[0])*scale;
-    out->color[1] = (b->color[1] - a->color[1])*scale;
-    out->color[2] = (b->color[2] - a->color[2])*scale;
-    out->color[3] = (b->color[3] - a->color[3])*scale;
-}
-
-static inline void sw_add_vertex_grad_PC(sw_vertex_t *SW_RESTRICT out, const sw_vertex_t *SW_RESTRICT gradients)
-{
-    // Add gradients to Position
-    out->position[0] += gradients->position[0];
-    out->position[1] += gradients->position[1];
-    out->position[2] += gradients->position[2];
-    out->position[3] += gradients->position[3];
-
-    // Add gradients to Color
-    out->color[0] += gradients->color[0];
-    out->color[1] += gradients->color[1];
-    out->color[2] += gradients->color[2];
-    out->color[3] += gradients->color[3];
-}
-
-static inline void sw_add_vertex_grad_scaled_PC(sw_vertex_t *SW_RESTRICT out, const sw_vertex_t *SW_RESTRICT gradients, float scale)
-{
-    // Add gradients to Position
-    out->position[0] += gradients->position[0]*scale;
-    out->position[1] += gradients->position[1]*scale;
-    out->position[2] += gradients->position[2]*scale;
-    out->position[3] += gradients->position[3]*scale;
-
-    // Add gradients to Color
-    out->color[0] += gradients->color[0]*scale;
-    out->color[1] += gradients->color[1]*scale;
-    out->color[2] += gradients->color[2]*scale;
-    out->color[3] += gradients->color[3]*scale;
 }
 
 // Half conversion functions
@@ -3093,18 +3003,38 @@ static bool sw_polygon_clip(sw_vertex_t polygon[SW_MAX_CLIPPED_POLYGON_VERTICES]
     [SW_FLAGS(__VA_ARGS__)] = SW_CONCATX(PREFIX, SW_NAME(__VA_ARGS__)),
 
 // Variant lists: X(STATES...) invoked once per specialization
-// Triangle/quad: TEXTURE_2D, DEPTH_TEST, BLEND
+// Triangle/quad: COLOR_INTERP, TEXTURE_2D, DEPTH_TEST, BLEND
+#define SW_RASTER_VARIANTS_4(X, ...)                            \
+    X(__VA_ARGS__, NONE)                                        \
+    X(__VA_ARGS__, COLOR_INTERP)                                \
+    X(__VA_ARGS__, TEXTURE_2D)                                  \
+    X(__VA_ARGS__, DEPTH_TEST)                                  \
+    X(__VA_ARGS__, BLEND)                                       \
+    X(__VA_ARGS__, COLOR_INTERP, TEXTURE_2D)                    \
+    X(__VA_ARGS__, COLOR_INTERP, DEPTH_TEST)                    \
+    X(__VA_ARGS__, COLOR_INTERP, BLEND)                         \
+    X(__VA_ARGS__, TEXTURE_2D, DEPTH_TEST)                      \
+    X(__VA_ARGS__, TEXTURE_2D, BLEND)                           \
+    X(__VA_ARGS__, DEPTH_TEST, BLEND)                           \
+    X(__VA_ARGS__, COLOR_INTERP, TEXTURE_2D, DEPTH_TEST)        \
+    X(__VA_ARGS__, COLOR_INTERP, TEXTURE_2D, BLEND)             \
+    X(__VA_ARGS__, COLOR_INTERP, DEPTH_TEST, BLEND)             \
+    X(__VA_ARGS__, TEXTURE_2D, DEPTH_TEST, BLEND)               \
+    X(__VA_ARGS__, COLOR_INTERP, TEXTURE_2D, DEPTH_TEST, BLEND)
+
+// Variant lists: X(STATES...) invoked once per specialization
+// Line: COLOR_INTERP, DEPTH_TEST, BLEND
 #define SW_RASTER_VARIANTS_3(X, ...)                \
     X(__VA_ARGS__, NONE)                            \
-    X(__VA_ARGS__, TEXTURE_2D)                      \
+    X(__VA_ARGS__, COLOR_INTERP)                    \
     X(__VA_ARGS__, DEPTH_TEST)                      \
     X(__VA_ARGS__, BLEND)                           \
-    X(__VA_ARGS__, TEXTURE_2D, DEPTH_TEST)          \
-    X(__VA_ARGS__, TEXTURE_2D, BLEND)               \
+    X(__VA_ARGS__, COLOR_INTERP, DEPTH_TEST)        \
+    X(__VA_ARGS__, COLOR_INTERP, BLEND)             \
     X(__VA_ARGS__, DEPTH_TEST, BLEND)               \
-    X(__VA_ARGS__, TEXTURE_2D, DEPTH_TEST, BLEND)
+    X(__VA_ARGS__, COLOR_INTERP, DEPTH_TEST, BLEND)
 
-// Line/point: DEPTH_TEST, BLEND
+// Point: DEPTH_TEST, BLEND
 #define SW_RASTER_VARIANTS_2(X, ...)    \
     X(__VA_ARGS__, NONE)                \
     X(__VA_ARGS__, DEPTH_TEST)          \
@@ -3114,10 +3044,14 @@ static bool sw_polygon_clip(sw_vertex_t polygon[SW_MAX_CLIPPED_POLYGON_VERTICES]
 
 // Triangle rasterizer variant dispatch
 //-------------------------------------------------------------------------------------------
-#define SW_RASTER_TRIANGLE_STATE_MASK SW_FLAGS(TEXTURE_2D, DEPTH_TEST, BLEND)
+#define SW_RASTER_TRIANGLE_STATE_MASK SW_FLAGS(COLOR_INTERP, TEXTURE_2D, DEPTH_TEST, BLEND)
 
 #define SW_RASTER_TRIANGLE_STATES NONE
 #include __FILE__ // IWYU pragma: keep
+#undef SW_RASTER_TRIANGLE_STATES
+
+#define SW_RASTER_TRIANGLE_STATES COLOR_INTERP
+#include __FILE__
 #undef SW_RASTER_TRIANGLE_STATES
 
 #define SW_RASTER_TRIANGLE_STATES TEXTURE_2D
@@ -3129,6 +3063,18 @@ static bool sw_polygon_clip(sw_vertex_t polygon[SW_MAX_CLIPPED_POLYGON_VERTICES]
 #undef SW_RASTER_TRIANGLE_STATES
 
 #define SW_RASTER_TRIANGLE_STATES BLEND
+#include __FILE__
+#undef SW_RASTER_TRIANGLE_STATES
+
+#define SW_RASTER_TRIANGLE_STATES COLOR_INTERP, TEXTURE_2D
+#include __FILE__
+#undef SW_RASTER_TRIANGLE_STATES
+
+#define SW_RASTER_TRIANGLE_STATES COLOR_INTERP, DEPTH_TEST
+#include __FILE__
+#undef SW_RASTER_TRIANGLE_STATES
+
+#define SW_RASTER_TRIANGLE_STATES COLOR_INTERP, BLEND
 #include __FILE__
 #undef SW_RASTER_TRIANGLE_STATES
 
@@ -3144,25 +3090,44 @@ static bool sw_polygon_clip(sw_vertex_t polygon[SW_MAX_CLIPPED_POLYGON_VERTICES]
 #include __FILE__
 #undef SW_RASTER_TRIANGLE_STATES
 
+#define SW_RASTER_TRIANGLE_STATES COLOR_INTERP, TEXTURE_2D, DEPTH_TEST
+#include __FILE__
+#undef SW_RASTER_TRIANGLE_STATES
+
+#define SW_RASTER_TRIANGLE_STATES COLOR_INTERP, DEPTH_TEST, BLEND
+#include __FILE__
+#undef SW_RASTER_TRIANGLE_STATES
+
+#define SW_RASTER_TRIANGLE_STATES COLOR_INTERP, TEXTURE_2D, BLEND
+#include __FILE__
+#undef SW_RASTER_TRIANGLE_STATES
+
 #define SW_RASTER_TRIANGLE_STATES TEXTURE_2D, DEPTH_TEST, BLEND
 #include __FILE__
 #undef SW_RASTER_TRIANGLE_STATES
 
-// Forward declarations because clangd does not follow #include __FILE__ to avoid infinite recursion
-// These declarations make all variants visible to static analysis tools without affecting compilation
-SW_RASTER_VARIANTS_3(SW_RASTER_FWD, sw_raster_triangle_, (const sw_vertex_t*, const sw_vertex_t*, const sw_vertex_t*)) // NOLINT
+#define SW_RASTER_TRIANGLE_STATES COLOR_INTERP, TEXTURE_2D, DEPTH_TEST, BLEND
+#include __FILE__
+#undef SW_RASTER_TRIANGLE_STATES
+
+// Forward declarations for static analyzer like clangd that do not handle self-inclusion correctly
+SW_RASTER_VARIANTS_4(SW_RASTER_FWD, sw_raster_triangle_, (const sw_vertex_t*, const sw_vertex_t*, const sw_vertex_t*)) // NOLINT
 
 static const sw_raster_triangle_f SW_RASTER_TRIANGLE_TABLE[] = {
-    SW_RASTER_VARIANTS_3(SW_RASTER_ENTRY, sw_raster_triangle_)
+    SW_RASTER_VARIANTS_4(SW_RASTER_ENTRY, sw_raster_triangle_)
 };
 //-------------------------------------------------------------------------------------------
 
 // Quad rasterizer variant dispatch
 //-------------------------------------------------------------------------------------------
-#define SW_RASTER_QUAD_STATE_MASK SW_FLAGS(TEXTURE_2D, DEPTH_TEST, BLEND)
+#define SW_RASTER_QUAD_STATE_MASK SW_FLAGS(COLOR_INTERP, TEXTURE_2D, DEPTH_TEST, BLEND)
 
 #define SW_RASTER_QUAD_STATES NONE
 #include __FILE__ // IWYU pragma: keep
+#undef SW_RASTER_QUAD_STATES
+
+#define SW_RASTER_QUAD_STATES COLOR_INTERP
+#include __FILE__
 #undef SW_RASTER_QUAD_STATES
 
 #define SW_RASTER_QUAD_STATES TEXTURE_2D
@@ -3174,6 +3139,18 @@ static const sw_raster_triangle_f SW_RASTER_TRIANGLE_TABLE[] = {
 #undef SW_RASTER_QUAD_STATES
 
 #define SW_RASTER_QUAD_STATES BLEND
+#include __FILE__
+#undef SW_RASTER_QUAD_STATES
+
+#define SW_RASTER_QUAD_STATES COLOR_INTERP, TEXTURE_2D
+#include __FILE__
+#undef SW_RASTER_QUAD_STATES
+
+#define SW_RASTER_QUAD_STATES COLOR_INTERP, DEPTH_TEST
+#include __FILE__
+#undef SW_RASTER_QUAD_STATES
+
+#define SW_RASTER_QUAD_STATES COLOR_INTERP, BLEND
 #include __FILE__
 #undef SW_RASTER_QUAD_STATES
 
@@ -3189,23 +3166,44 @@ static const sw_raster_triangle_f SW_RASTER_TRIANGLE_TABLE[] = {
 #include __FILE__
 #undef SW_RASTER_QUAD_STATES
 
+#define SW_RASTER_QUAD_STATES COLOR_INTERP, TEXTURE_2D, DEPTH_TEST
+#include __FILE__
+#undef SW_RASTER_QUAD_STATES
+
+#define SW_RASTER_QUAD_STATES COLOR_INTERP, TEXTURE_2D, BLEND
+#include __FILE__
+#undef SW_RASTER_QUAD_STATES
+
+#define SW_RASTER_QUAD_STATES COLOR_INTERP, DEPTH_TEST, BLEND
+#include __FILE__
+#undef SW_RASTER_QUAD_STATES
+
 #define SW_RASTER_QUAD_STATES TEXTURE_2D, DEPTH_TEST, BLEND
 #include __FILE__
 #undef SW_RASTER_QUAD_STATES
 
-SW_RASTER_VARIANTS_3(SW_RASTER_FWD, sw_raster_quad_, (const sw_vertex_t*, const sw_vertex_t*, const sw_vertex_t*, const sw_vertex_t*)) // NOLINT
+#define SW_RASTER_QUAD_STATES COLOR_INTERP, TEXTURE_2D, DEPTH_TEST, BLEND
+#include __FILE__
+#undef SW_RASTER_QUAD_STATES
+
+// Forward declarations for static analyzer like clangd that do not handle self-inclusion correctly
+SW_RASTER_VARIANTS_4(SW_RASTER_FWD, sw_raster_quad_, (const sw_vertex_t*, const sw_vertex_t*, const sw_vertex_t*, const sw_vertex_t*)) // NOLINT
 
 static const sw_raster_quad_f SW_RASTER_QUAD_TABLE[] = {
-    SW_RASTER_VARIANTS_3(SW_RASTER_ENTRY, sw_raster_quad_)
+    SW_RASTER_VARIANTS_4(SW_RASTER_ENTRY, sw_raster_quad_)
 };
 //-------------------------------------------------------------------------------------------
 
 // Line rasterizer variant dispatch
 //-------------------------------------------------------------------------------------------
-#define SW_RASTER_LINE_STATE_MASK SW_FLAGS(DEPTH_TEST, BLEND)
+#define SW_RASTER_LINE_STATE_MASK SW_FLAGS(COLOR_INTERP, DEPTH_TEST, BLEND)
 
 #define SW_RASTER_LINE_STATES NONE
 #include __FILE__ // IWYU pragma: keep
+#undef SW_RASTER_LINE_STATES
+
+#define SW_RASTER_LINE_STATES COLOR_INTERP
+#include __FILE__
 #undef SW_RASTER_LINE_STATES
 
 #define SW_RASTER_LINE_STATES DEPTH_TEST
@@ -3216,14 +3214,27 @@ static const sw_raster_quad_f SW_RASTER_QUAD_TABLE[] = {
 #include __FILE__
 #undef SW_RASTER_LINE_STATES
 
+#define SW_RASTER_LINE_STATES COLOR_INTERP, DEPTH_TEST
+#include __FILE__
+#undef SW_RASTER_LINE_STATES
+
+#define SW_RASTER_LINE_STATES COLOR_INTERP, BLEND
+#include __FILE__
+#undef SW_RASTER_LINE_STATES
+
 #define SW_RASTER_LINE_STATES DEPTH_TEST, BLEND
 #include __FILE__
 #undef SW_RASTER_LINE_STATES
 
-SW_RASTER_VARIANTS_2(SW_RASTER_FWD, sw_raster_line_, (const sw_vertex_t*, const sw_vertex_t*)) // NOLINT
+#define SW_RASTER_LINE_STATES COLOR_INTERP, DEPTH_TEST, BLEND
+#include __FILE__
+#undef SW_RASTER_LINE_STATES
+
+// Forward declarations for static analyzer like clangd that do not handle self-inclusion correctly
+SW_RASTER_VARIANTS_3(SW_RASTER_FWD, sw_raster_line_, (const sw_vertex_t*, const sw_vertex_t*)) // NOLINT
 
 static const sw_raster_line_f SW_RASTER_LINE_TABLE[] = {
-    SW_RASTER_VARIANTS_2(SW_RASTER_ENTRY, sw_raster_line_)
+    SW_RASTER_VARIANTS_3(SW_RASTER_ENTRY, sw_raster_line_)
 };
 //-------------------------------------------------------------------------------------------
 
@@ -3247,6 +3258,7 @@ static const sw_raster_line_f SW_RASTER_LINE_TABLE[] = {
 #include __FILE__
 #undef SW_RASTER_POINT_STATES
 
+// Forward declarations for static analyzer like clangd that do not handle self-inclusion correctly
 SW_RASTER_VARIANTS_2(SW_RASTER_FWD, sw_raster_point_, (const sw_vertex_t*)) // NOLINT
 
 static const sw_raster_point_f SW_RASTER_POINT_TABLE[] = {
@@ -5225,17 +5237,80 @@ void swGetFramebufferAttachmentParameteriv(SWattachment attachment, SWattachget 
 #define SW_RASTER_TRIANGLE_SPAN  SW_CONCATX(sw_raster_triangle_span_, SW_NAME(SW_RASTER_TRIANGLE_STATES))
 #define SW_RASTER_TRIANGLE       SW_CONCATX(sw_raster_triangle_, SW_NAME(SW_RASTER_TRIANGLE_STATES))
 
-#if (SW_RASTER_TRIANGLE_FLAGS) & SW_STATE_TEXTURE_2D
-    #define SW_GET_GRAD         sw_get_vertex_grad_PCT
-    #define SW_ADD_GRAD         sw_add_vertex_grad_PCT
-    #define SW_ADD_GRAD_SCALED  sw_add_vertex_grad_scaled_PCT
+#if (SW_RASTER_TRIANGLE_FLAGS) & SW_STATE_COLOR_INTERP
+    #define SW_SPAN_FLAT_COLOR_PARAM
+    #define SW_SPAN_FLAT_COLOR_ARG
 #else
-    #define SW_GET_GRAD         sw_get_vertex_grad_PC
-    #define SW_ADD_GRAD         sw_add_vertex_grad_PC
-    #define SW_ADD_GRAD_SCALED  sw_add_vertex_grad_scaled_PC
+    #define SW_SPAN_FLAT_COLOR_PARAM , const float flatColor[4]
+    #define SW_SPAN_FLAT_COLOR_ARG   , flatColor
 #endif
 
-static void SW_RASTER_TRIANGLE_SPAN(const sw_vertex_t *start, const sw_vertex_t *end, float dUdy, float dVdy)
+#define SW_GRAD SW_CONCATX(sw_grad_, SW_NAME(SW_RASTER_TRIANGLE_STATES))
+#define SW_VADD SW_CONCATX(sw_vadd_, SW_NAME(SW_RASTER_TRIANGLE_STATES))
+#define SW_VFMA SW_CONCATX(sw_vfma_, SW_NAME(SW_RASTER_TRIANGLE_STATES))
+
+static SW_FORCE_INLINE void SW_GRAD(sw_vertex_t *SW_RESTRICT out, const sw_vertex_t *SW_RESTRICT a, const sw_vertex_t *SW_RESTRICT b, float scale)
+{
+    out->position[0] = (b->position[0] - a->position[0])*scale;
+    out->position[1] = (b->position[1] - a->position[1])*scale;
+    out->position[2] = (b->position[2] - a->position[2])*scale;
+    out->position[3] = (b->position[3] - a->position[3])*scale;
+
+#if (SW_RASTER_TRIANGLE_FLAGS) & SW_STATE_COLOR_INTERP
+    out->color[0] = (b->color[0] - a->color[0])*scale;
+    out->color[1] = (b->color[1] - a->color[1])*scale;
+    out->color[2] = (b->color[2] - a->color[2])*scale;
+    out->color[3] = (b->color[3] - a->color[3])*scale;
+#endif
+
+#if (SW_RASTER_TRIANGLE_FLAGS) & SW_STATE_TEXTURE_2D
+    out->texcoord[0] = (b->texcoord[0] - a->texcoord[0])*scale;
+    out->texcoord[1] = (b->texcoord[1] - a->texcoord[1])*scale;
+#endif
+}
+
+static SW_FORCE_INLINE void SW_VADD(sw_vertex_t *SW_RESTRICT out, const sw_vertex_t *SW_RESTRICT gradients)
+{
+    out->position[0] += gradients->position[0];
+    out->position[1] += gradients->position[1];
+    out->position[2] += gradients->position[2];
+    out->position[3] += gradients->position[3];
+
+#if (SW_RASTER_TRIANGLE_FLAGS) & SW_STATE_COLOR_INTERP
+    out->color[0] += gradients->color[0];
+    out->color[1] += gradients->color[1];
+    out->color[2] += gradients->color[2];
+    out->color[3] += gradients->color[3];
+#endif
+
+#if (SW_RASTER_TRIANGLE_FLAGS) & SW_STATE_TEXTURE_2D
+    out->texcoord[0] += gradients->texcoord[0];
+    out->texcoord[1] += gradients->texcoord[1];
+#endif
+}
+
+static SW_FORCE_INLINE void SW_VFMA(sw_vertex_t *SW_RESTRICT out, const sw_vertex_t *SW_RESTRICT gradients, float scale)
+{
+    out->position[0] += gradients->position[0]*scale;
+    out->position[1] += gradients->position[1]*scale;
+    out->position[2] += gradients->position[2]*scale;
+    out->position[3] += gradients->position[3]*scale;
+
+#if (SW_RASTER_TRIANGLE_FLAGS) & SW_STATE_COLOR_INTERP
+    out->color[0] += gradients->color[0]*scale;
+    out->color[1] += gradients->color[1]*scale;
+    out->color[2] += gradients->color[2]*scale;
+    out->color[3] += gradients->color[3]*scale;
+#endif
+
+#if (SW_RASTER_TRIANGLE_FLAGS) & SW_STATE_TEXTURE_2D
+    out->texcoord[0] += gradients->texcoord[0]*scale;
+    out->texcoord[1] += gradients->texcoord[1]*scale;
+#endif
+}
+
+static void SW_RASTER_TRIANGLE_SPAN(const sw_vertex_t *start, const sw_vertex_t *end,
+                                    float dUdy, float dVdy SW_SPAN_FLAT_COLOR_PARAM)
 {
     // Gets the start/end coordinates and skip empty lines
     int xStart = (int)start->position[0];
@@ -5256,15 +5331,18 @@ static void SW_RASTER_TRIANGLE_SPAN(const sw_vertex_t *start, const sw_vertex_t 
     float dxRcp = sw_rcp(end->position[0] - start->position[0]);
 
     // Compute the interpolation steps along the X axis
+#if (SW_RASTER_TRIANGLE_FLAGS) & SW_STATE_DEPTH_TEST
+    float dZdx = (end->position[2] - start->position[2])*dxRcp;
+#endif
     float dWdx = (end->position[3] - start->position[3])*dxRcp;
+
+#if (SW_RASTER_TRIANGLE_FLAGS) & SW_STATE_COLOR_INTERP
     float dCdx[4] = {
         (end->color[0] - start->color[0])*dxRcp,
         (end->color[1] - start->color[1])*dxRcp,
         (end->color[2] - start->color[2])*dxRcp,
         (end->color[3] - start->color[3])*dxRcp
     };
-#if (SW_RASTER_TRIANGLE_FLAGS) & SW_STATE_DEPTH_TEST
-    float dZdx = (end->position[2] - start->position[2])*dxRcp;
 #endif
 #if (SW_RASTER_TRIANGLE_FLAGS) & SW_STATE_TEXTURE_2D
     float dUdx = (end->texcoord[0] - start->texcoord[0])*dxRcp;
@@ -5278,15 +5356,18 @@ static void SW_RASTER_TRIANGLE_SPAN(const sw_vertex_t *start, const sw_vertex_t 
     float xOffset = xSubstep + dxStart;
 
     // Initializing the interpolation starting values
+#if (SW_RASTER_TRIANGLE_FLAGS) & SW_STATE_DEPTH_TEST
+    float z = start->position[2] + dZdx*xOffset;
+#endif
     float w = start->position[3] + dWdx*xOffset;
+
+#if (SW_RASTER_TRIANGLE_FLAGS) & SW_STATE_COLOR_INTERP
     float color[4] = {
         start->color[0] + dCdx[0]*xOffset,
         start->color[1] + dCdx[1]*xOffset,
         start->color[2] + dCdx[2]*xOffset,
         start->color[3] + dCdx[3]*xOffset
     };
-#if (SW_RASTER_TRIANGLE_FLAGS) & SW_STATE_DEPTH_TEST
-    float z = start->position[2] + dZdx*xOffset;
 #endif
 #if (SW_RASTER_TRIANGLE_FLAGS) & SW_STATE_TEXTURE_2D
     float u = start->texcoord[0] + dUdx*xOffset;
@@ -5316,12 +5397,10 @@ static void SW_RASTER_TRIANGLE_SPAN(const sw_vertex_t *start, const sw_vertex_t 
         float wB = w + dWdx*blockLenF;
         float wRcpB = sw_rcp(wB);
 
+    #if (SW_RASTER_TRIANGLE_FLAGS) & SW_STATE_COLOR_INTERP
         // Perspective-correct color at both block endpoints, then affine gradient
         float srcColor[4] = {
-            color[0]*wRcpA,
-            color[1]*wRcpA,
-            color[2]*wRcpA,
-            color[3]*wRcpA
+            color[0]*wRcpA, color[1]*wRcpA, color[2]*wRcpA, color[3]*wRcpA
         };
         float dSrcColordx[4] = {
             ((color[0] + dCdx[0]*blockLenF)*wRcpB - srcColor[0])*blockLenRcp,
@@ -5329,6 +5408,10 @@ static void SW_RASTER_TRIANGLE_SPAN(const sw_vertex_t *start, const sw_vertex_t 
             ((color[2] + dCdx[2]*blockLenF)*wRcpB - srcColor[2])*blockLenRcp,
             ((color[3] + dCdx[3]*blockLenF)*wRcpB - srcColor[3])*blockLenRcp
         };
+    #else
+        // Flat: constant across the whole triangle, no perspective correction needed
+        const float *srcColor = flatColor;
+    #endif
 
     #if (SW_RASTER_TRIANGLE_FLAGS) & SW_STATE_TEXTURE_2D
         // Perspective-correct UVs at both endpoints, then affine gradient
@@ -5388,10 +5471,12 @@ static void SW_RASTER_TRIANGLE_SPAN(const sw_vertex_t *start, const sw_vertex_t 
         #if (SW_RASTER_TRIANGLE_FLAGS) & SW_STATE_DEPTH_TEST
         discard:
         #endif
+        #if (SW_RASTER_TRIANGLE_FLAGS) & SW_STATE_COLOR_INTERP
             srcColor[0] += dSrcColordx[0];
             srcColor[1] += dSrcColordx[1];
             srcColor[2] += dSrcColordx[2];
             srcColor[3] += dSrcColordx[3];
+        #endif
             cPtr += SW_FRAMEBUFFER_COLOR_SIZE;
 
             #if (SW_RASTER_TRIANGLE_FLAGS) & SW_STATE_DEPTH_TEST
@@ -5411,10 +5496,12 @@ static void SW_RASTER_TRIANGLE_SPAN(const sw_vertex_t *start, const sw_vertex_t 
 
         // Advance perspective-space accumulators by the full block width
         w = wB;
+        #if (SW_RASTER_TRIANGLE_FLAGS) & SW_STATE_COLOR_INTERP
         color[0] += dCdx[0]*blockLenF;
         color[1] += dCdx[1]*blockLenF;
         color[2] += dCdx[2]*blockLenF;
         color[3] += dCdx[3]*blockLenF;
+        #endif
         #if (SW_RASTER_TRIANGLE_FLAGS) & SW_STATE_TEXTURE_2D
         u += dUdx*blockLenF;
         v += dVdx*blockLenF;
@@ -5450,9 +5537,9 @@ static void SW_RASTER_TRIANGLE(const sw_vertex_t *v0, const sw_vertex_t *v1, con
 
     // Compute gradients for each side of the triangle
     sw_vertex_t dVXdy02, dVXdy01, dVXdy12;
-    SW_GET_GRAD(&dVXdy02, v0, v2, h02Rcp);
-    SW_GET_GRAD(&dVXdy01, v0, v1, h01Rcp);
-    SW_GET_GRAD(&dVXdy12, v1, v2, h12Rcp);
+    SW_GRAD(&dVXdy02, v0, v2, h02Rcp);
+    SW_GRAD(&dVXdy01, v0, v1, h01Rcp);
+    SW_GRAD(&dVXdy12, v1, v2, h12Rcp);
 
     // Y subpixel correction
     float y0Substep = 1.0f - sw_fract(y0);
@@ -5460,8 +5547,18 @@ static void SW_RASTER_TRIANGLE(const sw_vertex_t *v0, const sw_vertex_t *v1, con
 
     // Get a copy of vertices for interpolation and apply substep correction
     sw_vertex_t lVert = *v0, rVert = *v0;
-    SW_ADD_GRAD_SCALED(&lVert, &dVXdy02, y0Substep);
-    SW_ADD_GRAD_SCALED(&rVert, &dVXdy01, y0Substep);
+    SW_VFMA(&lVert, &dVXdy02, y0Substep);
+    SW_VFMA(&rVert, &dVXdy01, y0Substep);
+
+#if !((SW_RASTER_TRIANGLE_FLAGS) & SW_STATE_COLOR_INTERP)
+    float invW = 1.0f / v0->position[3];
+    float flatColor[4] = {
+        v0->color[0]*invW,
+        v0->color[1]*invW,
+        v0->color[2]*invW,
+        v0->color[3]*invW
+    };
+#endif
 
     // Y bounds (vertical clipping)
     int yTop = (int)y0;
@@ -5475,14 +5572,14 @@ static void SW_RASTER_TRIANGLE(const sw_vertex_t *v0, const sw_vertex_t *v1, con
         bool longSideIsLeft = (lVert.position[0] < rVert.position[0]);
         const sw_vertex_t *a = longSideIsLeft? &lVert : &rVert;
         const sw_vertex_t *b = longSideIsLeft? &rVert : &lVert;
-        SW_RASTER_TRIANGLE_SPAN(a, b, dVXdy02.texcoord[0], dVXdy02.texcoord[1]);
-        SW_ADD_GRAD(&lVert, &dVXdy02);
-        SW_ADD_GRAD(&rVert, &dVXdy01);
+        SW_RASTER_TRIANGLE_SPAN(a, b, dVXdy02.texcoord[0], dVXdy02.texcoord[1] SW_SPAN_FLAT_COLOR_ARG);
+        SW_VADD(&lVert, &dVXdy02);
+        SW_VADD(&rVert, &dVXdy01);
     }
 
     // Get a copy of next right for interpolation and apply substep correction
     rVert = *v1;
-    SW_ADD_GRAD_SCALED(&rVert, &dVXdy12, y1Substep);
+    SW_VFMA(&rVert, &dVXdy12, y1Substep);
 
     // Scanline for the lower part of the triangle
     for (int y = yMid; y < yBot; y++)
@@ -5491,15 +5588,14 @@ static void SW_RASTER_TRIANGLE(const sw_vertex_t *v0, const sw_vertex_t *v1, con
         bool longSideIsLeft = (lVert.position[0] < rVert.position[0]);
         const sw_vertex_t *a = longSideIsLeft? &lVert : &rVert;
         const sw_vertex_t *b = longSideIsLeft? &rVert : &lVert;
-        SW_RASTER_TRIANGLE_SPAN(a, b, dVXdy02.texcoord[0], dVXdy02.texcoord[1]);
-        SW_ADD_GRAD(&lVert, &dVXdy02);
-        SW_ADD_GRAD(&rVert, &dVXdy12);
+        SW_RASTER_TRIANGLE_SPAN(a, b, dVXdy02.texcoord[0], dVXdy02.texcoord[1] SW_SPAN_FLAT_COLOR_ARG);
+        SW_VADD(&lVert, &dVXdy02);
+        SW_VADD(&rVert, &dVXdy12);
     }
 }
 
-#undef SW_GET_GRAD
-#undef SW_ADD_GRAD
-#undef SW_ADD_GRAD_SCALED
+#undef SW_SPAN_FLAT_COLOR_PARAM
+#undef SW_SPAN_FLAT_COLOR_ARG
 
 #endif // SW_RASTER_TRIANGLE_STATES
 //-------------------------------------------------------------------------------------------
@@ -5555,6 +5651,7 @@ static void SW_RASTER_QUAD(const sw_vertex_t *a, const sw_vertex_t *b,
     float xSubstep = 1.0f - sw_fract(tl->position[0]);
     float ySubstep = 1.0f - sw_fract(tl->position[1]);
 
+#if (SW_RASTER_QUAD_FLAGS) & SW_STATE_COLOR_INTERP
     // Gradients along X (tl->tr) and Y (tl->bl)
     float dCdx[4] = {
         (tr->color[0] - tl->color[0])*wRcp,
@@ -5568,6 +5665,9 @@ static void SW_RASTER_QUAD(const sw_vertex_t *a, const sw_vertex_t *b,
         (bl->color[2] - tl->color[2])*hRcp,
         (bl->color[3] - tl->color[3])*hRcp,
     };
+#else
+    const float *flatColor = tl->color;
+#endif
 
 #if (SW_RASTER_QUAD_FLAGS) & SW_STATE_DEPTH_TEST
     float dZdx = (tr->position[2] - tl->position[2])*wRcp;
@@ -5584,12 +5684,14 @@ static void SW_RASTER_QUAD(const sw_vertex_t *a, const sw_vertex_t *b,
     float vRow = tl->texcoord[1] + dVdx*xSubstep + dVdy*ySubstep;
 #endif
 
+#if (SW_RASTER_QUAD_FLAGS) & SW_STATE_COLOR_INTERP
     float cRow[4] = {
         tl->color[0] + dCdx[0]*xSubstep + dCdy[0]*ySubstep,
         tl->color[1] + dCdx[1]*xSubstep + dCdy[1]*ySubstep,
         tl->color[2] + dCdx[2]*xSubstep + dCdy[2]*ySubstep,
         tl->color[3] + dCdx[3]*xSubstep + dCdy[3]*ySubstep,
     };
+#endif
 
     int stride = RLSW.colorBuffer->width;
     uint8_t *cPixels = RLSW.colorBuffer->pixels;
@@ -5602,10 +5704,12 @@ static void SW_RASTER_QUAD(const sw_vertex_t *a, const sw_vertex_t *b,
     float dyMin = (float)(yLoopMin - yMin);
 
     // Correct our start by how far it's clipped outside the framebuffer
+#if (SW_RASTER_QUAD_FLAGS) & SW_STATE_COLOR_INTERP
     cRow[0] += dCdx[0]*dxMin + dCdy[0]*dyMin;
     cRow[1] += dCdx[1]*dxMin + dCdy[1]*dyMin;
     cRow[2] += dCdx[2]*dxMin + dCdy[2]*dyMin;
     cRow[3] += dCdx[3]*dxMin + dCdy[3]*dyMin;
+#endif
     #if (SW_RASTER_QUAD_FLAGS) & SW_STATE_DEPTH_TEST
     zRow += dZdy*dyMin + dZdx*dxMin;
     #endif
@@ -5627,16 +5731,17 @@ static void SW_RASTER_QUAD(const sw_vertex_t *a, const sw_vertex_t *b,
         float u = uRow;
         float v = vRow;
     #endif
-        float color[4] = {
-            cRow[0],
-            cRow[1],
-            cRow[2],
-            cRow[3]
-        };
+    #if (SW_RASTER_QUAD_FLAGS) & SW_STATE_COLOR_INTERP
+        float color[4] = { cRow[0], cRow[1], cRow[2], cRow[3] };
+    #endif
 
         for (int x = xLoopMin; x < xLoopMax; x++)
         {
+        #if (SW_RASTER_QUAD_FLAGS) & SW_STATE_COLOR_INTERP
             float srcColor[4] = { color[0], color[1], color[2], color[3] };
+        #else
+            float srcColor[4] = { flatColor[0], flatColor[1], flatColor[2], flatColor[3] };
+        #endif
 
             #if (SW_RASTER_QUAD_FLAGS) & SW_STATE_DEPTH_TEST
             {
@@ -5674,10 +5779,12 @@ static void SW_RASTER_QUAD(const sw_vertex_t *a, const sw_vertex_t *b,
         discard:
         #endif
             // Move one pixel over without touching the original "start offset"
+        #if (SW_RASTER_QUAD_FLAGS) & SW_STATE_COLOR_INTERP
             color[0] += dCdx[0];
             color[1] += dCdx[1];
             color[2] += dCdx[2];
             color[3] += dCdx[3];
+        #endif
 
             #if (SW_RASTER_QUAD_FLAGS) & SW_STATE_DEPTH_TEST
             {
@@ -5699,10 +5806,12 @@ static void SW_RASTER_QUAD(const sw_vertex_t *a, const sw_vertex_t *b,
         // The for loop is clamped to the right side of the screen
         // However, these cursor start vars are still on the left
         // That's fine, advancing to the next row
+    #if (SW_RASTER_QUAD_FLAGS) & SW_STATE_COLOR_INTERP
         cRow[0] += dCdy[0];
         cRow[1] += dCdy[1];
         cRow[2] += dCdy[2];
         cRow[3] += dCdy[3];
+    #endif
 
         #if (SW_RASTER_QUAD_FLAGS) & SW_STATE_DEPTH_TEST
         {
@@ -5764,10 +5873,12 @@ static void SW_RASTER_LINE_THIN(const sw_vertex_t *v0, const sw_vertex_t *v1)
 #if (SW_RASTER_LINE_FLAGS) & SW_STATE_DEPTH_TEST
     float zInc = (v1->position[2] - v0->position[2])*stepRcp;
 #endif
+#if (SW_RASTER_LINE_FLAGS) & SW_STATE_COLOR_INTERP
     float rInc = (v1->color[0] - v0->color[0])*stepRcp;
     float gInc = (v1->color[1] - v0->color[1])*stepRcp;
     float bInc = (v1->color[2] - v0->color[2])*stepRcp;
     float aInc = (v1->color[3] - v0->color[3])*stepRcp;
+#endif
 
     // Initializing the interpolation starting values
     float x = x0 + xInc*substep;
@@ -5775,10 +5886,12 @@ static void SW_RASTER_LINE_THIN(const sw_vertex_t *v0, const sw_vertex_t *v1)
 #if (SW_RASTER_LINE_FLAGS) & SW_STATE_DEPTH_TEST
     float z = v0->position[2] + zInc*substep;
 #endif
+#if (SW_RASTER_LINE_FLAGS) & SW_STATE_COLOR_INTERP
     float r = v0->color[0] + rInc*substep;
     float g = v0->color[1] + gInc*substep;
     float b = v0->color[2] + bInc*substep;
     float a = v0->color[3] + aInc*substep;
+#endif
 
     // Start line rasterization
     const int fbWidth = RLSW.colorBuffer->width;
@@ -5811,7 +5924,11 @@ static void SW_RASTER_LINE_THIN(const sw_vertex_t *v0, const sw_vertex_t *v1)
         }
         #endif
 
+    #if (SW_RASTER_LINE_FLAGS) & SW_STATE_COLOR_INTERP
         float srcColor[4] = {r, g, b, a};
+    #else
+        const float *srcColor = v0->color;
+    #endif
 
         #if (SW_RASTER_LINE_FLAGS) & SW_STATE_BLEND
         {
@@ -5836,10 +5953,12 @@ static void SW_RASTER_LINE_THIN(const sw_vertex_t *v0, const sw_vertex_t *v1)
             z += zInc;
         }
         #endif
+        #if (SW_RASTER_LINE_FLAGS) & SW_STATE_COLOR_INTERP
         r += rInc;
         g += gInc;
         b += bInc;
         a += aInc;
+        #endif
     }
 }
 

--- a/src/external/rlsw.h
+++ b/src/external/rlsw.h
@@ -5799,41 +5799,32 @@ static void SW_RASTER_LINE_THIN(const sw_vertex_t *v0, const sw_vertex_t *v1)
         substep = (dy >= 0.0f)? (1.0f - sw_fract(y0)) : sw_fract(y0);
     }
 
-    // Compute per pixel increments
-    float xInc = dx/steps;
-    float yInc = dy/steps;
+    // Line setup, independent of pipeline state
     float stepRcp = sw_rcp(steps);
-#if (SW_RASTER_LINE_FLAGS) & SW_STATE_DEPTH_TEST
-    float zInc = (v1->position[2] - v0->position[2])*stepRcp;
-#endif
-#if (SW_RASTER_LINE_FLAGS) & SW_STATE_COLOR_INTERP
-    float rInc = (v1->color[0] - v0->color[0])*stepRcp;
-    float gInc = (v1->color[1] - v0->color[1])*stepRcp;
-    float bInc = (v1->color[2] - v0->color[2])*stepRcp;
-    float aInc = (v1->color[3] - v0->color[3])*stepRcp;
-#endif
-
-    // Initializing the interpolation starting values
-    float x = x0 + xInc*substep;
-    float y = y0 + yInc*substep;
-#if (SW_RASTER_LINE_FLAGS) & SW_STATE_DEPTH_TEST
-    float z = v0->position[2] + zInc*substep;
-#endif
-#if (SW_RASTER_LINE_FLAGS) & SW_STATE_COLOR_INTERP
-    float r = v0->color[0] + rInc*substep;
-    float g = v0->color[1] + gInc*substep;
-    float b = v0->color[2] + bInc*substep;
-    float a = v0->color[3] + aInc*substep;
-#endif
-
-    // Start line rasterization
+    float xInc = dx*stepRcp;
+    float yInc = dy*stepRcp;
+    int numPixels = (int)(steps - substep) + 1;
     const int fbWidth = RLSW.colorBuffer->width;
     uint8_t *cPixels = RLSW.colorBuffer->pixels;
 #if (SW_RASTER_LINE_FLAGS) & SW_STATE_DEPTH_TEST
     uint8_t *dPixels = RLSW.depthBuffer->pixels;
 #endif
 
-    int numPixels = (int)(steps - substep) + 1;
+    // Initializing the interpolation starting values
+    float x = x0 + xInc*substep;
+    float y = y0 + yInc*substep;
+#if (SW_RASTER_LINE_FLAGS) & SW_STATE_DEPTH_TEST
+    float zInc = (v1->position[2] - v0->position[2])*stepRcp;
+    float z = v0->position[2] + zInc*substep;
+#endif
+#if (SW_RASTER_LINE_FLAGS) & SW_STATE_COLOR_INTERP
+    float cInc[4], color[4];
+    SW_VEC_OP(cInc[i] = (v1->color[i] - v0->color[i])*stepRcp, i, 4);
+    SW_VEC_OP(color[i] = v0->color[i] + cInc[i]*substep, i, 4);
+#else
+    // Flat: constant across the whole line, computed once for the whole loop
+    const float *srcColor = v0->color;
+#endif
 
     for (int i = 0; i < numPixels; i++)
     {
@@ -5846,52 +5837,41 @@ static void SW_RASTER_LINE_THIN(const sw_vertex_t *v0, const sw_vertex_t *v1)
         uint8_t *dPtr = dPixels + baseOffset*SW_FRAMEBUFFER_DEPTH_SIZE;
     #endif
 
-        #if (SW_RASTER_LINE_FLAGS) & SW_STATE_DEPTH_TEST
+    #if (SW_RASTER_LINE_FLAGS) & SW_STATE_DEPTH_TEST
+        // TODO: Implement different depth funcs?
+        float depth = SW_FRAMEBUFFER_DEPTH_GET(dPtr, 0);
+        if (z <= depth)
         {
-            // TODO: Implement different depth funcs?
-            float depth = SW_FRAMEBUFFER_DEPTH_GET(dPtr, 0);
-            if (z > depth) goto discard;
-
             // TODO: Implement depth mask
             SW_FRAMEBUFFER_DEPTH_SET(dPtr, z, 0);
-        }
-        #endif
-
-    #if (SW_RASTER_LINE_FLAGS) & SW_STATE_COLOR_INTERP
-        float srcColor[4] = {r, g, b, a};
-    #else
-        const float *srcColor = v0->color;
     #endif
 
+        #if (SW_RASTER_LINE_FLAGS) & SW_STATE_COLOR_INTERP
+            const float *srcColor = color;
+        #endif
+
         #if (SW_RASTER_LINE_FLAGS) & SW_STATE_BLEND
-        {
             float dstColor[4];
             SW_FRAMEBUFFER_COLOR_GET(dstColor, cPtr, 0);
             RLSW.blendFunc(dstColor, srcColor);
             SW_FRAMEBUFFER_COLOR_SET(cPtr, dstColor, 0);
-        }
         #else
-        {
             SW_FRAMEBUFFER_COLOR_SET(cPtr, srcColor, 0);
-        }
         #endif
 
     #if (SW_RASTER_LINE_FLAGS) & SW_STATE_DEPTH_TEST
-    discard:
+        }
     #endif
+
+        // Advance unconditionally: depth test only guards the write above
         x += xInc;
         y += yInc;
-        #if (SW_RASTER_LINE_FLAGS) & SW_STATE_DEPTH_TEST
-        {
-            z += zInc;
-        }
-        #endif
-        #if (SW_RASTER_LINE_FLAGS) & SW_STATE_COLOR_INTERP
-        r += rInc;
-        g += gInc;
-        b += bInc;
-        a += aInc;
-        #endif
+    #if (SW_RASTER_LINE_FLAGS) & SW_STATE_DEPTH_TEST
+        z += zInc;
+    #endif
+    #if (SW_RASTER_LINE_FLAGS) & SW_STATE_COLOR_INTERP
+        SW_VEC_OP(color[i] += cInc[i], i, 4);
+    #endif
     }
 }
 

--- a/src/external/rlsw.h
+++ b/src/external/rlsw.h
@@ -3220,14 +3220,10 @@ static const sw_raster_quad_f SW_RASTER_QUAD_TABLE[] = {
 #include __FILE__
 #undef SW_RASTER_LINE_STATES
 
-SW_RASTER_VARIANTS_3(SW_RASTER_FWD, sw_raster_line_, (const sw_vertex_t*, const sw_vertex_t*)) // NOLINT
-SW_RASTER_VARIANTS_3(SW_RASTER_FWD, sw_raster_line_thick_, (const sw_vertex_t*, const sw_vertex_t*)) // NOLINT
+SW_RASTER_VARIANTS_2(SW_RASTER_FWD, sw_raster_line_, (const sw_vertex_t*, const sw_vertex_t*)) // NOLINT
 
 static const sw_raster_line_f SW_RASTER_LINE_TABLE[] = {
     SW_RASTER_VARIANTS_2(SW_RASTER_ENTRY, sw_raster_line_)
-};
-static const sw_raster_line_f SW_RASTER_LINE_THICK_TABLE[] = {
-    SW_RASTER_VARIANTS_2(SW_RASTER_ENTRY, sw_raster_line_thick_)
 };
 //-------------------------------------------------------------------------------------------
 
@@ -3638,17 +3634,8 @@ static bool sw_line_clip_and_project(sw_vertex_t *v0, sw_vertex_t *v1)
 static void sw_line_render(uint32_t state, sw_vertex_t *vertices)
 {
     if (!sw_line_clip_and_project(&vertices[0], &vertices[1])) return;
-
     state &= SW_RASTER_LINE_STATE_MASK;
-
-    if (RLSW.lineWidth >= 2.0f)
-    {
-        SW_RASTER_LINE_THICK_TABLE[state](&vertices[0], &vertices[1]);
-    }
-    else
-    {
-        SW_RASTER_LINE_TABLE[state](&vertices[0], &vertices[1]);
-    }
+    SW_RASTER_LINE_TABLE[state](&vertices[0], &vertices[1]);
 }
 //-------------------------------------------------------------------------------------------
 
@@ -5735,15 +5722,16 @@ static void SW_RASTER_QUAD(const sw_vertex_t *a, const sw_vertex_t *b,
 #endif // SW_RASTER_QUAD_STATES
 //-------------------------------------------------------------------------------------------
 
-// Quad rasterization functions
+// Line rasterization functions
 //-------------------------------------------------------------------------------------------
 #ifdef SW_RASTER_LINE_STATES
 
 #define SW_RASTER_LINE_FLAGS SW_FLAGS(SW_RASTER_LINE_STATES)
+#define SW_RASTER_LINE_THIN  SW_CONCATX(sw_raster_line_thin_, SW_NAME(SW_RASTER_LINE_STATES))
 #define SW_RASTER_LINE       SW_CONCATX(sw_raster_line_, SW_NAME(SW_RASTER_LINE_STATES))
-#define SW_RASTER_LINE_THICK SW_CONCATX(sw_raster_line_thick_, SW_NAME(SW_RASTER_LINE_STATES))
 
-static void SW_RASTER_LINE(const sw_vertex_t *v0, const sw_vertex_t *v1)
+// Renders a single-pixel-wide line; internal building block for SW_RASTER_LINE
+static void SW_RASTER_LINE_THIN(const sw_vertex_t *v0, const sw_vertex_t *v1)
 {
     // Convert from pixel-center convention (n+0.5) to pixel-origin convention (n)
     float x0 = v0->position[0] - 0.5f;
@@ -5855,8 +5843,14 @@ static void SW_RASTER_LINE(const sw_vertex_t *v0, const sw_vertex_t *v1)
     }
 }
 
-static void SW_RASTER_LINE_THICK(const sw_vertex_t *v0, const sw_vertex_t *v1)
+static void SW_RASTER_LINE(const sw_vertex_t *v0, const sw_vertex_t *v1)
 {
+    if (RLSW.lineWidth < 2.0f)
+    {
+        SW_RASTER_LINE_THIN(v0, v1);
+        return;
+    }
+
     sw_vertex_t tv0, tv1;
 
     int x0 = (int)v0->position[0];
@@ -5867,7 +5861,7 @@ static void SW_RASTER_LINE_THICK(const sw_vertex_t *v0, const sw_vertex_t *v1)
     int dx = x1 - x0;
     int dy = y1 - y0;
 
-    SW_RASTER_LINE(v0, v1);
+    SW_RASTER_LINE_THIN(v0, v1);
 
     if ((dx != 0) && (abs(dy/dx) < 1))
     {
@@ -5878,11 +5872,11 @@ static void SW_RASTER_LINE_THICK(const sw_vertex_t *v0, const sw_vertex_t *v1)
             tv0 = *v0, tv1 = *v1;
             tv0.position[1] -= i;
             tv1.position[1] -= i;
-            SW_RASTER_LINE(&tv0, &tv1);
+            SW_RASTER_LINE_THIN(&tv0, &tv1);
             tv0 = *v0, tv1 = *v1;
             tv0.position[1] += i;
             tv1.position[1] += i;
-            SW_RASTER_LINE(&tv0, &tv1);
+            SW_RASTER_LINE_THIN(&tv0, &tv1);
         }
     }
     else if (dy != 0)
@@ -5894,11 +5888,11 @@ static void SW_RASTER_LINE_THICK(const sw_vertex_t *v0, const sw_vertex_t *v1)
             tv0 = *v0, tv1 = *v1;
             tv0.position[0] -= i;
             tv1.position[0] -= i;
-            SW_RASTER_LINE(&tv0, &tv1);
+            SW_RASTER_LINE_THIN(&tv0, &tv1);
             tv0 = *v0, tv1 = *v1;
             tv0.position[0] += i;
             tv1.position[0] += i;
-            SW_RASTER_LINE(&tv0, &tv1);
+            SW_RASTER_LINE_THIN(&tv0, &tv1);
         }
     }
 }

--- a/src/external/rlsw.h
+++ b/src/external/rlsw.h
@@ -5341,6 +5341,13 @@ static void SW_RASTER_TRIANGLE_SPAN(const sw_vertex_t *start, const sw_vertex_t 
     float dxStart = (float)(xLoopStart - xStart);
     float xOffset = xSubstep + dxStart;
 
+    // Pre-calculate the starting pointers for the framebuffer row
+    int baseOffset = y*RLSW.colorBuffer->width + xLoopStart;
+    uint8_t *cPtr = (uint8_t *)(RLSW.colorBuffer->pixels) + baseOffset*SW_FRAMEBUFFER_COLOR_SIZE;
+#if (SW_RASTER_TRIANGLE_FLAGS) & SW_STATE_DEPTH_TEST
+    uint8_t *dPtr = (uint8_t *)(RLSW.depthBuffer->pixels) + baseOffset*SW_FRAMEBUFFER_DEPTH_SIZE;
+#endif
+
     // Initializing the interpolation starting values
 #if (SW_RASTER_TRIANGLE_FLAGS) & SW_STATE_DEPTH_TEST
     float z = start->position[2] + ctx->dZdx*xOffset;
@@ -5358,13 +5365,6 @@ static void SW_RASTER_TRIANGLE_SPAN(const sw_vertex_t *start, const sw_vertex_t 
 #if (SW_RASTER_TRIANGLE_FLAGS) & SW_STATE_TEXTURE_2D
     float texcoord[2];
     SW_VEC_OP(texcoord[i] = start->texcoord[i] + ctx->dTdx[i]*xOffset, i, 2);
-#endif
-
-    // Pre-calculate the starting pointers for the framebuffer row
-    int baseOffset = y*RLSW.colorBuffer->width + xLoopStart;
-    uint8_t *cPtr = (uint8_t *)(RLSW.colorBuffer->pixels) + baseOffset*SW_FRAMEBUFFER_COLOR_SIZE;
-#if (SW_RASTER_TRIANGLE_FLAGS) & SW_STATE_DEPTH_TEST
-    uint8_t *dPtr = (uint8_t *)(RLSW.depthBuffer->pixels) + baseOffset*SW_FRAMEBUFFER_DEPTH_SIZE;
 #endif
 
 #define SW_AFFINE_BLOCK 16
@@ -5603,14 +5603,18 @@ static void SW_RASTER_QUAD(const sw_vertex_t *a, const sw_vertex_t *b,
     // For axis-aligned quads x+y and x-y uniquely identify each corner
     const sw_vertex_t *verts[4] = { a, b, c, d };
     const sw_vertex_t *tl = verts[0], *tr = verts[0], *br = verts[0], *bl = verts[0];
+    float tlSum = tl->position[0] + tl->position[1];
+    float trDiff = tr->position[0] - tr->position[1];
+    float brSum = br->position[0] + br->position[1];
+    float blDiff = bl->position[0] - bl->position[1];
     for (int i = 1; i < 4; i++)
     {
         float sum  = verts[i]->position[0] + verts[i]->position[1];
         float diff = verts[i]->position[0] - verts[i]->position[1];
-        if (sum  < tl->position[0] + tl->position[1]) tl = verts[i];
-        if (diff > tr->position[0] - tr->position[1]) tr = verts[i];
-        if (sum  > br->position[0] + br->position[1]) br = verts[i];
-        if (diff < bl->position[0] - bl->position[1]) bl = verts[i];
+        if (sum  < tlSum)  { tl = verts[i]; tlSum = sum; }
+        if (diff > trDiff) { tr = verts[i]; trDiff = diff; }
+        if (sum  > brSum)  { br = verts[i]; brSum = sum; }
+        if (diff < blDiff) { bl = verts[i]; blDiff = diff; }
     }
 
     int xMin = (int)tl->position[0];
@@ -5630,18 +5634,27 @@ static void SW_RASTER_QUAD(const sw_vertex_t *a, const sw_vertex_t *b,
     float h = (float)(yMax - yMin);
     if ((w <= 0) || (h <= 0)) return;
 
+    // Per-quad setup, independent of pipeline state
     float wRcp = sw_rcp(w);
     float hRcp = sw_rcp(h);
-
-    // Subpixel corrections
     float xSubstep = 1.0f - sw_fract(tl->position[0]);
     float ySubstep = 1.0f - sw_fract(tl->position[1]);
+    // Distance the in-bounds boundary is from the quad's edges, only on the left and top
+    float dxMin = (float)(xLoopMin - xMin);
+    float dyMin = (float)(yLoopMin - yMin);
+    int stride = RLSW.colorBuffer->width;
+    uint8_t *cPixels = RLSW.colorBuffer->pixels;
+#if (SW_RASTER_QUAD_FLAGS) & SW_STATE_DEPTH_TEST
+    uint8_t *dPixels = RLSW.depthBuffer->pixels;
+#endif
 
 #if (SW_RASTER_QUAD_FLAGS) & SW_STATE_DEPTH_TEST
     // Gradients along X (tl->tr) and Y (tl->bl)
     float dZdx = (tr->position[2] - tl->position[2])*wRcp;
     float dZdy = (bl->position[2] - tl->position[2])*hRcp;
     float zRow = tl->position[2] + dZdx*xSubstep + dZdy*ySubstep;
+    // Correct start by how far it's clipped outside the framebuffer
+    zRow += dZdy*dyMin + dZdx*dxMin;
 #endif
 
 #if (SW_RASTER_QUAD_FLAGS) & SW_STATE_COLOR_INTERP
@@ -5649,6 +5662,7 @@ static void SW_RASTER_QUAD(const sw_vertex_t *a, const sw_vertex_t *b,
     SW_VEC_OP(dCdx[i] = (tr->color[i] - tl->color[i])*wRcp, i, 4);
     SW_VEC_OP(dCdy[i] = (bl->color[i] - tl->color[i])*hRcp, i, 4);
     SW_VEC_OP(cRow[i] = tl->color[i] + dCdx[i]*xSubstep + dCdy[i]*ySubstep, i, 4);
+    SW_VEC_OP(cRow[i] += dCdx[i]*dxMin + dCdy[i]*dyMin, i, 4);
 #else
     const float *flatColor = tl->color;
 #endif
@@ -5658,30 +5672,10 @@ static void SW_RASTER_QUAD(const sw_vertex_t *a, const sw_vertex_t *b,
     SW_VEC_OP(dTdx[i] = (tr->texcoord[i] - tl->texcoord[i])*wRcp, i, 2);
     SW_VEC_OP(dTdy[i] = (bl->texcoord[i] - tl->texcoord[i])*hRcp, i, 2);
     SW_VEC_OP(tcRow[i] = tl->texcoord[i] + dTdx[i]*xSubstep + dTdy[i]*ySubstep, i, 2);
+    SW_VEC_OP(tcRow[i] += dTdy[i]*dyMin + dTdx[i]*dxMin, i, 2);
 
     // Constant across the whole quad: resolved once, called directly per pixel
     sw_texture_sampler_f sample = sw_texture_pick_sampler(RLSW.boundTexture, dTdx, dTdy);
-#endif
-
-    int stride = RLSW.colorBuffer->width;
-    uint8_t *cPixels = RLSW.colorBuffer->pixels;
-#if (SW_RASTER_QUAD_FLAGS) & SW_STATE_DEPTH_TEST
-    uint8_t *dPixels = RLSW.depthBuffer->pixels;
-#endif
-
-    // Calculate the distance the in-bounds boundary is from the quad's edges, only on the left and top
-    float dxMin = (float)(xLoopMin - xMin);
-    float dyMin = (float)(yLoopMin - yMin);
-
-    // Correct our start by how far it's clipped outside the framebuffer
-#if (SW_RASTER_QUAD_FLAGS) & SW_STATE_DEPTH_TEST
-    zRow += dZdy*dyMin + dZdx*dxMin;
-#endif
-#if (SW_RASTER_QUAD_FLAGS) & SW_STATE_COLOR_INTERP
-    SW_VEC_OP(cRow[i] += dCdx[i]*dxMin + dCdy[i]*dyMin, i, 4);
-#endif
-#if (SW_RASTER_QUAD_FLAGS) & SW_STATE_TEXTURE_2D
-    SW_VEC_OP(tcRow[i] += dTdy[i]*dyMin + dTdx[i]*dxMin, i, 2);
 #endif
 
     for (int y = yLoopMin; y < yLoopMax; y++)


### PR DESCRIPTION
## Summary

While experimenting with a different way to handle framebuffers, I ended up simplifying the variant-generation system for the rasterizer's pipeline specializations.
That simplification unlocked a series of small cascading optimizations, which I've bundled into this PR.

## Changes

### Variant generation

- Replaced the hand-written `SW_RASTER_VARIANTS(X)` X-macro lists (one explicit `NAME, FLAGS` pair per specialization) with a token-based system, a variant is now just a plain list of state names (eg. `TEXTURE_2D, DEPTH_TEST`), from which the function name, its `SW_STATE_*` flags, and its dispatch table slot are all derived automatically via `SW_FLAGS(...)`/`SW_NAME(...)`.
- This removes the risk of a name/flag mismatch (previously two independent sources of truth per variant) and made adding new pipeline states straightforward.
- Added a small vector-math helper macro `SW_VEC_OP` to cut down on repetitive per-component code across triangle/quad/line rasterizers.

### New pipeline state: `COLOR_INTERP`

- Added `SW_STATE_COLOR_INTERP`, toggled off automatically when all vertices of a primitive share the same color.
- When disabled the rasterizer skips per-pixel/per-scanline color interpolation entirely, and uses a single flat color instead, cheaper than a "flat shading" pass since no interpolation math runs at all.
- Applied to triangle, quad, and line rasterizers.

### Rasterization optimizations

- **Triangle**: attribute x/y-derivatives (`dWdx`, `dZdx`, `dCdx`, `dTdx`, `dTdy`) are now computed once per triangle via a whole-triangle plane-gradient solve, instead of being recomputed on every scanline.
- **Triangle**: perspective-correct interpolation (w-tracking and block subdivision) is now skipped entirely for variants that don't need it (no `COLOR_INTERP`, no `TEXTURE_2D`; eg. plain depth/blend-only triangles).
- **Triangle/Quad**: the min/mag texture filter is now resolved once per primitive (`sw_texture_pick_sampler`) instead of being recomputed for every sampled pixel.
- **Quad**: avoids an unnecessary per-pixel color copy when there's no texture to modulate against.
- Removed `goto` based depth-test discard in triangle/quad/line rasterizers in favor of a branch that fully disappears from the compiled variants where depth testing is disabled.

### Misc

- Removed explicit `inline` keywords, letting the compiler decide on its own, but kept `SW_INLINE` (forced inlining) only for the cases where it's known to matter.
- Improved/added comments in a few non-obvious spots (perspective math, degenerate-triangle guards, etc).

## Performance

Without detailed profiling, `models_first_person_maze` (O2, default conservative rlsw config) gained roughly 20 FPS avg on my Ryzen 5 3600.

`textures_bunny_mark` showed no noticeable difference, but rasterization itself isn't the main bottleneck now on "modern desktop hardware" _(as implemented, naturally)_.
That said, the `COLOR_INTERP` elimination should matter more on more limited targets where every avoided interpolation counts.

## Future work

- The same "skip interpolation when constant across the primitive" could later be applied to clipping and vertex processing, not just rasterization, not an immediate priority though.
- Rasterization still has room for further hardware-specific specializations, and other techniques like "deferred rendering" could also be beneficial, at the cost of using a bit more memory.