### PR TITLE
Fix make shell detection

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -122,6 +122,14 @@ BUILD_WEB_RESOURCES_PATH  ?= $(dir $<)resources@resources
 # WARNING: Requires raylib compiled with GRAPHICS_API_OPENGL_ES3
 BUILD_WEB_WEBGL2      ?= FALSE
 
+# Detect the shell used by make: cmd preserves quotes, while sh removes them.
+ifndef PLATFORM_SHELL
+    PLATFORM_SHELL = sh
+    ifeq ($(shell echo "test"),"test")
+        PLATFORM_SHELL = cmd
+    endif
+endif
+
 # Determine PLATFORM_OS when required
 ifeq ($(TARGET_PLATFORM),$(filter $(TARGET_PLATFORM),PLATFORM_DESKTOP_GLFW PLATFORM_DESKTOP_SDL PLATFORM_DESKTOP_RGFW PLATFORM_WEB PLATFORM_WEB_RGFW))
     # No uname.exe on MinGW!, but OS=Windows_NT on Windows!
@@ -784,7 +792,11 @@ endif
 clean:
 ifeq ($(TARGET_PLATFORM),PLATFORM_DESKTOP_GLFW)
     ifeq ($(PLATFORM_OS),WINDOWS)
+        ifeq ($(PLATFORM_SHELL),cmd)
 		del *.o *.exe /s
+        else
+		find . -type f '(' -name '*.o' -o -name '*.exe' ')' -exec rm -f {} +
+        endif
     endif
     ifeq ($(PLATFORM_OS),BSD)
 		find . -type f -perm -ugo+x -delete
@@ -801,19 +813,23 @@ ifeq ($(TARGET_PLATFORM),PLATFORM_DESKTOP_GLFW)
 endif
 ifeq ($(TARGET_PLATFORM),PLATFORM_DESKTOP_WIN32)
     ifeq ($(PLATFORM_OS),WINDOWS)
-        del *.o *.exe /s
+        ifeq ($(PLATFORM_SHELL),cmd)
+		del *.o *.exe /s
+        else
+		find . -type f '(' -name '*.o' -o -name '*.exe' ')' -exec rm -f {} +
+        endif
     endif
     ifeq ($(PLATFORM_OS),BSD)
-        find . -type f -perm -ugo+x -delete
-        rm -fv *.o
+		find . -type f -perm -ugo+x -delete
+		rm -fv *.o
     endif
     ifeq ($(PLATFORM_OS),LINUX)
-        find . -type f -executable -delete
-        rm -fv *.o
+		find . -type f -executable -delete
+		rm -fv *.o
     endif
     ifeq ($(PLATFORM_OS),OSX)
-        find . -type f -perm +ugo+x -delete
-        rm -f *.o
+		find . -type f -perm +ugo+x -delete
+		rm -f *.o
     endif
 endif
 ifeq ($(TARGET_PLATFORM),PLATFORM_DRM)
@@ -821,7 +837,7 @@ ifeq ($(TARGET_PLATFORM),PLATFORM_DRM)
 	rm -fv *.o
 endif
 ifeq ($(TARGET_PLATFORM),$(filter $(TARGET_PLATFORM),PLATFORM_WEB PLATFORM_WEB_RGFW))
-    ifeq ($(PLATFORM_OS),WINDOWS)
+    ifeq ($(PLATFORM_SHELL),cmd)
 		del *.wasm *.html *.js *.data
     else
 		rm -f */*.wasm */*.html */*.js */*.data

--- a/src/Makefile
+++ b/src/Makefile
@@ -141,15 +141,20 @@ ROOT = $(shell whoami)
 HOST_PLATFORM_OS ?= WINDOWS
 PLATFORM_OS ?= WINDOWS
 
+# Detect the shell used by make: cmd preserves quotes, while sh removes them.
+ifndef PLATFORM_SHELL
+    PLATFORM_SHELL = sh
+    ifeq ($(shell echo "test"),"test")
+        PLATFORM_SHELL = cmd
+    endif
+endif
+
 # Determine PLATFORM_OS when required
 ifeq ($(TARGET_PLATFORM),$(filter $(TARGET_PLATFORM),PLATFORM_DESKTOP_GLFW PLATFORM_DESKTOP_SDL PLATFORM_DESKTOP_RGFW PLATFORM_DESKTOP_WIN32 PLATFORM_WEB PLATFORM_WEB_RGFW PLATFORM_ANDROID))
     # No uname.exe on MinGW!, but OS=Windows_NT on Windows!
     # ifeq ($(UNAME),Msys) -> Windows
     ifeq ($(OS),Windows_NT)
         PLATFORM_OS = WINDOWS
-        ifndef PLATFORM_SHELL
-            PLATFORM_SHELL = cmd
-        endif
     else
         UNAMEOS = $(shell uname)
         ifeq ($(UNAMEOS),Linux)
