### PR TITLE
[rlsw] Fix #ifdef -> #if for RLSW_DOUBLE_BUFFERING in sw_default_framebuffer_free()

### DIFF
--- a/src/external/rlsw.h
+++ b/src/external/rlsw.h
@@ -2524,7 +2524,7 @@ static void sw_default_framebuffer_free(sw_default_framebuffer_t *fb)
 {
     sw_texture_free(&fb->color);
     sw_texture_free(&fb->depth);
-#ifdef RLSW_DOUBLE_BUFFERING
+#if RLSW_DOUBLE_BUFFERING
     sw_texture_free(&fb->backColor);
 #endif
 }


### PR DESCRIPTION
### Build failure

Building with `PLATFORM=Memory` (headless target using the software renderer) fails to compile:

```text
src/external/rlsw.h: In function 'sw_default_framebuffer_free':
src/external/rlsw.h:2528:24: error: 'sw_default_framebuffer_t' has no
                                   member named 'backColor'
 2528 |     sw_texture_free(&fb->backColor);
      |                        ^~
make[2]: *** [raylib/CMakeFiles/raylib.dir/build.make:79:
              raylib/CMakeFiles/raylib.dir/rcore.c.o] Error 1
```

### Reproduction

```bash
cmake -DPLATFORM=Memory \
      -DGRAPHICS=GRAPHICS_API_OPENGL_SOFTWARE \
      -DBUILD_EXAMPLES=OFF \
      -DCMAKE_BUILD_TYPE=Release .
make
```

`PLATFORM=Memory` → `PLATFORM_CPP=PLATFORM_MEMORY` → `rcore.c` is compiled, which includes `rlsw.h`. On the Desktop target `rlsw.h` is not compiled, so the bug stays hidden.

### Fix

```diff
--- a/src/external/rlsw.h
+++ b/src/external/rlsw.h
@@ -2524,7 +2524,7 @@ static void sw_default_framebuffer_free(sw_default_framebuffer_t *fb)
     sw_texture_free(&fb->color);
     sw_texture_free(&fb->depth);
-#ifdef RLSW_DOUBLE_BUFFERING
+#if RLSW_DOUBLE_BUFFERING
     sw_texture_free(&fb->backColor);
 #endif
 }
```

A one-line fix, bringing `sw_default_framebuffer_free()` in line with the three other occurrences (`#if`, not `#ifdef`). `RLSW_DOUBLE_BUFFERING` defaults to `0` (lines 123-125), which makes the macro *defined* — so `#ifdef` compiles the access to `fb->backColor`, while the field only exists under `#if RLSW_DOUBLE_BUFFERING` (value check, lines 1017-1019). With the default `=0`, the `backColor` member is absent and the build breaks.

## Files changed

`src/external/rlsw.h` (+1, −1)