### PR TITLE
[external] Small fix to fix_win32_compatibility.h for newer windows SDK versions.

### DIFF
--- a/src/external/fix_win32_compatibility.h
+++ b/src/external/fix_win32_compatibility.h
@@ -46,6 +46,7 @@
 // include windows
 #define WIN32_LEAN_AND_MEAN 
 #include <windows.h>
+#include <playsoundapi.h>
 
 // remove all our redefinitions so that raylib can define them properly
 #undef CloseWindow


### PR DESCRIPTION
This PR makes a small change to the compatibility header. Newer versions of windows SDKs removed PlaySound from windows.h when WIN32_LEAN_AND_MEAN is defined, so to ensure it is picked up by the replacement macro we must include the sound header specifically.

This prevents a link error when including windows.h and raylib in the same translation unit.