### PR TITLE
[rcore][Android] Fix Android relaunch hang after destroy while paused

### DIFF
--- a/src/platforms/rcore_android.c
+++ b/src/platforms/rcore_android.c
@@ -801,6 +801,7 @@ void PollInputEvents(void)
         if (platform.app->destroyRequested != 0)
         {
             CORE.Window.shouldClose = true;
+            break;
         }
     }
 }


### PR DESCRIPTION
When the activity is destroyed while the app is paused, PollInputEvents kept looping after setting CORE.Window.shouldClose: while paused, ALooper_pollAll is called with an infinite timeout (-1), so on the next iteration it blocked forever waiting for an event that never arrives. main() never returned, the native thread stayed alive, and the following launch hung inheriting that thread.