### PR TITLE
[raudio][W.I.P] Separate audio devices from context, support other types other than playback

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -123,6 +123,10 @@
     //  - SUPPORT_FILEFORMAT_JPG
     #define SUPPORT_CLIPBOARD_IMAGE         1
 #endif
+#ifndef SUPPORT_POSIX_STRDUP
+    // Use posix strdup or built-in one
+    #define SUPPORT_POSIX_STRDUP            1
+#endif
 
 // rcore: Configuration values
 // NOTE: Below values are already defined inside [rcore.c] so there is no need to be

--- a/src/raudio.c
+++ b/src/raudio.c
@@ -47,6 +47,9 @@
 *           - Mixing channels support
 *           - Raw audio context support
 *
+*       Levi Spencer (github: @AllMeatball) (July. 2026)
+*           - Audio device listing (playback and capture)
+*
 *
 *   LICENSE: zlib/libpng
 *
@@ -378,6 +381,12 @@ struct rAudioProcessor {
     rAudioProcessor *prev;          // Previous audio processor on the list
 };
 
+// Audio device id abstraction struct
+// NOTE: This could do more in the future, other than storing ma_device_id.
+struct rAudioDeviceID {
+    ma_device_id id;
+};
+
 #define AudioBuffer rAudioBuffer    // WARNING: Renamed to avoid symbol collision with CoreAudio (macOS) AudioBuffer type
 
 // Audio data context
@@ -565,6 +574,95 @@ float GetMasterVolume(void)
     float volume = 0.0f;
     ma_device_get_master_volume(&AUDIO.System.device, &volume);
     return volume;
+}
+
+
+// Get list of all audio devices (playback and capture)
+bool GetAudioDeviceList(AudioDeviceList *devices)
+{
+    ma_device_info *playbackDevices = NULL;
+    ma_uint32       playbackDevicesCount = 0;
+
+    ma_device_info *captureDevices = NULL;
+    ma_uint32       captureDevicesCount = 0;
+
+    ma_result result = ma_context_get_devices(&AUDIO.System.context, &playbackDevices, &playbackDevicesCount, &captureDevices, &captureDevicesCount);
+
+    // ma_context_get_devices has failed, log that it did so and return false.
+    if (result != MA_SUCCESS) {
+        TRACELOG(LOG_WARNING, "AUDIO: Failed to get list of audio devices");
+        return false;
+    }
+
+    // Allocate list of devices.
+    devices->playbackDevices = RL_CALLOC( playbackDevicesCount, sizeof(AudioDevice) );
+    devices->captureDevices  = RL_CALLOC( captureDevicesCount, sizeof(AudioDevice) );
+
+    if (!devices->playbackDevices || !devices->captureDevices) {
+        TRACELOG(LOG_WARNING, "AUDIO: Failed to get list of audio devices");
+        return false;
+    }
+
+    devices->playbackDevicesCount = playbackDevicesCount;
+    devices->captureDevicesCount  = captureDevicesCount;
+
+    // Add playback devices.
+    for (unsigned int i = 0; i < playbackDevicesCount; i++)
+    {
+        ma_device_info device = playbackDevices[i];
+
+        rAudioDeviceID *id = RL_MALLOC(sizeof(rAudioDeviceID));
+        id->id = device.id;
+
+        devices->playbackDevices[i] = (AudioDevice){
+            .id = id,
+            .name = StringDuplicate(device.name),
+            .type = AUDIODEVICE_PLAYBACK,
+
+            .isDefault = device.isDefault == MA_TRUE,
+        };
+    }
+
+    // Add capture devices.
+    for (unsigned int i = 0; i < captureDevicesCount; i++)
+    {
+        ma_device_info device = captureDevices[i];
+
+        rAudioDeviceID *id = RL_MALLOC(sizeof(rAudioDeviceID));
+        id->id = device.id;
+
+        devices->playbackDevices[i] = (AudioDevice){
+            .id = id,
+            .name = StringDuplicate(device.name),
+            .type = AUDIODEVICE_CAPTURE,
+
+            .isDefault = device.isDefault == MA_TRUE,
+        };
+    }
+
+    return true;
+}
+
+// Unload audio device list
+void UnloadAudioDeviceList(AudioDeviceList devices)
+{
+    for (unsigned int i = 0; i < devices.playbackDevicesCount; i++)
+    {
+        AudioDevice device = devices.playbackDevices[i];
+        RL_FREE(device.id);
+        RL_FREE(device.name);
+    }
+
+    for (unsigned int i = 0; i < devices.captureDevicesCount; i++)
+    {
+        AudioDevice device = devices.captureDevices[i];
+        RL_FREE(device.id);
+        RL_FREE(device.name);
+    }
+
+
+    RL_FREE(devices.playbackDevices);
+    RL_FREE(devices.captureDevices);
 }
 
 //----------------------------------------------------------------------------------

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1113,6 +1113,7 @@ RLAPI void UnloadRandomSequence(int *sequence);         // Unload random values 
 RLAPI void TakeScreenshot(const char *fileName);                // Takes a screenshot of current screen (filename extension defines format)
 RLAPI void SetConfigFlags(unsigned int flags);                  // Set up init configuration flags (view FLAGS)
 RLAPI void OpenURL(const char *url);                            // Open URL with default system browser (if available)
