### PR TITLE
[rlgl] Replace GetPixelDataSize use with rlGetPixelDataSize

### DIFF
--- a/src/rlgl.h
+++ b/src/rlgl.h
@@ -3755,7 +3755,7 @@ void *rlReadTexturePixels(unsigned int id, int width, int height, int format)
     glReadPixels(0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE, pixels);
 #else
     // Reading data as original texture format, in some platforms (RPI, Wasm) it works
-    pixels = (unsigned char *)RL_MALLOC(GetPixelDataSize(width, height, format));
+    pixels = (unsigned char *)RL_MALLOC(rlGetPixelDataSize(width, height, format));
     unsigned int glInternalFormat = 0, glFormat = 0, glType = 0;
     rlGetGlTextureFormats(format, &glInternalFormat, &glFormat, &glType);
     glReadPixels(0, 0, width, height, glFormat, glType, pixels);


### PR DESCRIPTION
For OpenGL ES 2.0 targets, when `FBO_READ_TEXTURE_AS_RGBA` is **not** defined, `rlgl.h` currently uses the Raylib-specific `GetPixelDataSize` instead of `rlGetPixelDataSize`. I believe this is a typo, and that there's no reason to depend on Raylib for this, as all other uses are of `rlGetPixelDataSize`.

This probably hasn't surfaced before because it is a linking error only when using `rlgl` outside of Raylib.

This is my first PR/issue, so I'm not sure whether anything else is necessary. I built all examples on windows and they look good -- though the likely best path would be to build for an OpenGL ES 2.0-specific target, and I'm not entirely sure how to do that. It's such a small change that I think is safe as-is, though.