### PR TITLE
[Win32Compatability] Handle raylib conflict with PlaySoundW for wide string builds

### DIFF
--- a/src/external/fix_win32_compatibility.h
+++ b/src/external/fix_win32_compatibility.h
@@ -43,6 +43,7 @@
 #define DrawTextExA DrawTextExAWin32
 #define DrawTextExW DrawTextExWin32
 #define PlaySoundA PlaySoundAWin32
+#define PlaySoundW PlaySoundWWin32
 // include windows
 #define WIN32_LEAN_AND_MEAN 
 #include <windows.h>
@@ -62,3 +63,4 @@
 #undef DrawTextExA
 #undef DrawTextExW
 #undef PlaySoundA
+#undef PlaySoundW


### PR DESCRIPTION
If the user builds a raylib app set for windows wide string support, PlaySoundW will conflict with PlaySound, this fix adds PlaySoundW to the disabled windows functions in fixWin32Compatbility.h