+RLAPI char *StringDuplicate(const char *string);                // Duplicates string into a new copy (platform agnostic strdup)
 
 // Logging system
 RLAPI void SetTraceLogLevel(int logLevel);                      // Set the current threshold (minimum) log level

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -474,6 +474,26 @@ typedef struct Wave {
 // NOTE: Actual structs are defined internally in raudio module
 typedef struct rAudioBuffer rAudioBuffer;
 typedef struct rAudioProcessor rAudioProcessor;
+typedef struct rAudioDeviceID rAudioDeviceID;
+
+// Audio device, playback or capture
+typedef struct AudioDevice {
+    rAudioDeviceID *id;             // Pointer interal audio device id
+
+    char *name;                     // Audio device name (e.g. Ryzen HD Audio Controller)
+    unsigned int type;              // Audio device type (see AudioDeviceType)
+
+    bool isDefault;                 // If this audio device is default this should be set as true
+} AudioDevice;
+
+// Audio device list, contains both playback and capture devices (see AudioDevice)
+typedef struct AudioDeviceList {
+    unsigned int playbackDevicesCount;    // Playback device entries count
+    AudioDevice *playbackDevices;         // Playback device entries
+
+    unsigned int captureDevicesCount;     // Capture device entries count
+    AudioDevice *captureDevices;          // Capture device entries
+} AudioDeviceList;
 
 // AudioStream, custom audio stream
 typedef struct AudioStream {
@@ -962,6 +982,13 @@ typedef enum {
     NPATCH_THREE_PATCH_VERTICAL,    // Npatch layout: 1x3 tiles
     NPATCH_THREE_PATCH_HORIZONTAL   // Npatch layout: 3x1 tiles
 } NPatchLayout;
+
+// Audio device type
+typedef enum {
+    AUDIODEVICE_UNKNOWN = 0,        // Unknown or unspecified
+    AUDIODEVICE_PLAYBACK,           // Playback device (e.g. speakers, headphones etc.)
+    AUDIODEVICE_CAPTURE             // Capture device  (e.g. microphones, voice changers etc.)
+} AudioDeviceType;
 
 // Callbacks to hook some internal functions
 // WARNING: These callbacks are intended for advanced users
@@ -1680,6 +1707,8 @@ RLAPI void CloseAudioDevice(void);                                    // Close t
 RLAPI bool IsAudioDeviceReady(void);                                  // Check if audio device has been initialized successfully
 RLAPI void SetMasterVolume(float volume);                             // Set master volume (listener)
 RLAPI float GetMasterVolume(void);                                    // Get master volume (listener)
+RLAPI bool GetAudioDeviceList(AudioDeviceList *devices);              // Get list of all audio devices (playback and capture)
+RLAPI void UnloadAudioDeviceList(AudioDeviceList devices);            // Unload audio device list
 
 // Wave/Sound loading/unloading functions
 RLAPI Wave LoadWave(const char *fileName);                            // Load wave data from file

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -1853,6 +1853,33 @@ void SetConfigFlags(unsigned int flags)
     FLAG_SET(CORE.Window.flags, flags);
 }
 
+// Duplicates string into a new one (platform agnostic strdup)
+char *StringDuplicate(const char *string)
+{
+#if SUPPORT_POSIX_STRDUP
+    #if defined(_WIN32) || defined(_MSC_VER)
+    return _strdup(string);
+    #else
+    return strdup(string);
+    #endif
+#else
+    if (!string)
+        return NULL;
+
+    // NOTE: the final string (newString) should be stringLength + 1 (e.g. strlen("hello") + 1 = 6).
+    // one extra char is required for the null-terminator ('\0').
+
+    size_t stringLength = strlen(string);
+
+    char *newString = RL_CALLOC(stringLength + 1, sizeof(char));
+    strncpy(newString, string, stringLength);
+
+    newString[stringLength + 1] = '\0';
+
+    return newString;
+#endif
+}
+
 //----------------------------------------------------------------------------------
 // Module Functions Definition: Logging system
 //----------------------------------------------------------------------------------


### PR DESCRIPTION
### Reason
I have decided since miniaudio (what raylib uses under the hood) can use (and enumerate) separate audio devices for initialization, raylib should implement these too. 

A lot of games made today have sound configuration menus for input (capture) and output (playback) devices.

This is a draft due not having all of the features I want (some might be added already) (see _**Feature list**_)

### What it does
Currently it just lists out sound devices, no option for individual device setup at the moment.

### Added functions, types, config options etc.
#### Functions
- rcore: `StringDuplicate`
- raudio: `GetAudioDeviceList`, `GetAudioDeviceList`
#### Config Flags
- `SUPPORT_POSIX_STRDUP` (is 1 by default and may want to be change for compat reasons)
#### Types
- raudio (internal): `rAudioDeviceID`
- raudio (external): `AudioDevice`, `AudioDeviceList`, `AudioDeviceType`

**NOTE: the `StringDuplicate` function is used for copying the audio device names. if you want me to remove this or make it private to raylibs code, I am perfectly willing to do so.** 

### Feature list

- [x]  * Ability to list devices
- [ ]  * Individual/specific device setup (separating miniaudio context from device)
- [ ]  * Capture device / microphone support

### Stuff to improve

- I think that `rAudioDeviceID` is a _bit_ _**too**_ abstracted, a string format like "PulseAudio:hex" could be a better system
- `InitAudioDevice` may change into the following

- before:
```c
// ... init window and what not
InitAudioDevice();
// ... close everything
CloseAudioDevice();
```
- after:
```c
// ... init window and what not
InitAudioContext();

#ifdef USE_DEFAULT_AUDIO_DEVICE
SetAudioDevice(NULL); /* picks the default audio device */
#else
AudioDevice device = {};
/* get specific audio device from `GetAudioDeviceList` */
SetAudioDevice(&device);
#endif

// ... close everything
CloseAudioContext();
```

Let me know if there's anything here that I need to fix or change.