### PR TITLE
[rcore][GLFW] Fix window centering overflow with unsigned screen size

### DIFF
--- a/src/platforms/rcore_desktop_glfw.c
+++ b/src/platforms/rcore_desktop_glfw.c
@@ -1804,11 +1804,11 @@ int InitPlatform(void)
 
         // Center window into current monitor
     #if defined(__APPLE__)
-        CORE.Window.position.x = monitorX + (monitorWidth - CORE.Window.screen.width)/2;
-        CORE.Window.position.y = monitorY + (monitorHeight - CORE.Window.screen.height)/2;
+        CORE.Window.position.x = monitorX + (monitorWidth - (int)CORE.Window.screen.width)/2;
+        CORE.Window.position.y = monitorY + (monitorHeight - (int)CORE.Window.screen.height)/2;
     #else
-        CORE.Window.position.x = monitorX + (monitorWidth - CORE.Window.render.width)/2;
-        CORE.Window.position.y = monitorY + (monitorHeight - CORE.Window.render.height)/2;
+        CORE.Window.position.x = monitorX + (monitorWidth - (int)CORE.Window.render.width)/2;
+        CORE.Window.position.y = monitorY + (monitorHeight - (int)CORE.Window.render.height)/2;
     #endif
         SetWindowPosition(CORE.Window.position.x, CORE.Window.position.y);
 


### PR DESCRIPTION
Fixes #6002.

`Size` is `{ unsigned int width; unsigned int height; }` (rcore.c), so in `InitPlatform()` the centering subtraction is done in unsigned arithmetic. When the window is larger than the monitor workarea on either axis it wraps around instead of going negative, and the division by 2 keeps it positive:

```
monitor 1366x768, window 5000x3000
before:  pos = (2147481831, 2147482532)
after:   pos = (-1817, -1116)
```

X11 truncates that to 16 bits, which is where the reported off-screen window comes from (`0xF8E7` = -1817). This is also why `SetWindowPosition(0, 0)` right after `InitWindow()` works around it.

Casting to `int` is enough, no extra branches. Tested on Linux/X11:

- 5000x3000 window on a 1366x768 monitor: before the window landed off-screen at (-1817, -1116), after it is placed at (0, 0) and is visible.
- 640x480 window on the same monitor: centered at (363, 144) before and after, unchanged.

I could not test the reporter's exact setup (portrait primary monitor on Windows), only the same code path with an oversized window.
