### PR TITLE
[build][Zig] Improve project example

### DIFF
--- a/projects/Zig/src/core_basic_window.zig
+++ b/projects/Zig/src/core_basic_window.zig
@@ -31,6 +31,7 @@ pub fn main() void {
     // Initialization
     //--------------------------------------------------------------------------------------
     rl.InitWindow(screenWidth, screenHeight, "raylib [core] example - basic window");
+    defer rl.CloseWindow(); // Close window and OpenGL context
 
     if (builtin.os.tag == .emscripten) {
         std.os.emscripten.emscripten_set_main_loop(UpdateDrawFrame, 0, 1);
@@ -44,11 +45,6 @@ pub fn main() void {
             UpdateDrawFrame();
         }
     }
-
-    // De-Initialization
-    //--------------------------------------------------------------------------------------
-    rl.CloseWindow(); // Close window and OpenGL context
-    //--------------------------------------------------------------------------------------
 }
 
 //----------------------------------------------------------------------------------
@@ -63,11 +59,10 @@ fn UpdateDrawFrame() callconv(.c) void {
     // Draw
     //----------------------------------------------------------------------------------
     rl.BeginDrawing();
+    defer rl.EndDrawing();
 
     rl.ClearBackground(rl.RAYWHITE);
 
     rl.DrawText("Congrats! You created your first window!", 190, 200, 20, rl.LIGHTGRAY);
-
-    rl.EndDrawing();
     //----------------------------------------------------------------------------------
 }


### PR DESCRIPTION
The current code is not wrong, but it is not the Zig way of doing it, and as raylib aims to help people who are learning, it's better if the example project reflects what will be expected from someone working with Zig.

In Zig the de-initialization comes right after the initialization using [defer](https://ziglang.org/documentation/0.16.0/#defer) to execute the expression unconditionally at scope exit.

With this pattern it's less likely that one would forget the de-initialization as it's easier to check if the matching de-initialization is missing and also ensures it will run even if an error occurs in this scope.