### PR TITLE
[rcore][RGFW] Fix window Y position reading X in RGFW move callback

### DIFF
--- a/src/platforms/rcore_desktop_rgfw.c
+++ b/src/platforms/rcore_desktop_rgfw.c
@@ -613,7 +613,7 @@ static void RGFW_cb_windowmovefunc(const RGFW_event *e)
     if (e->common.win != platform.window) return;
 
     CORE.Window.position.x = platform.window->x;
-    CORE.Window.position.y = platform.window->x;
+    CORE.Window.position.y = platform.window->y;
 }
 static void RGFW_cb_keycharfunc(const RGFW_event *e)
 {


### PR DESCRIPTION
In `RGFW_cb_windowmovefunc`, the stored window Y position reads the window's X coordinate:

```c
CORE.Window.position.x = platform.window->x;
CORE.Window.position.y = platform.window->x;
```

The second line should read `platform.window->y`. This is confirmed by the equivalent assignment later in the same file (window setup), which correctly reads both coordinates:

```c
CORE.Window.position.x = platform.window->x;
CORE.Window.position.y = platform.window->y;
```

and by `GetWindowPosition`, which reads both `platform.window->x` and `platform.window->y`. As-is, handling a window-move event stores the X value into `CORE.Window.position.y`, so the reported Y position is wrong after moving the window.
