### PR TITLE
[rAduio] Add user data to Audio Stream callbacks

### DIFF
--- a/examples/audio/audio_stream_callback.c
+++ b/examples/audio/audio_stream_callback.c
@@ -39,10 +39,10 @@ typedef enum {
 //------------------------------------------------------------------------------------
 // Module Functions Declaration
 //------------------------------------------------------------------------------------
-static void SineCallback(void *framesOut, unsigned int frameCount);
-static void SquareCallback(void *framesOut, unsigned int frameCount);
-static void TriangleCallback(void *framesOut, unsigned int frameCount);
-static void SawtoothCallback(void *framesOut, unsigned int frameCount);
+static void SineCallback(void *framesOut, unsigned int frameCount, void* userData);
+static void SquareCallback(void *framesOut, unsigned int frameCount, void* userData);
+static void TriangleCallback(void *framesOut, unsigned int frameCount, void* userData);
+static void SawtoothCallback(void *framesOut, unsigned int frameCount, void* userData);
 
 static int waveFrequency = 440;
 static int newWaveFrequency = 440;
@@ -156,7 +156,7 @@ int main(void)
 //------------------------------------------------------------------------------------
 // Module Functions Definition
 //------------------------------------------------------------------------------------
-static void SineCallback(void *framesOut, unsigned int frameCount)
+static void SineCallback(void *framesOut, unsigned int frameCount, void* userData)
 {
     int wavelength = SAMPLE_RATE/waveFrequency;
 
@@ -179,7 +179,7 @@ static void SineCallback(void *framesOut, unsigned int frameCount)
     for (unsigned int i = 0; i < frameCount; i++) buffer[SAMPLE_RATE - frameCount + i] = ((float *)framesOut)[i];
 }
 
-static void SquareCallback(void *framesOut, unsigned int frameCount)
+static void SquareCallback(void *framesOut, unsigned int frameCount, void* userData)
 {
     int wavelength = SAMPLE_RATE/waveFrequency;
 
@@ -201,7 +201,7 @@ static void SquareCallback(void *framesOut, unsigned int frameCount)
     for (unsigned int i = 0; i < frameCount; i++) buffer[SAMPLE_RATE - frameCount + i] = ((float *)framesOut)[i];
 }
 
-static void TriangleCallback(void *framesOut, unsigned int frameCount)
+static void TriangleCallback(void *framesOut, unsigned int frameCount, void* userData)
 {
     int wavelength = SAMPLE_RATE/waveFrequency;
 
@@ -223,7 +223,7 @@ static void TriangleCallback(void *framesOut, unsigned int frameCount)
     for (unsigned int i = 0; i < frameCount; i++) buffer[SAMPLE_RATE - frameCount + i] = ((float *)framesOut)[i];
 }
 
-static void SawtoothCallback(void *framesOut, unsigned int frameCount)
+static void SawtoothCallback(void *framesOut, unsigned int frameCount, void* userData)
 {
     int wavelength = SAMPLE_RATE/waveFrequency;
 

--- a/src/raudio.c
+++ b/src/raudio.c
@@ -348,6 +348,7 @@ struct rAudioBuffer {
     unsigned int converterResidualCount;    // The number of valid frames sitting in converterResidual
 
     AudioCallback callback;         // Audio buffer callback for buffer filling on audio threads
+    void* userData;
     rAudioProcessor *processor;     // Audio processor
 
     float volume;                   // Audio buffer volume
@@ -374,6 +375,7 @@ struct rAudioBuffer {
 // NOTE: Useful to apply effects to an AudioBuffer
 struct rAudioProcessor {
     AudioCallback process;          // Processor callback function
+    void* userData;
     rAudioProcessor *next;          // Next audio processor on the list
     rAudioProcessor *prev;          // Previous audio processor on the list
 };
@@ -2256,10 +2258,16 @@ void SetAudioStreamBufferSizeDefault(int size)
 // Audio thread callback to request new data
 void SetAudioStreamCallback(AudioStream stream, AudioCallback callback)
 {
+    SetAudioStreamCallbackEX(stream, callback, NULL);
+}
+
+void SetAudioStreamCallbackEX(AudioStream stream, AudioCallback callback, void* userData)
+{
     if (stream.buffer != NULL)
     {
         ma_mutex_lock(&AUDIO.System.lock);
         stream.buffer->callback = callback;
+        stream.buffer->userData = userData;
         ma_mutex_unlock(&AUDIO.System.lock);
     }
 }
@@ -2273,6 +2281,7 @@ void AttachAudioStreamProcessor(AudioStream stream, AudioCallback process)
 
     rAudioProcessor *processor = (rAudioProcessor *)RL_CALLOC(1, sizeof(rAudioProcessor));
     processor->process = process;
+    processor->userData = stream.buffer->userData;
 
     rAudioProcessor *last = stream.buffer->processor;
 
@@ -2326,7 +2335,8 @@ void AttachAudioMixedProcessor(AudioCallback process)
 
     rAudioProcessor *processor = (rAudioProcessor *)RL_CALLOC(1, sizeof(rAudioProcessor));
     processor->process = process;
-
+    processor->userData = NULL;
+	
     rAudioProcessor *last = AUDIO.mixedProcessor;
 
     while (last && last->next)
@@ -2388,7 +2398,7 @@ static ma_uint32 ReadAudioBufferFramesInInternalFormat(AudioBuffer *audioBuffer,
     // Using audio buffer callback
     if (audioBuffer->callback)
     {
-        audioBuffer->callback(framesOut, frameCount);
+        audioBuffer->callback(framesOut, frameCount, audioBuffer->userData);
         audioBuffer->framesProcessed += frameCount;
 
         return frameCount;
@@ -2603,7 +2613,7 @@ static void OnSendAudioDataToDevice(ma_device *pDevice, void *pFramesOut, const 
                         rAudioProcessor *processor = audioBuffer->processor;
                         while (processor)
                         {
-                            processor->process(framesIn, framesJustRead);
+                            processor->process(framesIn, framesJustRead, audioBuffer->userData);
                             processor = processor->next;
                         }
 
@@ -2647,7 +2657,7 @@ static void OnSendAudioDataToDevice(ma_device *pDevice, void *pFramesOut, const 
     rAudioProcessor *processor = AUDIO.mixedProcessor;
     while (processor)
     {
-        processor->process(pFramesOut, frameCount);
+        processor->process(pFramesOut, frameCount, processor->userData);
         processor = processor->next;
     }
 

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1671,7 +1671,7 @@ RLAPI RayCollision GetRayCollisionQuad(Ray ray, Vector3 p1, Vector3 p2, Vector3 
 //------------------------------------------------------------------------------------
 // Audio Loading and Playing Functions (Module: audio)
 //------------------------------------------------------------------------------------
-typedef void (*AudioCallback)(void *bufferData, unsigned int frames);
+typedef void (*AudioCallback)(void *bufferData, unsigned int frames, void* userData);
 
 // Audio device management functions
 RLAPI void InitAudioDevice(void);                                     // Initialize audio device and context

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1744,6 +1744,7 @@ RLAPI void SetAudioStreamPitch(AudioStream stream, float pitch);      // Set pit
 RLAPI void SetAudioStreamPan(AudioStream stream, float pan);          // Set pan for audio stream (-1.0 left, 0.0 center, 1.0 right)
 RLAPI void SetAudioStreamBufferSizeDefault(int size);                 // Default size for new audio streams
 RLAPI void SetAudioStreamCallback(AudioStream stream, AudioCallback callback); // Audio thread callback to request new data
+RLAPI void SetAudioStreamCallbackEX(AudioStream stream, AudioCallback callback, void* userData); // Audio thread callback to request new data with user data
 
 RLAPI void AttachAudioStreamProcessor(AudioStream stream, AudioCallback processor); // Attach audio stream processor to stream, receives frames x 2 samples as 'float' (stereo)
 RLAPI void DetachAudioStreamProcessor(AudioStream stream, AudioCallback processor); // Detach audio stream processor from stream

--- a/tools/rlparser/output/raylib_api.json
+++ b/tools/rlparser/output/raylib_api.json
@@ -12800,6 +12800,25 @@
       ]
     },
     {
+      "name": "SetAudioStreamCallbackEX",
+      "description": "Audio thread callback to request new data with user data",
+      "returnType": "void",
+      "params": [
+        {
+          "type": "AudioStream",
+          "name": "stream"
+        },
+        {
+          "type": "AudioCallback",
+          "name": "callback"
+        },
+        {
+          "type": "void*",
+          "name": "userData"
+        }
+      ]
+    },
+    {
       "name": "AttachAudioStreamProcessor",
       "description": "Attach audio stream processor to stream, receives frames x 2 samples as 'float' (stereo)",
       "returnType": "void",

--- a/tools/rlparser/output/raylib_api.json
+++ b/tools/rlparser/output/raylib_api.json
@@ -3161,6 +3161,10 @@
         {
           "type": "unsigned int",
           "name": "frames"
+        },
+        {
+          "type": "void*",
+          "name": "userData"
         }
       ]
     }

--- a/tools/rlparser/output/raylib_api.lua
+++ b/tools/rlparser/output/raylib_api.lua
@@ -8612,6 +8612,16 @@ return {
       }
     },
     {
+      name = "SetAudioStreamCallbackEX",
+      description = "Audio thread callback to request new data with user data",
+      returnType = "void",
+      params = {
+        {type = "AudioStream", name = "stream"},
+        {type = "AudioCallback", name = "callback"},
+        {type = "void*", name = "userData"}
+      }
+    },
+    {
       name = "AttachAudioStreamProcessor",
       description = "Attach audio stream processor to stream, receives frames x 2 samples as 'float' (stereo)",
       returnType = "void",

--- a/tools/rlparser/output/raylib_api.lua
+++ b/tools/rlparser/output/raylib_api.lua
@@ -3122,7 +3122,8 @@ return {
       returnType = "void",
       params = {
         {type = "void *", name = "bufferData"},
-        {type = "unsigned int", name = "frames"}
+        {type = "unsigned int", name = "frames"},
+        {type = "void*", name = "userData"}
       }
     }
   },

--- a/tools/rlparser/output/raylib_api.sexpr
+++ b/tools/rlparser/output/raylib_api.sexpr
@@ -6567,6 +6567,14 @@
        ((type "AudioStream") (name "stream"))
        ((type "AudioCallback") (name "callback"))))
 
+    ((name "SetAudioStreamCallbackEX")
+     (description "Audio thread callback to request new data with user data")
+     (return-type "void")
+     (params
+       ((type "AudioStream") (name "stream"))
+       ((type "AudioCallback") (name "callback"))
+       ((type "void*") (name "userData"))))
+
     ((name "AttachAudioStreamProcessor")
      (description "Attach audio stream processor to stream, receives frames x 2 samples as 'float' (stereo)")
      (return-type "void")

--- a/tools/rlparser/output/raylib_api.sexpr
+++ b/tools/rlparser/output/raylib_api.sexpr
@@ -2217,7 +2217,8 @@
      (return-type "void")
      (params
        ((type "void *") (name "bufferData"))
-       ((type "unsigned int") (name "frames")))))
+       ((type "unsigned int") (name "frames"))
+       ((type "void*") (name "userData")))))
 
   (functions
     ((name "InitWindow")

--- a/tools/rlparser/output/raylib_api.txt
+++ b/tools/rlparser/output/raylib_api.txt
@@ -995,7 +995,7 @@ Callback 006: AudioCallback() (2 input parameters)
   Param[1]: bufferData (type: void *)
   Param[2]: frames (type: unsigned int)
 
-Functions found: 613
+Functions found: 614
 
 Function 001: InitWindow() (3 input parameters)
   Name: InitWindow
@@ -4897,24 +4897,31 @@ Function 609: SetAudioStreamCallback() (2 input parameters)
   Description: Audio thread callback to request new data
   Param[1]: stream (type: AudioStream)
   Param[2]: callback (type: AudioCallback)
-Function 610: AttachAudioStreamProcessor() (2 input parameters)
+Function 610: SetAudioStreamCallbackEX() (3 input parameters)
+  Name: SetAudioStreamCallbackEX
+  Return type: void
+  Description: Audio thread callback to request new data with user data
+  Param[1]: stream (type: AudioStream)
+  Param[2]: callback (type: AudioCallback)
+  Param[3]: userData (type: void*)
+Function 611: AttachAudioStreamProcessor() (2 input parameters)
   Name: AttachAudioStreamProcessor
   Return type: void
   Description: Attach audio stream processor to stream, receives frames x 2 samples as 'float' (stereo)
   Param[1]: stream (type: AudioStream)
   Param[2]: processor (type: AudioCallback)
-Function 611: DetachAudioStreamProcessor() (2 input parameters)
+Function 612: DetachAudioStreamProcessor() (2 input parameters)
   Name: DetachAudioStreamProcessor
   Return type: void
   Description: Detach audio stream processor from stream
   Param[1]: stream (type: AudioStream)
   Param[2]: processor (type: AudioCallback)
-Function 612: AttachAudioMixedProcessor() (1 input parameters)
+Function 613: AttachAudioMixedProcessor() (1 input parameters)
   Name: AttachAudioMixedProcessor
   Return type: void
   Description: Attach audio stream processor to the entire audio pipeline, receives frames x 2 samples as 'float' (stereo)
   Param[1]: processor (type: AudioCallback)
-Function 613: DetachAudioMixedProcessor() (1 input parameters)
+Function 614: DetachAudioMixedProcessor() (1 input parameters)
   Name: DetachAudioMixedProcessor
   Return type: void
   Description: Detach audio stream processor from the entire audio pipeline

--- a/tools/rlparser/output/raylib_api.txt
+++ b/tools/rlparser/output/raylib_api.txt
@@ -988,12 +988,13 @@ Callback 005: SaveFileTextCallback() (2 input parameters)
   Description: FileIO: Save text data
   Param[1]: fileName (type: const char *)
   Param[2]: text (type: const char *)
-Callback 006: AudioCallback() (2 input parameters)
+Callback 006: AudioCallback() (3 input parameters)
   Name: AudioCallback
   Return type: void
   Description: 
   Param[1]: bufferData (type: void *)
   Param[2]: frames (type: unsigned int)
+  Param[3]: userData (type: void*)
 
 Functions found: 614
 

--- a/tools/rlparser/output/raylib_api.xml
+++ b/tools/rlparser/output/raylib_api.xml
@@ -681,7 +681,7 @@
             <Param type="unsigned int" name="frames" desc="" />
         </Callback>
     </Callbacks>
-    <Functions count="613">
+    <Functions count="614">
         <Function name="InitWindow" retType="void" paramCount="3" desc="Initialize window and OpenGL context">
             <Param type="int" name="width" desc="" />
             <Param type="int" name="height" desc="" />
@@ -3282,6 +3282,11 @@
         <Function name="SetAudioStreamCallback" retType="void" paramCount="2" desc="Audio thread callback to request new data">
             <Param type="AudioStream" name="stream" desc="" />
             <Param type="AudioCallback" name="callback" desc="" />
+        </Function>
+        <Function name="SetAudioStreamCallbackEX" retType="void" paramCount="3" desc="Audio thread callback to request new data with user data">
+            <Param type="AudioStream" name="stream" desc="" />
+            <Param type="AudioCallback" name="callback" desc="" />
+            <Param type="void*" name="userData" desc="" />
         </Function>
         <Function name="AttachAudioStreamProcessor" retType="void" paramCount="2" desc="Attach audio stream processor to stream, receives frames x 2 samples as 'float' (stereo)">
             <Param type="AudioStream" name="stream" desc="" />

--- a/tools/rlparser/output/raylib_api.xml
+++ b/tools/rlparser/output/raylib_api.xml
@@ -676,9 +676,10 @@
             <Param type="const char *" name="fileName" desc="" />
             <Param type="const char *" name="text" desc="" />
         </Callback>
-        <Callback name="AudioCallback" retType="void" paramCount="2" desc="">
+        <Callback name="AudioCallback" retType="void" paramCount="3" desc="">
             <Param type="void *" name="bufferData" desc="" />
             <Param type="unsigned int" name="frames" desc="" />
+            <Param type="void*" name="userData" desc="" />
         </Callback>
     </Callbacks>
     <Functions count="614">


### PR DESCRIPTION
The current audio stream callback does not provide a way for the calling app to pass any user data to the callback that is run by the audio thread. This means that a calling app must have one compile time callback per audio stream since there is no way for it to know what stream the callback goes with.
This PR adds an EX version of the Add Stream Callback function that takes a void* that is passed to the callback, this way users can pass state data to the callback and make it more useful. 

This is a pretty standard way of passing user data into callbacks that the advanced users who are using the callbacks should understand.

This IS a breaking change, all existing callbacks will need a new argument, but it can be ignored. I feel the feature is not used commonly so the added functionality is worth the hassle of making current users perform a small update to the code. This will also help future proof the API.