### PR TITLE
[rlgl] Fix batching system grouping incompatible drawing commands (#6110)

### DIFF
--- a/src/rlgl.h
+++ b/src/rlgl.h
@@ -1452,7 +1452,8 @@ void rlBegin(int mode)
 {
     // Draw mode can be RL_LINES, RL_TRIANGLES and RL_QUADS
     // NOTE: In all three cases, vertex are accumulated over default internal vertex buffer
-    if (RLGL.currentBatch->draws[RLGL.currentBatch->drawCounter - 1].mode != mode)
+    if ((RLGL.currentBatch->draws[RLGL.currentBatch->drawCounter - 1].mode != mode) ||
+        (RLGL.currentBatch->draws[RLGL.currentBatch->drawCounter - 1].textureId != RLGL.State.currentTextureId))
     {
         if (RLGL.currentBatch->draws[RLGL.currentBatch->drawCounter - 1].vertexCount > 0)
         {
@@ -1476,7 +1477,7 @@ void rlBegin(int mode)
 
         RLGL.currentBatch->draws[RLGL.currentBatch->drawCounter - 1].mode = mode;
         RLGL.currentBatch->draws[RLGL.currentBatch->drawCounter - 1].textureId = RLGL.State.currentTextureId;
-        RLGL.State.currentTextureId = RLGL.State.defaultTextureId;
+        RLGL.currentBatch->draws[RLGL.currentBatch->drawCounter - 1].vertexCount = 0;
     }
 }
 


### PR DESCRIPTION
#6110 

rlBegin() was only checking primitive mode changes and skipping draw call splits when textureId changed (for example, DrawPlane after DrawBillboard). Now checks both mode and textureId against RLGL.State.currentTextureId before appending vertices.