### PR TITLE
[rcore][GLFW] Fixed issue with non-fullscreen window being able to be larger than a workable area

### DIFF
--- a/src/platforms/rcore_desktop_glfw.c
+++ b/src/platforms/rcore_desktop_glfw.c
@@ -1615,18 +1615,18 @@ int InitPlatform(void)
 
     if ((CORE.Window.screen.width == 0) || (CORE.Window.screen.height == 0)) FLAG_SET(CORE.Window.flags, FLAG_FULLSCREEN_MODE);
 
+    // NOTE: Fullscreen applications default to the primary monitor
+    GLFWmonitor* monitor = glfwGetPrimaryMonitor();
+    if (!monitor)
+    {
+        TRACELOG(LOG_WARNING, "GLFW: Failed to get primary monitor");
+        return -1;
+    }
+
     // Init window in fullscreen mode if requested
     // NOTE: Keeping original screen size for toggle
     if (FLAG_IS_SET(CORE.Window.flags, FLAG_FULLSCREEN_MODE))
     {
-        // NOTE: Fullscreen applications default to the primary monitor
-        GLFWmonitor *monitor = glfwGetPrimaryMonitor();
-        if (!monitor)
-        {
-            TRACELOG(LOG_WARNING, "GLFW: Failed to get primary monitor");
-            return -1;
-        }
-
         // Set dimensions from monitor
         const GLFWvidmode *mode = glfwGetVideoMode(monitor);
 
@@ -1666,6 +1666,15 @@ int InitPlatform(void)
         // Default to at least one pixel in size, as creation with a zero dimension is not allowed
         if (CORE.Window.screen.width == 0) CORE.Window.screen.width = 1;
         if (CORE.Window.screen.height == 0) CORE.Window.screen.height = 1;
+
+        int workX, workY, workW, workH;
+        glfwGetMonitorWorkarea(monitor, &workX, &workY, &workW, &workH);
+
+        // If the area requested by the user exceeds the maximum workable area, clamp it to that.
+        // GLFW has a problem where if the window is greater than the workable area (this means
+        // the taskbar / dockable areas) it won't show up if the window isn't fullscreen.
+        if (CORE.Window.screen.width > workW) CORE.Window.screen.width = workW;
+        if (CORE.Window.screen.height > workH) CORE.Window.screen.height = workH;
 
         platform.handle = glfwCreateWindow(CORE.Window.screen.width, CORE.Window.screen.height, (CORE.Window.title != 0)? CORE.Window.title : " ", NULL, NULL);
         if (!platform.handle)


### PR DESCRIPTION
GLFW has a problem where if the window is greater than the workable area (this means the taskbar / dockable areas) it won't show up if the window isn't fullscreen. 

This fix clamps the size of the window to that maximum workable area.
This has been tested by setting the maximum window size of the core_window_should_close example project to 1920x1080 (a standard 16:9 monitor as of 2026) and making sure the window is **NOT** fullscreen.