@@ -170,25 +175,12 @@ ifeq ($(TARGET_PLATFORM),$(filter $(TARGET_PLATFORM),PLATFORM_DESKTOP_GLFW PLATF
         ifeq ($(UNAMEOS),Darwin)
             PLATFORM_OS = OSX
         endif
-        ifndef PLATFORM_SHELL
-            PLATFORM_SHELL = sh
-        endif
     endif
 endif
 ifeq ($(TARGET_PLATFORM),PLATFORM_DRM)
     UNAMEOS = $(shell uname)
     ifeq ($(UNAMEOS),Linux)
         PLATFORM_OS = LINUX
-    endif
-    ifndef PLATFORM_SHELL
-        PLATFORM_SHELL = sh
-    endif
-endif
-ifeq ($(TARGET_PLATFORM),$(filter $(TARGET_PLATFORM),PLATFORM_WEB PLATFORM_WEB_RGFW))
-    ifeq ($(PLATFORM_OS),LINUX)
-        ifndef PLATFORM_SHELL
-            PLATFORM_SHELL = sh
-        endif
     endif
 endif
 
@@ -992,8 +984,6 @@ ifeq ($(TARGET_PLATFORM),PLATFORM_ANDROID)
 	rm -fv $(NATIVE_APP_GLUE)/android_native_app_glue.o
 endif
 
-# Set specific target variable
-clean_shell_cmd: SHELL=cmd
 clean_shell_cmd:
 	del *.o /s
 	cd $(RAYLIB_RELEASE_PATH) & \

--- a/tools/rexm/Makefile
+++ b/tools/rexm/Makefile
@@ -57,6 +57,14 @@ BUILD_WEB_ASYNCIFY_STACK_SIZE ?= 1048576
 BUILD_WEB_RESOURCES   ?= FALSE
 BUILD_WEB_RESOURCES_PATH  ?= resources
 
+# Detect the shell used by make: cmd preserves quotes, while sh removes them.
+ifndef PLATFORM_SHELL
+    PLATFORM_SHELL = sh
+    ifeq ($(shell echo "test"),"test")
+        PLATFORM_SHELL = cmd
+    endif
+endif
+
 # Determine PLATFORM_OS in case PLATFORM_DESKTOP selected
 ifeq ($(PLATFORM),PLATFORM_DESKTOP)
     # No uname.exe on MinGW!, but OS=Windows_NT on Windows!
@@ -345,7 +353,11 @@ $(PROJECT_NAME): $(OBJS)
 clean:
 ifeq ($(PLATFORM),PLATFORM_DESKTOP)
     ifeq ($(PLATFORM_OS),WINDOWS)
-		rm *.o *.exe
+        ifeq ($(PLATFORM_SHELL),cmd)
+		del /q *.o *.exe
+        else
+		rm -f *.o *.exe
+        endif
     endif
     ifeq ($(PLATFORM_OS),LINUX)
 		find . -type f -executable -delete
@@ -360,6 +372,10 @@ ifeq ($(PLATFORM),PLATFORM_DRM)
 	rm -fv *.o
 endif
 ifeq ($(PLATFORM),PLATFORM_WEB)
+    ifeq ($(PLATFORM_SHELL),cmd)
 	del *.o *.html *.js
+    else
+	rm -f *.o *.html *.js
+    endif
 endif
 	@echo Cleaning done

--- a/tools/rlparser/Makefile
+++ b/tools/rlparser/Makefile
@@ -2,6 +2,14 @@ EXTENSION?=txt
 FORMAT?=DEFAULT
 .PHONY: all parse clean raylib_api
 
+# Detect the shell used by make: cmd preserves quotes, while sh removes them.
+ifndef PLATFORM_SHELL
+    PLATFORM_SHELL = sh
+    ifeq ($(shell echo "test"),"test")
+        PLATFORM_SHELL = cmd
+    endif
+endif
+
 # Determine PLATFORM_OS
 # No uname.exe on MinGW!, but OS=Windows_NT on Windows!
 # ifeq ($(UNAME),Msys) -> Windows
@@ -117,4 +125,8 @@ all: rlparser
 
 # Clean rlparser and generated output files 
 clean:
-	rm -f rlparser *.json *.txt *.xml *.lua *.sexpr
+ifeq ($(PLATFORM_SHELL),cmd)
+	del /q rlparser.exe *.json *.txt *.xml *.lua *.sexpr
+else
+	rm -f rlparser rlparser.exe *.json *.txt *.xml *.lua *.sexpr
+endif

--- a/tools/rlparser/Makefile
+++ b/tools/rlparser/Makefile
@@ -117,11 +117,11 @@ parse: raylib_api.$(EXTENSION) raymath_api.$(EXTENSION) rlgl_api.$(EXTENSION) ra
 # API files for individual headers can be created likeso, provided the relevant header exists:
 # FORMAT=JSON EXTENSION=json make raygui_api.json
 all: rlparser
-	FORMAT=DEFAULT EXTENSION=txt $(MAKE) parse
-	FORMAT=JSON EXTENSION=json $(MAKE) parse
-	FORMAT=XML EXTENSION=xml $(MAKE) parse
-	FORMAT=LUA EXTENSION=lua $(MAKE) parse
-	FORMAT=SEXPR EXTENSION=sexpr $(MAKE) parse
+	$(MAKE) parse FORMAT=DEFAULT EXTENSION=txt
+	$(MAKE) parse FORMAT=JSON EXTENSION=json
+	$(MAKE) parse FORMAT=XML EXTENSION=xml
+	$(MAKE) parse FORMAT=LUA EXTENSION=lua
+	$(MAKE) parse FORMAT=SEXPR EXTENSION=sexpr
 
 # Clean rlparser and generated output files 
 clean:


### PR DESCRIPTION
  Fixes #6135.

  The Makefiles assume Windows means cmd, but GNU Make can select sh
  instead. This causes `make clean` to use the wrong shell commands.

  Detect the recipe shell using `echo "test"`: cmd preserves the quotes,
  while sh removes them. Apply this to the library, examples and tools,
  and remove the forced cmd shell from library cleanup. Explicit
  PLATFORM_SHELL overrides remain supported.

  Also fix Win32 clean recipe indentation and,
 pass rlparser's recursive make variables as command-line arguments
  so those calls work under both cmd and sh.