### PR TITLE
[rmodels] Fix glTF pose sampled at the end of an animation returning a pose from the start

### DIFF
--- a/src/rmodels.c
+++ b/src/rmodels.c
@@ -6390,6 +6390,7 @@ static bool GetPoseAtTimeGLTF(cgltf_interpolation_type interpolationType, cgltf_
     float tstart = 0.0f;
     float tend = 0.0f;
     int keyframe = 0;       // Defaults to first pose
+    bool found = false;
 
     for (int i = 0; i < (int)input->count - 1; i++)
     {
@@ -6402,8 +6403,24 @@ static bool GetPoseAtTimeGLTF(cgltf_interpolation_type interpolationType, cgltf_
         if ((tstart <= time) && (time < tend))
         {
             keyframe = i;
+            found = true;
             break;
         }
+    }
+
+    // No interval contains a time at (or past) the last keyframe, because the
+    // search above requires time < tend: clamp to the edge interval instead of
+    // falling back to keyframe 0, which returns a pose from the start
+    if (!found && ((int)input->count >= 2))
+    {
+        keyframe = (int)input->count - 2;
+
+        float tfirst = 0.0f;
+        if (!cgltf_accessor_read_float(input, 0, &tfirst, 1)) return false;
+        if (time < tfirst) keyframe = 0;
+
+        if (!cgltf_accessor_read_float(input, keyframe, &tstart, 1)) return false;
+        if (!cgltf_accessor_read_float(input, keyframe + 1, &tend, 1)) return false;
     }
 
     // Constant animation, no need to interpolate


### PR DESCRIPTION
When `GetPoseAtTimeGLTF()` is asked for a time at (or past) the last keyframe of a channel, it returns a pose from the **beginning** of the animation.

The interval search requires `time < tend`:

```c
int keyframe = 0;       // Defaults to first pose

for (int i = 0; i < (int)input->count - 1; i++)
{
    ...
    if ((tstart <= time) && (time < tend))
    {
        keyframe = i;
        break;
    }
}
```

A time equal to the last keyframe time satisfies no interval, so the loop ends without a match and `keyframe` keeps its `0` default. The pose is then interpolated from the first keyframe with `t` clamped to 1, i.e. the second keyframe of the channel.

This is not a corner case that needs an odd input to hit. `LoadModelAnimationsGLTF()` samples at `t = j/60` for `j` in `[0, keyframeCount)` with `keyframeCount = (int)(animDuration*GLTF_FRAMERATE) + 1`, so the last sample lands **exactly** on the end of the animation whenever `animDuration*60` is a whole number. On a set of 438 clips from 20 different glTF files, 375 hit it. The other 63 only escape because float rounding leaves the last sample slightly short.

Visually it reads as a jerk right before the animation ends — the model snaps to a near-start pose for one frame and then wraps around.

### Fix

When no interval contains the requested time, clamp to the edge interval — the last one if the time is at or past the end, the first one if it is before the start — instead of silently falling back to keyframe 0. The existing `t` clamp then yields the last (or first) pose.

### Measurements

Same file, same clip (0.85 s, 52 sampled poses, 19 bones), comparing the delta between consecutive poses against the median delta of that clip:

| | delta between the last two poses |
|---|---|
| before | 3.6872 (**23x** the median step) |
| after | 0.0244 (**0.3x**) |

The corrupted pose is gone and the final step costs the same as every other one. Verified against `master`, built with `make PLATFORM=PLATFORM_DESKTOP` with no new warnings.