### PR TITLE
[rexm] Fix `Makefile` and change port number.

### DIFF
--- a/tools/rexm/Makefile
+++ b/tools/rexm/Makefile
@@ -345,7 +345,7 @@ $(PROJECT_NAME): $(OBJS)
 clean:
 ifeq ($(PLATFORM),PLATFORM_DESKTOP)
     ifeq ($(PLATFORM_OS),WINDOWS)
-		del *.o *.exe /s
+		rm *.o *.exe
     endif
     ifeq ($(PLATFORM_OS),LINUX)
 		find . -type f -executable -delete

--- a/tools/rexm/rexm.c
+++ b/tools/rexm/rexm.c
@@ -1622,8 +1622,8 @@ int main(int argc, char *argv[])
                     // WARNING: Example download is asynchronous so reading fails on next step
                     // when looking for a file that could not have been downloaded yet
                     ChangeDirectory(TextFormat("%s", exBasePath));
-                    if (i == 0) system("start python -m http.server 8080"); // Init localhost just once
-                    system(TextFormat("start explorer \"http:\\localhost:8080/%s/%s.html", exCategory, exName));
+                    if (i == 0) system("start python -m http.server 38080"); // Init localhost just once
+                    system(TextFormat("start explorer \"http:\\localhost:38080/%s/%s.html", exCategory, exName));
                 }
 
                 // NOTE: Example .log is automatically downloaded into system Downloads directory on browser-example exectution


### PR DESCRIPTION
- Fix `Makefile`: The `make` program that comes with `w64devkit` uses a UNIX-style shell (`w64devkit/bin/sh.exe`) so we can't use `del` command (we could do `SHELL=cmd` on Windows, but this is easier, and the expectation is that `w64devkit` is being used anyway.)
- Change port number: `8080` is a pretty common port number, changing it helps to prevent conflicts with other running programs.