### PR TITLE
[rtextures] Review `ImageDrawCircle()` asymmetry

### DIFF
--- a/src/rtextures.c
+++ b/src/rtextures.c
@@ -3977,10 +3977,10 @@ void ImageDrawCircle(Image *dst, int centerX, int centerY, int radius, Color col
 
     while (y >= x)
     {
-        ImageDrawRectangle(dst, centerX - x, centerY + y, x*2, 1, color);
-        ImageDrawRectangle(dst, centerX - x, centerY - y, x*2, 1, color);
-        ImageDrawRectangle(dst, centerX - y, centerY + x, y*2, 1, color);
-        ImageDrawRectangle(dst, centerX - y, centerY - x, y*2, 1, color);
+        ImageDrawRectangle(dst, centerX - x, centerY + y, x*2 + 1, 1, color);
+        ImageDrawRectangle(dst, centerX - x, centerY - y, x*2 + 1, 1, color);
+        ImageDrawRectangle(dst, centerX - y, centerY + x, y*2 + 1, 1, color);
+        ImageDrawRectangle(dst, centerX - y, centerY - x, y*2 + 1, 1, color);
         x++;
 
         if (decesionParameter > 0)


### PR DESCRIPTION
Fixes #6117

`ImageDrawCircle` filled `2*radius` pixels wide but `2*radius + 1` tall. Each horizontal span started at `centerX - x` with width `2*x`, which covers `centerX - x` through `centerX + x - 1`, so the column at `centerX + x` was never written. The fill came out one column short on the right, half a pixel off-centre, and out of line with `ImageDrawCircleLines`, which is `2*radius + 1` in both directions.

This widens the four spans by one pixel. The fill becomes `(2r+1) x (2r+1)`, centred on `(centerX, centerY)`, and matches `ImageDrawCircleLines` exactly.

Verified on master (9f3cadf) with radii 1-6: before the change, 1, 5, 7, 9, 11 and 13 outline pixels fell outside the fill respectively. After it, zero for every radius.

Note this makes every filled circle one pixel wider than before, so existing output shifts. The alternative would be narrowing `ImageDrawCircleLines` instead, but the outline is the one that is currently correct and centred.
