### PR TITLE
[rlgl] Add render batch utility functions to control the current depth

### DIFF
--- a/src/rlgl.h
+++ b/src/rlgl.h
@@ -730,9 +730,13 @@ RLAPI int *rlGetShaderLocsDefault(void);                // Get default shader lo
 RLAPI rlRenderBatch rlLoadRenderBatch(int numBuffers, int bufferElements); // Load a render batch system
 RLAPI void rlUnloadRenderBatch(rlRenderBatch batch);    // Unload render batch system
 RLAPI void rlDrawRenderBatch(rlRenderBatch *batch);     // Draw render batch data (Update->Draw->Reset)
+RLAPI rlRenderBatch* rlGetRenderBatchActive(void);       // Get the active render batch
 RLAPI void rlSetRenderBatchActive(rlRenderBatch *batch); // Set the active render batch for rlgl (NULL for default internal)
 RLAPI void rlDrawRenderBatchActive(void);               // Update and draw internal render batch
 RLAPI bool rlCheckRenderBatchLimit(int vCount);         // Check internal buffer overflow for a given number of vertex
+
+RLAPI float rlGetRenderBatchDepth();                    // Get the depth for the active render batch
+RLAPI void rlSetRenderBatchDepth(float depth);          // Set the depth for the active render batch
 
 RLAPI void rlSetTexture(unsigned int id);               // Set current texture for render batch and check buffers limits
 
@@ -3179,6 +3183,12 @@ void rlDrawRenderBatch(rlRenderBatch *batch)
 #endif
 }
 
+// Get the active render batch for rlgl
+rlRenderBatch* rlGetRenderBatchActive()
+{
+    return RLGL.currentBatch;
+}
+
 // Set the active render batch for rlgl
 void rlSetRenderBatchActive(rlRenderBatch *batch)
 {
@@ -3223,6 +3233,18 @@ bool rlCheckRenderBatchLimit(int vCount)
 #endif
 
     return overflow;
+}
+
+// Get the depth for the active render batch
+float rlGetRenderBatchDepth()
+{
+    return RLGL.currentBatch->currentDepth;
+}
+
+// Set the depth for the active render batch
+void rlSetRenderBatchDepth(float depth)
+{
+    RLGL.currentBatch->currentDepth = depth;
 }
 
 // Textures data management


### PR DESCRIPTION
Allows existing draw functions to be drawn out of order with different depths. I can set the depth when making custom draw functions using `rlVertex3f` but it made more sense to solve from rlgl rather than reimplement every draw function I want to use for this. I also looked at `rlTranslatef` but that adds additional matrix multiplication that is not needed here and it also applies on top of the current depth which I would need the value of to offset it.

The use case is drawing a variety of entities in a game in an isometric grid where entities may appear behind buildings, other entities etc. They use a few different draw functions and while entities are currently sorted to draw in order, there are a large number of them so I would like to draw them out of order using depth testing to see if it improves the performance.

The main change is a utility function to get the active render batch to match the existing `rlSetRenderBatchActive`. This allows access to the default render batch that is created which allows me to change the depth and debug the render batch state.

I also added utility functions specifically for getting/setting the depth value. Wasn't sure if that would be useful to have as well.

Changes:
* Add `rlGetRenderBatchActive` to match `rlSetRenderBatchActive`.
* Add `rlGetRenderBatchDepth` to get the depth for the active render batch
* Add `rlSetRenderBatchDepth` to set the depth for the active render batch