### PR TITLE
[rexm] Improve `.log` file saving for `test` command.

### DIFF
--- a/examples/rexm_web_test_server.py
+++ b/examples/rexm_web_test_server.py
@@ -1,0 +1,49 @@
+import os
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        # The path we get is an absolute path on the server (which is not an absolute path on our local filesystem)
+        # Remove the leading slash so that its a relative path
+        path = self.path.lstrip("/")
+
+        # Set the correct content type
+        extension = os.path.splitext(self.path)[1];
+        if (extension == ".html"): content_type = 'text/html'
+        elif (extension == ".js"): content_type = 'text/javascript'
+        elif (extension == ".wasm"): content_type = 'application/wasm'
+        elif (extension == ".data"): content_type = 'application/octet-stream'
+        else:
+            # Some content type that we just ignore
+            self.send_response(501)
+            return
+
+        with open(path, "rb") as f:
+            content = f.read()
+
+        self.send_response(200)
+        self.send_header('Content-Type', content_type)
+        self.send_header('Content-Length', str(len(content)))
+        self.end_headers()
+        self.wfile.write(content)
+
+    # The only POST request we get is the one we send when we're saving the `exName.log` file
+    def do_POST(self):
+        path = self.path.lstrip("/")
+
+        content_length = int(self.headers['Content-Length'])
+        body = self.rfile.read(content_length)
+
+        with open(path, "wb") as f:
+            content = f.write(body)
+
+        self.send_response(200)
+        self.end_headers()
+
+if __name__ == "__main__":
+    with HTTPServer(("", 38080), Handler) as httpd:
+        try:
+            httpd.serve_forever()
+        except KeyboardInterrupt:
+            # Ctrl + C was pressed
+            pass

--- a/src/minshell.html
+++ b/src/minshell.html
@@ -37,29 +37,16 @@
         body { margin: 0px; overflow: hidden; background-color: black; }
         canvas.emscripten { border: 0px none; background-color: black; }
     </style>
-    <script type='text/javascript' src="https://cdn.jsdelivr.net/gh/eligrey/FileSaver.js/dist/FileSaver.min.js"> </script>
     <script type='text/javascript'>
-        function saveFileFromMEMFSToDisk(memoryFSname, localFSname)     // This can be called by C/C++ code
+        // Save a file from memory onto the server
+        function saveFileFromMEMFSToDisk(memoryFSname, localFSpath)     // This can be called by C/C++ code
         {
-            var isSafari = false; // Not supported, navigator.userAgent access is being restricted
-            //var isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
             var data = FS.readFile(memoryFSname);
-            var blob;
 
-            if (isSafari) blob = new Blob([data.buffer], { type: "application/octet-stream" });
-            else blob = new Blob([data.buffer], { type: "application/octet-binary" });
-
-            // NOTE: SaveAsDialog is a browser setting. For example, in Google Chrome,
-            // in Settings/Advanced/Downloads section you have a setting:
-            // 'Ask where to save each file before downloading' - which you can set true/false.
-            // If you enable this setting it would always ask you and bring the SaveAsDialog
-            saveAs(blob, localFSname);
-          
-            // Alternative implementation to avoid FileSaver.js
-            //const link = document.createElement("a");
-            //link.href = URL.createObjectURL(blob);
-            //link.download = localFSname;
-            //link.click();
+            var xhr = new XMLHttpRequest();
+            xhr.open("POST", localFSpath);
+            xhr.setRequestHeader("Content-Type", "text/plain");
+            xhr.send(data.buffer);
         }
     </script>
     </head>

--- a/src/shell.html
+++ b/src/shell.html
@@ -194,23 +194,16 @@ jwE50AGjLCVuS8Yt4H7OgZLKK5EKOsLviEWJSL/+0uMi7gLUSBseYwqEbXvSHCec1CJvZPyHCmYQffaB
 
     <textarea id="output" rows="8"></textarea>
 
-    <script type='text/javascript' src="https://cdn.jsdelivr.net/gh/eligrey/FileSaver.js/dist/FileSaver.min.js"> </script>
     <script type='text/javascript'>
