### PR TITLE
[raymath.h] Add lerp angle and normalized direction functions

### DIFF
--- a/src/raymath.h
+++ b/src/raymath.h
@@ -231,6 +231,15 @@ RMAPI float Lerp(float start, float end, float amount)
     return result;
 }
 
+// Calculate linear interpolation between two angles along the shortest path
+RMAPI float LerpAngle(float start, float end, float amount)
+{
+    float delta = remainderf(end - start, 2.0f * PI);
+    float result = start + delta * amount;
+
+    return result;
+}
+
 // Normalize input value within input range
 RMAPI float Normalize(float value, float start, float end)
 {

--- a/src/raymath.h
+++ b/src/raymath.h
@@ -452,6 +452,22 @@ RMAPI Vector2 Vector2Normalize(Vector2 v)
     return result;
 }
 
+// Calculate the normalized direction from one vector to another
+RMAPI Vector2 Vector2DirectionNormalized(Vector2 start, Vector2 end)
+{
+    Vector2 result = { end.x - start.x, end.y - start.y };
+
+    float length = sqrtf(result.x * result.x + result.y * result.y);
+    if (length > 0.0f)
+    {
+        float ilength = 1.0f/length;
+        result.x *= ilength;
+        result.y *= ilength;
+    }
+
+    return result;
+}
+
 // Transforms a Vector2 by a given Matrix
 RMAPI Vector2 Vector2Transform(Vector2 v, Matrix mat)
 {
@@ -819,6 +835,27 @@ RMAPI Vector3 Vector3Normalize(Vector3 v)
     {
         float ilength = 1.0f/length;
 
+        result.x *= ilength;
+        result.y *= ilength;
+        result.z *= ilength;
+    }
+
+    return result;
+}
+
+// Calculate the normalized direction from one vector to another
+RMAPI Vector3 Vector3DirectionNormalized(Vector3 start, Vector3 end)
+{
+    Vector3 result = {
+        end.x - start.x,
+        end.y - start.y,
+        end.z - start.z
+    };
+
+    float length = sqrtf(result.x * result.x + result.y * result.y + result.z * result.z);
+    if (length > 0.0f)
+    {
+        float ilength = 1.0f/length;
         result.x *= ilength;
         result.y *= ilength;
         result.z *= ilength;


### PR DESCRIPTION
Adds `LerpAngle` for linear interpolation along shortest angular path.
Also adds normalized direction functions for `Vector2` and `Vector3`.