### PR TITLE
Add Pulsar editor to project templates table

### DIFF
--- a/projects/README.md
+++ b/projects/README.md
@@ -9,6 +9,7 @@ IDE | Platform(s) | Source | Example(s)
 [CodeBlocks](http://www.codeblocks.org/) | Windows, Linux, macOS | ❌ | ✔️
 [Geany](https://www.geany.org/) | Windows, Linux | ✔️ | ✔️
 [Notepad++](https://notepad-plus-plus.org/) | Windows, Web | ✔️ | ✔️
+[Pulsar](https://pulsar-edit.dev) | Windows, Linux, macOS | ✔️ | ✔️
 [SublimeText](https://www.sublimetext.com/) | Windows, Linux, macOS | ✔️ | ✔️
 [VS2022](https://www.visualstudio.com) | Windows | ✔️ | ✔️
 [VSCode](https://code.visualstudio.com/) | Windows, Linux, macOS | ❌ | ✔️


### PR DESCRIPTION
Hello raylib friends! 👋

Small doc addition: this adds a row for the [Pulsar](https://pulsar-edit.dev) editor to the project templates table in `projects/README.md`. here is the add-on repo: https://github.com/romulofer/raylib