### PR TITLE
[rlparser] Fix formatting to follow raylib conventions

### DIFF
--- a/tools/rlparser/rlparser.c
+++ b/tools/rlparser/rlparser.c
@@ -783,7 +783,8 @@ int main(int argc, char *argv[])
         c++; 
         
         // Maybe type pointer part
-        if (linePtr[c] == '*') {
+        if (linePtr[c] == '*') 
+        {
             while(linePtr[c] == '*') c++;
             typeLen = c - typeStart;
         }


### PR DESCRIPTION
Moved curly brace to newline in `if` block.