### PR TITLE
[build][Zig] Fix web examples building all the time

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -719,7 +719,6 @@ fn addExamples(
                 .shell_file_path = b.path("src/shell.html"),
                 .install_dir = install_dir,
             });
-            b.getInstallStep().dependOn(emcc_step);
 
             const html_filename = try std.fmt.allocPrint(b.allocator, "{s}.html", .{wasm.name});
             const emrun_step = emsdk.emrunStep(


### PR DESCRIPTION
Similar to #5869 but for the web target, it was running the `emcc_step` for each example even when requesting to just build raylib.