### PR TITLE
[rcore] Fix ComputeSHA256() wrong hash when message length mod 64 is 56..59

### DIFF
--- a/src/rcore.c
+++ b/src/rcore.c
@@ -3535,7 +3535,7 @@ unsigned int *ComputeSHA256(const unsigned char *data, int dataSize)
     hash[7] = 0x5be0cd19;
 
     const unsigned long long bitLen = 8ULL*dataSize;
-    unsigned long long paddedSize = dataSize + sizeof(dataSize);
+    unsigned long long paddedSize = dataSize + sizeof(bitLen); // Reserve room for the 64 bit message length appended at the end
     paddedSize += (64 - (paddedSize%64));
     unsigned char *buffer = (unsigned char *)RL_CALLOC(paddedSize, sizeof(unsigned char));
 


### PR DESCRIPTION
Fixes #6143.

`ComputeSHA256()` reserves the padding tail with `sizeof(dataSize)`. `dataSize` is `int`, so that reserves 4 bytes, but SHA-256 needs 9: the `0x80` marker plus a 64-bit big-endian message length. The write a few lines below already uses `sizeof(bitLen)` (8 bytes), so the reserve and the write disagreed.

When only 5 to 8 bytes of room remained, the length field was written over the `0x80` marker and the tail of the message, and the padded size was one block short of the canonical size. Every write stayed inside the allocation, so the digest was silently wrong rather than crashing. This affected `dataSize % 64 ∈ {56, 57, 58, 59}`, which is 4/64 = 6.25% of input lengths, including the FIPS 180-4 two-block test vector.

Reserving `sizeof(bitLen)` fixes it. With an 8 byte reserve the existing round-up line produces exactly the canonical padded size for every length: writing `r = (dataSize + 8) mod 64`, when `r != 0` the result is the smallest multiple of 64 at or above `dataSize + 9`, and when `r == 0` (`dataSize ≡ 56 mod 64`) it adds the extra block the standard requires. Room after the message is `8 + (64 - r) >= 9` in all cases.

This PR changes only one line in `src/rcore.c`.

Validation: the 56 byte FIPS 180-4 vector fails before the change and passes afterward. All 5 NIST vectors pass (lengths 0, 3, 56, 112 and 1000000). Every length from 0 to 4096 matches a reference SHA-256, covering all 64 residue classes mod 64 sixty-four times each, as do 3000 pseudo-random messages at pseudo-random lengths up to 70000 bytes; before the change those same runs produced 256 and 210 wrong digests respectively. Comparing the padding arithmetic against the canonical padded size over lengths 0 to 10,000,000 gives 0 mismatches, and `paddedSize % 64 == 0` with room `>= dataSize + 9` holds throughout; the old expression gave 625,000 mismatches over that range. The full harness runs clean under AddressSanitizer and UndefinedBehaviorSanitizer. `ComputeSHA1()`, `ComputeMD5()`, `ComputeCRC32()`, `EncodeDataBase64()` and `DecodeDataBase64()` were re-checked against reference implementations and are unchanged and correct. `rcore.c` compiles with no warnings under `-Wall -Wextra`; the only warning in a full build is the pre-existing `'mi' may be used uninitialized` in bundled `external/m3d.h`, reached via `rmodels.c`.

The test harnesses are local and are not included in this PR. Built and tested on Linux with GCC (`PLATFORM_DESKTOP_GLFW`, `GRAPHICS_API_OPENGL_33`); not tested on Windows, macOS or Web, though the change is platform independent integer arithmetic. Note that digests returned for the affected lengths change with this fix, which is the intent: they now match the standard.
