### PR TITLE
Fix DrawSphereWires

### DIFF
--- a/src/rmodels.c
+++ b/src/rmodels.c
@@ -532,7 +532,9 @@ void DrawSphereEx(Vector3 centerPos, float radius, int rings, int slices, Color 
 }
 
 // Draw sphere wires
-void DrawSphereWires(Vector3 centerPos, float radius, int rings, int slices, Color color)
+// lat = number of latitude divisions
+// lon = number of longitude divisions
+void DrawSphereWires(Vector3 centerPos, float radius, int lat, int lon, Color color)
 {
     rlPushMatrix();
         // NOTE: Transformation is applied in inverse order (scale -> translate)
@@ -542,30 +544,45 @@ void DrawSphereWires(Vector3 centerPos, float radius, int rings, int slices, Col
         rlBegin(RL_LINES);
             rlColor4ub(color.r, color.g, color.b, color.a);
 
-            for (int i = 0; i < (rings + 2); i++)
+            for (int i = 0; i < lat; i++)
             {
-                for (int j = 0; j < slices; j++)
+                for (int j = 0; j < lon; j++)
                 {
-                    rlVertex3f(cosf(DEG2RAD*(270 + (180.0f/(rings + 1))*i))*sinf(DEG2RAD*(360.0f*j/slices)),
-                               sinf(DEG2RAD*(270 + (180.0f/(rings + 1))*i)),
-                               cosf(DEG2RAD*(270 + (180.0f/(rings + 1))*i))*cosf(DEG2RAD*(360.0f*j/slices)));
-                    rlVertex3f(cosf(DEG2RAD*(270 + (180.0f/(rings + 1))*(i + 1)))*sinf(DEG2RAD*(360.0f*(j + 1)/slices)),
-                               sinf(DEG2RAD*(270 + (180.0f/(rings + 1))*(i + 1))),
-                               cosf(DEG2RAD*(270 + (180.0f/(rings + 1))*(i + 1)))*cosf(DEG2RAD*(360.0f*(j + 1)/slices)));
+                    // Latitude lines
+                    rlVertex3f(
+                        sinf(PI*i/lat) * sinf(2.0f*PI*j/lon),
+                        cosf(PI*i/lat),
+                        sinf(PI*i/lat) * cosf(2.0f*PI*j/lon)
+                    );
+                    rlVertex3f(
+                        sinf(PI*i/lat) * sinf(2.0f*PI*(j+1)/lon),
+                        cosf(PI*i/lat),
+                        sinf(PI*i/lat) * cosf(2.0f*PI*(j+1)/lon)
+                    );
 
-                    rlVertex3f(cosf(DEG2RAD*(270 + (180.0f/(rings + 1))*(i + 1)))*sinf(DEG2RAD*(360.0f*(j + 1)/slices)),
-                               sinf(DEG2RAD*(270 + (180.0f/(rings + 1))*(i + 1))),
-                               cosf(DEG2RAD*(270 + (180.0f/(rings + 1))*(i + 1)))*cosf(DEG2RAD*(360.0f*(j + 1)/slices)));
-                    rlVertex3f(cosf(DEG2RAD*(270 + (180.0f/(rings + 1))*(i + 1)))*sinf(DEG2RAD*(360.0f*j/slices)),
-                               sinf(DEG2RAD*(270 + (180.0f/(rings + 1))*(i + 1))),
-                               cosf(DEG2RAD*(270 + (180.0f/(rings + 1))*(i + 1)))*cosf(DEG2RAD*(360.0f*j/slices)));
+                    // Longitude lines
+                    rlVertex3f(
+                        sinf(PI*i/lat) * sinf(2.0f*PI*j/lon),
+                        cosf(PI*i/lat),
+                        sinf(PI*i/lat) * cosf(2.0f*PI*j/lon)
+                    );
+                    rlVertex3f(
+                        sinf(PI*(i+1)/lat) * sinf(2.0f*PI*j/lon),
+                        cosf(PI*(i+1)/lat),
+                        sinf(PI*(i+1)/lat) * cosf(2.0f*PI*j/lon)
+                    );
 
-                    rlVertex3f(cosf(DEG2RAD*(270 + (180.0f/(rings + 1))*(i + 1)))*sinf(DEG2RAD*(360.0f*j/slices)),
-                               sinf(DEG2RAD*(270 + (180.0f/(rings + 1))*(i + 1))),
-                               cosf(DEG2RAD*(270 + (180.0f/(rings + 1))*(i + 1)))*cosf(DEG2RAD*(360.0f*j/slices)));
-                    rlVertex3f(cosf(DEG2RAD*(270 + (180.0f/(rings + 1))*i))*sinf(DEG2RAD*(360.0f*j/slices)),
-                               sinf(DEG2RAD*(270 + (180.0f/(rings + 1))*i)),
-                               cosf(DEG2RAD*(270 + (180.0f/(rings + 1))*i))*cosf(DEG2RAD*(360.0f*j/slices)));
+                    // Diagonal Lines
+                    rlVertex3f(
+                        sinf(PI*i/lat) * sinf(2.0f*PI*j/lon),
+                        cosf(PI*i/lat),
+                        sinf(PI*i/lat) * cosf(2.0f*PI*j/lon)
+                    );
+                    rlVertex3f(
+                        sinf(PI*(i+1)/lat) * sinf(2.0f*PI*(j+1)/lon),
+                        cosf(PI*(i+1)/lat),
+                        sinf(PI*(i+1)/lat) * cosf(2.0f*PI*(j+1)/lon)
+                    );
                 }
             }
         rlEnd();


### PR DESCRIPTION
In addition to significantly simplifying the code, the following bugs were fixed:

- Top "cap" of the sphere was double-covered
- Sphere had an additional latitude division than specified