-        function saveFileFromMEMFSToDisk(memoryFSname, localFSname)     // This can be called by C/C++ code
+        // Save a file from memory onto the server
+        function saveFileFromMEMFSToDisk(memoryFSname, localFSpath)     // This can be called by C/C++ code
         {
-            var isSafari = false; // Not supported, navigator.userAgent access is being restricted
-            //var isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
             var data = FS.readFile(memoryFSname);
-            var blob;
 
-            if (isSafari) blob = new Blob([data.buffer], { type: "application/octet-stream" });
-            else blob = new Blob([data.buffer], { type: "application/octet-binary" });
-
-            // NOTE: SaveAsDialog is a browser setting. For example, in Google Chrome,
-            // in Settings/Advanced/Downloads section you have a setting:
-            // 'Ask where to save each file before downloading' - which you can set true/false.
-            // If you enable this setting it would always ask you and bring the SaveAsDialog
-            saveAs(blob, localFSname);
+            var xhr = new XMLHttpRequest();
+            xhr.open("POST", localFSpath);
+            xhr.setRequestHeader("Content-Type", "text/plain");
+            xhr.send(data.buffer);
         }
     </script>
     <script type='text/javascript'>

--- a/tools/rexm/Makefile
+++ b/tools/rexm/Makefile
@@ -345,6 +345,7 @@ $(PROJECT_NAME): $(OBJS)
 clean:
 ifeq ($(PLATFORM),PLATFORM_DESKTOP)
     ifeq ($(PLATFORM_OS),WINDOWS)
+		SHELL=cmd
 		del *.o *.exe /s
     endif
     ifeq ($(PLATFORM_OS),LINUX)

--- a/tools/rexm/rexm.c
+++ b/tools/rexm/rexm.c
@@ -1622,8 +1622,8 @@ int main(int argc, char *argv[])
                     // WARNING: Example download is asynchronous so reading fails on next step
                     // when looking for a file that could not have been downloaded yet
                     ChangeDirectory(TextFormat("%s", exBasePath));
-                    if (i == 0) system("start python -m http.server 8080"); // Init localhost just once
-                    system(TextFormat("start explorer \"http:\\localhost:8080/%s/%s.html", exCategory, exName));
+                    if (i == 0) system("start python -m http.server 38080"); // Init localhost just once
+                    system(TextFormat("start explorer \"http:\\localhost:38080/%s/%s.html", exCategory, exName));
                 }
 
                 // NOTE: Example .log is automatically downloaded into system Downloads directory on browser-example exectution

--- a/tools/rexm/rexm.c
+++ b/tools/rexm/rexm.c
@@ -1517,6 +1517,9 @@ int main(int argc, char *argv[])
             LOG("INFO: Command requested: TEST\n");
             LOG("INFO: Example(s) to be build and tested: %i [%s]\n", exBuildListCount, (exBuildListCount == 1)? exBuildList[0] : argv[2]);
 
+            // Create directory for logs (build and run logs)
+            MakeDirectory(TextFormat("%s/%s/logs", exBasePath, exCategory));
+
             for (int i = 0; i < exBuildListCount; i++)
             {
                 // Get example name and category
@@ -1531,9 +1534,6 @@ int main(int argc, char *argv[])
                     (strcmp(exName, "core_custom_frame_control") == 0)) continue;
 
                 LOG("INFO: [%i/%i] Testing example: [%s]\n", i + 1, exBuildListCount, exName);
-
-                // Create directory for logs (build and run logs)
-                MakeDirectory(TextFormat("%s/%s/logs", exBasePath, exCategory));
 
                 // Steps to follow
                 // STEP 1: Load example.c and replace required code to inject basic testing code: frames to run
@@ -1580,17 +1580,22 @@ int main(int argc, char *argv[])
                     "    if ((argc > 1) && (argc == 3) && (strcmp(argv[1], \"--frames\") != 0)) requestedTestFrames = atoi(argv[2]);\n";
 
                 static const char *returnReplaceText =
-                    "    SaveFileText(\"outputLogFileName\", logText);\n"
-                    "    emscripten_run_script(\"saveFileFromMEMFSToDisk('outputLogFileName','outputLogFileName')\");\n\n"
+                    "    SaveFileText(\"memoryFsName\", logText);\n"
+                    "    emscripten_run_script(\"saveFileFromMEMFSToDisk('memoryFsName','localPath')\");\n\n"
                     "    return 0";
