### PR TITLE
feat(models): add opt-in u32 mesh index support

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -695,6 +695,7 @@ MODELS = \
     models/models_loading_m3d \
     models/models_loading_vox \
     models/models_mesh_generation \
+    models/models_mesh_u32_indices \
     models/models_mesh_picking \
     models/models_orthographic_projection \
     models/models_point_rendering \

--- a/examples/models/models_mesh_u32_indices.c
+++ b/examples/models/models_mesh_u32_indices.c
@@ -1,45 +1,87 @@
 /*******************************************************************************************
 *
-*   raylib [models] example - Mesh with 32-bit indices
+*   raylib [models] example - Mesh with 16-bit and 32-bit indices
 *
-*   Confirms that index 65536 is preserved instead of being truncated to u16.
+*   Confirms that legacy u16 indices and u32 index 65536 are both preserved, drawn,
+*   used for tangent generation, and used for mesh collision tests.
 *
 ********************************************************************************************/
 
 #include "raylib.h"
+#include "raymath.h"
+
+#include <string.h>
+
+// Set the position, normal and texture coordinate for one mesh vertex
+static void SetMeshVertex(Mesh *mesh, int index, float x, float y, float u, float v)
+{
+    mesh->vertices[index*3] = x;
+    mesh->vertices[index*3 + 1] = y;
+    mesh->normals[index*3 + 2] = 1.0f;
+    mesh->texcoords[index*2] = u;
+    mesh->texcoords[index*2 + 1] = v;
+}
 
 int main(void)
 {
-    const int vertexCount = 65537;
+    const int u32VertexCount = 65537;
 
-    InitWindow(800, 450, "raylib [models] example - mesh u32 indices");
+    InitWindow(800, 450, "raylib [models] example - mesh u16 and u32 indices");
 
     Camera3D camera = { 0 };
-    camera.position = (Vector3){ 0.0f, 0.0f, 4.0f };
+    camera.position = (Vector3){ 0.0f, 0.0f, 6.0f };
     camera.target = (Vector3){ 0.0f, 0.0f, 0.0f };
     camera.up = (Vector3){ 0.0f, 1.0f, 0.0f };
     camera.fovy = 45.0f;
     camera.projection = CAMERA_PERSPECTIVE;
 
-    Mesh mesh = { 0 };
-    mesh.vertexCount = vertexCount;
-    mesh.triangleCount = 1;
-    mesh.vertices = (float *)MemAlloc(vertexCount*3*sizeof(float));
-    mesh.indices32 = (unsigned int *)MemAlloc(3*sizeof(unsigned int));
-    mesh.indexType = MESH_INDEX_UINT32;
+    // Legacy u16 mesh regression case
+    Mesh mesh16 = { 0 };
+    mesh16.vertexCount = 3;
+    mesh16.triangleCount = 1;
+    mesh16.vertices = (float *)MemAlloc(mesh16.vertexCount*3*sizeof(float));
+    mesh16.texcoords = (float *)MemAlloc(mesh16.vertexCount*2*sizeof(float));
+    mesh16.normals = (float *)MemAlloc(mesh16.vertexCount*3*sizeof(float));
+    mesh16.indices = (unsigned short *)MemAlloc(3*sizeof(unsigned short));
+    memset(mesh16.vertices, 0, mesh16.vertexCount*3*sizeof(float));
+    memset(mesh16.texcoords, 0, mesh16.vertexCount*2*sizeof(float));
+    memset(mesh16.normals, 0, mesh16.vertexCount*3*sizeof(float));
+    SetMeshVertex(&mesh16, 0, -1.0f, -1.0f, 0.0f, 0.0f);
+    SetMeshVertex(&mesh16, 1, 1.0f, -1.0f, 1.0f, 0.0f);
+    SetMeshVertex(&mesh16, 2, 0.0f, 1.0f, 0.5f, 1.0f);
+    mesh16.indices[0] = 0;
+    mesh16.indices[1] = 1;
+    mesh16.indices[2] = 2;
+    GenMeshTangents(&mesh16);
+    UploadMesh(&mesh16, false);
+    Model model16 = LoadModelFromMesh(mesh16);
 
-    mesh.vertices[0] = -1.0f;
-    mesh.vertices[1] = -1.0f;
-    mesh.vertices[3] = 1.0f;
-    mesh.vertices[4] = -1.0f;
-    mesh.vertices[65536*3 + 1] = 1.0f;
+    // u32 mesh regression case: the third vertex cannot be addressed by a u16 index
+    Mesh mesh32 = { 0 };
+    mesh32.vertexCount = u32VertexCount;
+    mesh32.triangleCount = 1;
+    mesh32.vertices = (float *)MemAlloc(mesh32.vertexCount*3*sizeof(float));
+    mesh32.texcoords = (float *)MemAlloc(mesh32.vertexCount*2*sizeof(float));
+    mesh32.normals = (float *)MemAlloc(mesh32.vertexCount*3*sizeof(float));
+    mesh32.indices32 = (unsigned int *)MemAlloc(3*sizeof(unsigned int));
+    mesh32.indexType = MESH_INDEX_UINT32;
+    memset(mesh32.vertices, 0, mesh32.vertexCount*3*sizeof(float));
+    memset(mesh32.texcoords, 0, mesh32.vertexCount*2*sizeof(float));
+    memset(mesh32.normals, 0, mesh32.vertexCount*3*sizeof(float));
+    SetMeshVertex(&mesh32, 0, -1.0f, -1.0f, 0.0f, 0.0f);
+    SetMeshVertex(&mesh32, 1, 1.0f, -1.0f, 1.0f, 0.0f);
+    SetMeshVertex(&mesh32, 65536, 0.0f, 1.0f, 0.5f, 1.0f);
+    mesh32.indices32[0] = 0;
+    mesh32.indices32[1] = 1;
+    mesh32.indices32[2] = 65536;
+    GenMeshTangents(&mesh32);
+    UploadMesh(&mesh32, false);
+    Model model32 = LoadModelFromMesh(mesh32);
 
-    mesh.indices32[0] = 0;
-    mesh.indices32[1] = 1;
-    mesh.indices32[2] = 65536;
-
-    UploadMesh(&mesh, false);
-    Model model = LoadModelFromMesh(mesh);
+    Ray ray16 = { (Vector3){ -1.5f, 0.0f, 5.0f }, (Vector3){ 0.0f, 0.0f, -1.0f } };
+    Ray ray32 = { (Vector3){ 1.5f, 0.0f, 5.0f }, (Vector3){ 0.0f, 0.0f, -1.0f } };
+    bool u16Collision = GetRayCollisionMesh(ray16, mesh16, MatrixTranslate(-1.5f, 0.0f, 0.0f)).hit;
+    bool u32Collision = GetRayCollisionMesh(ray32, mesh32, MatrixTranslate(1.5f, 0.0f, 0.0f)).hit;
 
     SetTargetFPS(60);
 
@@ -51,17 +93,20 @@ int main(void)
             ClearBackground(RAYWHITE);
 
             BeginMode3D(camera);
-                DrawModel(model, (Vector3){ 0.0f, 0.0f, 0.0f }, 1.0f, MAROON);
+                DrawModel(model16, (Vector3){ -1.5f, 0.0f, 0.0f }, 1.0f, DARKBLUE);
+                DrawModel(model32, (Vector3){ 1.5f, 0.0f, 0.0f }, 1.0f, MAROON);
                 DrawGrid(10, 1.0f);
             EndMode3D();
 
-            DrawText("Mesh index 65536 is stored and drawn as u32", 10, 10, 20, DARKGRAY);
-            DrawText("Expected result: one non-degenerate red triangle", 10, 36, 20, DARKGRAY);
-            DrawFPS(10, 70);
+            DrawText("Left: legacy u16 mesh     Right: u32 mesh with index 65536", 10, 10, 20, DARKGRAY);
+            DrawText(TextFormat("Mesh collision: u16 %s, u32 %s", u16Collision? "ok" : "failed", u32Collision? "ok" : "failed"), 10, 36, 20, DARKGRAY);
+            DrawText("Both paths also run GenMeshTangents()", 10, 62, 20, DARKGRAY);
+            DrawFPS(10, 96);
         EndDrawing();
     }
 
