### PR TITLE
[rcore][win32] Implement GetClipboardImage()

### DIFF
--- a/src/platforms/rcore_desktop_win32.c
+++ b/src/platforms/rcore_desktop_win32.c
@@ -1129,12 +1129,37 @@ const char *GetClipboardText(void)
     return NULL;
 }
 
+#if SUPPORT_CLIPBOARD_IMAGE && SUPPORT_MODULE_RTEXTURES
+    #define WIN32_CLIPBOARD_IMPLEMENTATION
+    #define WINUSER_ALREADY_INCLUDED
+    #define WINBASE_ALREADY_INCLUDED
+    #define WINGDI_ALREADY_INCLUDED
+    #include "../external/win32_clipboard.h"
+#endif
+
 // Get clipboard image
 Image GetClipboardImage(void)
 {
     Image image = { 0 };
 
-    TRACELOG(LOG_WARNING, "GetClipboardText not implemented");
+#if SUPPORT_CLIPBOARD_IMAGE && SUPPORT_MODULE_RTEXTURES
+    unsigned int dataSize = 0;
+    void *fileData = NULL;
+    int width = 0;
+    int height = 0;
+
+    fileData = (void *)Win32GetClipboardImageData(&width, &height, &dataSize);
+
+    if (fileData == NULL) TRACELOG(LOG_WARNING, "Clipboard image: Couldn't get clipboard data.");
+    else 
+    {
+        image = LoadImageFromMemory(".bmp", (const unsigned char*)fileData, (int)dataSize);
+
+        RL_FREE(fileData);
+    }
+#else
+    TRACELOG(LOG_WARNING, "Clipboard image: SUPPORT_CLIPBOARD_IMAGE requires SUPPORT_MODULE_RTEXTURES to work properly");
+#endif // SUPPORT_CLIPBOARD_IMAGE
 
     return image;
 }


### PR DESCRIPTION
GetClipboardImage() was still a stub on the native Win32 backend — it just logged a warning, and the message was wrong anyway (it said "GetClipboardText not implemented").

src/external/win32_clipboard.h is already in the repo and already used by the GLFW and RGFW backends, so this just wires it up the same way.

I followed the RGFW pattern rather than the GLFW one, because rcore_desktop_win32.c already includes windows.h and needs the WINUSER/WINBASE/WINGDI_ALREADY_INCLUDED guards to avoid redefinitions.

Also frees the buffer returned by Win32GetClipboardImageData() after decoding — LoadImageFromMemory() copies into its own allocation, so the raw BMP bytes are orphaned otherwise. Same fix as [#5968](https://github.com/raysan5/raylib/pull/5968) did for the SDL backend. Note that GLFW and RGFW still have this leak; happy to do those in a separate PR if you want them consistent.

Tested on Windows 10 with MSVC:

pasting an image works, including repeatedly
empty clipboard and text-in-clipboard both warn and return an empty Image, no crash
builds with SUPPORT_CLIPBOARD_IMAGE set to both 0 and 1
default GLFW build unaffected, no new warnings

Found this while testing the textures_clipboard_image example. Its Ctrl+V path doesn't currently work on this backend since the modifier keys aren't mapped yet in GetKeyFromWparam(), so I tested with a local tweak — looking at that separately.