### PR TITLE
[cmake] Propagate Cocoa backend frameworks to consumers of static raylib on macOS

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,5 +1,17 @@
 # Setup the project and settings
+cmake_minimum_required(VERSION 3.22)
 project(examples)
+
+# Include raylib's cmake helper functions, so the examples can also be
+# configured standalone (`cd examples && cmake .`) and not only as part
+# of the raylib project.
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/../cmake")
+include(AddIfFlagCompiles)
+
+# Default to the Desktop platform when configured standalone.
+if (NOT DEFINED PLATFORM)
+    set(PLATFORM "Desktop" CACHE STRING "Platform to build examples for")
+endif ()
 
 # Directories that contain examples
 set(example_dirs

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -117,8 +117,9 @@ if (NOT BUILD_SHARED_LIBS)
 
         # Bundled GLFW links its Cocoa backend frameworks privately, so they
         # must be propagated to consumers of the static library, whose final
-        # link line would otherwise miss them.
-        if (APPLE)
+        # link line would otherwise miss them. Only the Desktop platform uses
+        # bundled GLFW; other platforms (e.g. Memory) have no Cocoa/GLFW symbols.
+        if (APPLE AND PLATFORM STREQUAL "Desktop")
             find_library(COCOA_FRAMEWORK Cocoa)
             find_library(IOKIT_FRAMEWORK IOKit)
             find_library(QUARTZCORE_FRAMEWORK QuartzCore)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -114,6 +114,19 @@ if (NOT BUILD_SHARED_LIBS)
 
     if (NOT glfw3_FOUND)
         list(REMOVE_ITEM raylib_install_private_libs glfw)
+
+        # Bundled GLFW links its Cocoa backend frameworks privately, so they
+        # must be propagated to consumers of the static library, whose final
+        # link line would otherwise miss them.
+        if (APPLE)
+            find_library(COCOA_FRAMEWORK Cocoa)
+            find_library(IOKIT_FRAMEWORK IOKit)
+            find_library(QUARTZCORE_FRAMEWORK QuartzCore)
+            list(APPEND raylib_install_private_libs
+                ${COCOA_FRAMEWORK}
+                ${IOKIT_FRAMEWORK}
+                ${QUARTZCORE_FRAMEWORK})
+        endif ()
     endif()
 
     foreach(lib IN LISTS raylib_install_private_libs)


### PR DESCRIPTION
Closes #6080

## Problem

When raylib is built as a **static** library and consumed via `find_package(raylib)` on macOS, linking fails with undefined Objective-C symbols:

```
  "_objc_retain", referenced from:
      __glfwCreateStandardCursorCocoa in libraylib.a(cocoa_window.m.o)
ld: symbol(s) not found for architecture x86_64
```

Root cause chain:
1. Bundled GLFW links its Cocoa backend frameworks (`Cocoa`, `IOKit`, `QuartzCore`) as **PRIVATE**
2. The static-install export block in `src/CMakeLists.txt` removes `glfw` from exported dependencies (correct — its symbols are inside the archive)
3. But the frameworks GLFW needed are not re-exported either, so the installed package only carries `OpenGL.framework`

## Fix

In the static-only export block, when the bundled GLFW is used on `APPLE`, append the same three frameworks GLFW's Cocoa backend declares, resolved via `find_library()`. Shared builds are untouched (the block is guarded by `NOT BUILD_SHARED_LIBS`).

## Verification (macOS 15, Intel, Apple clang 14)

Full standalone flow, before → after:

| Step | Before | After |
|---|---|---|
| `cd examples && cmake .. -DCMAKE_PREFIX_PATH=<stage>` | configures (after #6079) | ✅ |
| `make core_basic_window` | ❌ ld: objc symbols not found | ✅ links |

Repro script:
```
cmake .. -DBUILD_SHARED_LIBS=OFF -DBUILD_EXAMPLES=OFF && make -j3
cmake --install . --prefix /tmp/raylib-stage
cd ../examples && cmake .. -DCMAKE_PREFIX_PATH=/tmp/raylib-stage && make core_basic_window
```

Note: this PR depends on #6079 for the examples to configure standalone; the library-side fix here is independent.