### PR TITLE
[rshapes] Fix `DrawRectangleLinesEx()`

### DIFF
--- a/src/rshapes.c
+++ b/src/rshapes.c
@@ -631,7 +631,9 @@ void DrawRectangleLines(int posX, int posY, int width, int height, Color color)
 // Draw rectangle outline with line thickness
 void DrawRectangleLinesEx(Rectangle rec, float thick, Color color)
 {
-    if ((thick > rec.width) || (thick > rec.height))
+    if (thick <= 0.0f) return;
+
+    if ((thick > rec.width/2) || (thick > rec.height/2))
     {
         if (rec.width >= rec.height) thick = rec.height/2;
         else if (rec.width <= rec.height) thick = rec.width/2;


### PR DESCRIPTION
Previously `DrawRectangleLinesEx()` would draw lines overlapping each other when they were thick enough (which was only noticeable if the color's alpha was lower than 255.)