### PR TITLE
[rcore][desktop] Fix clipboard image memory leak (GLFW, RGFW)

### DIFF
--- a/src/platforms/rcore_desktop_glfw.c
+++ b/src/platforms/rcore_desktop_glfw.c
@@ -1073,7 +1073,12 @@ Image GetClipboardImage(void)
     bmpData = (void *)Win32GetClipboardImageData(&width, &height, &dataSize);
 
     if (bmpData == NULL) TRACELOG(LOG_WARNING, "Clipboard image: Couldn't get clipboard data.");
-    else image = LoadImageFromMemory(".bmp", (const unsigned char *)bmpData, (int)dataSize);
+    else
+    {
+        image = LoadImageFromMemory(".bmp", (const unsigned char *)bmpData, (int)dataSize);
+
+        RL_FREE(bmpData);
+    }
 
 #elif defined(__linux__) && defined(_GLFW_X11)
     // REF: https://github.com/ColleagueRiley/Clipboard-Copy-Paste/blob/main/x11.c

--- a/src/platforms/rcore_desktop_rgfw.c
+++ b/src/platforms/rcore_desktop_rgfw.c
@@ -1329,7 +1329,12 @@ Image GetClipboardImage(void)
     fileData = (void *)Win32GetClipboardImageData(&width, &height, &dataSize);
 
     if (fileData == NULL) TRACELOG(LOG_WARNING, "Clipboard image: Couldn't get clipboard data");
-    else image = LoadImageFromMemory(".bmp", (const unsigned char *)fileData, (int)dataSize);
+    else
+    {
+        image = LoadImageFromMemory(".bmp", (const unsigned char *)fileData, (int)dataSize);
+
+        RL_FREE(fileData);
+    }
 
 #elif defined(__linux__) && defined(DRGFW_X11)
 


### PR DESCRIPTION
Follow-up to [#6091](https://github.com/raysan5/raylib/pull/6091). Win32GetClipboardImageData() returns an RL_MALLOC'd buffer, and LoadImageFromMemory() decodes into its own allocation, so the raw BMP bytes are leaked on every paste. Same fix [#5968](https://github.com/raysan5/raylib/pull/5968) applied to the SDL backend.

Tested on Windows with both backends — repeated pastes work, no change in behaviour.

Unrelated, but noticed while in there: the RGFW X11 branches at lines 1310 and 1334 check defined(DRGFW_X11), but the macro is RGFW_X11 (src/Makefile:513 passes -DRGFW_X11). Looks like the -D got into the name, so those paths are dead on Linux. Left it alone since I can't test X11 — happy to patch if you want.