### PR TITLE
[rtext] Fix TextToPascal()/TextToCamel() truncating text after a separator

### DIFF
--- a/src/rtext.c
+++ b/src/rtext.c
@@ -2186,9 +2186,11 @@ char *TextToPascal(const char *text)
             if (text[j] != '_') buffer[i] = text[j];
             else
             {
-                j++;
+                while (text[j] == '_') j++;     // Skip one or more separators
+                if (text[j] == '\0') break;     // Text ends on a separator, nothing left to copy
+
                 if ((text[j] >= 'a') && (text[j] <= 'z')) buffer[i] = text[j] - 32;
-                else if ((text[j] >= '0') && (text[j] <= '9')) buffer[i] = text[j];
+                else buffer[i] = text[j];       // Character can not be upper-cased, copy it as is
             }
         }
     }
@@ -2268,8 +2270,11 @@ char *TextToCamel(const char *text)
             if (text[j] != '_') buffer[i] = text[j];
             else
             {
-                j++;
+                while (text[j] == '_') j++;     // Skip one or more separators
+                if (text[j] == '\0') break;     // Text ends on a separator, nothing left to copy
+
                 if ((text[j] >= 'a') && (text[j] <= 'z')) buffer[i] = text[j] - 32;
+                else buffer[i] = text[j];       // Character can not be upper-cased, copy it as is
             }
         }
     }


### PR DESCRIPTION
`TextToPascal()` and `TextToCamel()` drop everything after an underscore unless the character right after it is one they explicitly handle. `TextToPascal()` (src/rtext.c:2186) handles `a`-`z` and `0`-`9`, `TextToCamel()` (src/rtext.c:2270) handles only `a`-`z`. For anything else neither branch runs, `buffer[i]` keeps the zero from the `memset()` at the top of the function, and the returned string ends right there.

So `TextToPascal("text_UTF8_load")` returns `"Text"`, and `TextToCamel("sound_3d_mix")` returns `"sound"`. An upper case letter after the separator truncates both, a digit after the separator truncates `TextToCamel()`, and two underscores in a row truncate both.

The same code also reads one byte past the string. When `_` is the last character, `j++` lands on the `\0`, neither branch matches, and then the loop increment moves `j` one further before the condition reads `text[j]`.

This skips the whole run of separators, stops when that reaches the end of the text, and copies a character that has no upper case form as it is. That last `else` also covers digits, so it replaces the `0`-`9` branch `TextToPascal()` had.

Verified at a2cc9b1 on macOS arm64 with Apple clang 17, CMake configured with `-DBUILD_EXAMPLES=ON`. The program below links against the built `libraylib.a` and opens no window. Before the change:

```
input            TextToPascal   expected            TextToCamel    expected       
-------------------------------------------------------------------------------------
hello_world      HelloWorld     HelloWorld     ok   helloWorld     helloWorld     ok
hello_World      Hello          HelloWorld     FAIL hello          helloWorld     FAIL
value_2          Value2         Value2         ok   value          value2         FAIL
sound_3d_mix     Sound3dMix     Sound3dMix     ok   sound          sound3dMix     FAIL
text_UTF8_load   Text           TextUTF8Load   FAIL text           textUTF8Load   FAIL
hello_           Hello          Hello          ok   hello          hello          ok
a__b             A              AB             FAIL a              aB             FAIL

FAILURES: 8 of 14

Guard page check, text "hello_" with its '\0' as the last readable byte:
  TextToPascal  CRASHED, read past the terminator
  TextToCamel   CRASHED, read past the terminator

RESULT: failures present
```

After:

```
input            TextToPascal   expected            TextToCamel    expected       
-------------------------------------------------------------------------------------
hello_world      HelloWorld     HelloWorld     ok   helloWorld     helloWorld     ok
hello_World      HelloWorld     HelloWorld     ok   helloWorld     helloWorld     ok
value_2          Value2         Value2         ok   value2         value2         ok
sound_3d_mix     Sound3dMix     Sound3dMix     ok   sound3dMix     sound3dMix     ok
text_UTF8_load   TextUTF8Load   TextUTF8Load   ok   textUTF8Load   textUTF8Load   ok
hello_           Hello          Hello          ok   hello          hello          ok
a__b             AB             AB             ok   aB             aB             ok

FAILURES: 0 of 14

Guard page check, text "hello_" with its '\0' as the last readable byte:
  TextToPascal  returned "Hello", no read past the terminator
  TextToCamel   returned "hello", no read past the terminator

RESULT: all checks passed
```

The last check writes `"hello_"` so its `\0` is the final byte of a readable page with an unreadable page right behind it, which is why the read past the terminator shows up as a crash rather than as a wrong string.

`TextToPascal("raylib_fun_videogames_programming")` and `TextToCamel("raylib_fun_videogames_programming")` from examples/text/text_strings_management.c are unchanged, and `TextToSnake()` is not touched. The library and 225 examples build clean, and so do tools/rlparser and tools/rexm.
