### PR TITLE
[cmake] Fix standalone configuration of examples project

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,5 +1,17 @@
 # Setup the project and settings
+cmake_minimum_required(VERSION 3.22)
 project(examples)
+
+# Include raylib's cmake helper functions, so the examples can also be
+# configured standalone (`cd examples && cmake .`) and not only as part
+# of the raylib project.
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/../cmake")
+include(AddIfFlagCompiles)
+
+# Default to the Desktop platform when configured standalone.
+if (NOT DEFINED PLATFORM)
+    set(PLATFORM "Desktop" CACHE STRING "Platform to build examples for")
+endif ()
 
 # Directories that contain examples
 set(example_dirs


### PR DESCRIPTION
## Problem

Configuring the examples as a standalone project currently fails:

```
cd examples && mkdir build && cd build && cmake ..
-- Configuring incomplete, errors occurred!
CMake Error at CMakeLists.txt:37 (add_if_flag_compiles):
  Unknown CMake command "add_if_flag_compiles".
```

Two causes:
1. `add_if_flag_compiles()` is defined in `cmake/AddIfFlagCompiles.cmake`, which is only included by the root project — never when examples are configured on their own
2. No `cmake_minimum_required()` in this file, which is a hard error on CMake 4.x

## Fix

- Add `cmake_minimum_required(VERSION 3.22)`, matching the root project
- Add `../cmake` to `CMAKE_MODULE_PATH` and include `AddIfFlagCompiles`, so the pthread/c11 flag checks work standalone
- Default `PLATFORM` to `Desktop` when it isn't inherited from a parent raylib build

## Verification (macOS 15, Intel, Apple clang 14)

- **Before:** `cmake ..` fails with `Unknown CMake command "add_if_flag_compiles"`
- **After:** standalone configure completes and generates build files for all examples
- Normal path unaffected: root project with `-DBUILD_EXAMPLES=ON` still configures and builds examples correctly

Note: after this fix, standalone configure succeeds but linking against an *installed* static raylib fails on macOS because the installed CMake package only propagates `OpenGL.framework` (`Cocoa`/`IOKit` are missing). That looks like a separate pre-existing issue — happy to file/fix it next if confirmed.