### PR TITLE
[rcore] Change GetPrevDirectoryPath() behavior to fit its description

### DIFF
--- a/src/rcore.c
+++ b/src/rcore.c
@@ -2583,19 +2583,27 @@ const char *GetPrevDirectoryPath(const char *dirPath)
 {
     static char prevDirPath[MAX_FILEPATH_LENGTH] = { 0 };
     memset(prevDirPath, 0, MAX_FILEPATH_LENGTH);
-    int dirPathLength = (int)strlen(dirPath);
 
-    if (dirPathLength <= 3) snprintf(prevDirPath, MAX_FILEPATH_LENGTH, "%s", dirPath);
-
-    for (int i = (dirPathLength - 1); (i >= 0) && (dirPathLength > 3); i--)
+    const int lastIndex = (int)strlen(dirPath) - 1;
+    bool isFile = IsPathFile(dirPath);
+    for (int i = lastIndex; i >= 0; i--)
     {
+        // If the character is a path separator.
         if ((dirPath[i] == '\\') || (dirPath[i] == '/'))
         {
-            // Check for root: "C:\" or "/"
-            if (((i == 2) && (dirPath[1] ==':')) || (i == 0)) i++;
+            // If this character is a leading '/' (e.g. the '/' in "/usr") or
+            // part of a drive root (e.g. "C:\"), include it with the result.
+            if ((i == 0) || ((i == 2) && (dirPath[1] == ':'))) i += 1;
+            // If this character is a trailing path separator (e.g. the last
+            // '/' in "/usr/bin/" or the last '\' in "C:\raylib\"), continue.
+            else if (i == lastIndex) continue;
 
-            memcpy(prevDirPath, dirPath, i);
-            break;
+            if (!isFile)
+            {
+                memcpy(prevDirPath, dirPath, i);
+                break;
+            }
+            else isFile = false;
         }
     }
 


### PR DESCRIPTION
GetPrevDirectoryPath()'s description says it gets the previous directory for a given path. After using it, I've found some cases where it fails to do that. What I'm proposing here changes its behavior like so:

```
Path                             -> Current              | New                 
-------------------------------------------------------------------------------
D:\Code\tests\raylib\test.exe    -> D:\Code\tests\raylib | D:\Code\tests          <---
test.exe                         ->                      |                     
one/file.txt                     -> one                  |                        <---
one/two/file.txt                 -> one/two              | one                    <---
/                                -> /                    | /                   
/usr/bin/game                    -> /usr/bin             | /usr/bin            
/usr/bin/game/                   -> /usr/bin/game        | /usr/bin               <---
one/two                          -> one                  | one                 
one/two/three                    -> one/two              | one/two             
one\two                          -> one                  | one                 
one\two\                         -> one\two              | one                    <---
C:\                              -> C:\                  | C:\                 
C:\raylib                        -> C:\                  | C:\                 
C:\raylib\                       -> C:\raylib            | C:\                    <---
./                               -> ./                   |                        <---
./folder                         -> .                    | .                   
./folder/                        -> ./folder             | .                      <---
~/.config/game                   -> ~/.config            | ~/.config           
~/.config/                       -> ~/.config            | ~                      <---
~                                -> ~                    |                        <---
not a path                       ->                      |                     
                                 ->                      |                     
```

Given the path in the first column, the current function returns the string in the second column and the changes return the string in the third column. The <--- arrows indicate they differ.

The specific problems I see relate to trailing path separators and paths to files.
The paths "/usr/bin" and "/usr/bin/" are the same directory but the the current function returns different strings.
The (relative) path "one/two/file.txt" is a path to a file in the directory "one/two" so the previous directory would just be "one" but the current function seems to treat the file as a directory causing "one/two" to be returned.

Regarding . ("this directory") and ~ (home folder), I'm inclined to think of them as aliases and something the application should handle rather than this library. Treating them as if they're just a regular directory name seems correct to me so the behavior there hasn't changed.