### PR TITLE
[rshapes] Fix drawing circle sectors

### DIFF
--- a/src/rshapes.c
+++ b/src/rshapes.c
@@ -1576,8 +1576,13 @@ void DrawCircleSectorLines(Vector2 center, float radius, float startAngle, float
         endAngle = tmp;
     }
 
+    bool showCapLines = true;
     // Drawing a whole circle, things get weird without limiting the circle to 360 degrees
-    if (endAngle - startAngle >= 360.0f) endAngle = startAngle + 360.0f;
+    if (endAngle - startAngle >= 360.0f)
+    {
+        showCapLines = false;
+        endAngle = startAngle + 360.0f;
+    }
 
     int minSegments = (int)ceilf((endAngle - startAngle)/90);
 
@@ -1592,7 +1597,6 @@ void DrawCircleSectorLines(Vector2 center, float radius, float startAngle, float
 
     float stepLength = (endAngle - startAngle)/(float)segments;
     float angle = startAngle;
-    bool showCapLines = true;
 
     rlBegin(RL_LINES);
         if (showCapLines)
@@ -1804,8 +1808,13 @@ void DrawRingLines(Vector2 center, float innerRadius, float outerRadius, float s
         endAngle = tmp;
     }
 
+    bool showCapLines = true;
     // Drawing a whole circle, things get weird without limiting the circle to 360 degrees
-    if (endAngle - startAngle >= 360.0f) endAngle = startAngle + 360.0f;
+    if (endAngle - startAngle >= 360.0f)
+    {
+        showCapLines = false;
+        endAngle = startAngle + 360.0f;
+    }
 
     int minSegments = (int)ceilf((endAngle - startAngle)/90);
 
@@ -1826,7 +1835,6 @@ void DrawRingLines(Vector2 center, float innerRadius, float outerRadius, float s
 
     float stepLength = (endAngle - startAngle)/(float)segments;
     float angle = startAngle;
-    bool showCapLines = true;
 
     rlBegin(RL_LINES);
         if (showCapLines)

--- a/src/rshapes.c
+++ b/src/rshapes.c
@@ -1481,6 +1481,9 @@ void DrawCircleSector(Vector2 center, float radius, float startAngle, float endA
         endAngle = tmp;
     }
 
+    // Drawing a whole circle, things get weird without limiting the circle to 360 degrees
+    if (endAngle - startAngle >= 360.0f) endAngle = startAngle + 360.0f;
+
     int minSegments = (int)ceilf((endAngle - startAngle)/90);
 
     if (segments < minSegments)
@@ -1572,6 +1575,9 @@ void DrawCircleSectorLines(Vector2 center, float radius, float startAngle, float
         startAngle = endAngle;
         endAngle = tmp;
     }
+
+    // Drawing a whole circle, things get weird without limiting the circle to 360 degrees
+    if (endAngle - startAngle >= 360.0f) endAngle = startAngle + 360.0f;
 
     int minSegments = (int)ceilf((endAngle - startAngle)/90);
 
@@ -1704,6 +1710,9 @@ void DrawRing(Vector2 center, float innerRadius, float outerRadius, float startA
         endAngle = tmp;
     }
 
+    // Drawing a whole circle, things get weird without limiting the circle to 360 degrees
+    if (endAngle - startAngle >= 360.0f) endAngle = startAngle + 360.0f;
+
     int minSegments = (int)ceilf((endAngle - startAngle)/90);
 
     if (segments < minSegments)
@@ -1794,6 +1803,9 @@ void DrawRingLines(Vector2 center, float innerRadius, float outerRadius, float s
         startAngle = endAngle;
         endAngle = tmp;
     }
+
+    // Drawing a whole circle, things get weird without limiting the circle to 360 degrees
+    if (endAngle - startAngle >= 360.0f) endAngle = startAngle + 360.0f;
 
     int minSegments = (int)ceilf((endAngle - startAngle)/90);
 


### PR DESCRIPTION
Functions that draw a sector of a circle would keep drawing segments past a full rotation, which looked bad.

Example of previous behavior from `DrawCircleSector()` (the brighter red area is where it's overlapping itself due to not stopping at 360 degrees.)
<img width="529" height="436" alt="circle_overlapping" src="https://github.com/user-attachments/assets/0ece0cb1-2112-4185-8649-eb718a6b6a56" />

Additionally, `DrawCircleSectorLines()` and `DrawRingLines()` drew the cap lines even when drawing a full circle, which seems undesirable (though that could just be a matter of taste.)

With caps
<img width="470" height="197" alt="with_caps" src="https://github.com/user-attachments/assets/22c0d63c-5ef9-434b-bf0e-83f7461bfc66" />

Without caps
<img width="470" height="196" alt="without_caps" src="https://github.com/user-attachments/assets/147ce0ec-2a9b-4c6c-8d29-5f18e154e9bf" />