### PR TITLE
[rcore_web_emscripten] Fix time calculation in GetTime function

### DIFF
--- a/src/platforms/rcore_web_emscripten.c
+++ b/src/platforms/rcore_web_emscripten.c
@@ -962,7 +962,7 @@ void SwapScreenBuffer(void)
 // Get elapsed time measure in seconds since InitTimer()
 double GetTime(void)
 {
-    double time = emscripten_get_now()*1000.0;
+    double time = emscripten_get_now()/1000.0;
 
     return time;
 }


### PR DESCRIPTION
emscripten_get_now returns milliseconds, need to divide not multiply to get seconds.

Also, should I even be using this platform? I'm confused about the web platforms.