### PR TITLE
[rtext] Fix TextSplit() reading past its buffer on text of 1024 bytes or more

### DIFF
--- a/src/rtext.c
+++ b/src/rtext.c
@@ -2082,7 +2082,8 @@ char **TextSplit(const char *text, char delimiter, int *count)
         counter = 1;
 
         // Count how many substrings ar found on text and set pointers to every one
-        for (int i = 0; i < MAX_TEXT_BUFFER_LENGTH; i++)
+        // NOTE: Last buffer byte is reserved to terminate the last substring
+        for (int i = 0; i < MAX_TEXT_BUFFER_LENGTH - 1; i++)
         {
             buffer[i] = text[i];
             if (buffer[i] == '\0') break;


### PR DESCRIPTION
`TextSplit()` fills its whole static buffer, so when the text reaches `MAX_TEXT_BUFFER_LENGTH` there is no byte left to terminate the last substring. `src/rtext.c:2085` loops `for (int i = 0; i < MAX_TEXT_BUFFER_LENGTH; i++)` and writes `buffer[i] = text[i]` up to `i == MAX_TEXT_BUFFER_LENGTH - 1`, so the loop can end with the buffer full of text and no `'\0'` left in it. Reading the last substring it returned then runs off the end of the array.

There is a second way out of the same loop: if the delimiter lands on the last buffer byte, `buffers[counter] = buffer + i + 1` at `src/rtext.c:2092` stores `buffer + MAX_TEXT_BUFFER_LENGTH`, one past the end, and that pointer is the last substring.

The function's own note says the maximum size of text to split is `MAX_TEXT_BUFFER_LENGTH`, so text of that size is meant to come back truncated but still as valid C strings. `TextSplit(LoadFileText(fileName), '\n', &count)` is a common way to walk a file, and files over 1 KB are normal, so this is easy to reach.

The fix stops the copy one byte earlier. The buffer is `memset()` to zero at the top of the function, so its last byte stays `'\0'` and terminates whatever the last substring turns out to be, and `buffer + i + 1` can no longer point past the end.

Checked at f25c824 on macOS arm64 with Apple clang 17, using a standalone program with `TextSplit()` copied verbatim out of `src/rtext.c`, no window and no GPU. A FAIL below means the last substring starts outside the buffer, or the buffer holds no `'\0'` at its last byte. Before:

```
MAX_TEXT_BUFFER_LENGTH = 1024

short text                   len  100  count  11  last substring at buffer+100   buffer[1023] = 0x00  ok
fits exactly                 len 1023  count 103  last substring at buffer+1020  buffer[1023] = 0x00  ok
one byte over                len 1024  count 103  last substring at buffer+1020  buffer[1023] = 0x6a  FAIL
well over                    len 4000  count 103  last substring at buffer+1020  buffer[1023] = 0x6a  FAIL
delimiter on last byte       len 4000  count  65  last substring at buffer+1024  buffer[1023] = 0x00  FAIL
no delimiter at all          len 4000  count   1  last substring at buffer+0     buffer[1023] = 0x6a  FAIL

FAILURES: 4 of 6
```

After:

```
MAX_TEXT_BUFFER_LENGTH = 1024

short text                   len  100  count  11  last substring at buffer+100   buffer[1023] = 0x00  ok
fits exactly                 len 1023  count 103  last substring at buffer+1020  buffer[1023] = 0x00  ok
one byte over                len 1024  count 103  last substring at buffer+1020  buffer[1023] = 0x00  ok
well over                    len 4000  count 103  last substring at buffer+1020  buffer[1023] = 0x00  ok
delimiter on last byte       len 4000  count  64  last substring at buffer+1008  buffer[1023] = 0x00  ok
no delimiter at all          len 4000  count   1  last substring at buffer+0     buffer[1023] = 0x00  ok

FAILURES: 0 of 6
```

Calling `strlen()` on that last substring with a 4000 byte input reports `global-buffer-overflow ... 0 bytes after global variable 'TextSplit.buffer' ... of size 1024` under AddressSanitizer before the change, for both delimiter spacings, and reports a length with no error after it.

Old and new were also run side by side on 14313 inputs, every length from 0 to 1100 bytes crossed with delimiter spacings 2 to 40, comparing substring count, every substring offset and the full buffer contents. They agree on every input up to 1023 bytes and first differ at exactly 1024, which is where the old loop overruns.

`clang -c -std=c99 -Wall -Wextra -DPLATFORM_DESKTOP -Isrc -Isrc/external/glfw/include src/rtext.c` gives the same one pre-existing warning as master, `unused parameter 'dataSize'` at `rtext.c:614`, and nothing new. The three `TextSplit()` call sites in the tree, `examples/text/text_words_alignment.c:53`, `examples/text/text_strings_management.c:319` and `tools/rexm/rexm.c:2502`, all pass short text and are unaffected. raygui's `GuiTextSplit()` is a separate copy and is not touched.
