### PR TITLE
[raudio] Fix crash on CloseAudioDevice: uninit device before mutex

### DIFF
--- a/src/raudio.c
+++ b/src/raudio.c
@@ -533,8 +533,9 @@ void CloseAudioDevice(void)
 {
     if (AUDIO.System.isReady)
     {
-        ma_mutex_uninit(&AUDIO.System.lock);
+        // Stop the device first (joins the callback thread) before destroying the mutex it locks
         ma_device_uninit(&AUDIO.System.device);
+        ma_mutex_uninit(&AUDIO.System.lock);
         ma_context_uninit(&AUDIO.System.context);
 
         AUDIO.System.isReady = false;


### PR DESCRIPTION
On Android (AAudio) the callback thread could still run when the mutex was destroyed, causing a SIGABRT (pthread_mutex_lock on a destroyed mutex). Uninit the device first so its callback thread stops before ma_mutex_uninit.