### PR TITLE
[examples] Unload source images in textures_image_rotate

### DIFF
--- a/examples/textures/textures_image_rotate.c
+++ b/examples/textures/textures_image_rotate.c
@@ -44,6 +44,10 @@ int main(void)
     textures[1] = LoadTextureFromImage(image90);
     textures[2] = LoadTextureFromImage(imageNeg90);
 
+    UnloadImage(image45);
+    UnloadImage(image90);
+    UnloadImage(imageNeg90);
+
     int currentTexture = 0;
 
     SetTargetFPS(60);               // Set our game to run at 60 frames-per-second


### PR DESCRIPTION
The `textures_image_rotate` example loads and rotates three images, uploads them as textures, and retains the CPU image allocations until process exit.

Call `UnloadImage` for all three source images after `LoadTextureFromImage`, once their data has been uploaded.

Validation on Windows with GCC 15.2:
- Built raylib with CMake and compiled/linked the complete example with `-Wall -Wextra -Werror`.
- Ran the actual example initialization with real image decoding and rotation, replacing the window and GPU calls at the link boundary. The original example retained 3 CPU images before the first frame; the updated example retained 0. This check did not exercise GPU rendering.
