### PR TITLE
Fix memory leak in rtext LoadFontFromImage method

### DIFF
--- a/src/rtext.c
+++ b/src/rtext.c
@@ -438,7 +438,10 @@ Font LoadFontFromImage(Image image, Color key, int firstChar)
         if (!COLOR_EQUAL(pixels[y*image.width + x], key)) break;
     }
 
-    if ((x == 0) || (y == 0)) return font; // Security check
+    if ((x == 0) || (y == 0)) {
+        UnloadImageColors(pixels); // Unload pixel colors to prevent memory leak
+        return font; // Security check
+    }
 
     charSpacing = x;
     lineSpacing = y;


### PR DESCRIPTION
Fix for
[rtext] Memory leak at LoadFontFromImage when failing to compute spacing's

https://github.com/raysan5/raylib/issues/6097

Issue is memory is being allocated for the image but it's not being added in the returned font due to the early exit. So when the font is ultimately destroyed, this memory is not freed.