### PR TITLE
Use unmodified GLFW

### DIFF
--- a/src/external/glfw/README.md
+++ b/src/external/glfw/README.md
@@ -1,18 +1,198 @@
-# GLFW (modified for raylib)
+# GLFW
 
-This directory contains a modification of GLFW, whose official website and
-upstream repository are https://glfw.org and https://github.com/glfw/glfw,
-respectively.
+[![Build status](https://github.com/glfw/glfw/actions/workflows/build.yml/badge.svg)](https://github.com/glfw/glfw/actions)
+[![Build status](https://ci.appveyor.com/api/projects/status/0kf0ct9831i5l6sp/branch/master?svg=true)](https://ci.appveyor.com/project/elmindreda/glfw)
 
-In this modification, some static functions sharing the same name in different
-platforms have been renamed so all of GLFW's source files can be combined into
-one (as done by ``rglfw.c``). Also, the Null platform, which is not used by
-raylib, has been disabled. The renamed functions are:
+## Introduction
 
-```
-createKeyTables()
-translateKey()
-acquireMonitor()
-releaseMonitor()
-```
+GLFW is an Open Source, multi-platform library for OpenGL, OpenGL ES and Vulkan
+application development.  It provides a simple, platform-independent API for
+creating windows, contexts and surfaces, reading input, handling events, etc.
+
+GLFW is written primarily in C99, with parts of macOS support being written in
+Objective-C.
+
+GLFW supports Windows, macOS and Linux, and also works on many other Unix-like
+systems.  On Linux both Wayland and X11 are supported.
+
+GLFW is licensed under the [zlib/libpng
+license](https://www.glfw.org/license.html).
+
+You can [download](https://www.glfw.org/download.html) the latest stable release
+as source or Windows and macOS binaries.  There are [release
+tags](https://github.com/glfw/glfw/releases) with source and binary archives
+attached for every version since 3.0.
+
+The [documentation](https://www.glfw.org/docs/latest/) is available online and is
+also included in source and binary archives, except those generated
+automatically by Github.  The documentation contains guides, a tutorial and the
+API reference.  The [release
+notes](https://www.glfw.org/docs/latest/news.html) list the new features,
+caveats and deprecations in the latest release.  The [version
+history](https://www.glfw.org/changelog.html) lists every user-visible change
+for every release.
+
+GLFW exists because of the contributions of [many people](CONTRIBUTORS.md)
+around the world, whether by reporting bugs, providing community support, adding
+features, reviewing or testing code, debugging, proofreading docs, suggesting
+features or fixing bugs.
+
+
+## System requirements
+
+GLFW supports Windows 7 and later and macOS 10.11 and later.  On GNOME Wayland,
+window decorations will be very basic unless the
+[libdecor](https://gitlab.freedesktop.org/libdecor/libdecor) package is
+installed.  Linux and other Unix-like systems running X11 are supported even
+without a desktop environment or modern extensions, although some features
+require a clipboard manager or a modern window manager.
+
+See the [compatibility guide](https://www.glfw.org/docs/latest/compat.html)
+for more detailed information.
+
+
+## Compiling GLFW
+
+GLFW supports compilation with Visual C++ (2013 and later), GCC and Clang.  Both
+Clang-CL and MinGW-w64 are supported.  Other C99 compilers will likely also
+work, but this is not regularly tested.
+
+There are [pre-compiled binaries](https://www.glfw.org/download.html)
+available for Windows and macOS.
+
+GLFW itself needs only CMake and the headers and libraries for your operating
+system and window system.  No other SDKs are required.
+
+See the [compilation guide](https://www.glfw.org/docs/latest/compile.html) for
+more information about compiling GLFW and the exact dependencies required for
+each window system.
+
+The examples and test programs depend on a number of tiny libraries.  These are
+bundled in the `deps/` directory.  The repository has no submodules.
+
+ - [getopt\_port](https://github.com/kimgr/getopt_port/) for examples
+   with command-line options
+ - [TinyCThread](https://github.com/tinycthread/tinycthread) for threaded
+   examples
+ - [glad2](https://github.com/Dav1dde/glad) for loading OpenGL and Vulkan
+   functions
+ - [linmath.h](https://github.com/datenwolf/linmath.h) for linear algebra in
+   examples
+ - [Nuklear](https://github.com/Immediate-Mode-UI/Nuklear) for test and example UI
+ - [stb\_image\_write](https://github.com/nothings/stb) for writing images to disk
+
+The documentation is generated with [Doxygen](https://doxygen.org/) when the
+library is built, provided CMake could find a sufficiently new version of it
+during configuration.
+
+
+## Using GLFW
+
+See the [HTML documentation](https://www.glfw.org/docs/latest/) for a tutorial,
+guides and the API reference.
+
+
+## Contributing to GLFW
+
+See the [contribution
+guide](https://github.com/glfw/glfw/blob/master/docs/CONTRIBUTING.md) for
+more information.
+
+The `master` branch is the stable integration branch and _should_ always compile
+and run on all supported platforms.  Details of a newly added feature,
+including the public API, may change until it has been included in a release.
+
+The `latest` branch is equivalent to the [highest numbered](https://semver.org/)
+release, although it may not always point to the same commit as the tag for that
+release.
+
+The `ci` branch is used to trigger continuous integration jobs for code under
+testing and should never be relied on for any purpose.
+
+
+## Reporting bugs
+
+Bugs are reported to our [issue tracker](https://github.com/glfw/glfw/issues).
+Please check the [contribution
+guide](https://github.com/glfw/glfw/blob/master/docs/CONTRIBUTING.md) for
+information on what to include when reporting a bug.
+
+
+## Changelog since 3.5
+
+None.
+
+## Changelog since 3.4
+
+ - Added `GLFW_UNLIMITED_MOUSE_BUTTONS` input mode that allows mouse buttons beyond
+   the limit of the mouse button tokens to be reported (#2423)
+ - Added `glfwGetEGLConfig` function to query the `EGLConfig` of a window (#2045)
+ - Added `glfwGetGLXFBConfig` function to query the `GLXFBConfig` of a window (#1925)
+ - Updated minimum CMake version to 3.16 (#2541)
+ - Removed support for building with original MinGW (#2540)
+ - [Win32] Removed support for Windows XP and Vista (#2505)
+ - [Win32] Bugfix: Media keys were reported with a scancode of 256 (#1768,#2417,#2625)
+ - [Cocoa] Added `QuartzCore` framework as link-time dependency
+ - [Cocoa] Removed support for OS X 10.10 Yosemite and earlier (#2506)
+ - [Cocoa] Bugfix: Cmd+Period, Ctrl+Tab and Ctrl+Esc key events were not emitted
+   (#1362,#2278)
+ - [Wayland] Bugfix: The fractional scaling related objects were not destroyed
+ - [Wayland] Bugfix: `glfwInit` would segfault on compositor with no seat (#2517)
+ - [Wayland] Bugfix: A drag entering a non-GLFW surface could cause a segfault
+ - [Wayland] Bugfix: Ignore key repeat events when no window has keyboard focus (#2727)
+ - [Wayland] Bugfix: Reset key repeat timer when window destroyed (#2741,#2727)
+ - [Wayland] Bugfix: Memory would leak if reading a data offer failed midway
+ - [Wayland] Bugfix: Retrieved cursor position would be incorrect when hovering over
+                     fallback decorations
+ - [Wayland] Bugfix: Fallback decorations would report scroll events
+ - [Wayland] Bugfix: Keyboard repeat events halted when any key is released (#2568)
+ - [Wayland] Bugfix: Fallback decorations would show menu at wrong position
+ - [Wayland] Bugfix: The cursor was not updated when clicking through from
+   a modal to a fallback decoration
+ - [Wayland] Bugfix: The cursor position was not updated when clicking through
+   from a modal to the content area
+ - [Wayland] Bugfix: free modules at end of terminate function to resolve
+   potential segmentation fault (#2744)
+ - [Wayland] Bugfix: Confining or disabling the cursor could segfault on
+   compositors without `pointer-constraints-unstable-v1`
+ - [Wayland] Bugfix: Key repeat did not function on very old compositors
+ - [Wayland] Bugfix: The `libwayland-client` library was not unloaded at termination
+ - [Wayland] Bugfix: Scroll events were sent twice on some versions of GNOME (#2494)
+ - [Wayland] Bugfix: Two-dimensional scroll input was emitted as separate axes
+ - [Wayland] Bugfix: Mouse wheel scroll distance was incorrect on some compositors
+ - [Wayland] Bugfix: `glfwSwapBuffers` would halt with nonzero swap interval when window
+   was suspended (#1350,#2582,#2640,#2719,#2723,#2800,#2827)
+ - [Wayland] Bugfix: `glfwPostEmptyEvent` would leak a callback proxy (#2836)
+ - [Wayland] Bugfix: `glfwHideWindow` did not always send its request immediately
+ - [Wayland] Bugfix: Some event types were not always processed by `glfwPollEvents` or
+   `glfwWait*Events` (#2793,#2795)
+ - [Wayland] Bugfix: Scaled framebuffer size was sometimes incorect (#2713,#2810)
+ - [X11] Bugfix: Running without a WM could trigger an assert (#2593,#2601,#2631)
+ - [X11] Bugfix: Occasional crash when an idle display awakes (#2766) 
+ - [X11] Bugfix: Prevent BadWindow when creating small windows with a content scale
+   less than 1 (#2754)
+ - [X11] Bugfix: Clamp width and height to >= 1 to prevent BadValue error and app exit
+ - [X11] Bugfix: Floating windows silently became non-floating when hidden (#2276)
+ - [X11] Bugfix: The `libXext` library was not unloaded at termination
+ - [Linux] Bugfix: The header for `ioctl` was only implicitly included (#2778)
+ - [Null] Added Vulkan 'window' surface creation via `VK_EXT_headless_surface`
+ - [Null] Added EGL context creation on Mesa via `EGL_MESA_platform_surfaceless`
+ - [EGL] Allowed native access on Wayland with `GLFW_CONTEXT_CREATION_API` set to
+   `GLFW_NATIVE_CONTEXT_API` (#2518)
+
+
+## Contact
+
+On [glfw.org](https://www.glfw.org/) you can find the latest version of GLFW, as
+well as news, documentation and other information about the project.
+
+If you have questions related to the use of GLFW, we have a
+[forum](https://discourse.glfw.org/).
+
+If you have a bug to report, a patch to submit or a feature you'd like to
+request, please file it in the
+[issue tracker](https://github.com/glfw/glfw/issues) on GitHub.
+
+Finally, if you're interested in helping out with the development of GLFW or
+porting it to your favorite platform, join us on the forum or GitHub.
 

--- a/src/external/glfw/src/cocoa_init.m
+++ b/src/external/glfw/src/cocoa_init.m
@@ -1,8 +1,7 @@
 //========================================================================
-// GLFW 3.5 Cocoa (modified for raylib) - www.glfw.org; www.raylib.com
+// GLFW 3.5 Cocoa - www.glfw.org
 //------------------------------------------------------------------------
 // Copyright (c) 2009-2019 Camilla Löwy <elmindreda@glfw.org>
-// Copyright (c) 2024-2026 M374LX <wilsalx@gmail.com>
 //
 // This software is provided 'as-is', without any express or implied
 // warranty. In no event will the authors be held liable for any damages
@@ -176,7 +175,7 @@ static void createMenuBar(void)
 
 // Create key code translation tables
 //
-static void createKeyTablesCocoa(void)
+static void createKeyTables(void)
 {
     memset(_glfw.ns.keycodes, -1, sizeof(_glfw.ns.keycodes));
     memset(_glfw.ns.scancodes, -1, sizeof(_glfw.ns.scancodes));
@@ -584,7 +583,7 @@ int _glfwInitCocoa(void)
                name:NSTextInputContextKeyboardSelectionDidChangeNotification
              object:nil];
 
-    createKeyTablesCocoa();
+    createKeyTables();
 
     _glfw.ns.eventSource = CGEventSourceCreate(kCGEventSourceStateHIDSystemState);
     if (!_glfw.ns.eventSource)

--- a/src/external/glfw/src/cocoa_window.m
+++ b/src/external/glfw/src/cocoa_window.m
@@ -1,8 +1,7 @@
 //========================================================================
-// GLFW 3.5 Cocoa (modified for raylib) - www.glfw.org; www.raylib.com
+// GLFW 3.5 Cocoa - www.glfw.org
 //------------------------------------------------------------------------
 // Copyright (c) 2009-2019 Camilla Löwy <elmindreda@glfw.org>
-// Copyright (c) 2024-2026 M374LX <wilsalx@gmail.com>
 //
 // This software is provided 'as-is', without any express or implied
 // warranty. In no event will the authors be held liable for any damages
@@ -115,7 +114,7 @@ static void updateCursorMode(_GLFWwindow* window)
 
 // Make the specified window and its video mode active on its monitor
 //
-static void acquireMonitorCocoa(_GLFWwindow* window)
+static void acquireMonitor(_GLFWwindow* window)
 {
     _glfwSetVideoModeCocoa(window->monitor, &window->videoMode);
     const CGRect bounds = CGDisplayBounds(window->monitor->ns.displayID);
@@ -131,7 +130,7 @@ static void acquireMonitorCocoa(_GLFWwindow* window)
 
 // Remove the window and restore the original video mode
 //
-static void releaseMonitorCocoa(_GLFWwindow* window)
+static void releaseMonitor(_GLFWwindow* window)
 {
     if (window->monitor->window != window)
         return;
@@ -162,7 +161,7 @@ static int translateFlags(NSUInteger flags)
 
 // Translates a macOS keycode to a GLFW keycode
 //
-static int translateKeyCocoa(unsigned int key)
+static int translateKey(unsigned int key)
 {
     if (key >= sizeof(_glfw.ns.keycodes) / sizeof(_glfw.ns.keycodes[0]))
         return GLFW_KEY_UNKNOWN;
@@ -281,7 +280,7 @@ static const NSRange kEmptyRange = { NSNotFound, 0 };
 - (void)windowDidMiniaturize:(NSNotification *)notification
 {
     if (window->monitor)
-        releaseMonitorCocoa(window);
+        releaseMonitor(window);
 
     _glfwInputWindowIconify(window, GLFW_TRUE);
 }
@@ -289,7 +288,7 @@ static const NSRange kEmptyRange = { NSNotFound, 0 };
 - (void)windowDidDeminiaturize:(NSNotification *)notification
 {
     if (window->monitor)
-        acquireMonitorCocoa(window);
+        acquireMonitor(window);
 
     _glfwInputWindowIconify(window, GLFW_FALSE);
 }
@@ -563,7 +562,7 @@ static const NSRange kEmptyRange = { NSNotFound, 0 };
 
 - (void)keyDown:(NSEvent *)event
 {
-    const int key = translateKeyCocoa([event keyCode]);
+    const int key = translateKey([event keyCode]);
     const int mods = translateFlags([event modifierFlags]);
 
     _glfwInputKey(window, key, [event keyCode], GLFW_PRESS, mods);
@@ -576,7 +575,7 @@ static const NSRange kEmptyRange = { NSNotFound, 0 };
     int action;
     const unsigned int modifierFlags =
         [event modifierFlags] & NSEventModifierFlagDeviceIndependentFlagsMask;
-    const int key = translateKeyCocoa([event keyCode]);
+    const int key = translateKey([event keyCode]);
     const int mods = translateFlags(modifierFlags);
     const NSUInteger keyFlag = translateKeyToModifierFlag(key);
 
@@ -595,7 +594,7 @@ static const NSRange kEmptyRange = { NSNotFound, 0 };
 
 - (void)keyUp:(NSEvent *)event
 {
-    const int key = translateKeyCocoa([event keyCode]);
+    const int key = translateKey([event keyCode]);
     const int mods = translateFlags([event modifierFlags]);
     _glfwInputKey(window, key, [event keyCode], GLFW_RELEASE, mods);
 }
@@ -604,7 +603,7 @@ static const NSRange kEmptyRange = { NSNotFound, 0 };
 {
     // HACK: Some key combinations are consumed before reaching keyDown:
     //       so we claim those events and emit them here
-    const int key = translateKeyCocoa([event keyCode]);
+    const int key = translateKey([event keyCode]);
     const int mods = translateFlags([event modifierFlags]);
 
     if (mods & GLFW_MOD_CONTROL)
@@ -996,7 +995,7 @@ GLFWbool _glfwCreateWindowCocoa(_GLFWwindow* window,
     {
         _glfwShowWindowCocoa(window);
         _glfwFocusWindowCocoa(window);
-        acquireMonitorCocoa(window);
+        acquireMonitor(window);
 
         if (wndconfig->centerCursor)
             _glfwCenterCursorInContentArea(window);
@@ -1026,7 +1025,7 @@ void _glfwDestroyWindowCocoa(_GLFWwindow* window)
     [window->ns.object orderOut:nil];
 
     if (window->monitor)
-        releaseMonitorCocoa(window);
+        releaseMonitor(window);
 
     if (window->context.destroy)
         window->context.destroy(window);
@@ -1113,7 +1112,7 @@ void _glfwSetWindowSizeCocoa(_GLFWwindow* window, int width, int height)
     if (window->monitor)
     {
         if (window->monitor->window == window)
-            acquireMonitorCocoa(window);
+            acquireMonitor(window);
     }
     else
     {
@@ -1282,7 +1281,7 @@ void _glfwSetWindowMonitorCocoa(_GLFWwindow* window,
         if (monitor)
         {
             if (monitor->window == window)
-                acquireMonitorCocoa(window);
+                acquireMonitor(window);
         }
         else
         {
@@ -1300,7 +1299,7 @@ void _glfwSetWindowMonitorCocoa(_GLFWwindow* window,
     }
 
     if (window->monitor)
-        releaseMonitorCocoa(window);
+        releaseMonitor(window);
 
     _glfwInputWindowMonitor(window, monitor);
 
@@ -1338,7 +1337,7 @@ void _glfwSetWindowMonitorCocoa(_GLFWwindow* window,
         [window->ns.object setLevel:NSMainMenuWindowLevel + 1];
         [window->ns.object setHasShadow:NO];
 
-        acquireMonitorCocoa(window);
+        acquireMonitor(window);
     }
     else
     {

--- a/src/external/glfw/src/null_window.c
+++ b/src/external/glfw/src/null_window.c
@@ -1,9 +1,8 @@
 //========================================================================
-// GLFW 3.5 (modified for raylib) - www.glfw.org; www.raylib.com
+// GLFW 3.5 - www.glfw.org
 //------------------------------------------------------------------------
 // Copyright (c) 2016 Google Inc.
 // Copyright (c) 2016-2019 Camilla Löwy <elmindreda@glfw.org>
-// Copyright (c) 2024-2026 M374LX <wilsalx@gmail.com>
 //
 // This software is provided 'as-is', without any express or implied
 // warranty. In no event will the authors be held liable for any damages
@@ -61,12 +60,12 @@ static void fitToMonitor(_GLFWwindow* window)
     window->null.height = mode.height;
 }
 
-static void acquireMonitorNull(_GLFWwindow* window)
+static void acquireMonitor(_GLFWwindow* window)
 {
     _glfwInputMonitorWindow(window->monitor, window);
 }
 
-static void releaseMonitorNull(_GLFWwindow* window)
+static void releaseMonitor(_GLFWwindow* window)
 {
     if (window->monitor->window != window)
         return;
@@ -149,7 +148,7 @@ GLFWbool _glfwCreateWindowNull(_GLFWwindow* window,
     {
         _glfwShowWindowNull(window);
         _glfwFocusWindowNull(window);
-        acquireMonitorNull(window);
+        acquireMonitor(window);
 
         if (wndconfig->centerCursor)
             _glfwCenterCursorInContentArea(window);
@@ -170,7 +169,7 @@ GLFWbool _glfwCreateWindowNull(_GLFWwindow* window,
 void _glfwDestroyWindowNull(_GLFWwindow* window)
 {
     if (window->monitor)
-        releaseMonitorNull(window);
+        releaseMonitor(window);
 
     if (_glfw.null.focusedWindow == window)
         _glfw.null.focusedWindow = NULL;
@@ -205,14 +204,14 @@ void _glfwSetWindowMonitorNull(_GLFWwindow* window,
     }
 
     if (window->monitor)
-        releaseMonitorNull(window);
+        releaseMonitor(window);
 
     _glfwInputWindowMonitor(window, monitor);
 
     if (window->monitor)
     {
         window->null.visible = GLFW_TRUE;
-        acquireMonitorNull(window);
+        acquireMonitor(window);
         fitToMonitor(window);
     }
     else
@@ -342,7 +341,7 @@ void _glfwIconifyWindowNull(_GLFWwindow* window)
         _glfwInputWindowIconify(window, GLFW_TRUE);
 
         if (window->monitor)
-            releaseMonitorNull(window);
+            releaseMonitor(window);
     }
 }
 
@@ -354,7 +353,7 @@ void _glfwRestoreWindowNull(_GLFWwindow* window)
         _glfwInputWindowIconify(window, GLFW_FALSE);
 
         if (window->monitor)
-            acquireMonitorNull(window);
+            acquireMonitor(window);
     }
     else if (window->null.maximized)
     {

--- a/src/external/glfw/src/platform.c
+++ b/src/external/glfw/src/platform.c
@@ -74,9 +74,6 @@ GLFWbool _glfwSelectPlatform(int desiredID, _GLFWplatform* platform)
         return GLFW_FALSE;
     }
 
-    //Modification for raylib: this Null platform check is removed because it is
-    //not used by raylib
-#if 0
     // Only allow the Null platform if specifically requested
     if (desiredID == GLFW_PLATFORM_NULL)
         return _glfwConnectNull(desiredID, platform);
@@ -85,7 +82,6 @@ GLFWbool _glfwSelectPlatform(int desiredID, _GLFWplatform* platform)
         _glfwInputError(GLFW_PLATFORM_UNAVAILABLE, "This binary only supports the Null platform");
         return GLFW_FALSE;
     }
-#endif
 
 #if defined(_GLFW_WAYLAND) && defined(_GLFW_X11)
     if (desiredID == GLFW_ANY_PLATFORM)

--- a/src/external/glfw/src/win32_init.c
+++ b/src/external/glfw/src/win32_init.c
@@ -1,9 +1,8 @@
 //========================================================================
-// GLFW 3.5 Win32 (modified for raylib) - www.glfw.org; www.raylib.com
+// GLFW 3.5 Win32 - www.glfw.org
 //------------------------------------------------------------------------
 // Copyright (c) 2002-2006 Marcus Geelnard
 // Copyright (c) 2006-2019 Camilla Löwy <elmindreda@glfw.org>
-// Copyright (c) 2024-2026 M374LX <wilsalx@gmail.com>
 //
 // This software is provided 'as-is', without any express or implied
 // warranty. In no event will the authors be held liable for any damages
@@ -169,7 +168,7 @@ static GLFWbool loadLibraries(void)
 
 // Create key code translation tables
 //
-static void createKeyTablesWin32(void)
+static void createKeyTables(void)
 {
     int scancode;
 
@@ -660,7 +659,7 @@ int _glfwInitWin32(void)
     if (!loadLibraries())
         return GLFW_FALSE;
 
-    createKeyTablesWin32();
+    createKeyTables();
     _glfwUpdateKeyNamesWin32();
 
     if (_glfwIsWindows10Version1703OrGreaterWin32())

--- a/src/external/glfw/src/win32_window.c
+++ b/src/external/glfw/src/win32_window.c
@@ -1,9 +1,8 @@
 //========================================================================
-// GLFW 3.5 Win32 (modified for raylib) - www.glfw.org; www.raylib.com
+// GLFW 3.5 Win32 - www.glfw.org
 //------------------------------------------------------------------------
 // Copyright (c) 2002-2006 Marcus Geelnard
 // Copyright (c) 2006-2019 Camilla Löwy <elmindreda@glfw.org>
-// Copyright (c) 2024-2026 M374LX <wilsalx@gmail.com>
 //
 // This software is provided 'as-is', without any express or implied
 // warranty. In no event will the authors be held liable for any damages
@@ -438,7 +437,7 @@ static void fitToMonitor(_GLFWwindow* window)
 
 // Make the specified window and its video mode active on its monitor
 //
-static void acquireMonitorWin32(_GLFWwindow* window)
+static void acquireMonitor(_GLFWwindow* window)
 {
     if (!_glfw.win32.acquiredMonitorCount)
     {
@@ -459,7 +458,7 @@ static void acquireMonitorWin32(_GLFWwindow* window)
 
 // Remove the window and restore the original video mode
 //
-static void releaseMonitorWin32(_GLFWwindow* window)
+static void releaseMonitor(_GLFWwindow* window)
 {
     if (window->monitor->window != window)
         return;
@@ -469,7 +468,7 @@ static void releaseMonitorWin32(_GLFWwindow* window)
     {
         SetThreadExecutionState(ES_CONTINUOUS);
 
-        // HACK: Restore mouse trail length saved in acquireMonitorWin32
+        // HACK: Restore mouse trail length saved in acquireMonitor
         SystemParametersInfoW(SPI_SETMOUSETRAILS, _glfw.win32.mouseTrailSize, 0, 0);
     }
 
@@ -1049,10 +1048,10 @@ static LRESULT CALLBACK windowProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM l
             if (window->monitor && window->win32.iconified != iconified)
             {
                 if (iconified)
-                    releaseMonitorWin32(window);
+                    releaseMonitor(window);
                 else
                 {
-                    acquireMonitorWin32(window);
+                    acquireMonitor(window);
                     fitToMonitor(window);
                 }
             }
@@ -1527,7 +1526,7 @@ GLFWbool _glfwCreateWindowWin32(_GLFWwindow* window,
     {
         _glfwShowWindowWin32(window);
         _glfwFocusWindowWin32(window);
-        acquireMonitorWin32(window);
+        acquireMonitor(window);
         fitToMonitor(window);
 
         if (wndconfig->centerCursor)
@@ -1549,7 +1548,7 @@ GLFWbool _glfwCreateWindowWin32(_GLFWwindow* window,
 void _glfwDestroyWindowWin32(_GLFWwindow* window)
 {
     if (window->monitor)
-        releaseMonitorWin32(window);
+        releaseMonitor(window);
 
     if (window->context.destroy)
         window->context.destroy(window);
@@ -1670,7 +1669,7 @@ void _glfwSetWindowSizeWin32(_GLFWwindow* window, int width, int height)
     {
         if (window->monitor->window == window)
         {
-            acquireMonitorWin32(window);
+            acquireMonitor(window);
             fitToMonitor(window);
         }
     }
@@ -1842,7 +1841,7 @@ void _glfwSetWindowMonitorWin32(_GLFWwindow* window,
         {
             if (monitor->window == window)
             {
-                acquireMonitorWin32(window);
+                acquireMonitor(window);
                 fitToMonitor(window);
             }
         }
@@ -1872,7 +1871,7 @@ void _glfwSetWindowMonitorWin32(_GLFWwindow* window,
     }
 
     if (window->monitor)
-        releaseMonitorWin32(window);
+        releaseMonitor(window);
 
     _glfwInputWindowMonitor(window, monitor);
 
@@ -1890,7 +1889,7 @@ void _glfwSetWindowMonitorWin32(_GLFWwindow* window,
             flags |= SWP_FRAMECHANGED;
         }
 
-        acquireMonitorWin32(window);
+        acquireMonitor(window);
 
         GetMonitorInfoW(window->monitor->win32.handle, &mi);
         SetWindowPos(window->win32.handle, HWND_TOPMOST,

--- a/src/external/glfw/src/wl_init.c
+++ b/src/external/glfw/src/wl_init.c
@@ -1,8 +1,7 @@
 //========================================================================
-// GLFW 3.5 Wayland (modified for raylib) - www.glfw.org; www.raylib.com
+// GLFW 3.5 Wayland - www.glfw.org
 //------------------------------------------------------------------------
 // Copyright (c) 2014 Jonas Ådahl <jadahl@gmail.com>
-// Copyright (c) 2024-2026 M374LX <wilsalx@gmail.com>
 //
 // This software is provided 'as-is', without any express or implied
 // warranty. In no event will the authors be held liable for any damages
@@ -255,7 +254,7 @@ static const struct wl_callback_listener libdecorReadyListener =
 
 // Create key code translation tables
 //
-static void createKeyTablesWayland(void)
+static void createKeyTables(void)
 {
     memset(_glfw.wl.keycodes, -1, sizeof(_glfw.wl.keycodes));
     memset(_glfw.wl.scancodes, -1, sizeof(_glfw.wl.scancodes));
@@ -847,7 +846,7 @@ int _glfwInitWayland(void)
     _glfw.wl.registry = wl_display_get_registry(_glfw.wl.display);
     wl_registry_add_listener(_glfw.wl.registry, &registryListener, NULL);
 
-    createKeyTablesWayland();
+    createKeyTables();
 
     _glfw.wl.keyRepeatTimerfd =
         timerfd_create(CLOCK_MONOTONIC, TFD_CLOEXEC | TFD_NONBLOCK);

--- a/src/external/glfw/src/wl_window.c
+++ b/src/external/glfw/src/wl_window.c
@@ -1,8 +1,7 @@
 //========================================================================
-// GLFW 3.5 Wayland (modified for raylib) - www.glfw.org; www.raylib.com
+// GLFW 3.5 Wayland - www.glfw.org
 //------------------------------------------------------------------------
 // Copyright (c) 2014 Jonas Ådahl <jadahl@gmail.com>
-// Copyright (c) 2024-2026 M374LX <wilsalx@gmail.com>
 //
 // This software is provided 'as-is', without any express or implied
 // warranty. In no event will the authors be held liable for any damages
@@ -663,7 +662,7 @@ static void setIdleInhibitor(_GLFWwindow* window, GLFWbool enable)
 
 // Make the specified window and its video mode active on its monitor
 //
-static void acquireMonitorWayland(_GLFWwindow* window)
+static void acquireMonitor(_GLFWwindow* window)
 {
     if (window->wl.libdecor.frame)
     {
@@ -684,7 +683,7 @@ static void acquireMonitorWayland(_GLFWwindow* window)
 
 // Remove the window and restore the original video mode
 //
-static void releaseMonitorWayland(_GLFWwindow* window)
+static void releaseMonitor(_GLFWwindow* window)
 {
     if (window->wl.libdecor.frame)
         libdecor_frame_unset_fullscreen(window->wl.libdecor.frame);
@@ -1329,7 +1328,7 @@ static GLFWbool flushDisplay(void)
     return GLFW_TRUE;
 }
 
-static int translateKeyWayland(uint32_t scancode)
+static int translateKey(uint32_t scancode)
 {
     if (scancode < sizeof(_glfw.wl.keycodes) / sizeof(_glfw.wl.keycodes[0]))
         return _glfw.wl.keycodes[scancode];
@@ -1453,7 +1452,7 @@ static void handleEvents(double* timeout)
                     for (uint64_t i = 0; i < repeats; i++)
                     {
                         _glfwInputKey(_glfw.wl.keyboardFocus,
-                                      translateKeyWayland(_glfw.wl.keyRepeatScancode),
+                                      translateKey(_glfw.wl.keyRepeatScancode),
                                       _glfw.wl.keyRepeatScancode,
                                       GLFW_PRESS,
                                       _glfw.wl.xkb.modifiers);
@@ -1963,7 +1962,7 @@ static void keyboardHandleKey(void* userData,
     if (!window)
         return;
 
-    const int key = translateKeyWayland(scancode);
+    const int key = translateKey(scancode);
     const int action =
         state == WL_KEYBOARD_KEY_STATE_PRESSED ? GLFW_PRESS : GLFW_RELEASE;
 
@@ -2810,12 +2809,12 @@ void _glfwSetWindowMonitorWayland(_GLFWwindow* window,
     }
 
     if (window->monitor)
-        releaseMonitorWayland(window);
+        releaseMonitor(window);
 
     _glfwInputWindowMonitor(window, monitor);
 
     if (window->monitor)
-        acquireMonitorWayland(window);
+        acquireMonitor(window);
     else
         _glfwSetWindowSizeWayland(window, width, height);
 }

--- a/src/external/glfw/src/x11_init.c
+++ b/src/external/glfw/src/x11_init.c
@@ -1,9 +1,8 @@
 //========================================================================
-// GLFW 3.5 X11 (modified for raylib) - www.glfw.org; www.raylib.com
+// GLFW 3.5 X11 - www.glfw.org
 //------------------------------------------------------------------------
 // Copyright (c) 2002-2006 Marcus Geelnard
 // Copyright (c) 2006-2019 Camilla Löwy <elmindreda@glfw.org>
-// Copyright (c) 2024-2026 M374LX <wilsalx@gmail.com>
 //
 // This software is provided 'as-is', without any express or implied
 // warranty. In no event will the authors be held liable for any damages
@@ -211,7 +210,7 @@ static int translateKeySyms(const KeySym* keysyms, int width)
 
 // Create key code translation tables
 //
-static void createKeyTablesX11(void)
+static void createKeyTables(void)
 {
     int scancodeMin, scancodeMax;
 
@@ -910,7 +909,7 @@ static GLFWbool initExtensions(void)
     // Update the key code LUT
     // FIXME: We should listen to XkbMapNotify events to track changes to
     // the keyboard mapping.
-    createKeyTablesX11();
+    createKeyTables();
 
     // String format atoms
     _glfw.x11.NULL_ = XInternAtom(_glfw.x11.display, "NULL", False);

--- a/src/external/glfw/src/x11_window.c
+++ b/src/external/glfw/src/x11_window.c
@@ -1,9 +1,8 @@
 //========================================================================
-// GLFW 3.5 X11 (modified for raylib) - www.glfw.org; www.raylib.com
+// GLFW 3.5 X11 - www.glfw.org
 //------------------------------------------------------------------------
 // Copyright (c) 2002-2006 Marcus Geelnard
 // Copyright (c) 2006-2019 Camilla Löwy <elmindreda@glfw.org>
-// Copyright (c) 2024-2026 M374LX
 //
 // This software is provided 'as-is', without any express or implied
 // warranty. In no event will the authors be held liable for any damages
@@ -236,9 +235,9 @@ static int translateState(int state)
 
 // Translates an X11 key code to a GLFW key token
 //
-static int translateKeyX11(int scancode)
+static int translateKey(int scancode)
 {
-    // Use the pre-filled LUT (see createKeyTablesX11() in x11_init.c)
+    // Use the pre-filled LUT (see createKeyTables() in x11_init.c)
     if (scancode < 0 || scancode > 255)
         return GLFW_KEY_UNKNOWN;
 
@@ -1086,7 +1085,7 @@ static const char* getSelectionString(Atom selection)
 
 // Make the specified window and its video mode active on its monitor
 //
-static void acquireMonitorX11(_GLFWwindow* window)
+static void acquireMonitor(_GLFWwindow* window)
 {
     if (_glfw.x11.saver.count == 0)
     {
@@ -1125,7 +1124,7 @@ static void acquireMonitorX11(_GLFWwindow* window)
 
 // Remove the window and restore the original video mode
 //
-static void releaseMonitorX11(_GLFWwindow* window)
+static void releaseMonitor(_GLFWwindow* window)
 {
     if (window->monitor->window != window)
         return;
@@ -1247,7 +1246,7 @@ static void processEvent(XEvent *event)
 
         case KeyPress:
         {
-            const int key = translateKeyX11(keycode);
+            const int key = translateKey(keycode);
             const int mods = translateState(event->xkey.state);
             const int plain = !(mods & (GLFW_MOD_CONTROL | GLFW_MOD_ALT));
 
@@ -1319,7 +1318,7 @@ static void processEvent(XEvent *event)
 
         case KeyRelease:
         {
-            const int key = translateKeyX11(keycode);
+            const int key = translateKey(keycode);
             const int mods = translateState(event->xkey.state);
 
             if (!_glfw.x11.xkb.detectable)
@@ -1811,9 +1810,9 @@ static void processEvent(XEvent *event)
                     if (window->monitor)
                     {
                         if (iconified)
-                            releaseMonitorX11(window);
+                            releaseMonitor(window);
                         else
-                            acquireMonitorX11(window);
+                            acquireMonitor(window);
                     }
 
                     window->x11.iconified = iconified;
@@ -2030,7 +2029,7 @@ GLFWbool _glfwCreateWindowX11(_GLFWwindow* window,
     {
         _glfwShowWindowX11(window);
         updateWindowMode(window);
-        acquireMonitorX11(window);
+        acquireMonitor(window);
 
         if (wndconfig->centerCursor)
             _glfwCenterCursorInContentArea(window);
@@ -2055,7 +2054,7 @@ void _glfwDestroyWindowX11(_GLFWwindow* window)
         enableCursor(window);
 
     if (window->monitor)
-        releaseMonitorX11(window);
+        releaseMonitor(window);
 
     if (window->x11.ic)
     {
@@ -2215,7 +2214,7 @@ void _glfwSetWindowSizeX11(_GLFWwindow* window, int width, int height)
     if (window->monitor)
     {
         if (window->monitor->window == window)
-            acquireMonitorX11(window);
+            acquireMonitor(window);
     }
     else
     {
@@ -2518,7 +2517,7 @@ void _glfwSetWindowMonitorX11(_GLFWwindow* window,
         if (monitor)
         {
             if (monitor->window == window)
-                acquireMonitorX11(window);
+                acquireMonitor(window);
         }
         else
         {
@@ -2537,7 +2536,7 @@ void _glfwSetWindowMonitorX11(_GLFWwindow* window,
     {
         _glfwSetWindowDecoratedX11(window, window->decorated);
         _glfwSetWindowFloatingX11(window, window->floating);
-        releaseMonitorX11(window);
+        releaseMonitor(window);
     }
 
     _glfwInputWindowMonitor(window, monitor);
@@ -2552,7 +2551,7 @@ void _glfwSetWindowMonitorX11(_GLFWwindow* window,
         }
 
         updateWindowMode(window);
-        acquireMonitorX11(window);
+        acquireMonitor(window);
     }
     else
     {

--- a/src/rglfw.c
+++ b/src/rglfw.c
@@ -77,6 +77,8 @@
 #include "external/glfw/src/window.c"
 #include "external/glfw/src/input.c"
 #include "external/glfw/src/vulkan.c"
+#include "external/glfw/src/egl_context.c"
+#include "external/glfw/src/osmesa_context.c"
 
 #if defined(_WIN32) || defined(__CYGWIN__)
     #include "external/glfw/src/win32_init.c"
@@ -87,9 +89,6 @@
     #include "external/glfw/src/win32_time.c"
     #include "external/glfw/src/win32_thread.c"
     #include "external/glfw/src/wgl_context.c"
-
-    #include "external/glfw/src/egl_context.c"
-    #include "external/glfw/src/osmesa_context.c"
 #endif
 
 #if defined(__linux__)
@@ -99,9 +98,6 @@
     #include "external/glfw/src/posix_poll.c"
     #include "external/glfw/src/linux_joystick.c"
     #include "external/glfw/src/xkb_unicode.c"
-
-    #include "external/glfw/src/egl_context.c"
-    #include "external/glfw/src/osmesa_context.c"
 
     #if defined(_GLFW_WAYLAND)
         //These functions need to be temporarily renamed because including
@@ -154,9 +150,6 @@
     #include "external/glfw/src/x11_monitor.c"
     #include "external/glfw/src/x11_window.c"
     #include "external/glfw/src/glx_context.c"
-
-    #include "external/glfw/src/egl_context.c"
-    #include "external/glfw/src/osmesa_context.c"
 #endif
 
 #if defined(__APPLE__)
@@ -168,7 +161,4 @@
     #include "external/glfw/src/cocoa_window.m"
     #include "external/glfw/src/macos_time.c"
     #include "external/glfw/src/nsgl_context.m"
-
-    #include "external/glfw/src/egl_context.c"
-    #include "external/glfw/src/osmesa_context.c"
 #endif

--- a/src/rglfw.c
+++ b/src/rglfw.c
@@ -80,6 +80,13 @@
 #include "external/glfw/src/egl_context.c"
 #include "external/glfw/src/osmesa_context.c"
 
+//We need to define this function because GLFW calls it even though raylib does
+//not use GLFW's Null platform
+GLFWbool _glfwConnectNull(int platformID, _GLFWplatform* platform)
+{
+    return GLFW_FALSE;
+}
+
 #if defined(_WIN32) || defined(__CYGWIN__)
     #include "external/glfw/src/win32_init.c"
     #include "external/glfw/src/win32_module.c"

--- a/src/rglfw.c
+++ b/src/rglfw.c
@@ -104,15 +104,41 @@
     #include "external/glfw/src/osmesa_context.c"
 
     #if defined(_GLFW_WAYLAND)
+        //These functions need to be temporarily renamed because including
+        //source files for both Wayland and X11 results in pairs of functions
+        //with the same name and thus a build error
+        #define  createKeyTables createKeyTablesWayland
+        #define  translateKey    translateKeyWayland
+        #define  acquireMonitor  acquireMonitorWayland
+        #define  releaseMonitor  releaseMonitorWayland
+
         #include "external/glfw/src/wl_init.c"
         #include "external/glfw/src/wl_monitor.c"
         #include "external/glfw/src/wl_window.c"
+
+        #undef   createKeyTables
+        #undef   translateKey
+        #undef   acquireMonitor
+        #undef   releaseMonitor
     #endif
     #if defined(_GLFW_X11)
+        //These functions need to be temporarily renamed because including
+        //source files for both Wayland and X11 results in pairs of functions
+        //with the same name and thus a build error
+        #define  createKeyTables createKeyTablesX11
+        #define  translateKey    translateKeyX11
+        #define  acquireMonitor  acquireMonitorX11
+        #define  releaseMonitor  releaseMonitorX11
+
         #include "external/glfw/src/x11_init.c"
         #include "external/glfw/src/x11_monitor.c"
         #include "external/glfw/src/x11_window.c"
         #include "external/glfw/src/glx_context.c"
+
+        #undef   createKeyTables
+        #undef   translateKey
+        #undef   acquireMonitor
+        #undef   releaseMonitor
     #endif
 #endif
 


### PR DESCRIPTION
Turns out that we can use an unmodified GLFW and thus free raylib from this burden when updating the library.

We only need to temporarily rename four functions using ``#define`` and ``#undef`` and define an empty function named ``_glfwConnectNull()`` in ``rglfw.c``.