### PR TITLE
[rtextures] Fix GetPixelColor() reading the wrong bits for R5G5B5A1 blue

### DIFF
--- a/src/rtextures.c
+++ b/src/rtextures.c
@@ -5333,7 +5333,7 @@ Color GetPixelColor(const void *srcPtr, int format)
         {
             color.r = (unsigned char)((((unsigned short *)srcPtr)[0] >> 11)*255/31);
             color.g = (unsigned char)(((((unsigned short *)srcPtr)[0] >> 6) & 0b0000000000011111)*255/31);
-            color.b = (unsigned char)((((unsigned short *)srcPtr)[0] & 0b0000000000011111)*255/31);
+            color.b = (unsigned char)(((((unsigned short *)srcPtr)[0] >> 1) & 0b0000000000011111)*255/31);
             color.a = (((unsigned short *)srcPtr)[0] & 0b0000000000000001)? 255 : 0;
 
         } break;


### PR DESCRIPTION
`GetPixelColor()` decodes the blue channel of `PIXELFORMAT_UNCOMPRESSED_R5G5B5A1` from bits 4..0 (`src/rtextures.c:5336`). The format puts blue in bits 5..1 and alpha in bit 0 — which is what the encoders at `:1401`, `:2003`, `:3472` and `:5456` write, and what the other four decoders (`:1690`, `:3057`, `:3301`, `:5628`) read. It also matches `GL_UNSIGNED_SHORT_5_5_5_1`, the GL type this format maps to in `rlgl.h:3603` (OpenGL 4.6 core, table 8.5: components in bits 15..11 / 10..6 / 5..1 / 0). So the decoded blue was blue's low four bits shifted up, with the alpha bit pulled in as its LSB.

Measured at 9f3cadf on macOS/clang with a small harness:

* Pack `r == g == b == 20` and decode: `(164, 164, 74)`. 31 of the 32 possible greys decode with unequal channels. After the fix: `(164, 164, 164)`, 0 of 32.
* `SetPixelColor()` → `GetPixelColor()` round trip: 242 of 256 blue values off by more than one 5-bit step, worst `120 → 255`. After: 0 of 256, worst error 5 (quantisation).
* R5G6B5 and R4G4B4A4 decode white correctly before and after — this case was the only one wrong.
* Reverting the one line reproduces the numbers exactly; the naive "just shift it" edit (`(v & 0b11111) >> 1`) still gets 32 of 64 wrong, so the mask position matters, not just the shift.

`ImageDrawImage()` blends through `GetPixelColor()`, so this affects drawing onto an R5G5B5A1 image, not just direct calls.

Not fixed here, pre-existing, and worth knowing: `GetImageColor()`/`LoadImageColors()` scale with `(float)v*(255/31)`, and `255/31` is integer division = 8, so their 5-bit channels top out at 248 while `GetPixelColor()`'s `v*255/31` reaches 255. After this fix the two still disagree by up to 7 on blue. Happy to send that separately if you want it changed.

Introduced in ec09fea (2020) — the same commit added the encoder with `b << 1` and the decoder without the matching shift.

How I found it: I was diffing the several places in `rtextures.c` that decode the same packed formats, looking for ones that disagree with each other. I am not using raylib on a project and did not hit this in real work, so weigh it accordingly. AI-assisted (Claude); the measurements above are mine and reproducible. Not tested: big-endian, and I have not run the GL upload path for this format on a real texture.
