### PR TITLE
[rcore] Document that GetFPS() must be called every frame

### DIFF
--- a/src/raylib.h
+++ b/src/raylib.h
@@ -1093,7 +1093,7 @@ RLAPI Matrix GetCameraMatrix2D(Camera2D camera);                        // Get c
 RLAPI void SetTargetFPS(int fps);                       // Set target FPS (maximum)
 RLAPI float GetFrameTime(void);                         // Get time in seconds for last frame drawn (delta time)
 RLAPI double GetTime(void);                             // Get elapsed time in seconds since InitWindow()
-RLAPI int GetFPS(void);                                 // Get current FPS
+RLAPI int GetFPS(void);                                 // Get current FPS (averages the last 30 calls, so call it every frame)
 
 // Custom frame control functions
 // NOTE: Those functions are intended for advanced users that want full control over the frame processing

--- a/tools/rlparser/output/raylib_api.json
+++ b/tools/rlparser/output/raylib_api.json
@@ -4083,7 +4083,7 @@
     },
     {
       "name": "GetFPS",
-      "description": "Get current FPS",
+      "description": "Get current FPS (averages the last 30 calls, so call it every frame)",
       "returnType": "int"
     },
     {

--- a/tools/rlparser/output/raylib_api.lua
+++ b/tools/rlparser/output/raylib_api.lua
@@ -3789,7 +3789,7 @@ return {
     },
     {
       name = "GetFPS",
-      description = "Get current FPS",
+      description = "Get current FPS (averages the last 30 calls, so call it every frame)",
       returnType = "int"
     },
     {

--- a/tools/rlparser/output/raylib_api.sexpr
+++ b/tools/rlparser/output/raylib_api.sexpr
@@ -2736,7 +2736,7 @@
      (return-type "double"))
 
     ((name "GetFPS")
-     (description "Get current FPS")
+     (description "Get current FPS (averages the last 30 calls, so call it every frame)")
      (return-type "int"))
 
     ((name "SwapScreenBuffer")

--- a/tools/rlparser/output/raylib_api.txt
+++ b/tools/rlparser/output/raylib_api.txt
@@ -1510,7 +1510,7 @@ Function 095: GetTime() (0 input parameters)
 Function 096: GetFPS() (0 input parameters)
   Name: GetFPS
   Return type: int
-  Description: Get current FPS
+  Description: Get current FPS (averages the last 30 calls, so call it every frame)
   No input parameters
 Function 097: SwapScreenBuffer() (0 input parameters)
   Name: SwapScreenBuffer

--- a/tools/rlparser/output/raylib_api.xml
+++ b/tools/rlparser/output/raylib_api.xml
@@ -957,7 +957,7 @@
         </Function>
         <Function name="GetTime" retType="double" paramCount="0" desc="Get elapsed time in seconds since InitWindow()">
         </Function>
-        <Function name="GetFPS" retType="int" paramCount="0" desc="Get current FPS">
+        <Function name="GetFPS" retType="int" paramCount="0" desc="Get current FPS (averages the last 30 calls, so call it every frame)">
         </Function>
         <Function name="SwapScreenBuffer" retType="void" paramCount="0" desc="Swap back buffer with front buffer (screen drawing)">
         </Function>


### PR DESCRIPTION
`GetFPS()` is a sampler rather than a query, and the header does not say so.

Each call takes **at most one sample**, gated on `FPS_STEP`, writes
`GetFrameTime()/FPS_CAPTURE_FRAMES_COUNT` into a 30-slot ring, and returns
`1/sum-of-ring`:

```c
if ((GetTime() - last) > FPS_STEP)
{
    last = (float)GetTime();
    index = (index + 1)%FPS_CAPTURE_FRAMES_COUNT;
    average -= history[index];
    history[index] = fpsFrame/FPS_CAPTURE_FRAMES_COUNT;
    average += history[index];
}

fps = (int)roundf(1.0f/average);
```

So the ring needs 30 calls before `average` is the mean frame time. Calling
every frame reaches that in half a second. Calling from a timer, or from a
periodic summary, never reaches it: after n calls only n slots hold anything, so
it returns `1/(n * frame_time/30)`.

## Measured

An app with a steady 17.02 ms frame time, one binary, the call cadence being the
only variable:

| cadence | readings |
| --- | --- |
| one call per second, from a cold ring | 1773, 887, 591, 444, 354, 295, 253, 221 |
| every frame, same process moments later | 59, 59, 59, 58, 59 |

The first row is `1773/n` to within a percent at every point, which is the ring
filling one slot per call.

Called every frame, as `DrawFPS()` does and as the examples do, it is correct.
The reason this is worth a comment is that misuse has no tell: no error, and a
plausible-looking number rather than an obviously wrong one. It took a
frame-time series that stayed flat while the reported FPS decayed to notice.

## The change

Comment only, no behaviour change:

```c
-RLAPI int GetFPS(void);                                 // Get current FPS
+RLAPI int GetFPS(void);                                 // Get current FPS (averages the last 30 calls, so call it every frame)
```

The `rlparser` outputs carry the header comment as the function `description`,
so they are updated to match rather than regenerated. That keeps the diff to one
line per file; happy to regenerate them properly instead if you prefer.

Verified against `master` at `9b2efc45`, which is where this branches from.
`GetFPS()` is byte-identical there and at 6.0. raylib still builds with the
change (comment only).

Entirely reasonable to close this if per-frame calling is considered obvious
enough not to document.