-    UnloadModel(model);
+    UnloadModel(model16);
+    UnloadModel(model32);
     CloseWindow();
 
     return 0;

--- a/examples/models/models_mesh_u32_indices.c
+++ b/examples/models/models_mesh_u32_indices.c
@@ -1,0 +1,68 @@
+/*******************************************************************************************
+*
+*   raylib [models] example - Mesh with 32-bit indices
+*
+*   Confirms that index 65536 is preserved instead of being truncated to u16.
+*
+********************************************************************************************/
+
+#include "raylib.h"
+
+int main(void)
+{
+    const int vertexCount = 65537;
+
+    InitWindow(800, 450, "raylib [models] example - mesh u32 indices");
+
+    Camera3D camera = { 0 };
+    camera.position = (Vector3){ 0.0f, 0.0f, 4.0f };
+    camera.target = (Vector3){ 0.0f, 0.0f, 0.0f };
+    camera.up = (Vector3){ 0.0f, 1.0f, 0.0f };
+    camera.fovy = 45.0f;
+    camera.projection = CAMERA_PERSPECTIVE;
+
+    Mesh mesh = { 0 };
+    mesh.vertexCount = vertexCount;
+    mesh.triangleCount = 1;
+    mesh.vertices = (float *)MemAlloc(vertexCount*3*sizeof(float));
+    mesh.indices32 = (unsigned int *)MemAlloc(3*sizeof(unsigned int));
+    mesh.indexType = MESH_INDEX_UINT32;
+
+    mesh.vertices[0] = -1.0f;
+    mesh.vertices[1] = -1.0f;
+    mesh.vertices[3] = 1.0f;
+    mesh.vertices[4] = -1.0f;
+    mesh.vertices[65536*3 + 1] = 1.0f;
+
+    mesh.indices32[0] = 0;
+    mesh.indices32[1] = 1;
+    mesh.indices32[2] = 65536;
+
+    UploadMesh(&mesh, false);
+    Model model = LoadModelFromMesh(mesh);
+
+    SetTargetFPS(60);
+
+    while (!WindowShouldClose())
+    {
+        UpdateCamera(&camera, CAMERA_ORBITAL);
+
+        BeginDrawing();
+            ClearBackground(RAYWHITE);
+
+            BeginMode3D(camera);
+                DrawModel(model, (Vector3){ 0.0f, 0.0f, 0.0f }, 1.0f, MAROON);
+                DrawGrid(10, 1.0f);
+            EndMode3D();
+
+            DrawText("Mesh index 65536 is stored and drawn as u32", 10, 10, 20, DARKGRAY);
+            DrawText("Expected result: one non-degenerate red triangle", 10, 36, 20, DARKGRAY);
+            DrawFPS(10, 70);
+        EndDrawing();
+    }
+
+    UnloadModel(model);
+    CloseWindow();
+
+    return 0;
+}

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -342,6 +342,12 @@ typedef struct Camera2D {
     float zoom;             // Camera zoom (scaling around target), must not be set to 0, set to 1.0f for no scale
 } Camera2D;
 