-                char *returnReplaceTextUpdated = TextReplaceAlloc(returnReplaceText, "outputLogFileName", TextFormat("%s.log", exName));
+                char *returnReplaceTextUpdated[2] = { 0 };
+                returnReplaceTextUpdated[0] = TextReplaceAlloc(returnReplaceText, "memoryFsName", TextFormat("%s.log", exName));
+                // The path we specify will be relative to the directory containing the example's javascript file
+                // The javascript files are already in `exBasePath/exCategory`, so we don't need to specify the category directory
+                returnReplaceTextUpdated[1] = TextReplaceAlloc(returnReplaceTextUpdated[0], "localPath", TextFormat("logs/%s.log", exName));
 
                 char *srcTextUpdated[4] = { 0 };
                 srcTextUpdated[0] = TextReplaceAlloc(srcText, "int main(void)\n{", mainReplaceText);
                 srcTextUpdated[1] = TextReplaceAlloc(srcTextUpdated[0], "WindowShouldClose()", "WindowShouldClose() && (testFramesCount < requestedTestFrames)");
                 srcTextUpdated[2] = TextReplaceAlloc(srcTextUpdated[1], "EndDrawing();", "EndDrawing(); testFramesCount++;");
-                srcTextUpdated[3] = TextReplaceAlloc(srcTextUpdated[2], "    return 0", returnReplaceTextUpdated);
-                MemFree(returnReplaceTextUpdated);
+                srcTextUpdated[3] = TextReplaceAlloc(srcTextUpdated[2], "    return 0", returnReplaceTextUpdated[1]);
+
+                for (int i = 0; i < 2; i++) { MemFree(returnReplaceTextUpdated[i]); returnReplaceTextUpdated[i] = NULL; }
                 UnloadFileText(srcText);
 
                 SaveFileText(TextFormat("%s/%s/%s.c", exBasePath, exCategory, exName), srcTextUpdated[3]);
@@ -1621,8 +1626,11 @@ int main(int argc, char *argv[])
                 {
                     // WARNING: Example download is asynchronous so reading fails on next step
                     // when looking for a file that could not have been downloaded yet
-                    ChangeDirectory(TextFormat("%s", exBasePath));
-                    if (i == 0) system("start python -m http.server 38080"); // Init localhost just once
+                    if (i == 0)
+                    {
+                        ChangeDirectory(TextFormat("%s", exBasePath));
+                        system("start python rexm_web_test_server.py"); // Init localhost just once
+                    }
                     system(TextFormat("start explorer \"http:\\localhost:38080/%s/%s.html", exCategory, exName));
                 }
 

--- a/tools/rexm/rexm.c
+++ b/tools/rexm/rexm.c
@@ -1729,12 +1729,8 @@ int main(int argc, char *argv[])
                 UnloadTextLines(exTestBuildLogLines, exTestBuildLogLinesCount);
                 UnloadFileText(exTestBuildLog);
 
-#if defined(BUILD_TESTING_WEB)
-                // TODO: REVIEW: Hardcoded path where web logs are copied after automatic download
-                char *exTestLog = LoadFileText(TextFormat("D:/testing_logs_web/%s.log", exName));
-#else
                 char *exTestLog = LoadFileText(TextFormat("%s/%s/logs/%s.log", exBasePath, exCategory, exName));
-#endif
+
                 if (exTestLog == NULL)
                 {
                     LOG("WARNING: [%s] Execution log could not be loaded\n", exName);


### PR DESCRIPTION
Before, the `test` command used javascript (client) to save the generated log file, which doesn't allow you to specify a path to save the file to (for security reasons.)

`test` was already using a python server to run the web example, which we can take advantage of. Using a python script (`rexm_web_test_server.py`) we can control how we handle POST requests. With that, we can use javascript to send a POST request to the server, and the server can then save the log file (avoiding client restrictions.)

As an added bonus, we don't need `FileSaver.js` anymore.

## Miscellaneous changes

- Fix `tools/rexm/Makefile` so that it uses `SHELL=cmd` on Windows.
- Change the `test` command server port number from `8080` to `38080` to reduce conflicts with other programs.