### PR TITLE
[rcore][GLFW] Fix window landing off-screen when it's bigger than the monitor workarea

### DIFF
--- a/src/platforms/rcore_desktop_glfw.c
+++ b/src/platforms/rcore_desktop_glfw.c
@@ -1791,12 +1791,28 @@ int InitPlatform(void)
 
         // Center window into current monitor
     #if defined(__APPLE__)
-        CORE.Window.position.x = monitorX + (monitorWidth - CORE.Window.screen.width)/2;
-        CORE.Window.position.y = monitorY + (monitorHeight - CORE.Window.screen.height)/2;
+        const int windowWidthForCentering = CORE.Window.screen.width;
+        const int windowHeightForCentering = CORE.Window.screen.height;
     #else
-        CORE.Window.position.x = monitorX + (monitorWidth - CORE.Window.render.width)/2;
-        CORE.Window.position.y = monitorY + (monitorHeight - CORE.Window.render.height)/2;
+        const int windowWidthForCentering = CORE.Window.render.width;
+        const int windowHeightForCentering = CORE.Window.render.height;
     #endif
+
+        // NOTE: If the window is as large or larger than the monitor workarea on either axis
+        // (e.g. a landscape window on a portrait primary monitor), centering it can push part
+        // of it past the edge of the virtual desktop, which some window managers (Windows in
+        // particular) then mishandle, causing the window to disappear or get misplaced entirely.
+        // Anchor it to the workarea origin instead, same as done in SetWindowMonitor()
+        if ((windowWidthForCentering >= monitorWidth) || (windowHeightForCentering >= monitorHeight))
+        {
+            CORE.Window.position.x = monitorX;
+            CORE.Window.position.y = monitorY;
+        }
+        else
+        {
+            CORE.Window.position.x = monitorX + (monitorWidth - windowWidthForCentering)/2;
+            CORE.Window.position.y = monitorY + (monitorHeight - windowHeightForCentering)/2;
+        }
         SetWindowPosition(CORE.Window.position.x, CORE.Window.position.y);
 
         if (FLAG_IS_SET(CORE.Window.flags, FLAG_WINDOW_MINIMIZED)) MinimizeWindow();


### PR DESCRIPTION
Fixes #6002.

`InitPlatform()` centers the window with `monitorX + (monitorWidth - width)/2`. There's no check for the window being wider or taller than the monitor. When it is, that goes negative and the window gets placed outside the virtual desktop. On Windows this isn't just "off-center", `glfwSetWindowPos`/`GetWindowPosition` come back with garbage coordinates and the window can stay invisible until you drag it back with win+shift+arrow, which matches what's described in #6002 (portrait primary monitor, landscape window, window vanishes, `SetWindowPosition(0,0)` right after `InitWindow()` "fixes" it).

`SetWindowMonitor()` already handles this correctly, it anchors to the workarea origin instead of centering when the window doesn't fit. This PR just applies the same guard in `InitPlatform()`.

How I checked it: wrote a small repro that calls `InitWindow()` with a width bigger than my monitor and reads `GetWindowPosition()` right after.

Before:
```
RESULT window position: x=2147483392 y=66
```
After:
```
RESULT window position: x=0 y=0
```

Also checked a normal window size still centers the same as before (800x450 on a 1920x1032 workarea gives x=560 y=291, matches the math).

I don't have a real portrait-monitor multi-display setup to reproduce the exact report in #6002, only a single landscape monitor here, so I forced the same code path by requesting a window wider than my monitor instead. Same math, same branch, just couldn't test the literal portrait-monitor case.