+// Mesh index element type
+typedef enum MeshIndexType {
+    MESH_INDEX_UINT16 = 0,  // Indices are stored as unsigned short (legacy default)
+    MESH_INDEX_UINT32        // Indices are stored as unsigned int
+} MeshIndexType;
+
 // Mesh, vertex data and vao/vbo
 typedef struct Mesh {
     int vertexCount;        // Number of vertices stored in arrays
@@ -369,6 +375,10 @@ typedef struct Mesh {
     // OpenGL identifiers
     unsigned int vaoId;     // OpenGL Vertex Array Object id
     unsigned int *vboId;    // OpenGL Vertex Buffer Objects id (default vertex data)
+
+    // Extended index data (appended to preserve legacy Mesh field offsets)
+    unsigned int *indices32; // Vertex indices (u32, used when indexType is MESH_INDEX_UINT32)
+    MeshIndexType indexType; // Index data type (MESH_INDEX_UINT16 by default)
 } Mesh;
 
 // Shader

--- a/src/rlgl.h
+++ b/src/rlgl.h
@@ -1087,6 +1087,7 @@ typedef struct rlglData {
     struct {
         bool vao;                           // VAO support (OpenGL ES2 could not support VAO extension) (GL_ARB_vertex_array_object)
         bool instancing;                    // Instancing supported (GL_ANGLE_instanced_arrays, GL_EXT_draw_instanced + GL_EXT_instanced_arrays)
+        bool elementIndexUint;              // 32-bit element indices support (GL_OES_element_index_uint)
         bool texNPOT;                       // NPOT textures full support (GL_ARB_texture_non_power_of_two, GL_OES_texture_npot)
         bool texDepth;                      // Depth textures supported (GL_ARB_depth_texture, GL_OES_depth_texture)
         bool texDepthWebGL;                 // Depth textures supported WebGL specific (GL_WEBGL_depth_texture)
@@ -2403,6 +2404,7 @@ void rlLoadExtensions(void *loader)
     // Optional OpenGL 2.1 extensions
     RLGL.ExtSupported.vao = GLAD_GL_ARB_vertex_array_object;
     RLGL.ExtSupported.instancing = (GLAD_GL_EXT_draw_instanced && GLAD_GL_ARB_instanced_arrays);
+    RLGL.ExtSupported.elementIndexUint = true;
     RLGL.ExtSupported.texNPOT = GLAD_GL_ARB_texture_non_power_of_two;
     RLGL.ExtSupported.texFloat32 = GLAD_GL_ARB_texture_float;
     RLGL.ExtSupported.texFloat16 = GLAD_GL_ARB_texture_float;
@@ -2415,6 +2417,7 @@ void rlLoadExtensions(void *loader)
     // OpenGL 3.3 extensions supported by default (core)
     RLGL.ExtSupported.vao = true;
     RLGL.ExtSupported.instancing = true;
+    RLGL.ExtSupported.elementIndexUint = true;
     RLGL.ExtSupported.texNPOT = true;
     RLGL.ExtSupported.texFloat32 = true;
     RLGL.ExtSupported.texFloat16 = true;
@@ -2440,6 +2443,7 @@ void rlLoadExtensions(void *loader)
     // OpenGL ES 3.0 extensions supported by default (or it should be)
     RLGL.ExtSupported.vao = true;
     RLGL.ExtSupported.instancing = true;
+    RLGL.ExtSupported.elementIndexUint = true;
     RLGL.ExtSupported.texNPOT = true;
     RLGL.ExtSupported.texFloat32 = true;
     RLGL.ExtSupported.texFloat16 = true;
@@ -2510,6 +2514,10 @@ void rlLoadExtensions(void *loader)
 
             if ((glGenVertexArrays != NULL) && (glBindVertexArray != NULL) && (glDeleteVertexArrays != NULL)) RLGL.ExtSupported.vao = true;
         }
+
+        // Check 32-bit element index support (required by u32 mesh indices on OpenGL ES 2.0/WebGL 1.0)
+        if ((strcmp(extList[i], (const char *)"GL_OES_element_index_uint") == 0) ||
+            (strcmp(extList[i], (const char *)"OES_element_index_uint") == 0)) RLGL.ExtSupported.elementIndexUint = true;
 
         // Check instanced rendering support
         if (strstr(extList[i], (const char *)"instanced_arrays") != NULL) // Broad check for instanced_arrays
@@ -4089,7 +4097,7 @@ void rlDrawVertexArrayElementsEx(int offset, int count, const void *buffer, int 
 {
     unsigned int glIndexType = (indexType == RL_UNSIGNED_INT)? GL_UNSIGNED_INT : GL_UNSIGNED_SHORT;
 #if defined(GRAPHICS_API_OPENGL_ES2)
-    if (indexType == RL_UNSIGNED_INT)
+    if ((indexType == RL_UNSIGNED_INT) && !RLGL.ExtSupported.elementIndexUint)
     {
         TRACELOG(LOG_WARNING, "RLGL: 32-bit element indices require OpenGL ES 3.0 or OES_element_index_uint support");
         return;
@@ -4123,7 +4131,7 @@ void rlDrawVertexArrayElementsInstancedEx(int offset, int count, const void *buf
 #if defined(GRAPHICS_API_OPENGL_33) || defined(GRAPHICS_API_OPENGL_ES2)
     unsigned int glIndexType = (indexType == RL_UNSIGNED_INT)? GL_UNSIGNED_INT : GL_UNSIGNED_SHORT;
 #if defined(GRAPHICS_API_OPENGL_ES2)
-    if (indexType == RL_UNSIGNED_INT)
+    if ((indexType == RL_UNSIGNED_INT) && !RLGL.ExtSupported.elementIndexUint)
     {
         TRACELOG(LOG_WARNING, "RLGL: 32-bit element indices require OpenGL ES 3.0 or OES_element_index_uint support");
         return;

--- a/src/rlgl.h
+++ b/src/rlgl.h
@@ -273,6 +273,8 @@
 
 // GL equivalent data types
 #define RL_UNSIGNED_BYTE                        0x1401      // GL_UNSIGNED_BYTE
+#define RL_UNSIGNED_SHORT                       0x1403      // GL_UNSIGNED_SHORT
+#define RL_UNSIGNED_INT                         0x1405      // GL_UNSIGNED_INT
 #define RL_FLOAT                                0x1406      // GL_FLOAT
 
 // GL buffer usage hint
@@ -751,8 +753,10 @@ RLAPI void rlSetVertexAttributeDivisor(unsigned int index, int divisor); // Set 
 RLAPI void rlSetVertexAttributeDefault(int locIndex, const void *value, int attribType, int count); // Set vertex attribute default value, when attribute to provided
 RLAPI void rlDrawVertexArray(int offset, int count);    // Draw vertex array (currently active vao)
 RLAPI void rlDrawVertexArrayElements(int offset, int count, const void *buffer); // Draw vertex array elements
+RLAPI void rlDrawVertexArrayElementsEx(int offset, int count, const void *buffer, int indexType); // Draw vertex array elements with the provided RL index type
 RLAPI void rlDrawVertexArrayInstanced(int offset, int count, int instances); // Draw vertex array (currently active vao) with instancing
 RLAPI void rlDrawVertexArrayElementsInstanced(int offset, int count, const void *buffer, int instances); // Draw vertex array elements with instancing
+RLAPI void rlDrawVertexArrayElementsInstancedEx(int offset, int count, const void *buffer, int instances, int indexType); // Draw vertex array elements with instancing and the provided RL index type
 
 // Textures management
 RLAPI unsigned int rlLoadTexture(const void *data, int width, int height, int format, int mipmapCount); // Load texture data
@@ -4077,11 +4081,26 @@ void rlDrawVertexArray(int offset, int count)
 // Draw vertex array elements
 void rlDrawVertexArrayElements(int offset, int count, const void *buffer)
 {
-    // NOTE: Added pointer math separately from function to avoid UBSAN complaining
-    unsigned short *bufferPtr = (unsigned short *)buffer;
-    if (offset > 0) bufferPtr += offset;
+    rlDrawVertexArrayElementsEx(offset, count, buffer, RL_UNSIGNED_SHORT);
+}
 
-    glDrawElements(GL_TRIANGLES, count, GL_UNSIGNED_SHORT, (const unsigned short *)bufferPtr);
+// Draw vertex array elements with a caller-provided index type
+void rlDrawVertexArrayElementsEx(int offset, int count, const void *buffer, int indexType)
+{
+    unsigned int glIndexType = (indexType == RL_UNSIGNED_INT)? GL_UNSIGNED_INT : GL_UNSIGNED_SHORT;
+#if defined(GRAPHICS_API_OPENGL_ES2)
+    if (indexType == RL_UNSIGNED_INT)
+    {
+        TRACELOG(LOG_WARNING, "RLGL: 32-bit element indices require OpenGL ES 3.0 or OES_element_index_uint support");
+        return;
+    }
+#endif
+    // NOTE: Added pointer math separately from function to avoid UBSAN complaining
+    const int indexSize = (indexType == RL_UNSIGNED_INT)? (int)sizeof(unsigned int) : (int)sizeof(unsigned short);
+    const unsigned char *bufferPtr = (const unsigned char *)buffer;
+    if (offset > 0) bufferPtr += offset*indexSize;
+
+    glDrawElements(GL_TRIANGLES, count, glIndexType, bufferPtr);
 }
 
 // Draw vertex array instanced
@@ -4095,12 +4114,27 @@ void rlDrawVertexArrayInstanced(int offset, int count, int instances)
 // Draw vertex array elements instanced
 void rlDrawVertexArrayElementsInstanced(int offset, int count, const void *buffer, int instances)
 {
-#if defined(GRAPHICS_API_OPENGL_33) || defined(GRAPHICS_API_OPENGL_ES2)
-    // NOTE: Added pointer math separately from function to avoid UBSAN complaining
-    unsigned short *bufferPtr = (unsigned short *)buffer;
-    if (offset > 0) bufferPtr += offset;
+    rlDrawVertexArrayElementsInstancedEx(offset, count, buffer, instances, RL_UNSIGNED_SHORT);
+}
 
-    glDrawElementsInstanced(GL_TRIANGLES, count, GL_UNSIGNED_SHORT, (const unsigned short *)bufferPtr, instances);
+// Draw vertex array elements with instancing and a caller-provided index type
+void rlDrawVertexArrayElementsInstancedEx(int offset, int count, const void *buffer, int instances, int indexType)
+{
+#if defined(GRAPHICS_API_OPENGL_33) || defined(GRAPHICS_API_OPENGL_ES2)
+    unsigned int glIndexType = (indexType == RL_UNSIGNED_INT)? GL_UNSIGNED_INT : GL_UNSIGNED_SHORT;
+#if defined(GRAPHICS_API_OPENGL_ES2)
+    if (indexType == RL_UNSIGNED_INT)
+    {
+        TRACELOG(LOG_WARNING, "RLGL: 32-bit element indices require OpenGL ES 3.0 or OES_element_index_uint support");
+        return;
+    }
+#endif
+    // NOTE: Added pointer math separately from function to avoid UBSAN complaining
+    const int indexSize = (indexType == RL_UNSIGNED_INT)? (int)sizeof(unsigned int) : (int)sizeof(unsigned short);
+    const unsigned char *bufferPtr = (const unsigned char *)buffer;
+    if (offset > 0) bufferPtr += offset*indexSize;
+
+    glDrawElementsInstanced(GL_TRIANGLES, count, glIndexType, bufferPtr, instances);
 #endif
 }
 

--- a/src/rmodels.c
+++ b/src/rmodels.c
@@ -2164,11 +2164,12 @@ bool ExportMeshAsCode(Mesh mesh, const char *fileName)
         byteCount += sprintf(txtData + byteCount, "0x%x };\n\n", mesh.colors[mesh.vertexCount*4 - 1]);
     }
 
-    if (mesh.indices != NULL)       // Vertex indices (3 index per triangle - unsigned short)
+    if (MeshHasIndices(&mesh))      // Vertex indices (3 indices per triangle)
     {
-        byteCount += sprintf(txtData + byteCount, "static unsigned short %s_INDEX_DATA[%i] = { ", varFileName, mesh.triangleCount*3);
-        for (int i = 0; i < mesh.triangleCount*3 - 1; i++) byteCount += sprintf(txtData + byteCount, ((i%TEXT_BYTES_PER_LINE == 0)? "%i,\n" : "%i, "), mesh.indices[i]);
-        byteCount += sprintf(txtData + byteCount, "%i };\n", mesh.indices[mesh.triangleCount*3 - 1]);
+        const char *indexTypeName = (mesh.indexType == MESH_INDEX_UINT32)? "unsigned int" : "unsigned short";
+        byteCount += sprintf(txtData + byteCount, "static %s %s_INDEX_DATA[%i] = { ", indexTypeName, varFileName, mesh.triangleCount*3);
+        for (int i = 0; i < mesh.triangleCount*3 - 1; i++) byteCount += sprintf(txtData + byteCount, ((i%TEXT_BYTES_PER_LINE == 0)? "%u,\n" : "%u, "), GetMeshIndex(&mesh, i));
+        byteCount += sprintf(txtData + byteCount, "%u };\n", GetMeshIndex(&mesh, mesh.triangleCount*3 - 1));
     }
     //-----------------------------------------------------------------------------------------
 
@@ -3819,12 +3820,12 @@ void GenMeshTangents(Mesh *mesh)
         // Get triangle vertex indices
         int i0 = 0, i1 = 0, i2 = 0;
 
-        if (mesh->indices != NULL)
+        if (MeshHasIndices(mesh))
         {
             // Use indices if available
-            i0 = mesh->indices[t*3 + 0];
-            i1 = mesh->indices[t*3 + 1];
-            i2 = mesh->indices[t*3 + 2];
+            i0 = (int)GetMeshIndex(mesh, t*3 + 0);
+            i1 = (int)GetMeshIndex(mesh, t*3 + 1);
+            i2 = (int)GetMeshIndex(mesh, t*3 + 2);
         }
         else
         {

--- a/src/rmodels.c
+++ b/src/rmodels.c
@@ -157,6 +157,10 @@
 //----------------------------------------------------------------------------------
 // Module Internal Functions Declaration
 //----------------------------------------------------------------------------------
+static bool MeshHasIndices(const Mesh *mesh);            // Check whether a mesh has index data
+static const void *GetMeshIndexData(const Mesh *mesh);   // Get mesh index data pointer
+static unsigned int GetMeshIndex(const Mesh *mesh, int index); // Get one mesh index
+static unsigned int GetMeshIndexGLType(const Mesh *mesh); // Get RL element type for mesh indices
 #if SUPPORT_FILEFORMAT_OBJ
 static Model LoadOBJ(const char *fileName);     // Load OBJ mesh data
 #endif
@@ -1199,7 +1203,7 @@ bool IsModelValid(Model model)
         if ((model.meshes[i].colors != NULL) && (model.meshes[i].vboId[3] == 0)) { result = false; break; }     // Vertex colors buffer not uploaded to GPU
         if ((model.meshes[i].tangents != NULL) && (model.meshes[i].vboId[4] == 0)) { result = false; break; }   // Vertex tangents buffer not uploaded to GPU
         if ((model.meshes[i].texcoords2 != NULL) && (model.meshes[i].vboId[5] == 0)) { result = false; break; } // Vertex texcoords2 buffer not uploaded to GPU
-        if ((model.meshes[i].indices != NULL) && (model.meshes[i].vboId[6] == 0)) { result = false; break; }    // Vertex indices buffer not uploaded to GPU
+        if (MeshHasIndices(&model.meshes[i]) && (model.meshes[i].vboId[6] == 0)) { result = false; break; }    // Vertex indices buffer not uploaded to GPU
 #if SUPPORT_GPU_SKINNING
         if ((model.meshes[i].boneIndices != NULL) && (model.meshes[i].vboId[7] == 0)) { result = false; break; } // Vertex boneIndices buffer not uploaded to GPU
         if ((model.meshes[i].boneWeights != NULL) && (model.meshes[i].vboId[8] == 0)) { result = false; break; } // Vertex boneWeights buffer not uploaded to GPU
@@ -1272,6 +1276,28 @@ BoundingBox GetModelBoundingBox(Model model)
     bounds.max = Vector3Transform(bounds.max, model.transform);
 
     return bounds;
+}
+
+// Check whether a mesh has index data in its selected format
+static bool MeshHasIndices(const Mesh *mesh)
+{
+    return ((mesh->indexType == MESH_INDEX_UINT32) && (mesh->indices32 != NULL)) ||
+           ((mesh->indexType != MESH_INDEX_UINT32) && (mesh->indices != NULL));
+}
+
+static const void *GetMeshIndexData(const Mesh *mesh)
+{
+    return (mesh->indexType == MESH_INDEX_UINT32)? (const void *)mesh->indices32 : (const void *)mesh->indices;
+}
+
+static unsigned int GetMeshIndex(const Mesh *mesh, int index)
+{
+    return (mesh->indexType == MESH_INDEX_UINT32)? mesh->indices32[index] : mesh->indices[index];
+}
+
+static unsigned int GetMeshIndexGLType(const Mesh *mesh)
+{
+    return (mesh->indexType == MESH_INDEX_UINT32)? RL_UNSIGNED_INT : RL_UNSIGNED_SHORT;
 }
 
 // Upload vertex data into a VAO (if supported) and VBO
@@ -1428,9 +1454,10 @@ void UploadMesh(Mesh *mesh, bool dynamic)
     }
 #endif
 
-    if (mesh->indices != NULL)
+    if (MeshHasIndices(mesh))
     {
-        mesh->vboId[RL_DEFAULT_SHADER_ATTRIB_LOCATION_INDICES] = rlLoadVertexBufferElement(mesh->indices, mesh->triangleCount*3*sizeof(unsigned short), dynamic);
+        int indexSize = (mesh->indexType == MESH_INDEX_UINT32)? (int)sizeof(unsigned int) : (int)sizeof(unsigned short);
+        mesh->vboId[RL_DEFAULT_SHADER_ATTRIB_LOCATION_INDICES] = rlLoadVertexBufferElement(GetMeshIndexData(mesh), mesh->triangleCount*3*indexSize, dynamic);
     }
 
     if (mesh->vaoId > 0) TRACELOG(LOG_INFO, "VAO: [ID %i] Mesh uploaded successfully to VRAM (GPU)", mesh->vaoId);
@@ -1474,7 +1501,7 @@ void DrawMesh(Mesh mesh, Material material, Matrix transform)
                    material.maps[MATERIAL_MAP_DIFFUSE].color.b,
                    material.maps[MATERIAL_MAP_DIFFUSE].color.a);
 
-        if (mesh.indices != NULL) rlDrawVertexArrayElements(0, mesh.triangleCount*3, mesh.indices);
+        if (MeshHasIndices(&mesh)) rlDrawVertexArrayElementsEx(0, mesh.triangleCount*3, GetMeshIndexData(&mesh), GetMeshIndexGLType(&mesh));
         else rlDrawVertexArray(0, mesh.vertexCount);
     rlPopMatrix();
 
@@ -1644,7 +1671,7 @@ void DrawMesh(Mesh mesh, Material material, Matrix transform)
         }
 #endif
 
-        if (mesh.indices != NULL) rlEnableVertexBufferElement(mesh.vboId[RL_DEFAULT_SHADER_ATTRIB_LOCATION_INDICES]);
+        if (MeshHasIndices(&mesh)) rlEnableVertexBufferElement(mesh.vboId[RL_DEFAULT_SHADER_ATTRIB_LOCATION_INDICES]);
     }
 
     int eyeCount = 1;
@@ -1666,7 +1693,7 @@ void DrawMesh(Mesh mesh, Material material, Matrix transform)
         rlSetUniformMatrix(material.shader.locs[SHADER_LOC_MATRIX_MVP], matModelViewProjection);
 
         // Draw mesh
-        if (mesh.indices != NULL) rlDrawVertexArrayElements(0, mesh.triangleCount*3, 0);
+        if (MeshHasIndices(&mesh)) rlDrawVertexArrayElementsEx(0, mesh.triangleCount*3, 0, GetMeshIndexGLType(&mesh));
         else rlDrawVertexArray(0, mesh.vertexCount);
     }
 
@@ -1883,7 +1910,7 @@ void DrawMeshInstanced(Mesh mesh, Material material, const Matrix *transforms, i
         }
 #endif
 
-        if (mesh.indices != NULL) rlEnableVertexBufferElement(mesh.vboId[RL_DEFAULT_SHADER_ATTRIB_LOCATION_INDICES]);
+        if (MeshHasIndices(&mesh)) rlEnableVertexBufferElement(mesh.vboId[RL_DEFAULT_SHADER_ATTRIB_LOCATION_INDICES]);
     }
 
     int eyeCount = 1;
