### PR TITLE
[examples] Fix crash when model resources fail to load in animation examples

### DIFF
--- a/examples/models/models_animation_blend_custom.c
+++ b/examples/models/models_animation_blend_custom.c
@@ -81,6 +81,16 @@ int main(void)
     int animCount = 0;
     ModelAnimation *anims = LoadModelAnimations("resources/models/gltf/greenman.glb", &animCount);
 
+    // WARNING: Exit if example resources could not be loaded
+    if ((model.meshCount == 0) || (animCount == 0))
+    {
+        TraceLog(LOG_WARNING, "MODEL: Example resources could not be loaded");
+        UnloadModelAnimations(anims, animCount);
+        UnloadModel(model);
+        CloseWindow();
+        return 1;
+    }
+
     // Use specific animation indices: 2-walk/move, 3-attack
     int animIndex0 = 2; // Walk/Move animation (index 2)
     int animIndex1 = 3; // Attack animation (index 3)

--- a/examples/models/models_animation_blending.c
+++ b/examples/models/models_animation_blending.c
@@ -71,6 +71,16 @@ int main(void)
     int animCount = 0;
     ModelAnimation *anims = LoadModelAnimations("resources/models/gltf/robot.glb", &animCount);
 
+    // WARNING: Exit if example resources could not be loaded
+    if ((model.meshCount == 0) || (animCount == 0))
+    {
+        TraceLog(LOG_WARNING, "MODEL: Example resources could not be loaded");
+        UnloadModelAnimations(anims, animCount);
+        UnloadModel(model);
+        CloseWindow();
+        return 1;
+    }
+
     // Animation playing variables
     // NOTE: Two animations are played with a smooth transition between them
     int currentAnimPlaying = 0;         // Current animation playing (0 o 1)

--- a/examples/models/models_animation_gpu_skinning.c
+++ b/examples/models/models_animation_gpu_skinning.c
@@ -70,6 +70,16 @@ int main(void)
     int animCount = 0;
     ModelAnimation *anims = LoadModelAnimations("resources/models/gltf/greenman.glb", &animCount);
 
+    // WARNING: Exit if example resources could not be loaded
+    if ((model.meshCount == 0) || (animCount == 0))
+    {
+        TraceLog(LOG_WARNING, "MODEL: Example resources could not be loaded");
+        UnloadModelAnimations(anims, animCount);
+        UnloadModel(model);
+        CloseWindow();
+        return 1;
+    }
+
     // Animation playing variables
     unsigned int animIndex = 0;         // Current animation playing
     unsigned int animCurrentFrame = 0;  // Current animation frame

--- a/examples/models/models_animation_timing.c
+++ b/examples/models/models_animation_timing.c
@@ -46,6 +46,16 @@ int main(void)
     int animCount = 0;
     ModelAnimation *anims = LoadModelAnimations("resources/models/gltf/robot.glb", &animCount);
 
+    // WARNING: Exit if example resources could not be loaded
+    if ((model.meshCount == 0) || (animCount == 0))
+    {
+        TraceLog(LOG_WARNING, "MODEL: Example resources could not be loaded");
+        UnloadModelAnimations(anims, animCount);
+        UnloadModel(model);
+        CloseWindow();
+        return 1;
+    }
+
     // Animation playing variables
     int animIndex = 10;                  // Current animation playing
     float animCurrentFrame = 0.0f;      // Current animation frame (supporting interpolated frames)


### PR DESCRIPTION
Fixes the segfault reported in #5664 for `models_animation_blending`: when `resources/models/gltf/robot.glb` can not be opened, `LoadModelAnimations()` returns NULL with `animCount = 0`, and the example still indexes `anims[10]`.

While checking I found the same pattern in three more animation examples:

- `models_animation_gpu_skinning`: `(animIndex + 1) % animCount` divides by zero on key press, then reads `anims[animIndex]`
- `models_animation_timing`: update loop is guarded, but the UI drawing reads `anims[animIndex]` every frame unconditionally
- `models_animation_blend_custom`: index clamping does not help because the array itself is NULL

All four now exit early with a warning when the model or its animations could not be loaded, unloading what was created. All four still compile.