### PR TITLE
[rcore][GLFW] Fix `ToggleBorderlessWindowed()` entering exclusive fullscreen instead of windowed

### DIFF
--- a/src/platforms/rcore_desktop_glfw.c
+++ b/src/platforms/rcore_desktop_glfw.c
@@ -287,7 +287,7 @@ void ToggleBorderlessWindowed(void)
                 CORE.Window.screen.height = mode->height;
 
                 // Set screen position and size
-                glfwSetWindowMonitor(platform.handle, monitors[monitor], CORE.Window.position.x, CORE.Window.position.y,
+                glfwSetWindowMonitor(platform.handle, NULL, CORE.Window.position.x, CORE.Window.position.y,
                     CORE.Window.screen.width, CORE.Window.screen.height, mode->refreshRate);
 
                 // Refocus window

--- a/src/platforms/rcore_desktop_glfw.c
+++ b/src/platforms/rcore_desktop_glfw.c
@@ -288,7 +288,7 @@ void ToggleBorderlessWindowed(void)
 
                 // Set screen position and size
                 glfwSetWindowMonitor(platform.handle, NULL, CORE.Window.position.x, CORE.Window.position.y,
-                    CORE.Window.screen.width, CORE.Window.screen.height, mode->refreshRate);
+                    CORE.Window.screen.width, CORE.Window.screen.height, GLFW_DONT_CARE);
 
                 // Refocus window
                 glfwFocusWindow(platform.handle);
@@ -318,7 +318,7 @@ void ToggleBorderlessWindowed(void)
 
                 // Return to previous screen size and position
                 glfwSetWindowMonitor(platform.handle, NULL, CORE.Window.position.x, CORE.Window.position.y,
-                    CORE.Window.screen.width, CORE.Window.screen.height, mode->refreshRate);
+                    CORE.Window.screen.width, CORE.Window.screen.height, GLFW_DONT_CARE);
 
                 // Refocus window
                 glfwFocusWindow(platform.handle);


### PR DESCRIPTION
Fixes #5854 

`glfwSetWindowMonitor()` was called with a non NULL monitor handle when entering borderless windowed mode. Per GLFW's documented behavior, a non NULL monitor negotiates exclusive fullscreen, which is the same call `ToggleFullscreen()` makes not what borderless windowed is supposed to do. The windowed restore branch of this same function already calls `glfwSetWindowMonitor()` with NULL for this reason, this makes the enter branch consistent with it.

Checked on Windows 11 works as intended, although it's not a issue in linux i did checked on debian gnome and wslg, no issue there as well.