@@ -1905,7 +1932,7 @@ void DrawMeshInstanced(Mesh mesh, Material material, const Matrix *transforms, i
         rlSetUniformMatrix(material.shader.locs[SHADER_LOC_MATRIX_MVP], matModelViewProjection);
 
         // Draw mesh instanced
-        if (mesh.indices != NULL) rlDrawVertexArrayElementsInstanced(0, mesh.triangleCount*3, 0, instances);
+        if (MeshHasIndices(&mesh)) rlDrawVertexArrayElementsInstancedEx(0, mesh.triangleCount*3, 0, instances, GetMeshIndexGLType(&mesh));
         else rlDrawVertexArrayInstanced(0, mesh.vertexCount, instances);
     }
 
@@ -1956,6 +1983,7 @@ void UnloadMesh(Mesh mesh)
     RL_FREE(mesh.tangents);
     RL_FREE(mesh.texcoords2);
     RL_FREE(mesh.indices);
+    RL_FREE(mesh.indices32);
 
     // Unload mesh skin animation data
     RL_FREE(mesh.boneWeights);
@@ -2014,14 +2042,14 @@ bool ExportMesh(Mesh mesh, const char *fileName)
             byteCount += sprintf(txtData + byteCount, "vn %.4f %.4f %.4f\n", mesh.normals[v], mesh.normals[v + 1], mesh.normals[v + 2]);
         }
 
