### PR TITLE
Support rlGetActiveFramebuffer() on OpenGL ES 2.0.

### DIFF
--- a/src/rlgl.h
+++ b/src/rlgl.h
@@ -994,6 +994,7 @@ RLAPI void rlLoadDrawQuad(void);     // Load and draw a quad
     #if !defined(GRAPHICS_API_OPENGL_ES3)
         #define GL_READ_FRAMEBUFFER         GL_FRAMEBUFFER
         #define GL_DRAW_FRAMEBUFFER         GL_FRAMEBUFFER
+        #define GL_DRAW_FRAMEBUFFER_BINDING GL_FRAMEBUFFER_BINDING
     #endif
 #endif
 
@@ -1847,7 +1848,7 @@ void rlEnableFramebuffer(unsigned int id)
 unsigned int rlGetActiveFramebuffer(void)
 {
     GLint fboId = 0;
-#if (defined(GRAPHICS_API_OPENGL_33) || defined(GRAPHICS_API_OPENGL_ES3) || defined(GRAPHICS_API_OPENGL_SOFTWARE))
+#if (defined(GRAPHICS_API_OPENGL_33) || defined(GRAPHICS_API_OPENGL_ES2) || defined(GRAPHICS_API_OPENGL_SOFTWARE))
     glGetIntegerv(GL_DRAW_FRAMEBUFFER_BINDING, &fboId);
 #endif
     return fboId;


### PR DESCRIPTION
Alias GL_DRAW_FRAMEBUFFER_BINDING to GL_FRAMEBUFFER_BINDING for ES 2.0, alongside the existing GL_READ_FRAMEBUFFER/GL_DRAW_FRAMEBUFFER aliases, and widen the guard to ES 2.0. The guard now matches rlEnableFramebuffer() and rlDisableFramebuffer().

(Tested on WebKit WebGL, OpenGL ES 2.0 (WebGL 1.0).  Not tested on low-end hardware like RPi.)

Discussed briefly on Discord [here](https://discord.com/channels/426912293134270465/1531850358651883630/1544451914933207042).