-        if (mesh.indices != NULL)
+        if (MeshHasIndices(&mesh))
         {
             for (int i = 0, v = 0; i < mesh.triangleCount; i++, v += 3)
             {
                 byteCount += sprintf(txtData + byteCount, "f %i/%i/%i %i/%i/%i %i/%i/%i\n",
-                    mesh.indices[v] + 1, mesh.indices[v] + 1, mesh.indices[v] + 1,
-                    mesh.indices[v + 1] + 1, mesh.indices[v + 1] + 1, mesh.indices[v + 1] + 1,
-                    mesh.indices[v + 2] + 1, mesh.indices[v + 2] + 1, mesh.indices[v + 2] + 1);
+                    GetMeshIndex(&mesh, v) + 1, GetMeshIndex(&mesh, v) + 1, GetMeshIndex(&mesh, v) + 1,
+                    GetMeshIndex(&mesh, v + 1) + 1, GetMeshIndex(&mesh, v + 1) + 1, GetMeshIndex(&mesh, v + 1) + 1,
+                    GetMeshIndex(&mesh, v + 2) + 1, GetMeshIndex(&mesh, v + 2) + 1, GetMeshIndex(&mesh, v + 2) + 1);
             }
         }
         else
@@ -4273,11 +4301,11 @@ RayCollision GetRayCollisionMesh(Ray ray, Mesh mesh, Matrix transform)
             Vector3 c = { 0 };
             Vector3 *vertdata = (Vector3 *)mesh.vertices;
 
-            if (mesh.indices)
+            if (MeshHasIndices(&mesh))
             {
-                a = vertdata[mesh.indices[i*3 + 0]];
-                b = vertdata[mesh.indices[i*3 + 1]];
-                c = vertdata[mesh.indices[i*3 + 2]];
+                a = vertdata[GetMeshIndex(&mesh, i*3 + 0)];
+                b = vertdata[GetMeshIndex(&mesh, i*3 + 1)];
+                c = vertdata[GetMeshIndex(&mesh, i*3 + 2)];
             }
             else
             {
@@ -6089,7 +6117,7 @@ static Model LoadGLTF(const char *fileName)
 
                     model.meshes[meshIndex].triangleCount = (int)attribute->count/3;
 
-                    if (model.meshes[meshIndex].indices != NULL) TRACELOG(LOG_WARNING, "MODEL: [%s] Indices attribute data already loaded", fileName);
+                    if (MeshHasIndices(&model.meshes[meshIndex])) TRACELOG(LOG_WARNING, "MODEL: [%s] Indices attribute data already loaded", fileName);
                     else
                     {
                         if (attribute->component_type == cgltf_component_type_r_16u)
@@ -6109,11 +6137,10 @@ static Model LoadGLTF(const char *fileName)
                         }
                         else if (attribute->component_type == cgltf_component_type_r_32u)
                         {
-                            // Init raylib mesh indices to copy glTF attribute data
-                            model.meshes[meshIndex].indices = (unsigned short *)RL_MALLOC(attribute->count*sizeof(unsigned short));
-                            LOAD_ATTRIBUTE_CAST(attribute, 1, unsigned int, model.meshes[meshIndex].indices, unsigned short);
-
-                            TRACELOG(LOG_WARNING, "MODEL: [%s] Indices data converted from u32 to u16, possible loss of data", fileName);
+                            // Preserve glTF u32 indices to avoid truncating meshes with more than 65535 vertices
+                            model.meshes[meshIndex].indices32 = (unsigned int *)RL_MALLOC(attribute->count*sizeof(unsigned int));
+                            model.meshes[meshIndex].indexType = MESH_INDEX_UINT32;
+                            LOAD_ATTRIBUTE(attribute, 1, unsigned int, model.meshes[meshIndex].indices32)
                         }
                         else TRACELOG(LOG_WARNING, "MODEL: [%s] Indices data format not supported, use u16", fileName);
                     }


### PR DESCRIPTION
## Summary

Adds opt-in 32-bit mesh index support while preserving the existing 16-bit index path and API behavior.

`Mesh.indices` remains `unsigned short *` for backward compatibility. Meshes that require indices above `65535` can use the new `indices32` field together with `MESH_INDEX_UINT32`.

## Changes

- Added `MeshIndexType` with `MESH_INDEX_UINT16` and `MESH_INDEX_UINT32`.
- Added `Mesh.indices32` and `Mesh.indexType`.
- Appended the new `Mesh` fields to preserve the offsets of existing public fields.
- Updated mesh upload and draw paths to select the correct OpenGL index type:
  - `GL_UNSIGNED_SHORT` for `u16`
  - `GL_UNSIGNED_INT` for `u32`
- Updated indexed and instanced drawing paths.
- Updated mesh cleanup, validation, export, and collision-related index access.
- Updated the glTF loader to preserve `UNSIGNED_INT` index accessors instead of narrowing them to `u16`.
- Added a regression example containing an index value of `65536`.

## Compatibility

Existing applications and models using `Mesh.indices` continue to use 16-bit indices unchanged.

The new format is opt-in:

```c
mesh.indices32 = indices;
mesh.indexType = MESH_INDEX_UINT32;